### PR TITLE
Delete bound variables from `capCtx` when recursing into terms

### DIFF
--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -53,7 +53,7 @@ import Swarm.Game.State
 import Swarm.Game.Value
 import qualified Swarm.Game.World as W
 import Swarm.Language.Capability
-import Swarm.Language.Context
+import Swarm.Language.Context hiding (delete)
 import Swarm.Language.Pipeline
 import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Syntax

--- a/src/Swarm/Language/Context.hs
+++ b/src/Swarm/Language/Context.hs
@@ -58,6 +58,10 @@ singleton x t = Ctx (M.singleton x t)
 lookup :: Var -> Ctx t -> Maybe t
 lookup x (Ctx c) = M.lookup x c
 
+-- | Delete a variable from a context.
+delete :: Var -> Ctx t -> Ctx t
+delete x (Ctx c) = Ctx (M.delete x c)
+
 -- | Get the list of key-value associations from a context.
 assocs :: Ctx t -> [(Var, t)]
 assocs = M.assocs . unCtx


### PR DESCRIPTION
Fixes #389.