### PR TITLE
Add a dialog box to confirm quit

### DIFF
--- a/src/Swarm/TUI/Attr.hs
+++ b/src/Swarm/TUI/Attr.hs
@@ -17,6 +17,7 @@ module Swarm.TUI.Attr where
 
 import Brick
 import Brick.Forms
+import Brick.Widgets.Dialog
 import Brick.Widgets.List
 import qualified Graphics.Vty as V
 
@@ -53,6 +54,7 @@ swarmAttrMap =
     , (focusedFormInputAttr, V.defAttr)
     , (listSelectedFocusedAttr, bg V.blue)
     , (infoAttr, fg (V.rgbColor @Int 50 50 50))
+    , (buttonSelectedAttr, bg V.blue)
     , -- Default attribute
       (defAttr, V.defAttr)
     ]

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -106,15 +106,13 @@ handleEvent s (VtyEvent (V.EvKey V.KEsc []))
   | isJust (s ^. uiState . uiError) = continue $ s & uiState . uiError .~ Nothing
   | isJust (s ^. uiState . uiModal) = continue $ s & uiState . uiModal .~ Nothing
 handleEvent s (VtyEvent vev)
-  | isJust (s ^. uiState . uiModal) = do
-    s' <- s & uiState . uiModal . _Just . modalDialog %%~ handleDialogEvent vev
-    continue s'
+  | isJust (s ^. uiState . uiModal) = handleModalEvent s vev
 handleEvent s (VtyEvent (V.EvKey (V.KChar '\t') [])) = continue $ s & uiState . uiFocusRing %~ focusNext
 handleEvent s (VtyEvent (V.EvKey V.KBackTab [])) = continue $ s & uiState . uiFocusRing %~ focusPrev
 handleEvent s ev = do
   -- intercept special keys that works on all panels
   case ev of
-    ControlKey 'q' -> toggleModal s QuitModal -- shutdown s
+    ControlKey 'q' -> toggleModal s QuitModal
     MetaKey 'w' -> setFocus s WorldPanel
     MetaKey 'e' -> setFocus s RobotPanel
     MetaKey 'r' -> setFocus s REPLPanel

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -194,14 +194,24 @@ helpWidget = (helpKeys <=> fill ' ') <+> (helpCommands <=> fill ' ')
       , hCenter $ mkTable baseCommands
       ]
   baseCommands =
