### PR TITLE
hide `-Wprepositive-qualified-module` behind `ci` flag

### DIFF
--- a/feedback.yaml
+++ b/feedback.yaml
@@ -1,2 +1,4 @@
+# For use with https://github.com/NorfairKing/feedback
+
 loops:
   test: stack test --fast

--- a/feedback.yaml
+++ b/feedback.yaml
@@ -1,2 +1,2 @@
 loops:
-  test: stack test --fast --flag=swarm:ci
+  test: stack test --fast

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -54,7 +54,8 @@ common stan-config
 
 -- Harmless extensions from GHC2021
 common ghc2021-extensions
-    ghc-options:  -Wprepositive-qualified-module
+    if flag(ci)
+      ghc-options:  -Wprepositive-qualified-module
     default-extensions:
       BangPatterns
       DeriveAnyClass


### PR DESCRIPTION
Closes #528.

Hopefully this is a relatively simple solution.  We will still
warn (and hence fail) on prepositive `qualified` in CI, but it won't
trip up anyone building with `stack` and/or an older version of
`cabal` unless they explicitly use the `ci` flag.