### PR TITLE
Give the option to go immediately to the next challenge after completing one

### DIFF
--- a/data/scenarios/Tutorials/move.yaml
+++ b/data/scenarios/Tutorials/move.yaml
@@ -6,10 +6,12 @@ description: |
 #
 goal:
   - Robots can use the 'move' command to move forward one unit
-    in the direction they are currently facing. 
+    in the direction they are currently facing.
   - To complete this challenge, move your robot two spaces to the right,
     to the coordinates (2,0).
   - Note that you can chain commands with ';'.
+  - You can open this popup window at any time to remind yourself of the goal
+    using Ctrl-G.
 win: |
   try {
     loc <- as base {whereami};

--- a/src/Swarm/Game/Scenario.hs
+++ b/src/Swarm/Game/Scenario.hs
@@ -41,7 +41,7 @@ module Swarm.Game.Scenario (
   loadScenario,
   ScenarioCollection (..),
   scenarioCollectionToList,
-  ScenarioItem (..),
+  ScenarioItem (..), _SISingle, _SICollection,
   scenarioItemName,
   loadScenarios,
 ) where
@@ -354,3 +354,10 @@ loadScenarioFile em fileName = do
   case res of
     Left parseExn -> throwError @Text (from @String (prettyPrintParseException parseExn))
     Right c -> return c
+
+------------------------------------------------------------
+-- Some lenses + prisms
+------------------------------------------------------------
+
+makePrisms ''ScenarioItem
+

--- a/src/Swarm/Game/Scenario.hs
+++ b/src/Swarm/Game/Scenario.hs
@@ -41,7 +41,9 @@ module Swarm.Game.Scenario (
   loadScenario,
   ScenarioCollection (..),
   scenarioCollectionToList,
-  ScenarioItem (..), _SISingle, _SICollection,
+  ScenarioItem (..),
+  _SISingle,
+  _SICollection,
   scenarioItemName,
   loadScenarios,
 ) where
@@ -360,4 +362,3 @@ loadScenarioFile em fileName = do
 ------------------------------------------------------------
 
 makePrisms ''ScenarioItem
-

--- a/src/Swarm/Game/Scenario.hs
+++ b/src/Swarm/Game/Scenario.hs
@@ -43,7 +43,6 @@ module Swarm.Game.Scenario (
   scenarioCollectionToList,
   ScenarioItem (..),
   _SISingle,
-  _SICollection,
   scenarioItemName,
   loadScenarios,
 ) where

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -108,16 +108,14 @@ handleEvent :: AppState -> BrickEvent Name AppEvent -> EventM Name (Next AppStat
 handleEvent s
   | s ^. uiState . uiPlaying = handleMainEvent s
   | otherwise = case s ^. uiState . uiMenu of
-
-      -- If we reach the NoMenu case when uiPlaying is False, just
-      -- quit the app.  We should actually never reach this code (the
-      -- quitGame function would have already halted the app).
-      NoMenu -> \_ -> halt s
-
-      MainMenu l -> handleMainMenuEvent l s
-      NewGameMenu l -> handleNewGameMenuEvent l s
-      TutorialMenu -> pressAnyKey (MainMenu (mainMenu Tutorial)) s
-      AboutMenu -> pressAnyKey (MainMenu (mainMenu About)) s
+    -- If we reach the NoMenu case when uiPlaying is False, just
+    -- quit the app.  We should actually never reach this code (the
+    -- quitGame function would have already halted the app).
+    NoMenu -> \_ -> halt s
+    MainMenu l -> handleMainMenuEvent l s
+    NewGameMenu l -> handleNewGameMenuEvent l s
+    TutorialMenu -> pressAnyKey (MainMenu (mainMenu Tutorial)) s
+    AboutMenu -> pressAnyKey (MainMenu (mainMenu About)) s
 
 -- | The event handler for the main menu.
 handleMainMenuEvent ::
@@ -144,23 +142,23 @@ handleMainMenuEvent menu s = \case
 -- | Load a 'Scenario' and start playing the game.
 startGame :: Scenario -> AppState -> EventM Name (Next AppState)
 startGame scene s = do
-  continue =<<
-    liftIO (
-      scenarioToAppState
-        scene
-        Nothing
-        Nothing
-
-        ( case s ^. uiState . uiMenu of
-            NewGameMenu (curMenu :| _) ->
-              let nextMenuList = BL.listMoveDown curMenu
-                  nextScenario
-                    | BL.listSelected curMenu == Just (length (BL.listElements curMenu) - 1) =
-                      Nothing
-                    | otherwise = BL.listSelectedElement nextMenuList >>= preview _SISingle . snd
-               in s & uiState . uiNextScenario .~ nextScenario
-            _ -> s & uiState . uiNextScenario .~ Nothing
-        ))
+  continue
+    =<< liftIO
+      ( scenarioToAppState
+          scene
+          Nothing
+          Nothing
+          ( case s ^. uiState . uiMenu of
+              NewGameMenu (curMenu :| _) ->
+                let nextMenuList = BL.listMoveDown curMenu
+                    nextScenario
+                      | BL.listSelected curMenu == Just (length (BL.listElements curMenu) - 1) =
+                        Nothing
+                      | otherwise = BL.listSelectedElement nextMenuList >>= preview _SISingle . snd
+                 in s & uiState . uiNextScenario .~ nextScenario
+              _ -> s & uiState . uiNextScenario .~ Nothing
+          )
+      )
 
 -- | If we are in a New Game menu, advance the menu to the next item in order.
 advanceMenu :: Menu -> Menu

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -432,7 +432,7 @@ data MainMenuEntry = NewGame | Tutorial | About | Quit
   deriving (Eq, Ord, Show, Read, Bounded, Enum)
 
 data Menu
-  = NoMenu    -- We started playing directly from command line, no menu to show
+  = NoMenu -- We started playing directly from command line, no menu to show
   | MainMenu (BL.List Name MainMenuEntry)
   | NewGameMenu (NonEmpty (BL.List Name ScenarioItem)) -- stack of scenario item lists
   | TutorialMenu

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -30,6 +30,7 @@ module Swarm.TUI.Model (
   MainMenuEntry (..),
   mainMenu,
   Menu (..),
+  _NewGameMenu,
 
   -- * UI state
 
@@ -74,7 +75,8 @@ module Swarm.TUI.Model (
   -- ** UI Model
   UIState,
   uiMenu,
-  uiPrevMenu,
+  uiPlaying,
+  uiNextScenario,
   uiCheatMode,
   uiFocusRing,
   uiWorldCursor,
@@ -417,8 +419,7 @@ data ModalType
   | GoalModal [Text]
   deriving (Eq, Show)
 
-data ButtonSelection = Cancel | Confirm
-  deriving (Eq, Show)
+data ButtonSelection = CancelButton | QuitButton | NextButton Scenario
 
 data Modal = Modal
   { _modalType :: ModalType
@@ -431,7 +432,7 @@ data MainMenuEntry = NewGame | Tutorial | About | Quit
   deriving (Eq, Ord, Show, Read, Bounded, Enum)
 
 data Menu
-  = NoMenu
+  = NoMenu    -- We started playing directly from command line, no menu to show
   | MainMenu (BL.List Name MainMenuEntry)
   | NewGameMenu (NonEmpty (BL.List Name ScenarioItem)) -- stack of scenario item lists
   | TutorialMenu
@@ -493,7 +494,8 @@ markGoalRead gs = gs
 -- see the lenses below.
 data UIState = UIState
   { _uiMenu :: Menu
-  , _uiPrevMenu :: Menu
+  , _uiPlaying :: Bool
+  , _uiNextScenario :: Maybe Scenario
   , _uiCheatMode :: Bool
   , _uiFocusRing :: FocusRing Name
   , _uiWorldCursor :: Maybe W.Coords
@@ -544,8 +546,13 @@ let exclude = ['_lgTicksPerSecond]
 -- | The current menu state.
 uiMenu :: Lens' UIState Menu
 
--- | The previous menu state, to go back after playing a game
-uiPrevMenu :: Lens' UIState Menu
+-- | Are we currently playing the game?  True = we are playing, and
+--   should thus display a world, REPL, etc.; False = we should
+--   display the current menu.
+uiPlaying :: Lens' UIState Bool
+
+-- | The next scenario after the current one, if any.
+uiNextScenario :: Lens' UIState (Maybe Scenario)
 
 -- | Cheat mode, i.e. are we allowed to turn creative mode on and off?
 uiCheatMode :: Lens' UIState Bool
@@ -739,7 +746,8 @@ initUIState showMainMenu cheatMode = liftIO $ do
   return $
     UIState
       { _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
-      , _uiPrevMenu = NoMenu
+      , _uiPlaying = not showMainMenu
+      , _uiNextScenario = Nothing
       , _uiCheatMode = cheatMode
       , _uiFocusRing = initFocusRing
       , _uiWorldCursor = Nothing
@@ -859,7 +867,7 @@ scenarioToUIState :: Scenario -> UIState -> IO UIState
 scenarioToUIState scene u =
   return $
     u
-      & uiMenu .~ NoMenu
+      & uiPlaying .~ True
       & uiGoal .~ maybe NoGoal UnreadGoal (scene ^. scenarioGoal)
       & uiFocusRing .~ initFocusRing
       & uiInventory .~ Nothing
@@ -867,3 +875,4 @@ scenarioToUIState scene u =
       & uiShowZero .~ True
       & lgTicksPerSecond .~ initLgTicksPerSecond
       & resetWithREPLForm (mkReplForm $ CmdPrompt "")
+      & uiReplHistory %~ restartREPLHistory

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -95,15 +95,13 @@ drawUI :: AppState -> [Widget Name]
 drawUI s
   | s ^. uiState . uiPlaying = drawGameUI s
   | otherwise = case s ^. uiState . uiMenu of
-
-      -- We should never reach the NoMenu case if uiPlaying is false; we would have
-      -- quit the app instead.  But just in case, we display the main menu anyway.
-      NoMenu -> [drawMainMenuUI (s ^. uiState . appData . at "logo") (mainMenu NewGame)]
-
-      MainMenu l -> [drawMainMenuUI (s ^. uiState . appData . at "logo") l]
-      NewGameMenu stk -> [drawNewGameMenuUI stk]
-      TutorialMenu -> [drawTutorialMenuUI]
-      AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
+    -- We should never reach the NoMenu case if uiPlaying is false; we would have
+    -- quit the app instead.  But just in case, we display the main menu anyway.
+    NoMenu -> [drawMainMenuUI (s ^. uiState . appData . at "logo") (mainMenu NewGame)]
+    MainMenu l -> [drawMainMenuUI (s ^. uiState . appData . at "logo") l]
+    NewGameMenu stk -> [drawNewGameMenuUI stk]
+    TutorialMenu -> [drawTutorialMenuUI]
+    AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
 
 drawMainMenuUI :: Maybe Text -> BL.List Name MainMenuEntry -> Widget Name
 drawMainMenuUI logo l =
@@ -315,10 +313,10 @@ drawModal s = \case
 
 quitMsg :: Menu -> Text
 quitMsg m = "Are you sure you want to " <> quitAction <> "? All progress will be lost!"
-  where
-    quitAction = case m of
-      NoMenu -> "quit"
-      _ -> "quit and return to the menu"
+ where
+  quitAction = case m of
+    NoMenu -> "quit"
+    _ -> "quit and return to the menu"
 
 -- | Generate a fresh modal window of the requested type.
 generateModal :: AppState -> ModalType -> Modal


### PR DESCRIPTION
- Always have `uiMenu` store the current menu; while playing, it represents the menu we should return to if we quit
- Get rid of `uiPrevMenu` which is thus no longer needed
- `NoMenu` is now only used to represent the scenario when we started via command-line options and thus should not return to a menu when we quit
- Add `uiPlaying` to denote whether we are playing the game or displaying a menu (`NoMenu` used to be used for this purpose)
- Only advance to the next scenario in the menu when actually completing the previous one.  For example if we start a scenario then quit before completing it, the menu will still be highlighting the same scenario.  But if we complete a scenario and then quit to the menu, the next one will be highlighted.
- Closes #355.  As [explained in a comment there](https://github.com/swarm-game/swarm/issues/355#issuecomment-1166343849), I think true "meta-scenarios" as originally described are needlessly complex. This PR gives us something that should be good enough: scenarios that have win conditions, placed in the same folder, can now be played sequentially without ever returning to the menu in between.
