### PR TITLE
upgrade to `brick-0.69`

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-18.12
 extra-deps:
-- brick-0.64.2
+- brick-0.69
 - word-wrap-0.5
 - hashable-1.3.4.1
 - git: https://github.com/colinhect/hsnoise

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -93,7 +93,7 @@ library
     build-depends:    base                          >= 4.14 && < 4.16,
                       aeson                         >= 1.5 && < 1.6,
                       array                         >= 0.5.4 && < 0.6,
-                      brick                         >= 0.64.2 && < 0.65,
+                      brick                         >= 0.68.1 && < 0.70,
                       clock                         >= 0.8.2 && < 0.9,
                       containers                    >= 0.6.2 && < 0.7,
                       directory                     >= 1.3 && < 1.4,


### PR DESCRIPTION
Closes #340.  I don't foresee any problems with this but want to make sure CI passes before merging.