### PR TITLE
Refactor `Display` code and add invisibility

### DIFF
--- a/data/scenarios/Challenges/teleport.yaml
+++ b/data/scenarios/Challenges/teleport.yaml
@@ -24,8 +24,7 @@ robots:
   - name: portkey1
     system: true
     display:
-      char: ' '
-      attr: rock
+      invisible: true
     loc: [0,0]
     dir: [0,0]
     program: |
@@ -40,8 +39,7 @@ robots:
   - name: portkey2
     system: true
     display:
-      char: ' '
-      attr: rock
+      invisible: true
     loc: [16,0]
     dir: [0,0]
     program: |

--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -5,3 +5,4 @@
 504-teleport-self.yaml
 508-capability-subset.yaml
 201-require
+555-teleport-location.yaml

--- a/data/scenarios/Testing/555-teleport-location.yaml
+++ b/data/scenarios/Testing/555-teleport-location.yaml
@@ -1,0 +1,25 @@
+name: Teleport updates robotsByLocation
+description: |
+  Teleporting another robot should correctly update the robotsByLocation map.
+  https://github.com/swarm-game/swarm/issues/555
+creative: True
+win: |
+  try {
+    as base {has "rock"}
+  } { return false }
+solution: |
+  fred <- robotNamed "fred";
+  myLoc <- whereami;
+  teleport fred myLoc;
+  salvage
+robots:
+  - name: base
+    loc: [0,0]
+    dir: [1,0]
+  - name: fred
+    loc: [1,0]
+    dir: [0,0]
+    inventory:
+      - [1, rock]
+world:
+  default: [grass, null]

--- a/src/Swarm/Game/Display.hs
+++ b/src/Swarm/Game/Display.hs
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -22,11 +20,12 @@ module Swarm.Game.Display (
   -- ** Fields
   defaultChar,
   orientationMap,
+  curOrientation,
   displayAttr,
   displayPriority,
 
-  -- ** Lookup
-  lookupDisplay,
+  -- ** Rendering
+  displayChar,
   displayWidget,
 
   -- ** Construction
@@ -60,6 +59,7 @@ instance Hashable AttrName
 data Display = Display
   { _defaultChar :: Char
   , _orientationMap :: Map Direction Char
+  , _curOrientation :: Maybe Direction
   , _displayAttr :: AttrName
   , _displayPriority :: Priority
   }
@@ -76,6 +76,10 @@ defaultChar :: Lens' Display Char
 --   the 'defaultChar' will be used.
 orientationMap :: Lens' Display (Map Direction Char)
 
+-- | The display caches the current orientation of the entity, so we
+--   know which character to use from the orientation map.
+curOrientation :: Lens' Display (Maybe Direction)
+
 -- | The attribute to use for display.
 displayAttr :: Lens' Display AttrName
 
@@ -88,6 +92,7 @@ instance FromJSON Display where
     Display
       <$> v .: "char"
       <*> v .:? "orientationMap" .!= M.empty
+      <*> v .:? "curOrientation"
       <*> v .:? "attr" .!= entityAttr
       <*> v .:? "priority" .!= 1
 
@@ -100,16 +105,15 @@ instance ToJSON Display where
       ]
         ++ ["orientationMap" .= (d ^. orientationMap) | not (M.null (d ^. orientationMap))]
 
--- | Look up the character that should be used for a display, possibly
---   given an orientation as input.
-lookupDisplay :: Maybe Direction -> Display -> Char
-lookupDisplay Nothing disp = disp ^. defaultChar
-lookupDisplay (Just v) disp = M.lookup v (disp ^. orientationMap) ? (disp ^. defaultChar)
+-- | Look up the character that should be used for a display.
+displayChar :: Display -> Char
+displayChar disp = case disp ^. curOrientation of
+  Nothing -> disp ^. defaultChar
+  Just dir -> M.lookup dir (disp ^. orientationMap) ? (disp ^. defaultChar)
 
