### PR TITLE
Exit the game when the previous menu is not set

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -255,10 +255,13 @@ quitGame :: AppState -> EventM Name (Next AppState)
 quitGame s = do
   let hist = mapMaybe getREPLEntry $ getLatestREPLHistoryItems maxBound history
   liftIO $ (`T.appendFile` T.unlines hist) =<< getSwarmHistoryPath True
-  let s' =
-        s & uiState . uiReplHistory %~ restartREPLHistory
-          & uiState . uiMenu .~ (s ^. uiState . uiPrevMenu)
-  continue s'
+  case s ^. uiState . uiPrevMenu of
+    NoMenu -> halt s
+    menu ->
+      let s' =
+            s & uiState . uiReplHistory %~ restartREPLHistory
+              & uiState . uiMenu .~ menu
+       in continue s'
  where
   history = s ^. uiState . uiReplHistory
 

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -285,13 +285,16 @@ drawDialog s = case s ^. uiModal of
 generateModal :: AppState -> ModalType -> Modal
 generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth `min` requiredWidth)) widget
  where
+  haltingMessage = case s ^. uiState . uiPrevMenu of
+    NoMenu -> Just "Quit"
+    _ -> Nothing
   (title, widget, buttons, requiredWidth) =
     case mt of
       HelpModal -> (" Help ", helpWidget, Nothing, maxModalWindowWidth)
       WinModal ->
         let winMsg = "Congratulations!"
             continueMsg = "Keep playing"
-            stopMsg = "Pick the next game"
+            stopMsg = fromMaybe "Pick the next game" haltingMessage
          in ( ""
             , padBottom (Pad 1) $ hCenter $ txt winMsg
             , Just (0, [(stopMsg, Confirm), (continueMsg, Cancel)])
@@ -300,9 +303,10 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
       DescriptionModal e -> (descriptionTitle e, descriptionWidget s e, Nothing, 100)
       QuitModal ->
         let quitMsg = "Are you sure you want to quit this game and return to the menu?"
+            stopMsg = fromMaybe "Quit to menu" haltingMessage
          in ( ""
             , padBottom (Pad 1) $ hCenter $ txt quitMsg
-            , Just (0, [("Keep playing", Cancel), ("Quit to menu", Confirm)])
+            , Just (0, [("Keep playing", Cancel), (stopMsg, Confirm)])
             , T.length quitMsg + 4
             )
 


### PR DESCRIPTION
This change fixes an issue when the game is started directly using
the `-s` command line argument. The new behavior is to halt the game
when no previous menu is set.