### PR TITLE
Add branch filter to reduce CI cost

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -23,7 +23,7 @@
 #
 name: Haskell-CI
 on:
-  push: 
+  push:
     paths:
       - '**.hs'
       - '**.sw'
@@ -31,6 +31,8 @@ on:
       - '*.yaml'
       - 'data/**.yaml'
       - 'cabal.project*'
+    branches:
+      - "main"
   # reuse the same filter for pull-requests
   pull_request:
     paths:
@@ -41,6 +43,8 @@ on:
       - '*.yaml'
       - 'data/**.yaml'
       - 'cabal.project*'
+    branches:
+      - "main"
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -31,6 +31,7 @@ on:
       - '*.yaml'
       - 'data/**.yaml'
       - 'cabal.project*'
+      - '.github/workflows/haskell-ci.yml'
     branches:
       - "main"
   # reuse the same filter for pull-requests
@@ -43,6 +44,7 @@ on:
       - '*.yaml'
       - 'data/**.yaml'
       - 'cabal.project*'
+      - '.github/workflows/haskell-ci.yml'
     branches:
       - "main"
 jobs:


### PR DESCRIPTION
The action presently runs twice because both `on` conditions matche
every contributions. With this change, the push action only triggers
for the final push to the main branch, and the pull_requeste action
only triggers for PR made for the main branch.

That also means restyled PR should not trigger CI as they are made
for non main branches.