### PR TITLE
Add available commands help

### DIFF
--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -186,10 +186,13 @@ data Notifications a = Notifications
   }
   deriving (Eq, Show)
 
-makeLenses ''Notifications
+instance Semigroup (Notifications a) where
+  Notifications count1 xs1 <> Notifications count2 xs2 = Notifications (count1 + count2) (xs1 <> xs2)
 
-emptyNotifications :: Notifications a
-emptyNotifications = Notifications 0 []
+instance Monoid (Notifications a) where
+  mempty = Notifications 0 []
+
+makeLenses ''Notifications
 
 ------------------------------------------------------------
 -- The main GameState record type
@@ -546,8 +549,8 @@ initGameState = do
       , _runStatus = Running
       , _robotMap = IM.empty
       , _robotsByLocation = M.empty
-      , _availableRecipes = emptyNotifications
-      , _availableCommands = emptyNotifications
+      , _availableRecipes = mempty
+      , _availableCommands = mempty
       , _allDiscoveredEntities = empty
       , _activeRobots = IS.empty
       , _waitingRobots = M.empty

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -283,7 +283,7 @@ ensureCanExecute c = case constCaps c of
     sys <- use systemRobot
     robotCaps <- use robotCapabilities
     let hasCaps = cap `S.member` robotCaps
