### PR TITLE
Tab completion

### DIFF
--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -17,6 +17,9 @@
 -- 'Swarm.Language.Pipeline.processTerm' instead, which parses,
 -- typechecks, elaborates, and capability checks a term all at once.
 module Swarm.Language.Parse (
+  -- * Reserved words
+  reservedWords,
+
   -- * Parsers
   Parser,
   parsePolytype,

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -208,8 +208,6 @@ handleMainEvent s = \case
     ReadGoal g -> toggleModal s (GoalModal g) >>= continue
   VtyEvent vev
     | isJust (s ^. uiState . uiModal) -> handleModalEvent s vev
-  CharKey '\t' -> continue $ s & uiState . uiFocusRing %~ focusNext
-  Key V.KBackTab -> continue $ s & uiState . uiFocusRing %~ focusPrev
   -- special keys that work on all panels
   MetaKey 'w' -> setFocus s WorldPanel
   MetaKey 'e' -> setFocus s RobotPanel

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -49,12 +50,13 @@ import Data.Bits
 import Data.Either (isRight)
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
-import qualified Data.Set as S
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
-import qualified Data.Vector as V
+import Data.Set qualified as S
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import Data.Vector qualified as V
 import Linear
 import System.Clock
 import Witch (into)
@@ -63,12 +65,12 @@ import Brick hiding (Direction)
 import Brick.Focus
 import Brick.Forms
 import Brick.Widgets.Dialog
-import qualified Brick.Widgets.List as BL
-import qualified Graphics.Vty as V
+import Brick.Widgets.List qualified as BL
+import Graphics.Vty qualified as V
 
 import Brick.Widgets.List (handleListEvent)
-import qualified Control.Carrier.Lift as Fused
-import qualified Control.Carrier.State.Lazy as Fused
+import Control.Carrier.Lift qualified as Fused
+import Control.Carrier.State.Lazy qualified as Fused
 import Swarm.Game.CESK (cancel, emptyStore, initMachine)
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Robot
@@ -76,7 +78,7 @@ import Swarm.Game.Scenario (ScenarioCollection, ScenarioItem (..), scenarioColle
 import Swarm.Game.State
 import Swarm.Game.Step (gameTick)
 import Swarm.Game.Value (Value (VUnit), prettyValue)
-import qualified Swarm.Game.World as W
+import Swarm.Game.World qualified as W
 import Swarm.Language.Capability
 import Swarm.Language.Context
 import Swarm.Language.Pipeline


### PR DESCRIPTION
- Tab no longer cycles between panels (closes #316).  Now that we have keyboard shortcuts *and* you can click to move the panel focus, that seems sufficient.
- Very basic REPL tab completion (closes #207).  Currently tries to complete against all reserved words and all in-scope names.

Known limitations/things that should be improved:
- Doesn't do anything when there are multiple matches.  So if you type a partial word and hitting Tab does nothing, there is no way to know whether it's because it matched nothing, or it matched more than one thing.
- Doesn't work if the word to complete is preceded by punctuation instead of whitespace.