### PR TITLE
Add generator for recipe dependencies

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,7 +31,7 @@ cliParser =
   subparser
     ( command "format" (info (format <**> helper) (progDesc "Format a file"))
         <> command "lsp" (info (pure LSP) (progDesc "Start the LSP"))
-        <> command "generate" (info (docgen <**> helper) (progDesc "Generate docs"))
+        <> command "generate" (info (DocGen <$> docgen <**> helper) (progDesc "Generate docs"))
     )
     <|> Run <$> seed <*> scenario <*> run <*> cheat
  where
@@ -39,8 +39,10 @@ cliParser =
   format =
     (Format Stdin <$ switch (long "stdin" <> help "Read code from stdin"))
       <|> (Format . File <$> strArgument (metavar "FILE"))
-  docgen :: Parser CLI
-  docgen = DocGen RecipeGraph <$ switch (long "recipe-graph" <> help "Output graphviz dotfile of entity dependencies based on recipes")
+  docgen :: Parser GenerateDocs
+  docgen =
+    subparser
+      (command "recipes" (info (pure RecipeGraph) $ progDesc "Output graphviz dotfile of entity dependencies based on recipes"))
   seed :: Parser (Maybe Int)
   seed = optional $ option auto (long "seed" <> short 's' <> metavar "INT" <> help "Seed to use for world generation")
   scenario :: Parser (Maybe String)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,7 @@ import Swarm.App (appMain)
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Pipeline (processTerm)
 import System.Exit
+import Swarm.DocGen (GenerateDocs (..), generateDocs)
 
 data CLI
   = Run
@@ -22,6 +23,7 @@ data CLI
       (Maybe FilePath) -- file to run
       Bool -- cheat mode
   | Format Input
+  | DocGen GenerateDocs
   | LSP
 
 cliParser :: Parser CLI
@@ -29,6 +31,7 @@ cliParser =
   subparser
     ( command "format" (info (format <**> helper) (progDesc "Format a file"))
         <> command "lsp" (info (pure LSP) (progDesc "Start the LSP"))
+        <> command "generate" (info (docgen <**> helper) (progDesc "Generate docs"))
     )
     <|> Run <$> seed <*> scenario <*> run <*> cheat
  where
@@ -36,6 +39,8 @@ cliParser =
   format =
     (Format Stdin <$ switch (long "stdin" <> help "Read code from stdin"))
       <|> (Format . File <$> strArgument (metavar "FILE"))
+  docgen :: Parser CLI
+  docgen = DocGen RecipeGraph <$ switch (long "recipe-graph" <> help "Output graphviz dotfile of entity dependencies based on recipes")
   seed :: Parser (Maybe Int)
   seed = optional $ option auto (long "seed" <> short 's' <> metavar "INT" <> help "Seed to use for world generation")
   scenario :: Parser (Maybe String)
@@ -87,4 +92,5 @@ main = do
   case cli of
     Run seed scenario toRun cheat -> appMain seed scenario toRun cheat
     Format fo -> formatFile fo
+    DocGen g -> generateDocs g
     LSP -> lspMain

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,10 +11,10 @@ import qualified Data.Text.IO as Text
 import GitHash
 import Options.Applicative
 import Swarm.App (appMain)
+import Swarm.DocGen (GenerateDocs (..), generateDocs)
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Pipeline (processTerm)
 import System.Exit
-import Swarm.DocGen (GenerateDocs (..), generateDocs)
 
 data CLI
   = Run

--- a/src/Swarm/DocGen.hs
+++ b/src/Swarm/DocGen.hs
@@ -64,7 +64,8 @@ generateRecipe = simpleErrorHandle $ do
 
 recipesToDot :: Scenario -> EntityMap -> [Recipe Entity] -> Dot ()
 recipesToDot classic emap recipes = do
-  Dot.attribute ("rankdir", "BT")
+  Dot.attribute ("rankdir", "LR")
+  Dot.attribute ("ranksep", "2")
   world <- diamond "World"
   base <- diamond "Base"
   -- --------------------------------------------------------------------------