-    [ ("build <name> {<commands>}", "Create a robot")
-    , ("make <name>", "Craft an item")
+    [ ("build {<commands>}", "Create a robot")
+    , ("make \"<name>\"", "Craft an item")
     , ("move", "Move one step in the current direction")
     , ("turn <dir>", "Change the current direction")
     , ("grab", "Grab whatver is available")
-    , ("give <robot> <item>", "Give an item to another robot")
-    , ("has <item>", "Check for an item in the inventory")
+    , ("give <robot> \"<item>\"", "Give an item to another robot")
+    , ("has \"<item>\"", "Check for an item in the inventory")
     ]
+
+handleModalEvent :: AppState -> V.Event -> EventM Name (Next AppState)
+handleModalEvent s ev = case ev of
+  V.EvKey V.KEnter [] ->
+    case s ^? uiState . uiModal . _Just . modalDialog . to dialogSelectedIndex of
+      Just (Just 1) -> shutdown s
+      _ -> toggleModal s QuitModal
+  _ -> do
+    s' <- s & uiState . uiModal . _Just . modalDialog %%~ handleDialogEvent ev
+    continue s'
 
 -- | Shut down the application.  Currently all it does is write out
 --   the updated REPL history to a @.swarm_history@ file.

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -61,10 +61,8 @@ import Witch (into)
 import Brick hiding (Direction)
 import Brick.Focus
 import Brick.Forms
-import Brick.Widgets.Center (hCenter)
 import Brick.Widgets.Dialog
 import qualified Brick.Widgets.List as BL
-import qualified Brick.Widgets.Table as BT
 import qualified Graphics.Vty as V
 
 import qualified Control.Carrier.Lift as Fused
@@ -84,6 +82,7 @@ import Swarm.Language.Syntax
 import Swarm.Language.Types
 import Swarm.TUI.List
 import Swarm.TUI.Model
+import Swarm.TUI.View (generateModal)
 import Swarm.Util hiding ((<<.=))
 
 -- | Pattern synonyms to simplify brick event handler
@@ -151,55 +150,6 @@ toggleModal s mt = do
   -- TODO: manage unpause more safely to also cover
   -- the world event handler for the KChar 'p'.
   resetLastFrameTime curTime = uiState . lastFrameTime .~ curTime
-
-generateModal :: ModalType -> Modal
-generateModal mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth `min` requiredWidth)) widget
- where
-  (title, widget, buttons, requiredWidth) =
-    case mt of
-      HelpModal -> ("Help", helpWidget, Nothing, maxModalWindowWidth)
-      WinModal -> ("", txt "Congratulations!", Nothing, maxModalWindowWidth)
-      QuitModal ->
-        let quitMsg = "Are you sure you want to quit?"
-         in ( ""
-            , padBottom (Pad 1) $ hCenter $ txt quitMsg
-            , Just (0, [("Cancel", False), ("Quit", True)])
-            , T.length quitMsg + 4
-            )
-
-helpWidget :: Widget Name
-helpWidget = (helpKeys <=> fill ' ') <+> (helpCommands <=> fill ' ')
- where
-  helpKeys =
-    vBox
-      [ hCenter $ txt "Global Keybindings"
-      , hCenter $ mkTable glKeyBindings
-      ]
-  mkTable = BT.renderTable . BT.table . map toWidgets
-  toWidgets (k, v) = [txt k, txt v]
-  glKeyBindings =
-    [ ("F1", "Help")
-    , ("Ctrl-q", "quit the game")
-    , ("Tab", "cycle panel focus")
-    , ("Meta-w", "focus on the world map")
-    , ("Meta-e", "focus on the robot inventory")
-    , ("Meta-r", "focus on the REPL")
-    , ("Meta-t", "focus on the info panel")
-    ]
-  helpCommands =
-    vBox
-      [ hCenter $ txt "Commands"
-      , hCenter $ mkTable baseCommands
-      ]
-  baseCommands =
-    [ ("build {<commands>}", "Create a robot")
-    , ("make \"<name>\"", "Craft an item")
-    , ("move", "Move one step in the current direction")
-    , ("turn <dir>", "Change the current direction")
-    , ("grab", "Grab whatver is available")
-    , ("give <robot> \"<item>\"", "Give an item to another robot")
-    , ("has \"<item>\"", "Check for an item in the inventory")
-    ]
 
 handleModalEvent :: AppState -> V.Event -> EventM Name (Next AppState)
 handleModalEvent s ev = case ev of

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -107,7 +107,7 @@ handleEvent s (VtyEvent (V.EvKey V.KEsc []))
 handleEvent s ev = do
   -- intercept special keys that works on all panels
   case ev of
-    ControlKey 'q' -> shutdown s
+    ControlKey 'q' -> toggleModal s QuitModal -- shutdown s
     MetaKey 'w' -> setFocus s WorldPanel
     MetaKey 'e' -> setFocus s RobotPanel
     MetaKey 'r' -> setFocus s REPLPanel

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -61,7 +61,10 @@ import Witch (into)
 import Brick hiding (Direction)
 import Brick.Focus
 import Brick.Forms
+import Brick.Widgets.Center (hCenter)
+import Brick.Widgets.Dialog
 import qualified Brick.Widgets.List as BL
+import qualified Brick.Widgets.Table as BT
 import qualified Graphics.Vty as V
 
 import qualified Control.Carrier.Lift as Fused
@@ -99,11 +102,15 @@ handleEvent s (AppEvent Frame)
 handleEvent s (VtyEvent (V.EvResize _ _)) = do
   invalidateCacheEntry WorldCache
   continue s
-handleEvent s (VtyEvent (V.EvKey (V.KChar '\t') [])) = continue $ s & uiState . uiFocusRing %~ focusNext
-handleEvent s (VtyEvent (V.EvKey V.KBackTab [])) = continue $ s & uiState . uiFocusRing %~ focusPrev
 handleEvent s (VtyEvent (V.EvKey V.KEsc []))
   | isJust (s ^. uiState . uiError) = continue $ s & uiState . uiError .~ Nothing
   | isJust (s ^. uiState . uiModal) = continue $ s & uiState . uiModal .~ Nothing
+handleEvent s (VtyEvent vev)
+  | isJust (s ^. uiState . uiModal) = do
+    s' <- s & uiState . uiModal . _Just . modalDialog %%~ handleDialogEvent vev
+    continue s'
+handleEvent s (VtyEvent (V.EvKey (V.KChar '\t') [])) = continue $ s & uiState . uiFocusRing %~ focusNext
+handleEvent s (VtyEvent (V.EvKey V.KBackTab [])) = continue $ s & uiState . uiFocusRing %~ focusPrev
 handleEvent s ev = do
   -- intercept special keys that works on all panels
   case ev of
