### PR TITLE
fix the way win conditions are checked

### DIFF
--- a/data/scenarios/Testing/504-teleport-self.yaml
+++ b/data/scenarios/Testing/504-teleport-self.yaml
@@ -1,0 +1,37 @@
+name: Teleport self in win condition check
+description: |
+  `teleport self` did not work in the win condition check.
+  https://github.com/swarm-game/swarm/issues/504
+win: |
+  try {
+    create "tree"; place "tree";
+    teleport self (5,0);
+    ishere "tree"
+  } { return false }
+solution: |
+  place "tree"
+robots:
+  - name: base
+    loc: [5,0]
+    dir: [1,0]
+    devices:
+      - treads
+      - logger
+      - grabber
+    inventory:
+    - [1, tree]
+world:
+  default: [blank, none]
+  palette:
+    '.': [grass, null]
+    '┌': [stone, upper left corner]
+    '┐': [stone, upper right corner]
+    '└': [stone, lower left corner]
+    '┘': [stone, lower right corner]
+    '─': [stone, horizontal wall]
+    '│': [stone, vertical wall]
+  upperleft: [-1, 1]
+  map: |
+    ┌──────┐
+    │......│
+    └──────┘

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -137,6 +137,7 @@ testScenarioSolution _ci _em =
         [ expectFailBecause "Awaiting fix (#394)" $
             testSolution Default "Testing/394-build-drill"
         , testSolution Default "Testing/428-drowning-destroy"
+        , testSolution Default "Testing/504-teleport-self"
         ]
     ]
  where


### PR DESCRIPTION
- Put the robot doing the checking in the robot map so it (or other
  robots) are able to look it up.  Fixes #504.
- Execute the win condition check *hypothetically*, in a copy of the
  game state which is discarded afterwards.  I kind of can't believe
  we weren't already doing this.  It used to be possible for the win
  condition check to actually modify the world! Thankfully none of
  the current tests actually used this evil power.