### PR TITLE
Make ctrl-q works inside modal

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -184,6 +184,8 @@ handleMainEvent s = \case
     | Just g <- s ^. uiState . uiGoal . to goalNeedsDisplay ->
       toggleModal s (GoalModal g) <&> (uiState . uiGoal %~ markGoalRead) >>= runFrameUI
     | otherwise -> runFrameUI s
+  -- ctrl-q works everywhere
+  ControlKey 'q' -> toggleModal s QuitModal >>= continue
   VtyEvent (V.EvResize _ _) -> do
     invalidateCacheEntry WorldCache
     continue s
@@ -203,7 +205,6 @@ handleMainEvent s = \case
   CharKey '\t' -> continue $ s & uiState . uiFocusRing %~ focusNext
   Key V.KBackTab -> continue $ s & uiState . uiFocusRing %~ focusPrev
   -- special keys that work on all panels
-  ControlKey 'q' -> toggleModal s QuitModal >>= continue
   MetaKey 'w' -> setFocus s WorldPanel
   MetaKey 'e' -> setFocus s RobotPanel
   MetaKey 'r' -> setFocus s REPLPanel


### PR DESCRIPTION
This change enables using <kbd>CTRL</kbd><kbd>q</kbd> to close a visible modal.