### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -53,6 +53,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.3
+            compilerKind: ghc
+            compilerVersion: 9.2.3
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.0.2
             compilerKind: ghc
             compilerVersion: 9.0.2

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -198,6 +198,7 @@ jobs:
           echo "package swarm" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
+          flags: +ci
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(swarm)$/; }' >> cabal.project.local
           cat cabal.project

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-2a842658
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-436fbe9d
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -166,10 +166,10 @@ jobs:
           cabal-docspec --version
       - name: install hlint
         run: |
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $ARG_COMPILER --dry-run hlint  --constraint='hlint >=3.3 && <3.4' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then if [ ! -e $HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint ]; then echo "Downloading HLint version $HLINTVER"; mkdir -p $HOME/.haskell-ci-tools; curl --write-out 'Status Code: %{http_code} Redirects: %{num_redirects} Total time: %{time_total} Total Dsize: %{size_download}\n' --silent --location --output $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz "https://github.com/ndmitchell/hlint/releases/download/v$HLINTVER/hlint-$HLINTVER-x86_64-linux.tar.gz"; tar -xzv -f $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz -C $HOME/.haskell-ci-tools; fi ; fi
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then mkdir -p $CABAL_DIR/bin && ln -sf "$HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint" $CABAL_DIR/bin/hlint ; fi
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then hlint --version ; fi
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $ARG_COMPILER --dry-run hlint  --constraint='hlint >=3.3 && <3.4' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then if [ ! -e $HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint ]; then echo "Downloading HLint version $HLINTVER"; mkdir -p $HOME/.haskell-ci-tools; curl --write-out 'Status Code: %{http_code} Redirects: %{num_redirects} Total time: %{time_total} Total Dsize: %{size_download}\n' --silent --location --output $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz "https://github.com/ndmitchell/hlint/releases/download/v$HLINTVER/hlint-$HLINTVER-x86_64-linux.tar.gz"; tar -xzv -f $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz -C $HOME/.haskell-ci-tools; fi ; fi
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then mkdir -p $CABAL_DIR/bin && ln -sf "$HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint" $CABAL_DIR/bin/hlint ; fi
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then hlint --version ; fi
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -229,8 +229,8 @@ jobs:
           cabal-docspec $ARG_COMPILER
       - name: hlint
         run: |
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then (cd ${PKGDIR_swarm} && hlint -h ${GITHUB_WORKSPACE}/source/.hlint.yaml -XHaskell2010 -XStrictData src) ; fi
-          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then (cd ${PKGDIR_swarm} && hlint -h ${GITHUB_WORKSPACE}/source/.hlint.yaml -XHaskell2010 app) ; fi
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then (cd ${PKGDIR_swarm} && hlint -h ${GITHUB_WORKSPACE}/source/.hlint.yaml -XHaskell2010 -XStrictData src) ; fi
+          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then (cd ${PKGDIR_swarm} && hlint -h ${GITHUB_WORKSPACE}/source/.hlint.yaml -XHaskell2010 app) ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_swarm} || false

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,6 +26,7 @@ pull_request_rules:
       - -files~=^[^/]*\.yaml$
       - -files~=^data/.*\.yaml$
     - and:
+      - check-success=Haskell-CI - Linux - ghc-9.2.3
       - check-success=Haskell-CI - Linux - ghc-9.0.2
       - check-success=Haskell-CI - Linux - ghc-8.10.7
   - label=merge me

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -19,7 +19,7 @@ benchmarks: True
 
 -- Run HLint
 hlint: True
-hlint-job: 9.0.2
+hlint-job: 8.10.7
 hlint-yaml: .hlint.yaml
 hlint-download-binary: True
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -22,3 +22,6 @@ hlint: True
 hlint-job: 9.0.2
 hlint-yaml: .hlint.yaml
 hlint-download-binary: True
+
+raw-project
+  flags: +ci

--- a/cabal.project
+++ b/cabal.project
@@ -3,16 +3,4 @@ source-repository-package
   location: https://github.com/colinhect/hsnoise
   tag: 4ccff11dea7e8d94e6a5fcaf8f43857bd65bd72d
 
--- get latest th-extras for ghc-9.0.1 compat
--- when changing these, update the stack.yaml too
-source-repository-package
-  type: git
-  location: https://github.com/mokus0/th-extras
-  tag: 0d050b24ec5ef37c825b6f28ebd46787191e2a2d
-source-repository-package
-  type: git
-  location: https://github.com/obsidiansystems/dependent-sum
-  tag: 080b089f2951cd5851cee0d62f81d6ac7b1e2028
-  subdir: dependent-sum dependent-sum-template
-
 packages: .