@@ -113,26 +120,24 @@ handleEvent s ev = do
     MetaKey 'r' -> setFocus s REPLPanel
     MetaKey 't' -> setFocus s InfoPanel
     FKey 1 -> toggleModal s HelpModal
-    _anyOtherEvent
-      | isJust (s ^. uiState . uiModal) -> continueWithoutRedraw s
-      | otherwise ->
-        -- and dispatch the other to the focused panel handler
-        case focusGetCurrent (s ^. uiState . uiFocusRing) of
-          Just REPLPanel -> handleREPLEvent s ev
-          Just WorldPanel -> handleWorldEvent s ev
-          Just RobotPanel -> handleRobotPanelEvent s ev
-          Just InfoPanel -> handleInfoPanelEvent s ev
-          _ -> continueWithoutRedraw s
+    _anyOtherEvent ->
+      -- and dispatch the other to the focused panel handler
+      case focusGetCurrent (s ^. uiState . uiFocusRing) of
+        Just REPLPanel -> handleREPLEvent s ev
+        Just WorldPanel -> handleWorldEvent s ev
+        Just RobotPanel -> handleRobotPanelEvent s ev
+        Just InfoPanel -> handleInfoPanelEvent s ev
+        _ -> continueWithoutRedraw s
 
 setFocus :: AppState -> Name -> EventM Name (Next AppState)
 setFocus s name = continue $ s & uiState . uiFocusRing %~ focusSetCurrent name
 
-toggleModal :: AppState -> Modal -> EventM Name (Next AppState)
-toggleModal s modal = do
+toggleModal :: AppState -> ModalType -> EventM Name (Next AppState)
+toggleModal s mt = do
   curTime <- liftIO $ getTime Monotonic
   continue $
     s & case s ^. uiState . uiModal of
-      Nothing -> (uiState . uiModal ?~ modal) . ensurePause
+      Nothing -> (uiState . uiModal ?~ generateModal mt) . ensurePause
       Just _ -> (uiState . uiModal .~ Nothing) . maybeUnpause . resetLastFrameTime curTime
  where
   -- Set the game to AutoPause if needed
@@ -148,6 +153,55 @@ toggleModal s modal = do
   -- TODO: manage unpause more safely to also cover
   -- the world event handler for the KChar 'p'.
   resetLastFrameTime curTime = uiState . lastFrameTime .~ curTime
+
+generateModal :: ModalType -> Modal
+generateModal mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth `min` requiredWidth)) widget
+ where
+  (title, widget, buttons, requiredWidth) =
+    case mt of
+      HelpModal -> ("Help", helpWidget, Nothing, maxModalWindowWidth)
+      WinModal -> ("", txt "Congratulations!", Nothing, maxModalWindowWidth)
+      QuitModal ->
+        let quitMsg = "Are you sure you want to quit?"
+         in ( ""
+            , padBottom (Pad 1) $ hCenter $ txt quitMsg
+            , Just (0, [("Cancel", False), ("Quit", True)])
+            , T.length quitMsg + 4
+            )
+
+helpWidget :: Widget Name
+helpWidget = (helpKeys <=> fill ' ') <+> (helpCommands <=> fill ' ')
+ where
+  helpKeys =
+    vBox
+      [ hCenter $ txt "Global Keybindings"
+      , hCenter $ mkTable glKeyBindings
+      ]
+  mkTable = BT.renderTable . BT.table . map toWidgets
+  toWidgets (k, v) = [txt k, txt v]
+  glKeyBindings =
+    [ ("F1", "Help")
+    , ("Ctrl-q", "quit the game")
+    , ("Tab", "cycle panel focus")
+    , ("Meta-w", "focus on the world map")
+    , ("Meta-e", "focus on the robot inventory")
+    , ("Meta-r", "focus on the REPL")
+    , ("Meta-t", "focus on the info panel")
+    ]
+  helpCommands =
+    vBox
+      [ hCenter $ txt "Commands"
+      , hCenter $ mkTable baseCommands
+      ]
+  baseCommands =
+    [ ("build <name> {<commands>}", "Create a robot")
+    , ("make <name>", "Craft an item")
+    , ("move", "Move one step in the current direction")
+    , ("turn <dir>", "Change the current direction")
+    , ("grab", "Grab whatver is available")
+    , ("give <robot> <item>", "Give an item to another robot")
+    , ("has <item>", "Check for an item in the inventory")
+    ]
 
 -- | Shut down the application.  Currently all it does is write out
 --   the updated REPL history to a @.swarm_history@ file.
