### PR TITLE
resolve seed every time a scenario is selected to be played

### DIFF
--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -476,27 +476,28 @@ playScenario em scenario userSeed toRun g = do
     Just s -> return s
     Nothing -> randomRIO (0, maxBound :: Int)
 
-  return $ g
-    { _creativeMode = scenario ^. scenarioCreative
-    , _winCondition = theWinCondition
-    , _runStatus = Running
-    , _robotMap = IM.fromList $ map (view robotID &&& id) robotList
-    , _robotsByLocation =
-        M.fromListWith IS.union $
-          map (view robotLocation &&& (IS.singleton . view robotID)) robotList
-    , _activeRobots = setOf (traverse . robotID) robotList
-    , _waitingRobots = M.empty
-    , _gensym = initGensym
-    , _randGen = mkStdGen seed
-    , _world = theWorld seed
-    , _viewCenterRule = VCRobot baseID
-    , _viewCenter = V2 0 0
-    , _needsRedraw = False
-    , _replStatus = REPLDone
-    , _messageQueue = []
-    , _focusedRobotID = baseID
-    , _ticks = 0
-    }
+  return $
+    g
+      { _creativeMode = scenario ^. scenarioCreative
+      , _winCondition = theWinCondition
+      , _runStatus = Running
+      , _robotMap = IM.fromList $ map (view robotID &&& id) robotList
+      , _robotsByLocation =
+          M.fromListWith IS.union $
+            map (view robotLocation &&& (IS.singleton . view robotID)) robotList
+      , _activeRobots = setOf (traverse . robotID) robotList
+      , _waitingRobots = M.empty
+      , _gensym = initGensym
+      , _randGen = mkStdGen seed
+      , _world = theWorld seed
+      , _viewCenterRule = VCRobot baseID
+      , _viewCenter = V2 0 0
+      , _needsRedraw = False
+      , _replStatus = REPLDone
+      , _messageQueue = []
+      , _focusedRobotID = baseID
+      , _ticks = 0
+      }
  where
   baseID = 0
   (things, devices) = partition (null . view entityCapabilities) (M.elems (entitiesByName em))

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -136,10 +136,13 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) s = \case
   Key V.KEnter ->
     case snd <$> BL.listSelectedElement curMenu of
       Nothing -> continueWithoutRedraw s
-      Just (SISingle scene) ->
+      Just (SISingle scene) -> do
+        let gs = s ^. gameState
+        gs' <- liftIO $ playScenario (gs ^. entityMap) scene Nothing Nothing gs
+
         continue $
           s & uiState . uiMenu .~ NoMenu
-            & gameState %~ playScenario (s ^. gameState . entityMap) scene Nothing
+            & gameState .~ gs'
       Just (SICollection _ c) ->
         continue $
           s & uiState . uiMenu .~ NewGameMenu (NE.cons (mkScenarioList c) scenarioStack)


### PR DESCRIPTION
Seed resolution used to happen in `loadScenarioFile`, but that was the
wrong place.  Resolution now happens in `playScenario`.  This means that, e.g. if you
select "New Game > Classic" from the menu, then quit back to the menu, then start
a second new game, you will get a different random world each time.

Fixes #369.