--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -484,6 +484,10 @@ instance Hashable Inventory where
   hash = inventoryHash
   hashWithSalt s = hashWithSalt s . inventoryHash
 
+-- | Inventories are compared by hash for efficiency.
+instance Eq Inventory where
+  (==) = (==) `on` hash
+
 -- | Look up an entity in an inventory, returning the number of copies
 --   contained.
 lookup :: Entity -> Inventory -> Count

--- a/src/Swarm/Language/LSP.hs
+++ b/src/Swarm/Language/LSP.hs
@@ -84,8 +84,8 @@ validateSwarmCode doc version content = do
     let diags =
           [ J.Diagnostic
               ( J.Range
-                  (J.Position startLine startCol)
-                  (J.Position endLine endCol)
+                  (J.Position (fromIntegral startLine) (fromIntegral startCol))
+                  (J.Position (fromIntegral endLine) (fromIntegral endCol))
               )
               (Just J.DsWarning) -- severity
               Nothing -- code
@@ -114,6 +114,6 @@ handlers =
         mdoc <- getVirtualFile doc
         case mdoc of
           Just vf@(VirtualFile _ version _rope) -> do
-            validateSwarmCode doc (Just version) (virtualFileText vf)
+            validateSwarmCode doc (Just $ fromIntegral version) (virtualFileText vf)
           _ -> debug $ "No virtual file found for: " <> from (show msg)
     ]

--- a/src/Swarm/Util/Yaml.hs
+++ b/src/Swarm/Util/Yaml.hs
@@ -30,6 +30,7 @@ module Swarm.Util.Yaml (
 ) where
 
 import Control.Monad.Reader
+import Data.Aeson.Key (fromText)
 import Data.Aeson.Types (explicitParseField, explicitParseFieldMaybe)
 import Data.Bifunctor (first)
 import Data.Maybe (fromMaybe)
@@ -114,12 +115,12 @@ decodeFileEitherE e file = do
 -- | A variant of '.:' for 'ParserE': project out a field of an
 --   'Object', passing along the extra environment.
 (..:) :: FromJSONE e a => Object -> Text -> ParserE e a
