### PR TITLE
Tweaks to mines

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -96,6 +96,7 @@
   display:
     attr: copper'
     char: 'Å'
+    priority: 11
   description:
   - A copper vein that can be actively mined to produce copper ore.
   properties: []
@@ -159,6 +160,7 @@
   display:
     attr: iron'
     char: 'Å'
+    priority: 11
   description:
   - An iron vein that can be actively mined to produce iron ore.
   properties: []
@@ -177,6 +179,7 @@
   display:
     attr: quartz
     char: 'Å'
+    priority: 11
   description:
   - A quartz vein that can be actively mined to produce quartz.
   properties: []
@@ -194,6 +197,7 @@
   display:
     attr: rock
     char: 'Å'
+    priority: 11
   description:
   - A deep mine that yields rare and wonderful treasures to those who are patient.
   - But be careful lest you delve too greedily and too deep.

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -947,7 +947,9 @@ execConst c vs s k = do
             `isJustOrFail` ["You don't have the ingredients to drill", indefinite (nextE ^. entityName) <> "."]
 
         let (out, down) = L.partition ((`hasProperty` Portable) . snd) outs
-            changeInv inv' = L.foldl' (flip $ uncurry insertCount) inv' out
+            changeInv =
+              flip (L.foldl' (flip $ uncurry insertCount)) out
+                . flip (L.foldl' (flip $ insertCount 0)) (map snd down)
             changeWorld = changeWorld' nextE nextLoc down
 
         -- take recipe inputs from inventory and add outputs after recipeTime


### PR DESCRIPTION
- Give all mines priority 11 so they display on top of robots
- Make drilled mines known by adding them to the inventory with count 0