### PR TITLE
Add robotNumbered command for debugging

### DIFF
--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1011,6 +1011,14 @@ execConst c vs s k = do
         let robotValue = VRobot (r ^. robotID)
         return $ Out robotValue s k
       _ -> badConst
+    RobotNumbered -> case vs of
+      [VInt rid] -> do
+        r <-
+          robotWithID (fromIntegral rid)
+            >>= (`isJustOrFail` ["There is no robot with number", from (show rid)])
+        let robotValue = VRobot (r ^. robotID)
+        return $ Out robotValue s k
+      _ -> badConst
     Say -> case vs of
       [VString msg] -> do
         rn <- use robotName -- XXX use robot name + ID

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -294,6 +294,7 @@ constCaps =
     -- Some God-like sensing abilities.
     As -> [CGod]
     RobotNamed -> [CGod]
+    RobotNumbered -> [CGod]
     -- String operations, which for now are enabled by CLog
     Format -> [CLog]
     Concat -> [CLog]

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -353,6 +353,8 @@ data Const
     As
   | -- | Find a robot by name.
     RobotNamed
+  | -- | Find a robot by number.
+    RobotNumbered
   deriving (Eq, Ord, Enum, Bounded, Data, Show)
 
 allConst :: [Const]
@@ -491,6 +493,7 @@ constInfo c = case c of
   AppF -> binaryOp "$" 0 R
   As -> commandLow 2
   RobotNamed -> commandLow 1
+  RobotNumbered -> commandLow 1
  where
   unaryOp s p side = ConstInfo {syntax = s, fixity = p, constMeta = ConstMUnOp side}
   binaryOp s p side = ConstInfo {syntax = s, fixity = p, constMeta = ConstMBinOp side}

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -499,6 +499,7 @@ inferConst c = toU $ case c of
   AppF -> [tyQ| (a -> b) -> a -> b |]
   As -> [tyQ| robot -> {cmd a} -> cmd a |]
   RobotNamed -> [tyQ| string -> cmd robot |]
+  RobotNumbered -> [tyQ| int -> cmd robot |]
  where
   cmpBinT = [tyQ| a -> a -> bool |]
   arithBinT = [tyQ| int -> int -> int |]


### PR DESCRIPTION
Sometimes I need a dirty and direct way to get the n-th robot in the world quickly.

The name of the command is longer by design so that it does not get confused with the proposed `child` command or custom user definitions.

- part of #343