--- | Given the (optional) orientation of an entity and its display,
---   return a widget showing the entity.
-displayWidget :: Maybe Direction -> Display -> Widget n
-displayWidget orient disp = withAttr (disp ^. displayAttr) $ str [lookupDisplay orient disp]
+-- | Render a display as a UI widget.
+displayWidget :: Display -> Widget n
+displayWidget disp = withAttr (disp ^. displayAttr) $ str [displayChar disp]
 
 -- | The default way to display some terrain using the given character
 --   and attribute, with priority 0.
@@ -126,15 +130,17 @@ defaultEntityDisplay c =
   Display
     { _defaultChar = c
     , _orientationMap = M.empty
+    , _curOrientation = Nothing
     , _displayAttr = entityAttr
     , _displayPriority = 1
     }
 
--- | Construct a default robot display, with display characters
---   @"X^>v<"@, the default robot attribute, and priority 10.
+-- | Construct a default robot display for a given orientation, with
+--   display characters @"X^>v<"@, the default robot attribute, and
+--   priority 10.
 --
--- Note that the 'defaultChar' is used for direction 'DDown'
--- and is overriden for the special base robot.
+--   Note that the 'defaultChar' is used for direction 'DDown'
+--   and is overriden for the special base robot.
 defaultRobotDisplay :: Display
 defaultRobotDisplay =
   Display
@@ -146,6 +152,7 @@ defaultRobotDisplay =
           , (DSouth, 'v')
           , (DNorth, '^')
           ]
+    , _curOrientation = Nothing
     , _displayAttr = robotAttr
     , _displayPriority = 10
     }