@@ -375,7 +429,7 @@ updateUI = do
     case w of
       Won False -> do
         gameState . winCondition .= Won True
-        uiState . uiModal .= Just WinModal
+        uiState . uiModal .= Just (generateModal WinModal)
         return True
       _ -> return False
 

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -154,8 +154,8 @@ toggleModal s mt = do
 handleModalEvent :: AppState -> V.Event -> EventM Name (Next AppState)
 handleModalEvent s ev = case ev of
   V.EvKey V.KEnter [] ->
-    case s ^? uiState . uiModal . _Just . modalDialog . to dialogSelectedIndex of
-      Just (Just 1) -> shutdown s
+    case s ^? uiState . uiModal . _Just . modalDialog . to dialogSelection of
+      Just (Just Confirm) -> shutdown s
       _ -> toggleModal s QuitModal
   _ -> do
     s' <- s & uiState . uiModal . _Just . modalDialog %%~ handleDialogEvent ev

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -285,6 +285,7 @@ replIndexIsAtInput repl = repl ^. replIndex == replLength repl
 data Modal
   = HelpModal
   | WinModal
+  | QuitModal
   deriving (Eq, Show)
 
 -- | An entry in the inventory list displayed in the info panel.  We

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -19,7 +19,6 @@ module Swarm.TUI.Model (
   Name (..),
   ModalType (..),
   Modal (..),
-  maxModalWindowWidth,
   modalType,
   modalDialog,
   modalWidget,
@@ -301,10 +300,6 @@ data Modal = Modal
   }
 
 makeLenses ''Modal
