### PR TITLE
Make the `salvage` command take one tick to transfer each item

### DIFF
--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -359,6 +359,10 @@ stepCESK cesk = case cesk of
     return $ Up (Fatal (T.append "Antiquoted variable found at runtime: $str:" v)) s k
   In (TAntiInt v) _ s k ->
     return $ Up (Fatal (T.append "Antiquoted variable found at runtime: $int:" v)) s k
+  -- Normally it's not possible to have a TRobot value in surface
+  -- syntax, but the salvage command generates a program that needs to
+  -- refer directly to the salvaging robot.
+  In (TRobot rid) _ s k -> return $ Out (VRobot rid) s k
   -- Function constants of arity 0 are evaluated immediately
   -- (e.g. parent, self).  Any other constant is turned into a VCApp,
   -- which is waiting for arguments and/or an FExec frame.
@@ -1248,11 +1252,15 @@ execConst c vs s k = do
         case mtarget of
           Nothing -> return $ Out VUnit s k -- Nothing to salvage
           Just target -> do
-            -- Copy over the salvaged robot's inventory
-            robotInventory %= E.union (target ^. robotInventory)
-            robotInventory %= E.union (target ^. installedDevices)
+            -- Copy the salvaged robot's installed devices into its inventory, in preparation
+            -- for transferring it.
+            let salvageInventory = E.union (target ^. robotInventory) (target ^. installedDevices)
+            robotMap . at (target ^. robotID) . traverse . robotInventory .= salvageInventory
 
-            -- Also copy over its log, if we have one
+            let salvageItems = concatMap (\(n, e) -> replicate n (e ^. entityName)) (E.elems salvageInventory)
+                numItems = length salvageItems
+
+            -- Copy over the salvaged robot's log, if we have one
             inst <- use installedDevices
             em <- use entityMap
             creative <- use creativeMode
@@ -1261,10 +1269,27 @@ execConst c vs s k = do
                 `isJustOr` Fatal "While executing 'salvage': there's no such thing as a logger!?"
             when (creative || inst `E.contains` logger) $ robotLog <>= target ^. robotLog
 
-            -- Finally, delete the salvaged robot
-            deleteRobot (target ^. robotID)
+            -- Now reprogram the robot being salvaged to 'give' each
+            -- item in its inventory to us, one at a time, then
+            -- self-destruct at the end.  Make it a system robot so we
+            -- don't have to worry about capabilities.
+            robotMap . at (target ^. robotID) . traverse . systemRobot .= True
 
-            return $ Out VUnit s k
+            ourID <- use @Robot robotID
+
+            -- The program for the salvaged robot to run
+            let giveInventory =
+                  foldr (TBind Nothing . giveItem) (TConst Selfdestruct) salvageItems
+                giveItem item = TApp (TApp (TConst Give) (TRobot ourID)) (TString item)
+
+            -- Reprogram and activate the salvaged robot
+            robotMap . at (target ^. robotID) . traverse . machine
+              .= In giveInventory empty emptyStore [FExec]
+            activateRobot (target ^. robotID)
+
+            -- Now wait the right amount of time for it to finish.
+            time <- use ticks
+            return $ Waiting (time + fromIntegral numItems + 1) (Out VUnit s k)
       _ -> badConst
     -- run can take both types of text inputs
     -- with and without file extension as in


### PR DESCRIPTION
I initially thought this would be tricky, but it's not: all we need to
do is reprogram the salvaged robot to give the salvaging robot one
item at a time.

Closes #202.