### PR TITLE
Restore REPL on Ctr+C

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -272,7 +272,7 @@ stripCmd pty                    = pty
 handleREPLEvent :: AppState -> BrickEvent Name AppEvent -> EventM Name (Next AppState)
 handleREPLEvent s (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl]))
   = continue $ s
-          & uiState . uiReplForm %~ updateFormState ""
+      & uiState . uiReplForm %~ updateFormState ""
 handleREPLEvent s (VtyEvent (V.EvKey V.KEnter []))
   = case processTerm' topCtx topCapCtx entry of
       Right t@(ProcessedTerm _ (Module ty _) _ _) ->

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -272,7 +272,7 @@ stripCmd pty                    = pty
 handleREPLEvent :: AppState -> BrickEvent Name AppEvent -> EventM Name (Next AppState)
 handleREPLEvent s (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl]))
   = continue $ s
-      & gameState . robotMap . ix "base" . machine .~ idleMachine
+          & uiState . uiReplForm %~ updateFormState ""
 handleREPLEvent s (VtyEvent (V.EvKey V.KEnter []))
   = case processTerm' topCtx topCapCtx entry of
       Right t@(ProcessedTerm _ (Module ty _) _ _) ->


### PR DESCRIPTION
Currently, if I write something in the REPL and press Ctr+C, the REPL form gets updated and puts three periods (`...`), and if I type something I will just be adding characters to whatever string I had before pressing Ctr+C. I would expect Ctr+C to behave just like in most terminals, that is, delete anything I had written at that moment and restore the it to `> `. This PR does just that. 