--- a/src/Swarm/DocGen.hs
+++ b/src/Swarm/DocGen.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE GADTSyntax #-}
 
 module Swarm.DocGen (
   generateDocs,

--- a/src/Swarm/DocGen.hs
+++ b/src/Swarm/DocGen.hs
@@ -1,0 +1,247 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE GADTSyntax #-}
+
+module Swarm.DocGen (
+  generateDocs,
+  GenerateDocs (..),
+) where
+
+import Control.Lens (view, (^.))
+import Control.Monad (zipWithM, zipWithM_, (<=<))
+import Control.Monad.Except (ExceptT, runExceptT)
+import Data.Bifunctor (Bifunctor (bimap), second)
+import Data.Containers.ListUtils (nubOrd)
+import Data.Foldable (toList)
+import Data.Map.Lazy (Map)
+import Data.Map.Lazy qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text, unpack)
+import Data.Tuple (swap)
+import Swarm.Game.Entity (Count, Entity, EntityMap (entitiesByName), entityName, loadEntities)
+import Swarm.Game.Entity qualified as E
+import Swarm.Game.Recipe (Recipe, loadRecipes, recipeInputs, recipeOutputs, recipeRequirements)
+import Swarm.Game.Robot (installedDevices, robotInventory, setRobotID)
+import Swarm.Game.Scenario (Scenario, loadScenario, scenarioRobots)
+import Swarm.Game.WorldGen (testWorld2Entites)
+import Swarm.Util (isRightOr)
+import Text.Dot (Dot, NodeId)
+import Text.Dot qualified as Dot
+
+-- ============================================================================
+-- MAIN ENTRYPOINT TO CLI DOCUMENTATION GENERATOR
+-- ============================================================================
+--
+-- These are the exported functions used by the executable.
+--
+-- ----------------------------------------------------------------------------
+
+data GenerateDocs where
+  -- | Entity dependencies by recipes.
+  RecipeGraph :: GenerateDocs
+  deriving (Eq, Show)
+
+generateDocs :: GenerateDocs -> IO ()
+generateDocs = \case
+  RecipeGraph -> generateRecipe >>= putStrLn
+
+-- ----------------------------------------------------------------------------
+-- GENERATE GRAPHVIZ: ENTITY DEPENDENCIES BY RECIPES
+-- ----------------------------------------------------------------------------
+
+generateRecipe :: IO String
+generateRecipe = simpleErrorHandle $ do
+  entities <- loadEntities >>= guardRight "load entities"
+  recipes <- loadRecipes entities >>= guardRight "load recipes"
+  classic <- classicScenario
+  return . Dot.showDot $ recipesToDot classic entities recipes
+
+recipesToDot :: Scenario -> EntityMap -> [Recipe Entity] -> Dot ()
+recipesToDot classic emap recipes = do
+  Dot.attribute ("rankdir", "BT")
+  world <- diamond "World"
+  base <- diamond "Base"
+  -- --------------------------------------------------------------------------
+  -- add nodes with for all the known entites
+  let enames' = toList . Map.keysSet . entitiesByName $ emap
+      enames = filter (`Set.notMember` ignoredEntites) enames'
+  ebmap <- Map.fromList . zip enames <$> mapM (box . unpack) enames
+  -- --------------------------------------------------------------------------
+  -- getters for the NodeId based on entity name or the whole entity
+  let safeGetEntity m e = fromMaybe (error $ unpack e <> " is not an entity!?") $ m Map.!? e
+      getE = safeGetEntity ebmap
+      nid = getE . view entityName
+  -- --------------------------------------------------------------------------
+  -- Get the starting inventories, entites present in the world and compute
+  -- how hard each entity is to get - see 'recipeLevels'.
+  let devs = startingDevices classic
+      inv = startingInventory classic
+      worldEntites = Set.map (safeGetEntity $ entitiesByName emap) testWorld2Entites
+      levels = recipeLevels recipes (Set.unions [worldEntites, devs])
+  -- --------------------------------------------------------------------------
+  -- Base inventory
+  (_bc, ()) <- Dot.cluster $ do
+    Dot.attribute ("style", "filled")
+    Dot.attribute ("color", "lightgrey")
+    mapM_ ((uncurry (---<>) . ((1, base),)) . (1,) . nid) devs
+    mapM_ ((uncurry (--->) . ((1, base),)) . second nid . swap) $ Map.toList inv
+  -- --------------------------------------------------------------------------
+  -- World entites
+  (_wc, ()) <- Dot.cluster $ do
+    Dot.attribute ("style", "filled")
+    Dot.attribute ("color", "forestgreen")
+    mapM_ ((uncurry (Dot..->.) . (world,)) . getE) (toList testWorld2Entites)
+  -- --------------------------------------------------------------------------
+  let -- put a hidden node above and below entites and connect them by hidden edges
+      wrapBelowAbove :: Set Entity -> Dot (NodeId, NodeId)
+      wrapBelowAbove ns = do
+        b <- hiddenNode
+        t <- hiddenNode
+        let ns' = map nid $ toList ns
+        mapM_ (b .~>.) ns'
+        mapM_ (.~>. t) ns'
+        return (b, t)
+      -- put set of entites in nice
+      subLevel :: Int -> Set Entity -> Dot (NodeId, NodeId)
+      subLevel i ns = fmap snd . Dot.cluster $ do
+        Dot.attribute ("style", "filled")
+        Dot.attribute ("color", "khaki")
+        bt <- wrapBelowAbove ns
+        Dot.attribute ("rank", "sink")
+        -- the normal label for cluster would be cover by lines
+        _bigLabel <-
+          Dot.node
+            [ ("shape", "plain")
+            , ("label", "Bottom Label")
+            , ("fontsize", "20pt")
+            , ("label", "Level #" <> show i)
+            ]
+        return bt
+  -- --------------------------------------------------------------------------
+  -- order entites into clusters based on how "far" they are from
+  -- what is available at the start - see 'recipeLevels'.
+  bottom <- wrapBelowAbove worldEntites
+  ls <- zipWithM subLevel [1 ..] (tail levels)
+  let invisibleLine = zipWithM_ (.~>.)
+  tls <- mapM (const hiddenNode) levels
+  bls <- mapM (const hiddenNode) levels
+  invisibleLine tls bls
+  invisibleLine bls (tail tls)
+  let sameBelowAbove (b1, t1) (b2, t2) = Dot.same [b1, b2] >> Dot.same [t1, t2]
+  zipWithM_ sameBelowAbove (bottom : ls) (zip bls tls)
+  -- --------------------------------------------------------------------------
+  -- add node for the world and draw a line to each entity found in the wild
+  -- finally draw recipes
+  let allToNID = both (second nid)
+      recipeInOut r = [(i, o) | i <- r ^. recipeInputs, o <- r ^. recipeOutputs]
+      recipeReqOut r = [(q, o) | q <- r ^. recipeRequirements, o <- r ^. recipeOutputs]
+      recipesToPairs f rs = allToNID <$> nubOrd (concatMap f rs)
+  mapM_ (uncurry (--->)) (recipesToPairs recipeInOut recipes)
+  mapM_ (uncurry (---<>)) (recipesToPairs recipeReqOut recipes)
+
+-- ----------------------------------------------------------------------------
+-- RECIPE LEVELS
+-- ----------------------------------------------------------------------------
+
+-- | Order entites in sets depending on how soon it is possible to obtain them.
+--
+-- So:
+--  * Level 0 - starting entites (for example those obtainable in the world)
+--  * Level N+1 - everything possible to make (or drill) from Level N
+--
+-- This is almost a BFS, but the requirement is that the set of entites
+-- required for recipe is subset of the entites known in Level N.
+--
+-- If we ever depend on some graph library, this could be rewritten
+-- as some BFS-like algorithm with added recipe nodes, but you would
+-- need to enforce the condition that recipes need ALL incoming edges.
+recipeLevels :: [Recipe Entity] -> Set Entity -> [Set Entity]
+recipeLevels recipes start = levels
+ where
+  recipeParts r = ((r ^. recipeInputs) <> (r ^. recipeRequirements), r ^. recipeOutputs)
+  m :: [(Set Entity, Set Entity)]
+  m = map (both (Set.fromList . map snd) . recipeParts) recipes
+  levels :: [Set Entity]
+  levels = reverse $ go [start] start
+   where
+    isKnown known (i, _o) = null $ i Set.\\ known
+    nextLevel known = Set.unions . map snd $ filter (isKnown known) m
+    go ls known =
+      let n = nextLevel known Set.\\ known
+       in if null n
+            then ls
+            else go (n : ls) (Set.union n known)
+
+-- | Get classic scenario to figure out starting entites.
+classicScenario :: ExceptT Text IO Scenario
+classicScenario = do
+  entities <- loadEntities >>= guardRight "load entities"
+  loadScenario "data/scenarios/00-classic.yaml" entities
+
+startingDevices :: Scenario -> Set Entity
+startingDevices = Set.fromList . map snd . E.elems . view installedDevices . setRobotID 0 . head . view scenarioRobots
+
+startingInventory :: Scenario -> Map Entity Int
+startingInventory = Map.fromList . map swap . E.elems . view robotInventory . setRobotID 0 . head . view scenarioRobots
+
+-- | Ignore utility entites that are just used for tutorials and challenges.
+ignoredEntites :: Set Text
+ignoredEntites =
+  Set.fromList
+    [ "upper left corner"
+    , "upper right corner"
+    , "lower left corner"
+    , "lower right corner"
+    , "horizontal wall"
+    , "vertical wall"
+    ]
+
+-- ----------------------------------------------------------------------------
+-- GRAPHVIZ HELPERS
+-- ----------------------------------------------------------------------------
+
+customNode :: [(String, String)] -> String -> Dot NodeId
+customNode attrs label = Dot.node $ [("style", "filled"), ("label", label)] <> attrs
+
+box, diamond :: String -> Dot NodeId
+box = customNode [("shape", "box")]
+diamond = customNode [("shape", "diamond")]
+
+-- | Hidden node - used for layout.
+hiddenNode :: Dot NodeId
+hiddenNode = Dot.node [("style", "invis")]
+
+-- | Hidden edge - used for layout.
+(.~>.) :: NodeId -> NodeId -> Dot ()
+i .~>. j = Dot.edge i j [("style", "invis")]
+
+-- | Edge for recipe inputs and outputs.
+(--->) :: (Count, NodeId) -> (Count, NodeId) -> Dot ()
+(c1, e1) ---> (c2, e2) = Dot.edge e1 e2 attrs
+ where
+  attrs = [("headlabel", show c2), ("taillabel", show c1)]
+
+-- | Edge for recipe requirements and outputs.
+(---<>) :: (Count, NodeId) -> (Count, NodeId) -> Dot ()
+(_c1, e1) ---<> (c2, e2) = Dot.edge e1 e2 attrs
+ where
+  attrs = [("headlabel", show c2), ("arrowhead", "diamond"), ("color", "blue")]
+
+-- ----------------------------------------------------------------------------
+-- UTILITY
+-- ----------------------------------------------------------------------------
+
+both :: Bifunctor p => (a -> d) -> p a a -> p d d
+both f = bimap f f
+
+guardRight :: Text -> Either Text a -> ExceptT Text IO a
+guardRight what i = i `isRightOr` (\e -> "Failed to " <> what <> ": " <> e)
+
+simpleErrorHandle :: ExceptT Text IO a -> IO a
+simpleErrorHandle = either (fail . unpack) pure <=< runExceptT