-v ..: x = E $ \e -> explicitParseField (parseJSONE' e) v x
+v ..: x = E $ \e -> explicitParseField (parseJSONE' e) v (fromText x)
 
 -- | A variant of '.:?' for 'ParserE': project out an optional field of an
 --   'Object', passing along the extra environment.
 (..:?) :: FromJSONE e a => Object -> Text -> ParserE e (Maybe a)
-v ..:? x = E $ \e -> explicitParseFieldMaybe (parseJSONE' e) v x
+v ..:? x = E $ \e -> explicitParseFieldMaybe (parseJSONE' e) v (fromText x)
 
 -- | A variant of '.!=' for any functor.
 (..!=) :: Functor f => f (Maybe a) -> a -> f a

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,3 @@
-resolver: lts-18.12
 extra-deps:
 - brick-0.69
 - word-wrap-0.5
@@ -9,6 +8,4 @@ extra-deps:
 - simple-enumeration-0.2.1@sha256:8625b269c1650d3dd0e3887351c153049f4369853e0d525219e07480ea004b9f,1178
 - fused-effects-1.1.1.1@sha256:c029c5fb0b2154281221a71ff25709d2a11347fe061fa8c2398e7fe52a16008d,4932
 - fused-effects-lens-1.2.0.1@sha256:675fddf183215b6f3c1f2a0823359a648756435fd1966284e61830ec28ad61fa,1466
-
-# Allow a newer minor version of GHC than the snapshot specifies
-# compiler-check: newer-minor
+resolver: lts-19.8

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,18 +2,10 @@ resolver: lts-18.12
 extra-deps:
 - brick-0.69
 - word-wrap-0.5
-- hashable-1.3.4.1
+- hashable-1.3.5.0
+- base-orphans-0.8.6
 - git: https://github.com/colinhect/hsnoise
   commit: 4ccff11dea7e8d94e6a5fcaf8f43857bd65bd72d
-# get latest th-extras for ghc-9.0.1 compat
-# when changing these, update the cabal.project too
-- git: https://github.com/mokus0/th-extras
-  commit: 0d050b24ec5ef37c825b6f28ebd46787191e2a2d
-- git: https://github.com/obsidiansystems/dependent-sum
-  commit: 080b089f2951cd5851cee0d62f81d6ac7b1e2028
-  subdirs:
-  - dependent-sum
-  - dependent-sum-template
 - simple-enumeration-0.2.1@sha256:8625b269c1650d3dd0e3887351c153049f4369853e0d525219e07480ea004b9f,1178
 - fused-effects-1.1.1.1@sha256:c029c5fb0b2154281221a71ff25709d2a11347fe061fa8c2398e7fe52a16008d,4932
 - fused-effects-lens-1.2.0.1@sha256:675fddf183215b6f3c1f2a0823359a648756435fd1966284e61830ec28ad61fa,1466

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -90,8 +90,8 @@ library
     other-modules:    Paths_swarm
     autogen-modules:  Paths_swarm
 
-    build-depends:    base                          >= 4.14 && < 4.16,
-                      aeson                         >= 1.5 && < 1.6,
+    build-depends:    base                          >= 4.14 && < 4.17,
+                      aeson                         >= 2 && < 2.1,
                       array                         >= 0.5.4 && < 0.6,
                       brick                         >= 0.68.1 && < 0.70,
                       clock                         >= 0.8.2 && < 0.9,
@@ -101,12 +101,12 @@ library
                       filepath                      >= 1.4 && < 1.5,
                       fused-effects                 >= 1.1.1.1 && < 1.2,
                       fused-effects-lens            >= 1.2.0.1 && < 1.3,
-                      hashable                      >= 1.3.4 && < 1.4,
-                      megaparsec                    >= 9.0 && < 9.2,
+                      hashable                      >= 1.3.4 && < 1.5,
+                      megaparsec                    >= 9.0 && < 9.3,
                       hsnoise                       >= 0.0.2 && < 0.1,
-                      lens                          >= 4.19 && < 5.1,
+                      lens                          >= 4.19 && < 5.2,
                       linear                        >= 1.21.6 && < 1.22,
-                      lsp                           >= 1.2 && < 1.3,
+                      lsp                           >= 1.2 && < 1.5,
                       mtl                           >= 2.2.2 && < 2.3,
                       minimorph                     >= 0.3 && < 0.4,
                       murmur3                       >= 1.0.4 && < 1.1,
@@ -117,13 +117,13 @@ library
                       split                         >= 0.2.3 && < 0.3,
                       stm                           >= 2.5.0 && < 2.6,
                       syb                           >= 0.7 && < 0.8,
-                      template-haskell              >= 2.16 && < 2.18,
-                      text                          >= 1.2.4 && < 1.3,
+                      template-haskell              >= 2.16 && < 2.19,
+                      text                          >= 1.2.4 && < 2.1,
                       unification-fd                >= 0.11  && < 0.12,
                       unordered-containers          >= 0.2.14 && < 0.3,
                       vector                        >= 0.12 && < 0.13,
-                      vty                           >= 5.33 && < 5.34,
-                      witch                         >= 0.3.4 && < 0.4,
+                      vty                           >= 5.33 && < 5.36,
+                      witch                         >= 0.3.4 && < 1.1,
                       word-wrap                     >= 0.5 && < 0.6,
                       yaml                          >= 0.11 && < 0.12,
     hs-source-dirs:   src
@@ -133,7 +133,7 @@ library
 executable swarm
     import:           stan-config, common
     main-is:          Main.hs
-    build-depends:    optparse-applicative          >= 0.16 && < 0.17,
+    build-depends:    optparse-applicative          >= 0.16 && < 0.18,
                       githash                       >= 0.1.6 && < 0.2,
                       -- Imports shared with the library don't need bounds
                       base,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -18,7 +18,7 @@ maintainer:         byorgey@gmail.com
 bug-reports:        https://github.com/swarm-game/swarm/issues
 copyright:          Brent Yorgey 2021
 category:           Game
-tested-with:        GHC ==8.10.7 || ==9.0.2
+tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.3
 extra-source-files: CHANGELOG.md
                     example/*.sw
 data-dir:           data/


### PR DESCRIPTION
- bump upper bounds on dependencies
  - fixes breaking type changes in Aeson (`KeyMap`) and LSP (`UInt`)
- remove special `th-extras` and `depenent-sum` deps
- adds GHC 9.2 to CI
- closes #366