### PR TITLE
reset some UI state fields when beginning a new game

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -169,6 +169,7 @@ resetUIState =
     . (uiInventory .~ Nothing)
     . (uiShowFPS .~ False)
     . (uiShowZero .~ True)
+    . (lgTicksPerSecond .~ initLgTicksPerSecond)
 
 mkScenarioList :: Bool -> ScenarioCollection -> BL.List Name ScenarioItem
 mkScenarioList cheat = flip (BL.list ScenarioList) 1 . V.fromList . filterTest . scenarioCollectionToList

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -149,6 +149,7 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) s = \case
         continue $
           s & uiState . uiMenu .~ NoMenu
             & uiState . uiPrevMenu .~ nextMenu
+            & uiState %~ resetUIState
             & gameState .~ gs'
       Just (SICollection _ c) ->
         continue $
@@ -160,6 +161,14 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) s = \case
     menu' <- handleListEvent ev curMenu
     continue $ s & uiState . uiMenu .~ NewGameMenu (menu' :| rest)
   _ -> continueWithoutRedraw s
+
+-- | Reset the UI state when beginning a new game.
+resetUIState :: UIState -> UIState
+resetUIState =
+  (uiFocusRing .~ initFocusRing)
+    . (uiInventory .~ Nothing)
+    . (uiShowFPS .~ False)
+    . (uiShowZero .~ True)
 
 mkScenarioList :: Bool -> ScenarioCollection -> BL.List Name ScenarioItem
 mkScenarioList cheat = flip (BL.list ScenarioList) 1 . V.fromList . filterTest . scenarioCollectionToList


### PR DESCRIPTION
Reset `uiFocusRing`, `uiInventory`, `uiShowFPS`, and `uiShowZero`.

Fixes #444.