--- a/src/Swarm/Game/WorldGen.hs
+++ b/src/Swarm/Game/WorldGen.hs
@@ -46,25 +46,26 @@ data Origin = Natural | Artificial deriving (Eq, Ord, Show, Read)
 type Seed = Int
 
 testWorld2Entites :: S.Set Text
-testWorld2Entites = S.fromList
-  [ "mountain"
-  , "boulder"
-  , "LaTeX"
-  , "tree"
-  , "rock"
-  , "sand"
-  , "wavy water"
-  , "water"
-  , "flower"
-  , "bit (0)"
-  , "bit (1)"
-  , "Linux"
-  , "lambda"
-  , "pixel (R)"
-  , "pixel (G)"
-  , "pixel (B)"
-  , "copper ore"
-  ]
+testWorld2Entites =
+  S.fromList
+    [ "mountain"
+    , "boulder"
+    , "LaTeX"
+    , "tree"
+    , "rock"
+    , "sand"
+    , "wavy water"
+    , "water"
+    , "flower"
+    , "bit (0)"
+    , "bit (1)"
+    , "Linux"
+    , "lambda"
+    , "pixel (R)"
+    , "pixel (G)"
+    , "pixel (B)"
+    , "copper ore"
+    ]
 
 -- | A more featureful test world.
 testWorld2 :: Seed -> WorldFun TerrainType Text