--- a/src/Swarm/Game/Display.hs
+++ b/src/Swarm/Game/Display.hs
@@ -38,16 +38,16 @@ module Swarm.Game.Display (
 
 import Brick (AttrName, Widget, str, withAttr)
 import Control.Lens hiding (Const, from, (.=))
-import Data.Hashable
+import Data.Hashable (Hashable)
 import Data.Map (Map)
 import Data.Map qualified as M
 
 import Data.Yaml
 import GHC.Generics (Generic)
 
-import Swarm.Language.Syntax
-import Swarm.TUI.Attr
-import Swarm.Util
+import Swarm.Language.Syntax (Direction (..))
+import Swarm.TUI.Attr (entityAttr, robotAttr)
+import Swarm.Util (maxOn, (?))
 
 -- | Display priority.  Entities with higher priority will be drawn on
 --   top of entities with lower priority.

--- a/src/Swarm/Game/Display.hs
+++ b/src/Swarm/Game/Display.hs
@@ -26,7 +26,8 @@ module Swarm.Game.Display (
 
   -- ** Rendering
   displayChar,
-  displayWidget,
+  renderDisplay,
+  hidden,
 
   -- ** Construction
   defaultTerrainDisplay,
@@ -64,6 +65,9 @@ data Display = Display
   , _displayPriority :: Priority
   }
   deriving (Eq, Ord, Show, Generic, Hashable)
+
+instance Semigroup Display where
+  (<>) = maxOn _displayPriority
 
 makeLensesWith (lensRules & generateSignatures .~ False) ''Display
 
@@ -112,8 +116,13 @@ displayChar disp = case disp ^. curOrientation of
   Just dir -> M.lookup dir (disp ^. orientationMap) ? (disp ^. defaultChar)
 
 -- | Render a display as a UI widget.
-displayWidget :: Display -> Widget n
-displayWidget disp = withAttr (disp ^. displayAttr) $ str [displayChar disp]
+renderDisplay :: Display -> Widget n
+renderDisplay disp = withAttr (disp ^. displayAttr) $ str [displayChar disp]
+
+-- | Modify a display to use a @?@ character for entities that are
+--   hidden/unknown.
+hidden :: Display -> Display
+hidden = (defaultChar .~ '?') . (curOrientation .~ Nothing)
 
 -- | The default way to display some terrain using the given character
 --   and attribute, with priority 0.

--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -448,7 +448,7 @@ entityInventory = hashedLens _entityInventory (\e x -> e {_entityInventory = x})
 
 -- | Display an entity as a single character.
 displayEntity :: Entity -> Widget n
-displayEntity e = displayWidget (e ^. entityDisplay)
+displayEntity e = renderDisplay (e ^. entityDisplay)
 
 ------------------------------------------------------------
 -- Inventory

--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -110,7 +110,6 @@ import Swarm.Util.Yaml
 
 import Swarm.Game.Display
 import Swarm.Language.Capability
-import Swarm.Language.Syntax (toDirection)
 import Swarm.Util (plural, reflow, (?))
 
 import Paths_swarm
@@ -449,7 +448,7 @@ entityInventory = hashedLens _entityInventory (\e x -> e {_entityInventory = x})
 
 -- | Display an entity as a single character.
 displayEntity :: Entity -> Widget n
-displayEntity e = displayWidget ((e ^. entityOrientation) >>= toDirection) (e ^. entityDisplay)
+displayEntity e = displayWidget (e ^. entityDisplay)
 
 ------------------------------------------------------------
 -- Inventory

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -34,6 +34,7 @@ module Swarm.Game.State (
   paused,
   robotMap,
   robotsByLocation,
+  robotsAtLocation,
   activeRobots,
   waitingRobots,
   availableRecipes,
@@ -100,7 +101,7 @@ import Data.IntSet.Lens (setOf)
 import Data.List (partition)
 import Data.Map (Map)
 import Data.Map qualified as M
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set qualified as S
 import Data.Text (Text)
 import Data.Text qualified as T (lines)
@@ -297,6 +298,15 @@ robotMap :: Lens' GameState (IntMap Robot)
 --   Fortunately, there are relatively few ways for these things to
 --   happen.
 robotsByLocation :: Lens' GameState (Map (V2 Int64) IntSet)
+
+-- | Get a list of all the robots at a particular location.
+robotsAtLocation :: V2 Int64 -> GameState -> [Robot]
+robotsAtLocation loc gs =
+  mapMaybe (`IM.lookup` (gs ^. robotMap))
+    . maybe [] IS.toList
+    . M.lookup loc
+    . view robotsByLocation
+    $ gs
 
 -- | The list of entities that have been discovered.
 allDiscoveredEntities :: Lens' GameState Inventory

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -28,7 +28,7 @@ import Data.IntSet qualified as IS
 import Data.List (find)
 import Data.List qualified as L
 import Data.Map qualified as M
-import Data.Maybe (fromMaybe, isNothing, listToMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, isNothing, listToMaybe)
 import Data.Sequence qualified as Seq
 import Data.Set (Set)
 import Data.Set qualified as S
@@ -1314,11 +1314,8 @@ execConst c vs s k = do
     Salvage -> case vs of
       [] -> do
         loc <- use robotLocation
-        rm <- use robotMap
-        robotSet <- use (robotsByLocation . at loc)
-        let robotIDList = maybe [] IS.toList robotSet
-            mtarget = find okToSalvage . mapMaybe (`IM.lookup` rm) $ robotIDList
-            okToSalvage r = (r ^. robotID /= 0) && (not . isActive $ r)
+        let okToSalvage r = (r ^. robotID /= 0) && (not . isActive $ r)
+        mtarget <- gets (find okToSalvage . robotsAtLocation loc)
         case mtarget of
           Nothing -> return $ Out VUnit s k -- Nothing to salvage
           Just target -> do

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -19,8 +19,10 @@ import Control.Monad (forM, forM_, guard, msum, unless, when)
 import Data.Array (bounds, (!))
 import Data.Bifunctor (second)
 import Data.Bool (bool)
+import Data.Containers.ListUtils (nubOrd)
 import Data.Either (partitionEithers, rights)
 import Data.Foldable (traverse_)
+import Data.Functor (void)
 import Data.Functor.Const qualified as F
 import Data.Int (Int64)
 import Data.IntMap qualified as IM
@@ -66,8 +68,6 @@ import Control.Carrier.Throw.Either (ThrowC, runThrow)
 import Control.Effect.Error
 import Control.Effect.Lens
 import Control.Effect.Lift
-import Data.Containers.ListUtils (nubOrd)
-import Data.Functor (void)
 
 -- | The maximum number of CESK machine evaluation steps each robot is
 --   allowed during a single game tick.
@@ -94,23 +94,6 @@ gameTick = do
           then deleteRobot rn
           else do
             robotMap %= IM.insert rn curRobot'
-            let oldLoc = curRobot ^. robotLocation
-                newLoc = curRobot' ^. robotLocation
-
-                -- Make sure empty sets don't hang around in the
-                -- robotsByLocation map.  We don't want a key with an
-                -- empty set at every location any robot has ever
-                -- visited!
-                deleteOne _ Nothing = Nothing
-                deleteOne x (Just s)
-                  | IS.null s' = Nothing
-                  | otherwise = Just s'
-                 where
-                  s' = IS.delete x s
-
-            when (newLoc /= oldLoc) $ do
-              robotsByLocation . at oldLoc %= deleteOne rn
-              robotsByLocation . at newLoc . non Empty %= IS.insert rn
             time <- use ticks
             case waitingUntil curRobot' of
               Just wakeUpTime
@@ -730,18 +713,17 @@ execConst c vs s k = do
             (e `hasProperty` Liquid && CFloat `S.notMember` caps)
             destroyIfNotBase
 
-      robotLocation .= nextLoc
+      updateRobotLocation loc nextLoc
       flagRedraw
       return $ Out VUnit s k
     Teleport -> case vs of
       [VRobot rid, VPair (VInt x) (VInt y)] -> do
-        myID <- use robotID
         -- Make sure the other robot exists and is close
         target <- getRobotWithinTouch rid
         -- either change current robot or one in robot map
-        let (.==) l a = if myID == rid then l .= a else robotMap . ix rid . l .= a
-        let nextLoc = V2 (fromIntegral x) (fromIntegral y)
-        let caps = target ^. robotCapabilities
+        let oldLoc = target ^. robotLocation
+            nextLoc = V2 (fromIntegral x) (fromIntegral y)
+            caps = target ^. robotCapabilities
 
         me <- entityAt nextLoc
         -- Make sure nothing is in the way.
@@ -752,9 +734,9 @@ execConst c vs s k = do
             let drowning = e `hasProperty` Liquid && CFloat `S.notMember` caps
             when (unwalkable || drowning) $ do
               d <- isDestroyable target
-              when d $ selfDestruct .== True
+              when d $ onTarget rid (selfDestruct .= True)
 
-        robotLocation .== nextLoc
+        onTarget rid $ updateRobotLocation oldLoc nextLoc
         flagRedraw
         return $ Out VUnit s k
       _ -> badConst
@@ -1664,6 +1646,10 @@ execConst c vs s k = do
     -- Return the name of the item obtained.
     return $ Out (VString (e' ^. entityName)) s k
 
+------------------------------------------------------------
+-- Some utility functions
+------------------------------------------------------------
+
 -- | Give some entities from a parent robot (the robot represented by
 --   the ambient @State Robot@ effect) to a child robot (represented
 --   by the given 'RID') as part of a 'Build' or 'Reprogram' command.
@@ -1689,6 +1675,57 @@ provisionChild childID toInstall toGive = do
   creative <- use creativeMode
   unless creative $
     robotInventory %= (`E.difference` (toInstall `E.union` toGive))
+
+-- | Update the location of a robot, and simultaneously update the
+--   'robotsByLocation' map, so we can always look up robots by
+--   location.  This should be the /only/ way to update the location
+--   of a robot.
+updateRobotLocation ::
+  (Has (State GameState) sig m, Has (State Robot) sig m) =>
+  V2 Int64 ->
+  V2 Int64 ->
+  m ()
+updateRobotLocation oldLoc newLoc
+  | oldLoc == newLoc = return ()
+  | otherwise = do
+    rid <- use robotID
+    robotsByLocation . at oldLoc %= deleteOne rid
+    robotsByLocation . at newLoc . non Empty %= IS.insert rid
+    modify (unsafeSetRobotLocation newLoc)
+ where
+  -- Make sure empty sets don't hang around in the
+  -- robotsByLocation map.  We don't want a key with an
+  -- empty set at every location any robot has ever
+  -- visited!
+  deleteOne _ Nothing = Nothing
+  deleteOne x (Just s)
+    | IS.null s' = Nothing
+    | otherwise = Just s'
+   where
+    s' = IS.delete x s
+
+-- | Execute a stateful action on a target robot --- whether the
+--   current one or another.
+onTarget ::
+  (Has (State GameState) sig m, Has (State Robot) sig m) =>
+  RID ->
+  (forall sig' m'. (Has (State GameState) sig' m', Has (State Robot) sig' m') => m' ()) ->
+  m ()
+onTarget rid act = do
+  myID <- use robotID
+  case myID == rid of
+    True -> act
+    False -> do
+      mtgt <- use (robotMap . at rid)
+      case mtgt of
+        Nothing -> return ()
+        Just tgt -> do
+          tgt' <- execState @Robot tgt act
+          robotMap . ix rid .= tgt'
+
+------------------------------------------------------------
+-- Comparison
+------------------------------------------------------------
 
 -- | Evaluate the application of a comparison operator.  Returns
 --   @Nothing@ if the application does not make sense.
@@ -1748,6 +1785,10 @@ incomparable v1 v2 =
     CmdFailed Lt $
       T.unwords ["Comparison is undefined for ", prettyValue v1, "and", prettyValue v2]
 
+------------------------------------------------------------
+-- Arithmetic
+------------------------------------------------------------
+
 -- | Evaluate the application of an arithmetic operator, returning
 --   an exception in the case of a failing operation, or in case we
 --   incorrectly use it on a bad 'Const' in the library.
@@ -1773,6 +1814,10 @@ safeExp :: Has (Throw Exn) sig m => Integer -> Integer -> m Integer
 safeExp a b
   | b < 0 = throwError $ CmdFailed Exp "Negative exponent"
   | otherwise = return $ a ^ b
+
+------------------------------------------------------------
+-- Updating discovered entities, recipes, and commands
+------------------------------------------------------------
 
 -- | Update the global list of discovered entities, and check for new recipes.
 updateDiscoveredEntities :: (Has (State GameState) sig m, Has (State Robot) sig m) => Entity -> m ()

--- a/src/Swarm/Game/Terrain.hs
+++ b/src/Swarm/Game/Terrain.hs
@@ -9,13 +9,11 @@
 module Swarm.Game.Terrain (
   -- * Terrain
   TerrainType (..),
-  displayTerrain,
   terrainMap,
 ) where
 
-import Brick (Widget)
 import Data.Aeson (FromJSON (..), withText)
-import Data.Map (Map, (!))
+import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Text.Read (readMaybe)
@@ -39,10 +37,6 @@ instance FromJSON TerrainType where
     case readMaybe (into @String (T.toTitle t) ++ "T") of
       Just ter -> return ter
       Nothing -> fail $ "Unknown terrain type: " ++ into @String t
-
--- | Display a terrain type as a single charcter widget.
-displayTerrain :: TerrainType -> Widget n
-displayTerrain t = displayWidget (terrainMap ! t)
 
 -- | A map containing a 'Display' record for each different 'TerrainType'.
 terrainMap :: Map TerrainType Display

--- a/src/Swarm/Game/Terrain.hs
+++ b/src/Swarm/Game/Terrain.hs
@@ -42,7 +42,7 @@ instance FromJSON TerrainType where
 
 -- | Display a terrain type as a single charcter widget.
 displayTerrain :: TerrainType -> Widget n
-displayTerrain t = displayWidget Nothing (terrainMap ! t)
+displayTerrain t = displayWidget (terrainMap ! t)
 
 -- | A map containing a 'Display' record for each different 'TerrainType'.
 terrainMap :: Map TerrainType Display

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -23,7 +23,6 @@ module Swarm.TUI.View (
 
   -- * World
   drawWorld,
-  drawCell,
 
   -- * Robot panel
   drawRobotPanel,
@@ -38,16 +37,16 @@ module Swarm.TUI.View (
   drawREPL,
 ) where
 
-import Control.Arrow ((&&&))
 import Control.Lens hiding (Const, from)
 import Data.Array (range)
 import Data.Foldable qualified as F
 import Data.IntMap qualified as IM
 import Data.List qualified as L
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NE
 import Data.List.Split (chunksOf)
 import Data.Map qualified as M
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.String (fromString)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -66,6 +65,7 @@ import Brick.Widgets.Dialog
 import Brick.Widgets.List qualified as BL
 import Brick.Widgets.Table qualified as BT
 
+import Data.Semigroup (sconcat)
 import Swarm.Game.CESK (CESK (..))
 import Swarm.Game.Display
 import Swarm.Game.Entity as E
@@ -73,7 +73,7 @@ import Swarm.Game.Recipe
 import Swarm.Game.Robot
 import Swarm.Game.Scenario (ScenarioItem (..), scenarioDescription, scenarioItemName, scenarioName)
 import Swarm.Game.State
-import Swarm.Game.Terrain (displayTerrain)
+import Swarm.Game.Terrain (terrainMap)
 import Swarm.Game.World qualified as W
 import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Syntax
@@ -239,9 +239,7 @@ drawGameUI s =
 
 drawWorldCursorInfo :: GameState -> W.Coords -> Widget Name
 drawWorldCursorInfo g i@(W.Coords (y, x)) =
-  hBox [entity, txt $ " at " <> from (show x) <> " " <> from (show (y * (-1)))]
- where
-  entity = snd $ drawCell (hiding g) (g ^. world) i
+  hBox [drawLoc g i, txt $ " at " <> from (show x) <> " " <> from (show (y * (-1)))]
 
 -- | Render the type of the current REPL input to be shown to the user.
 drawType :: Polytype -> Widget Name
@@ -401,7 +399,7 @@ robotsListWidget s = viewport RobotsViewport Vertical (hCenter table)
     locWidget = hBox [worldCell, txt $ " " <> locStr]
      where
       rloc@(V2 x y) = robot ^. robotLocation
-      worldCell = snd $ drawCell (hiding g) (g ^. world) (W.locToCoords rloc)
+      worldCell = drawLoc g (W.locToCoords rloc)
       locStr = from (show x) <> " " <> from (show y)
 
     statusWidget = case robot ^. machine of
@@ -601,53 +599,37 @@ drawWorld g =
       let w = ctx ^. availWidthL
           h = ctx ^. availHeightL
           ixs = range (viewingRegion g (fromIntegral w, fromIntegral h))
-      render . vBox . map hBox . chunksOf w . map drawLoc $ ixs
+      render . vBox . map hBox . chunksOf w . map (drawLoc g) $ ixs
+
+-- | Render the 'Display' for a specific location.
+drawLoc :: GameState -> W.Coords -> Widget Name
+drawLoc g = renderDisplay . displayLoc g
+
+-- | Get the 'Display' for a specific location, by combining the
+--   'Display's for the terrain, entity, and robots at the location.
+displayLoc :: GameState -> W.Coords -> Display
+displayLoc g coords =
+  sconcat . NE.fromList $
+    [terrainMap M.! toEnum (W.lookupTerrain coords (g ^. world))]
+      ++ maybeToList (displayForEntity <$> W.lookupEntity coords (g ^. world))
+      ++ map (view robotDisplay) (robotsAtLocation (W.coordsToLoc coords) g)
  where
-  -- XXX update how this works!  Gather all displays, all
-  -- entities...  Should make a Display remember which is the
-  -- currently selected char (based on orientation); Entity lens for
-  -- setting orientation updates the Display too.  Then we can just
-  -- get all the Displays for each cell, make a monoid based on
-  -- priority.
+  displayForEntity :: Entity -> Display
+  displayForEntity e = (if known e then id else hidden) (e ^. entityDisplay)
 
-  robotsByLoc =
-    M.fromListWith (maxOn (^. robotDisplay . displayPriority)) . map (view robotLocation &&& id)
-      . IM.elems
-      $ g ^. robotMap
-
-  drawLoc :: W.Coords -> Widget Name
-  drawLoc coords =
-    let (ePrio, eWidget) = drawCell (hiding g) (g ^. world) coords
-     in case M.lookup (W.coordsToLoc coords) robotsByLoc of
-          Just r
-            | ePrio > (r ^. robotDisplay . displayPriority) -> eWidget
-            | otherwise -> displayWidget (r ^. robotDisplay)
-          Nothing -> eWidget
-
-data HideEntity = HideAllEntities | HideNoEntity | HideEntityUnknownTo Robot
-
-hiding :: GameState -> HideEntity
-hiding g
-  | g ^. creativeMode = HideNoEntity
-  | otherwise = maybe HideAllEntities HideEntityUnknownTo $ focusedRobot g
-
--- | Draw a single cell of the world, either hiding entities that current robot does not know,
---   or hiding all/none depending on Left value (True/False).
-drawCell :: HideEntity -> W.World Int Entity -> W.Coords -> (Int, Widget Name)
-drawCell edr w i = case W.lookupEntity i w of
-  Nothing -> (0, displayTerrain (toEnum (W.lookupTerrain i w)))
-  Just e ->
-    ( e ^. entityDisplay . displayPriority
-    , displayEntity (hide e)
-    )
- where
   known e =
     e `hasProperty` Known
-      || case edr of
+      || case hidingMode g of
         HideAllEntities -> False
         HideNoEntity -> True
         HideEntityUnknownTo ro -> ro `robotKnows` e
-  hide e = (if known e then id else entityDisplay . defaultChar %~ const '?') e
+
+data HideEntity = HideAllEntities | HideNoEntity | HideEntityUnknownTo Robot
+
+hidingMode :: GameState -> HideEntity
+hidingMode g
+  | g ^. creativeMode = HideNoEntity
+  | otherwise = maybe HideAllEntities HideEntityUnknownTo $ focusedRobot g
 
 ------------------------------------------------------------
 -- Robot inventory panel

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -621,9 +621,7 @@ drawWorld g =
      in case M.lookup (W.coordsToLoc coords) robotsByLoc of
           Just r
             | ePrio > (r ^. robotDisplay . displayPriority) -> eWidget
-            | otherwise ->
-              withAttr (r ^. robotDisplay . displayAttr) $
-                str [lookupDisplay ((r ^. robotOrientation) >>= toDirection) (r ^. robotDisplay)]
+            | otherwise -> displayWidget (r ^. robotDisplay)
           Nothing -> eWidget
 
 data HideEntity = HideAllEntities | HideNoEntity | HideEntityUnknownTo Robot

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -180,6 +180,7 @@ testScenarioSolution _ci _em =
             , testSolution Default "Testing/201-require/533-reprogram-simple"
             , testSolution Default "Testing/201-require/533-reprogram"
             ]
+        , testSolution Default "Testing/555-teleport-location"
         ]
     ]
  where


### PR DESCRIPTION
- Add invisibility (closes #421).  Every `Display` has an `invisible` flag, so entities can be invisible too.
- Refactor the world drawing code to simply collect and compose all the `Display`s for everything at each location.  The world drawing code is much simpler now.
- Along the way, I also found and fixed #555 : `teleport`, when applied to another robot, did not properly update the `robotsByLocation` map.  I've refactored things so it should be much harder to make this error in the future.