### PR TITLE
Make only base display as Omega

### DIFF
--- a/src/Swarm/Game/Display.hs
+++ b/src/Swarm/Game/Display.hs
@@ -133,11 +133,14 @@ defaultEntityDisplay c =
     }
 
 -- | Construct a default robot display, with display characters
---   @"Ω^>v<"@, the default robot attribute, and priority 10.
+--   @"X^>v<"@, the default robot attribute, and priority 10.
+--
+-- Note that the 'defaultChar' is used for direction 'DDown'
+-- and is overriden for the special base robot.
 defaultRobotDisplay :: Display
 defaultRobotDisplay =
   Display
-    { _defaultChar = 'Ω'
+    { _defaultChar = 'X'
     , _orientationMap =
         M.fromList
           [ (DEast, '>')

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -398,6 +398,7 @@ baseRobot devs toRun =
           []
           & entityOrientation ?~ east
           & entityDisplay . orientationMap .~ Empty
+          & entityDisplay . defaultChar .~ 'Ω'
     , _installedDevices = inst
     , _robotCapabilities = inventoryCapabilities inst
     , _robotLog = Seq.empty


### PR DESCRIPTION
- make robots look down as `'X'`

With the base not having any direction-specific characters, this just finishes the job and makes it fully distinct.

Closes #332 