--- a/src/Swarm/Game/WorldGen.hs
+++ b/src/Swarm/Game/WorldGen.hs
@@ -45,6 +45,27 @@ data Hardness = Soft | Hard deriving (Eq, Ord, Show, Read)
 data Origin = Natural | Artificial deriving (Eq, Ord, Show, Read)
 type Seed = Int
 
+testWorld2Entites :: S.Set Text
+testWorld2Entites = S.fromList
+  [ "mountain"
+  , "boulder"
+  , "LaTeX"
+  , "tree"
+  , "rock"
+  , "sand"
+  , "wavy water"
+  , "water"
+  , "flower"
+  , "bit (0)"
+  , "bit (1)"
+  , "Linux"
+  , "lambda"
+  , "pixel (R)"
+  , "pixel (G)"
+  , "pixel (B)"
+  , "copper ore"
+  ]
+
 -- | A more featureful test world.
 testWorld2 :: Seed -> WorldFun TerrainType Text
 testWorld2 baseSeed (Coords ix@(r, c)) =
@@ -77,7 +98,7 @@ testWorld2 baseSeed (Coords ix@(r, c)) =
     | h `mod` 10 == 0 = (GrassT, Just (T.concat ["bit (", from (show ((r + c) `mod` 2)), ")"]))
     | otherwise = (GrassT, Nothing)
   genBiome Big Soft Artificial