-    (sys || creative || not hasCaps)
+    (sys || creative || hasCaps)
       `holdsOr` Incapable FixByInstall (S.singleton cap) (TConst c)
 
 -- | Test whether the current robot has a given capability (either

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1678,10 +1678,10 @@ updateAvailableRecipes invs e = do
   allInRecipes <- use recipesIn
   let entityRecipes = recipesFor allInRecipes e
       usableRecipes = filter (knowsIngredientsFor invs) entityRecipes
-  Notifications prevCount knownRecipes <- use availableRecipes
+  knownRecipes <- use (availableRecipes . notificationsContent)
   let newRecipes = filter (`notElem` knownRecipes) usableRecipes
       newCount = length newRecipes
-  availableRecipes .= Notifications (newCount + prevCount) (newRecipes <> knownRecipes)
+  availableRecipes %= mappend (Notifications newCount newRecipes)
   updateAvailableCommands e
 
 updateAvailableCommands :: Has (State GameState) sig m => Entity -> m ()
@@ -1691,7 +1691,7 @@ updateAvailableCommands e = do
         Just cap -> cap `S.member` newCaps
         Nothing -> False
       entityConsts = filter (keepConsts . constCaps) allConst
-  Notifications prevCount knownCommands <- use availableCommands
+  knownCommands <- use (availableCommands . notificationsContent)
   let newCommands = filter (`notElem` knownCommands) entityConsts
       newCount = length newCommands
-  availableCommands .= Notifications (newCount + prevCount) (newCommands <> knownCommands)
+  availableCommands %= mappend (Notifications newCount newCommands)

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -202,7 +202,7 @@ requiredCaps' = go
     TBool _ -> S.empty
     -- Look up the capabilities required by a function/command
     -- constants using 'constCaps'.
-    TConst c -> constCaps c
+    TConst c -> maybe S.empty S.singleton (constCaps c)
     -- Note that a variable might not show up in the context, and
     -- that's OK.  In particular, only variables bound by 'TDef' go
     -- in the context; variables bound by a lambda or let will not
@@ -250,85 +250,84 @@ requiredCaps' = go
     TDef {} -> S.empty
 
 -- | Capabilities needed to evaluate or execute a constant.
-constCaps :: Const -> Set Capability
-constCaps =
-  S.fromList . \case
-    -- Some built-in constants that don't require any special capability.
-    Wait -> []
-    Noop -> []
-    AppF -> []
-    Force -> []
-    Return -> []
-    Parent -> []
-    Base -> []
-    Setname -> []
-    Undefined -> []
-    Fail -> []
-    -- Some straightforward ones.
-    Log -> [CLog]
-    Selfdestruct -> [CSelfdestruct]
-    Move -> [CMove]
-    Turn -> [CTurn]
-    Grab -> [CGrab]
-    Place -> [CPlace]
-    Give -> [CGive]
-    Install -> [CInstall]
-    Make -> [CMake]
-    Has -> []
-    Count -> [CCount]
-    If -> [CCond]
-    Blocked -> [CSensefront]
-    Scan -> [CScan]
-    Ishere -> [CSensehere]
-    Upload -> [CScan]
-    Build -> [CBuild]
-    Salvage -> [CSalvage]
-    Reprogram -> [CReprogram]
-    Drill -> [CDrill]
-    Neg -> [CArith]
-    Add -> [CArith]
-    Sub -> [CArith]
-    Mul -> [CArith]
-    Div -> [CArith]
-    Exp -> [CArith]
-    Whoami -> [CWhoami]
-    Self -> [CWhoami]
-    -- Some God-like abilities.
-    As -> [CGod]
-    RobotNamed -> [CGod]
-    RobotNumbered -> [CGod]
-    Create -> [CGod]
-    -- String operations, which for now are enabled by CLog
-    Format -> [CLog]
-    Concat -> [CLog]
-    -- Some additional straightforward ones, which however currently
-    -- cannot be used in classic mode since there is no craftable item
-    -- which conveys their capability.
-    Teleport -> [CTeleport] -- Some space-time machine like Tardis?
-    Appear -> [CAppear] -- paint?
-    Whereami -> [CSenseloc] -- GPS?
-    Random -> [CRandom] -- randomness device (with bitcoins)?
+constCaps :: Const -> Maybe Capability
+constCaps = \case
+  -- Some built-in constants that don't require any special capability.
+  Wait -> Nothing
+  Noop -> Nothing
+  AppF -> Nothing
+  Force -> Nothing
+  Return -> Nothing
+  Parent -> Nothing
+  Base -> Nothing
+  Setname -> Nothing
+  Undefined -> Nothing
+  Fail -> Nothing
+  -- Some straightforward ones.
+  Log -> Just CLog
+  Selfdestruct -> Just CSelfdestruct
+  Move -> Just CMove
+  Turn -> Just CTurn
+  Grab -> Just CGrab
+  Place -> Just CPlace
+  Give -> Just CGive
+  Install -> Just CInstall
+  Make -> Just CMake
+  Has -> Nothing
+  Count -> Just CCount
+  If -> Just CCond
+  Blocked -> Just CSensefront
+  Scan -> Just CScan
+  Ishere -> Just CSensehere
+  Upload -> Just CScan
+  Build -> Just CBuild
+  Salvage -> Just CSalvage
+  Reprogram -> Just CReprogram
+  Drill -> Just CDrill
+  Neg -> Just CArith
+  Add -> Just CArith
+  Sub -> Just CArith
+  Mul -> Just CArith
+  Div -> Just CArith
+  Exp -> Just CArith
+  Whoami -> Just CWhoami
+  Self -> Just CWhoami
+  -- Some God-like abilities.
+  As -> Just CGod
+  RobotNamed -> Just CGod
+  RobotNumbered -> Just CGod
+  Create -> Just CGod
+  -- String operations, which for now are enabled by CLog
+  Format -> Just CLog
+  Concat -> Just CLog
+  -- Some additional straightforward ones, which however currently
+  -- cannot be used in classic mode since there is no craftable item
+  -- which conveys their capability.
+  Teleport -> Just CTeleport -- Some space-time machine like Tardis?
+  Appear -> Just CAppear -- paint?
+  Whereami -> Just CSenseloc -- GPS?
+  Random -> Just CRandom -- randomness device (with bitcoins)?
 
-    -- comparator?
-    Eq -> [CCompare]
-    Neq -> [CCompare]
-    Lt -> [CCompare]
-    Gt -> [CCompare]
-    Leq -> [CCompare]
-    Geq -> [CCompare]
-    And -> []
-    Or -> []
-    -- Some more constants which *ought* to have their own capability but
-    -- currently don't.
-    Say -> []
-    View -> [] -- XXX this should also require something.
-    Run -> [] -- XXX this should also require a capability
-    -- which the base starts out with.
-    Not -> [] -- XXX some kind of boolean logic cap?
-    Inl -> [] -- XXX should require cap for sums
-    Inr -> []
-    Case -> []
-    Fst -> [] -- XXX should require cap for pairs
-    Snd -> []
-    Try -> [] -- XXX these definitely need to require something.
-    Knows -> []
+  -- comparator?
+  Eq -> Just CCompare
+  Neq -> Just CCompare
+  Lt -> Just CCompare
+  Gt -> Just CCompare
+  Leq -> Just CCompare
+  Geq -> Just CCompare
+  And -> Nothing
+  Or -> Nothing
+  -- Some more constants which *ought* to have their own capability but
+  -- currently don't.
+  Say -> Nothing
+  View -> Nothing -- XXX this should also require something.
+  Run -> Nothing -- XXX this should also require a capability
+  -- which the base starts out with.
+  Not -> Nothing -- XXX some kind of boolean logic cap?
+  Inl -> Nothing -- XXX should require cap for sums
+  Inr -> Nothing
+  Case -> Nothing
+  Fst -> Nothing -- XXX should require cap for pairs
+  Snd -> Nothing
+  Try -> Nothing -- XXX these definitely need to require something.
+  Knows -> Nothing

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -191,9 +191,12 @@ handleMainEvent s = \case
     | isJust (s ^. uiState . uiError) -> continue $ s & uiState . uiError .~ Nothing
     | isJust (s ^. uiState . uiModal) -> maybeUnpause s >>= (continue . (uiState . uiModal .~ Nothing))
   FKey 1 -> toggleModal s HelpModal >>= continue
-  FKey 2 | not (null (s ^. gameState . availableRecipes)) -> do
+  FKey 2 | not (null (s ^. gameState . availableRecipes . notificationsContent)) -> do
     s' <- toggleModal s RecipesModal
-    continue (s' & gameState . availableRecipesNewCount .~ 0)
+    continue (s' & gameState . availableRecipes . notificationsCount .~ 0)
+  FKey 3 | not (null (s ^. gameState . availableCommands . notificationsContent)) -> do
+    s' <- toggleModal s CommandsModal
+    continue (s' & gameState . availableCommands . notificationsCount .~ 0)
   ControlKey 'g' -> case s ^. uiState . uiGoal of
     NoGoal -> continueWithoutRedraw s
     UnreadGoal g -> toggleModal s (GoalModal g) >>= continue
@@ -294,6 +297,7 @@ handleModalEvent s = \case
     s' <- s & uiState . uiModal . _Just . modalDialog %%~ handleDialogEvent ev
     case s ^? uiState . uiModal . _Just . modalType of
       Just RecipesModal -> handleInfoPanelEvent s' recipesScroll (VtyEvent ev)
+      Just CommandsModal -> handleInfoPanelEvent s' commandsScroll (VtyEvent ev)
       _ -> continue s'
 
 -- | Quit a game.  Currently all it does is write out the updated REPL

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -116,6 +116,7 @@ module Swarm.TUI.Model (
   populateInventoryList,
   infoScroll,
   recipesScroll,
+  commandsScroll,
 
   -- * App state
   AppState,
@@ -209,6 +210,8 @@ data Name
     InfoViewport
   | -- | The scrollable viewport for the recipe list.
     RecipesViewport
+  | -- | The scrollable viewport for the commands list.
+    CommandsViewport
   deriving (Eq, Ord, Show, Read)
 
 infoScroll :: ViewportScroll Name
@@ -216,6 +219,9 @@ infoScroll = viewportScroll InfoViewport
 
 recipesScroll :: ViewportScroll Name
 recipesScroll = viewportScroll RecipesViewport
+
+commandsScroll :: ViewportScroll Name
+commandsScroll = viewportScroll CommandsViewport
 
 ------------------------------------------------------------
 -- REPL History
@@ -398,6 +404,7 @@ mkReplForm r = newForm [(replPromptAsWidget r <+>) @@= editTextField promptTextL
 data ModalType
   = HelpModal
   | RecipesModal
+  | CommandsModal
   | WinModal
   | QuitModal
   | DescriptionModal Entity


### PR DESCRIPTION
This change adds a new help panel with the list of recently acquired commands. The panels currently shows `command name :: command type signature`, for each newly available command.

Fixes https://github.com/swarm-game/swarm/issues/436