### PR TITLE
Tweaks to the REPL

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -209,7 +209,7 @@ handleMainEvent s = \case
   MetaKey 'r' -> setFocus s REPLPanel
   MetaKey 't' -> setFocus s InfoPanel
   -- toggle creative mode if in "cheat mode"
-  ControlKey 'k'
+  ControlKey 'v'
     | s ^. uiState . uiCheatMode -> continue (s & gameState . creativeMode %~ not)
   MouseDown n _ _ mouseLoc ->
     case n of

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -568,15 +568,17 @@ handleREPLEvent s (Key V.KEnter) =
           Right mt ->
             maybe id startBaseProgram mt
               . (uiState . uiReplHistory %~ addREPLItem (REPLEntry uinput))
-              . resetWithREPLForm (set promptUpdateL "" (s ^. uiState))
+              . (uiState %~ resetWithREPLForm (set promptUpdateL "" (s ^. uiState)))
               $ s
           Left err -> s & uiState . uiError ?~ err
       SearchPrompt t hist ->
         case lastEntry t hist of
-          Nothing -> resetWithREPLForm (mkReplForm $ CmdPrompt "") s
+          Nothing -> s & uiState %~ resetWithREPLForm (mkReplForm $ CmdPrompt "")
           Just found
-            | T.null t -> resetWithREPLForm (mkReplForm $ CmdPrompt "") s
-            | otherwise -> validateREPLForm $ resetWithREPLForm (mkReplForm $ CmdPrompt found) s
+            | T.null t -> s & uiState %~ resetWithREPLForm (mkReplForm $ CmdPrompt "")
+            | otherwise ->
+              s & uiState %~ resetWithREPLForm (mkReplForm $ CmdPrompt found)
+                & validateREPLForm
     else continueWithoutRedraw s
  where
   entry = formState (s ^. uiState . uiReplForm)
@@ -608,7 +610,7 @@ handleREPLEvent s EscapeKey =
   case s ^. uiState . uiReplForm . to formState of
     CmdPrompt _ -> continueWithoutRedraw s
     SearchPrompt _ _ ->
-      continue $ resetWithREPLForm (mkReplForm $ CmdPrompt "") s
+      continue $ s & uiState %~ resetWithREPLForm (mkReplForm $ CmdPrompt "")
 handleREPLEvent s ev = do
   f' <- handleFormEvent ev (s ^. uiState . uiReplForm)
   continue $
@@ -658,14 +660,6 @@ adjReplHistIndex d s =
   getCurrEntry = fromMaybe replLast . getCurrentItemText . view repl
   oldEntry = getCurrEntry s
   newEntry = getCurrEntry ns
-
--- Set the REPLForm to the given value, reseting type error checks to Nothing
--- and removing uiError
-resetWithREPLForm :: Form REPLPrompt AppEvent Name -> AppState -> AppState
-resetWithREPLForm f =
-  (uiState . uiReplForm .~ f)
-    . (uiState . uiReplType .~ Nothing)
-    . (uiState . uiError .~ Nothing)
 
 ------------------------------------------------------------
 -- World events

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -59,6 +59,7 @@ module Swarm.TUI.Model (
   promptUpdateL,
   mkReplForm,
   removeEntry,
+  resetWithREPLForm,
 
   -- ** Inventory
   InventoryListEntry (..),
@@ -807,6 +808,14 @@ populateInventoryList (Just r) = do
   -- the hash of the current robot.
   uiInventory .= Just (r ^. inventoryHash, lst)
 
+-- | Set the REPLForm to the given value, resetting type error checks to Nothing
+--   and removing uiError.
+resetWithREPLForm :: Form REPLPrompt AppEvent Name -> UIState -> UIState
+resetWithREPLForm f =
+  (uiReplForm .~ f)
+    . (uiReplType .~ Nothing)
+    . (uiError .~ Nothing)
+
 ------------------------------------------------------------
 -- App state (= UI state + game state) initialization
 ------------------------------------------------------------
@@ -845,3 +854,4 @@ scenarioToUIState scene u =
       & uiShowFPS .~ False
       & uiShowZero .~ True
       & lgTicksPerSecond .~ initLgTicksPerSecond
+      & resetWithREPLForm (mkReplForm $ CmdPrompt "")

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -425,7 +425,7 @@ drawKeyMenu s =
     [(NoHighlight, "F1", "help")]
       <> availRecipes
       <> [(NoHighlight, "Tab", "cycle")]
-      <> [(NoHighlight, "^k", "creative") | cheat]
+      <> [(NoHighlight, "^v", "creative") | cheat]
       <> [(NoHighlight, "^g", "goal") | goal]
 
   keyCmdsFor (Just REPLPanel) =


### PR DESCRIPTION
- Reset REPL state when starting a new game.
- Change creative mode cheat shortcut to `^V`, so `^K` can again be used in the REPL to delete everything from the cursor position to the end of the line.