### PR TITLE
Remove create capability

### DIFF
--- a/src/Swarm/Game/Exception.hs
+++ b/src/Swarm/Game/Exception.hs
@@ -117,9 +117,9 @@ formatIncapableFix = \case
 --   please install:
 --    - the one ring or magic wand
 --
--- >>> incapableError (S.singleton CCreate) (TConst Create)
--- Missing the create capability for:
---   'create'
+-- >>> incapableError (S.singleton CRandom) (TConst Random)
+-- Missing the random capability for:
+--   'random'
 --   but no device yet provides it. See
 --   https://github.com/swarm-game/swarm/issues/26
 formatIncapable :: EntityMap -> IncapableFix -> Set Capability -> Term -> Text

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -276,7 +276,6 @@ constCaps =
     Has -> []
     Count -> [CCount]
     If -> [CCond]
-    Create -> [CCreate]
     Blocked -> [CSensefront]
     Scan -> [CScan]
     Ishere -> [CSensehere]
@@ -295,6 +294,7 @@ constCaps =
     As -> [CGod]
     RobotNamed -> [CGod]
     RobotNumbered -> [CGod]
+    Create -> [CGod]
     -- String operations, which for now are enabled by CLog
     Format -> [CLog]
     Concat -> [CLog]


### PR DESCRIPTION
From #26 by @byorgey:

> Didn't realize we have a create capability. I always intended for `create` to be available only in creative mode, so maybe we should make it `CGod` also?