### PR TITLE
Returns to the scenario menu after winning a game

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -155,7 +155,7 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) s = \case
           s & uiState . uiMenu .~ NewGameMenu (NE.cons (mkScenarioList (s ^. uiState . uiCheatMode) c) scenarioStack)
   Key V.KEsc -> exitNewGameMenu s scenarioStack
   CharKey 'q' -> exitNewGameMenu s scenarioStack
-  ControlKey 'q' -> exitNewGameMenu s scenarioStack
+  ControlKey 'q' -> halt s
   VtyEvent ev -> do
     menu' <- handleListEvent ev curMenu
     continue $ s & uiState . uiMenu .~ NewGameMenu (menu' :| rest)

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -57,6 +57,7 @@ module Swarm.TUI.Model (
   -- ** UI Model
   UIState,
   uiMenu,
+  uiPrevMenu,
   uiCheatMode,
   uiFocusRing,
   uiReplForm,
@@ -359,6 +360,7 @@ makePrisms ''InventoryListEntry
 -- see the lenses below.
 data UIState = UIState
   { _uiMenu :: Menu
+  , _uiPrevMenu :: Menu
   , _uiCheatMode :: Bool
   , _uiFocusRing :: FocusRing Name
   , _uiReplForm :: Form Text AppEvent Name
@@ -406,6 +408,9 @@ let exclude = ['_lgTicksPerSecond]
 
 -- | The current menu state.
 uiMenu :: Lens' UIState Menu
+
+-- | The previous menu state, to go back after playing a game
+uiPrevMenu :: Lens' UIState Menu
 
 -- | Cheat mode, i.e. are we allowed to turn creative mode on and off?
 uiCheatMode :: Lens' UIState Bool
@@ -579,6 +584,7 @@ initUIState showMainMenu cheatMode = liftIO $ do
   return $
     UIState
       { _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
+      , _uiPrevMenu = NoMenu
       , _uiCheatMode = cheatMode
       , _uiFocusRing = initFocusRing
       , _uiReplForm = initReplForm

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -288,7 +288,15 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
   (title, widget, buttons, requiredWidth) =
     case mt of
       HelpModal -> (" Help ", helpWidget, Nothing, maxModalWindowWidth)
-      WinModal -> ("", txt "Congratulations!", Nothing, maxModalWindowWidth)
+      WinModal ->
+        let winMsg = "Congratulations!"
+            continueMsg = "Keep playing"
+            stopMsg = "Pick the next game"
+         in ( ""
+            , padBottom (Pad 1) $ hCenter $ txt winMsg
+            , Just (0, [(stopMsg, Confirm), (continueMsg, Cancel)])
+            , length continueMsg + length stopMsg + 32
+            )
       DescriptionModal e -> (descriptionTitle e, descriptionWidget s e, Nothing, 100)
       QuitModal ->
         let quitMsg = "Are you sure you want to quit this game and return to the menu?"


### PR DESCRIPTION
This change slightly improves the navigation by saving
the menu position so that the user gets back to the next
tutorial or challenge after winning a game.