-    | h `mod` 5000 == 0 = (DirtT, Just "linux")
+    | h `mod` 5000 == 0 = (DirtT, Just "Linux")
     | sample ix cl0 > 0.5 = (GrassT, Nothing)
     | otherwise = (DirtT, Nothing)
   genBiome Small Hard Artificial

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -86,6 +86,7 @@ library
                       Swarm.TUI.Controller
                       Swarm.App
                       Swarm.Util
+                      Swarm.DocGen
                       Swarm.Util.Yaml
     other-modules:    Paths_swarm
     autogen-modules:  Paths_swarm
@@ -97,6 +98,7 @@ library
                       clock                         >= 0.8.2 && < 0.9,
                       containers                    >= 0.6.2 && < 0.7,
                       directory                     >= 1.3 && < 1.4,
+                      dotgen                        >= 0.4 && < 0.5,
                       either                        >= 5.0 && < 5.1,
                       filepath                      >= 1.4 && < 1.5,
                       fused-effects                 >= 1.1.1.1 && < 1.2,


### PR DESCRIPTION
- add `generate` subparser to the executable
- create a generator for a Graphviz entity dependencies graph
- part of #344 

You can interactively test this with:
```bash
$ cabal run swarm:swarm -- generate recipes \
 | sed -n '/^digraph/,$p' > docs/recipes.dot
$ xdot docs/recipes.dot
```