### PR TITLE
Only append entry to REPL history if it is not the same as last entry

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -155,7 +155,7 @@ shutdown s = do
   liftIO $ writeFile ".swarm_history" (show hist)
   halt s'
  where
-  markOld (REPLEntry _ e) = REPLEntry False e
+  markOld (REPLEntry _ d e) = REPLEntry False d e
   markOld r = r
 
   isEntry REPLEntry {} = True
@@ -396,7 +396,7 @@ handleREPLEvent s (VtyEvent (V.EvKey V.KEnter [])) =
           s
             & uiState . uiReplForm %~ updateFormState ""
             & uiState . uiReplType .~ Nothing
-            & uiState . uiReplHistory %~ prependReplEntryIfNotDuplicate
+            & uiState . uiReplHistory %~ prependReplEntry
             & uiState . uiReplHistIdx .~ (-1)
             & uiState . uiError .~ Nothing
             & gameState . replStatus .~ REPLWorking ty Nothing
@@ -415,9 +415,9 @@ handleREPLEvent s (VtyEvent (V.EvKey V.KEnter [])) =
   topTypeCtx = s ^. gameState . robotMap . ix "base" . robotContext . defTypes
   topCapCtx = s ^. gameState . robotMap . ix "base" . robotContext . defCaps
   topValCtx = s ^. gameState . robotMap . ix "base" . robotContext . defVals
-  prependReplEntryIfNotDuplicate replHistory
-    | firstReplEntry replHistory == Just entry = replHistory
-    | otherwise = REPLEntry True entry : replHistory
+  prependReplEntry replHistory
+    | firstReplEntry replHistory == Just entry = REPLEntry True True entry : replHistory
+    | otherwise = REPLEntry True False entry : replHistory
 handleREPLEvent s (VtyEvent (V.EvKey V.KUp [])) =
   continue $ s & adjReplHistIndex (+)
 handleREPLEvent s (VtyEvent (V.EvKey V.KDown [])) =
@@ -451,7 +451,7 @@ adjReplHistIndex (+/-) s =
     & validateREPLForm
  where
   saveLastEntry = uiState . uiReplLast .~ formState (s ^. uiState . uiReplForm)
-  entries = [e | REPLEntry _ e <- s ^. uiState . uiReplHistory]
+  entries = [e | REPLEntry _ False e <- s ^. uiState . uiReplHistory]
   curIndex = s ^. uiState . uiReplHistIdx
   histLen = length entries
   newIndex = min (histLen - 1) (max (-1) (curIndex +/- 1))

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -148,22 +148,27 @@ data Modal
 
 -- | An item in the REPL history.
 data REPLHistItem
-  = -- | Something entered by the user.  The
+  = -- | Something entered by the user.  The first
     --   @Bool@ indicates whether it is
     --   something entered this session (it
     --   will be @False@ for entries that were
     --   loaded from the history file). This is
     --   so we know which ones to append to the
     --   history file on shutdown.
-    REPLEntry Bool Text
+    --   The second @Bool@ indicates whether it
+    --   is a duplicate of the preceding item (it
+    --   will be @True@ for duplicate entries).
+    --   This is so we can ignore it when scrolling
+    --   through the REPL history in the REPL window.
+    REPLEntry Bool Bool Text
   | -- | A response printed by the system.
     REPLOutput Text
   deriving (Eq, Ord, Show, Read)
 
--- | Given a REPL history return `Just` the most recent `Text`
---   entered by the user or `Nothing` if there is none.
+-- | Given a REPL history return @Just@ the most recent @Text@
+--   entered by the user or @Nothing@ if there is none.
 firstReplEntry :: [REPLHistItem] -> Maybe Text
-firstReplEntry ((REPLEntry _ entry) : _) = Just entry
+firstReplEntry ((REPLEntry _ _ entry) : _) = Just entry
 firstReplEntry (_ : rest) = firstReplEntry rest
 firstReplEntry [] = Nothing
 

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -560,8 +560,8 @@ drawREPL s =
         Just False -> [renderForm (s ^. uiState . uiReplForm)]
         _ -> [padRight Max $ txt "..."]
  where
-  newEntry (REPLEntry False _) = False
+  newEntry (REPLEntry False _ _) = False
   newEntry _ = True
 
-  fmt (REPLEntry _ e) = txt replPrompt <+> txt e
+  fmt (REPLEntry _ _ e) = txt replPrompt <+> txt e
   fmt (REPLOutput t) = txt t


### PR DESCRIPTION
Closes #75. 
A REPL entry is only appended to the REPL history if it is not a duplicate of the last entry.