-
--- | Width cap for modal and error message windows
-maxModalWindowWidth :: Int
-maxModalWindowWidth = 500
 
 -- | An entry in the inventory list displayed in the info panel.  We
 --   can either have an entity with a count in the robot's inventory,

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -18,6 +18,7 @@ module Swarm.TUI.Model (
   AppEvent (..),
   Name (..),
   ModalType (..),
+  ButtonSelection (..),
   Modal (..),
   modalType,
   modalDialog,
@@ -293,9 +294,12 @@ data ModalType
   | QuitModal
   deriving (Eq, Show)
 
+data ButtonSelection = Cancel | Confirm
+  deriving (Eq, Show)
+
 data Modal = Modal
   { _modalType :: ModalType
-  , _modalDialog :: Dialog Bool
+  , _modalDialog :: Dialog ButtonSelection
   , _modalWidget :: Widget Name
   }
 

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -62,7 +62,6 @@ module Swarm.TUI.Model (
   uiScrollToEnd,
   uiError,
   uiModal,
-  uiDialog,
   lgTicksPerSecond,
   lastFrameTime,
   accumulatedTime,
@@ -334,7 +333,6 @@ data UIState = UIState
   , _uiScrollToEnd :: Bool
   , _uiError :: Maybe Text
   , _uiModal :: Maybe Modal
-  , _uiDialog :: Maybe (Dialog Bool)
   , _uiShowFPS :: Bool
   , _uiShowZero :: Bool
   , _uiInventoryShouldUpdate :: Bool
@@ -399,11 +397,6 @@ uiError :: Lens' UIState (Maybe Text)
 -- | When this is @Just@, it represents a modal to be displayed on
 --   top of the UI, e.g. for the Help screen.
 uiModal :: Lens' UIState (Maybe Modal)
-
--- | When this is @Just@, it represents the dialog state (i.e. the
---   state of the buttons) for the modal to be displayed on top of the
---   UI.
-uiDialog :: Lens' UIState (Maybe (Dialog Bool))
 
 -- | A toggle to show the FPS by pressing `f`
 uiShowFPS :: Lens' UIState Bool
@@ -500,7 +493,6 @@ initUIState = liftIO $ do
       , _uiScrollToEnd = False
       , _uiError = Nothing
       , _uiModal = Nothing
-      , _uiDialog = Nothing
       , _uiShowFPS = False
       , _uiShowZero = True
       , _uiInventoryShouldUpdate = False

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -173,14 +173,10 @@ renderErrorDialog err = renderDialog (dialog (Just "Error") Nothing (maxModalWin
   errContent = txtWrapWith indent2 {preserveIndentation = True} err
   requiredWidth = 2 + maximum (textWidth <$> T.lines err)
 
--- | Render a fullscreen modal widget.
-renderModal :: Modal -> Widget Name
-renderModal (Modal _ d w) = renderDialog d w
-
 -- | Draw the error dialog window, if it should be displayed right now.
 drawDialog :: UIState -> Widget Name
 drawDialog s = overrideAttr borderAttr highlightAttr $ case s ^. uiModal of
-  Just m -> renderModal m
+  Just (Modal _ d w) -> renderDialog d w
   Nothing -> maybe emptyWidget renderErrorDialog (s ^. uiError)
 
 -- | Draw a menu explaining what key commands are available for the

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -58,7 +58,7 @@ import Text.Wrap
 import Brick hiding (Direction)
 import Brick.Focus
 import Brick.Forms
-import Brick.Widgets.Border (borderAttr, hBorder, hBorderWithLabel, joinableBorder, vBorder)
+import Brick.Widgets.Border (hBorder, hBorderWithLabel, joinableBorder, vBorder)
 import Brick.Widgets.Center (center, hCenter)
 import Brick.Widgets.Dialog
 import qualified Brick.Widgets.List as BL
@@ -177,7 +177,7 @@ renderErrorDialog err = renderDialog (dialog (Just "Error") Nothing (maxModalWin
 
 -- | Draw the error dialog window, if it should be displayed right now.
 drawDialog :: UIState -> Widget Name
-drawDialog s = overrideAttr borderAttr highlightAttr $ case s ^. uiModal of
+drawDialog s = case s ^. uiModal of
   Just (Modal _ d w) -> renderDialog d w
   Nothing -> maybe emptyWidget renderErrorDialog (s ^. uiError)
 

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -13,7 +13,7 @@ module Swarm.TUI.View (
   drawUI,
   drawTPS,
 
-  -- * Error dialog
+  -- * Dialog box
   drawDialog,
   chooseCursor,
 
@@ -180,18 +180,19 @@ renderErrorDialog err = renderDialog (dialog (Just "Error") Nothing (maxModalWin
 
 -- | Render a fullscreen widget with some padding
 renderModal :: Modal -> Widget Name
-renderModal modal = renderDialog (dialog (Just modalTitle) Nothing maxModalWindowWidth) modalWidget
+renderModal modal = renderDialog (dialog (Just modalTitle) modalButtons (maxModalWindowWidth `min` requiredWidth)) modalWidget
  where
-  modalWidget = Widget Fixed Fixed $ do
-    ctx <- getContext
-    let w = ctx ^. availWidthL
-        h = ctx ^. availHeightL
-        padding = 10
-    render $ setAvailableSize (w - padding, h - padding) modalContent
-  (modalTitle, modalContent) =
+  (modalTitle, modalWidget, modalButtons, requiredWidth) =
     case modal of
-      HelpModal -> ("Help", helpWidget)
-      WinModal -> ("", txt "Congratulations!")
+      HelpModal -> ("Help", helpWidget, Nothing, maxModalWindowWidth)
+      WinModal -> ("", txt "Congratulations!", Nothing, maxModalWindowWidth)
+      QuitModal ->
+        let quitMsg = "Are you sure you want to quit?"
+         in ( ""
+            , padBottom (Pad 1) $ hCenter $ txt quitMsg
+            , Just (0, [("Cancel", False), ("Quit", True)])
+            , T.length quitMsg + 4
+            )
 
 helpWidget :: Widget Name
 helpWidget = (helpKeys <=> fill ' ') <+> (helpCommands <=> fill ' ')

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -168,6 +168,10 @@ chooseCursor s locs = case s ^. uiState . uiModal of
   Nothing -> showFirstCursor s locs
   Just _ -> Nothing
 
+-- | Width cap for modal and error message windows
+maxModalWindowWidth :: Int
+maxModalWindowWidth = 500
+
 -- | Render the error dialog window with a given error message
 renderErrorDialog :: Text -> Widget Name
 renderErrorDialog err = renderDialog (dialog (Just "Error") Nothing (maxModalWindowWidth `min` requiredWidth)) errContent

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -197,7 +197,7 @@ generateModal mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth `m
         let quitMsg = "Are you sure you want to quit?"
          in ( ""
             , padBottom (Pad 1) $ hCenter $ txt quitMsg
-            , Just (0, [("Cancel", False), ("Quit", True)])
+            , Just (0, [("Cancel", Cancel), ("Quit", Confirm)])
             , T.length quitMsg + 4
             )
 


### PR DESCRIPTION
Closes #77 .  When hitting Ctrl-Q, now a dialog box opens up allowing you to confirm you want to quit or cancel.  The machinery for dealing with pop-up windows is somewhat generalized as well, which should make it easy to add other similar pop-up windows as needed in the future.