### PR TITLE
atomic race test: decrease from 100 to 25 weeds

### DIFF
--- a/data/scenarios/Testing/479-atomic-race.yaml
+++ b/data/scenarios/Testing/479-atomic-race.yaml
@@ -50,7 +50,7 @@ robots:
       - logger
       - grabber
     inventory:
-      - [100, weed]
+      - [25, weed]
     program: |
       def forever = \c. force c ; forever c end
       def tryplant =

--- a/data/scenarios/Testing/479-atomic.yaml
+++ b/data/scenarios/Testing/479-atomic.yaml
@@ -37,7 +37,7 @@ robots:
       - logger
       - grabber
     inventory:
-      - [100, weed]
+      - [25, weed]
     program: |
       def forever = \c. force c ; forever c end
       def tryplant =


### PR DESCRIPTION
This should decrease the time needed for `479-atomic.yaml` to succeed.  There was a spurious failure due, I think, to this test taking a bit too long.  This should allow it to comfortably succeed.