### PR TITLE
Improve say, add listen command and F5 messages

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -388,7 +388,7 @@
 
 - name: rubber
   display:
-    attr: stone
+    attr: rubber
     char: '%'
   description:
   - A flexible, durable material made from LaTeX.

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -816,6 +816,22 @@
   properties: [portable]
   capabilities: [log]
 
+- name: hearing aid
+  display:
+    attr: device
+    char: '@'
+  description:
+  - "Allows robot to hear what nearby robots are saying."
+  - "Simply having this device installed will automatically
+     add messages said by nearby robots to this robots log,
+     assuming it has a logger installed."
+  - "That way you can view any heard message later either in
+     the logger or the message window."
+  - "To wait for a message and get the string value, use:"
+  - "`l <- listen; log $ \"I have waited for someone to say \" ++ l`"
+  properties: [portable]
+  capabilities: [log]
+
 - name: counter
   display:
     attr: device

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -830,7 +830,7 @@
   - "To wait for a message and get the string value, use:"
   - "`l <- listen; log $ \"I have waited for someone to say \" ++ l`"
   properties: [portable]
-  capabilities: [log]
+  capabilities: [listen]
 
 - name: counter
   display:

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -821,9 +821,9 @@
     attr: device
     char: '@'
   description:
-  - "Allows robot to hear what nearby robots are saying."
+  - "Allows a robot to hear what nearby robots are saying."
   - "Simply having this device installed will automatically
-     add messages said by nearby robots to this robots log,
+     add messages said by nearby robots to this robot's log,
      assuming it has a logger installed."
   - "That way you can view any heard message later either in
      the logger or the message window."

--- a/data/recipes.yaml
+++ b/data/recipes.yaml
@@ -478,6 +478,15 @@
   out:
   - [1, strange loop]
 
+- in:
+  - [2, copper pipe]
+  - [4, copper wire]
+  - [1, paper]
+  - [1, lodestone]
+  out:
+  - [2, hearing aid]
+
+
 #########################################
 ##           QUARTZ + SILICON          ##
 #########################################

--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -24,23 +24,21 @@ objectives:
         exercises that introduce you to the way robots work and the programming
         language you will use to control them.
       - When you're ready for your first challenge, close this dialog with Esc or Ctrl-G,
-        and type `place "Ready!"` (without the backticks) at the prompt.
+        and type `say "Ready!"` (without the backticks) at the prompt.
     condition: |
       try {
-        as base {
-          b <- has "Ready!";
-          return (not b)
-        }
+        l <- robotNamed "listener";
+        as l {has "Ready!"}
       } { return false }
 solution: |
-  place "Ready!"
+  say "Ready!"
 entities:
   - name: Ready!
     display:
       attr: device
       char: 'R'
     description:
-      - Type `place "Ready!"` (without the backticks) at the prompt
+      - Type `say "Ready!"` (without the backticks) at the prompt
         once you are ready for the first tutorial challenge!
       - To open the full goal text again, you can hit Ctrl-G.
     properties: [known, portable]
@@ -54,6 +52,24 @@ robots:
     loc: [0,0]
     inventory:
       - [1, Ready!]
+  - name: listener
+    system: true
+    display:
+      invisible: true
+    loc: [0,0]
+    dir: [0,0]
+    inventory:
+      - [0, "Ready!"]
+    devices:
+      - logger
+    program: |
+      def forever = \c. force c; forever c end;
+      forever {
+        try {
+          m <- listen;
+          if (m == "Ready!") {create "Ready!"; log "Ready!"} {log $ "Wrong message: " ++ m};
+        } {log "Something bad happened!"}
+      }
 seed: 0
 world:
   offset: true

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -64,6 +64,7 @@
                "salvage"
                "reprogram"
                "say"
+               "listen"
                "log"
                "view"
                "appear"

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "swarm-language" extension will be documented in this file.
 
+## WIP
+- [Highlighter] added `listen` command
+
 ## version 0.0.5
 - [Highlighter] added the `atomic`, `installed` and `time` constants
 - [Highlighter] added `require` syntax (checking what follows it is left to typechecker)

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -60,7 +60,7 @@
 				},
 				{
 				"name": "keyword.other",
-				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|install|make|has|installed|count|drill|build|salvage|reprogram|say|log|view|appear|create|time|whereami|blocked|scan|upload|ishere|whoami|setname|random|run|return|try|atomic|teleport|as|robotnamed|robotnumbered|knows)\\b"
+				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|install|make|has|installed|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|time|whereami|blocked|scan|upload|ishere|whoami|setname|random|run|return|try|atomic|teleport|as|robotnamed|robotnumbered|knows)\\b"
 				}
 			]
 			},

--- a/src/Swarm/Game/Display.hs
+++ b/src/Swarm/Game/Display.hs
@@ -46,7 +46,7 @@ import Data.Yaml
 import GHC.Generics (Generic)
 
 import Swarm.Language.Syntax (Direction (..))
-import Swarm.TUI.Attr (entityAttr, robotAttr)
+import Swarm.TUI.Attr (entityAttr, robotAttr, worldPrefix)
 import Swarm.Util (maxOn, (?))
 
 -- | Display priority.  Entities with higher priority will be drawn on
@@ -105,7 +105,7 @@ instance FromJSON Display where
       <$> v .:? "char" .!= ' '
       <*> v .:? "orientationMap" .!= M.empty
       <*> v .:? "curOrientation"
-      <*> v .:? "attr" .!= entityAttr
+      <*> (fmap (worldPrefix <>) <$> v .:? "attr") .!= entityAttr
       <*> v .:? "priority" .!= 1
       <*> v .:? "invisible" .!= False
 

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -21,6 +21,7 @@ module Swarm.Game.Robot (
   -- * Robot log entries
   LogEntry (..),
   leText,
+  leSaid,
   leRobotName,
   leTime,
   leLocation,
@@ -75,6 +76,9 @@ module Swarm.Game.Robot (
   isActive,
   waitingUntil,
   getResult,
+
+  -- ** Constants
+  hearingDistance,
 ) where
 
 import Control.Lens hiding (contains)
@@ -127,6 +131,8 @@ data LogEntry = LogEntry
   { -- | The time at which the entry was created.
     --   Note that this is the first field we sort on.
     _leTime :: Integer
+  , -- | Whether this log records a said message.
+    _leSaid :: Bool
   , -- | The name of the robot that generated the entry.
     _leRobotName :: Text
   , -- | The ID of the robot that generated the entry.
@@ -512,3 +518,6 @@ waitingUntil robot =
 getResult :: Robot -> Maybe (Value, Store)
 {-# INLINE getResult #-}
 getResult = finalValue . view machine
+
+hearingDistance :: Num i => i
+hearingDistance = 32

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -23,6 +23,8 @@ module Swarm.Game.Robot (
   leText,
   leRobotName,
   leTime,
+  leLocation,
+  leRobotID,
 
   -- * Robots
   RobotPhase (..),
@@ -122,14 +124,19 @@ makeLenses ''RobotContext
 
 -- | An entry in a robot's log.
 data LogEntry = LogEntry
-  { -- | The text of the log entry.
-    _leText :: Text
+  { -- | The time at which the entry was created.
+    --   Note that this is the first field we sort on.
+    _leTime :: Integer
   , -- | The name of the robot that generated the entry.
     _leRobotName :: Text
-  , -- | The time at which the entry was created.
-    _leTime :: Integer
+  , -- | The ID of the robot that generated the entry.
+    _leRobotID :: Int
+  , -- | Location of the robot at log entry creation.
+    _leLocation :: V2 Int64
+  , -- | The text of the log entry.
+    _leText :: Text
   }
-  deriving (Show, Generic, FromJSON, ToJSON)
+  deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
 makeLenses ''LogEntry
 

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -19,6 +19,7 @@ module Swarm.Game.Robot (
   -- * Robots data
 
   -- * Robot log entries
+  LogSource (..),
   LogEntry (..),
   leText,
   leSaid,
@@ -126,13 +127,16 @@ data RobotContext = RobotContext
 
 makeLenses ''RobotContext
 
+data LogSource = Said | Logged | ErrorTrace
+  deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
+
 -- | An entry in a robot's log.
 data LogEntry = LogEntry
   { -- | The time at which the entry was created.
     --   Note that this is the first field we sort on.
     _leTime :: Integer
   , -- | Whether this log records a said message.
-    _leSaid :: Bool
+    _leSaid :: LogSource
   , -- | The name of the robot that generated the entry.
     _leRobotName :: Text
   , -- | The ID of the robot that generated the entry.

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -488,16 +488,16 @@ messageNotifications = to getNotif
     -- classic players only get to see messages that they said and a one message that they just heard
     -- other they have to get from log
     latestMsg = messageIsRecent gs
-    closeMsg = messageIsFromNearby gs
+    closeMsg = messageIsFromNearby (gs ^. viewCenter)
     focusedOrLatestClose mq =
       (Seq.take 1 . Seq.reverse . Seq.filter closeMsg $ Seq.takeWhileR latestMsg mq)
         <> Seq.filter ((== gs ^. focusedRobotID) . view leRobotID) mq
 
 messageIsRecent :: GameState -> LogEntry -> Bool
-messageIsRecent gs e = e ^. leTime == (gs ^. ticks)
+messageIsRecent gs e = e ^. leTime >= gs ^. ticks - 1
 
-messageIsFromNearby :: GameState -> LogEntry -> Bool
-messageIsFromNearby gs e = maybe False (\r -> manhattan (r ^. robotLocation) (e ^. leLocation) <= hearingDistance) (focusedRobot gs)
+messageIsFromNearby :: V2 Int64 -> LogEntry -> Bool
+messageIsFromNearby l e = manhattan l (e ^. leLocation) <= hearingDistance
 
 -- | Given a current mapping from robot names to robots, apply a
 --   'ViewCenterRule' to derive the location it refers to.  The result

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -36,10 +36,12 @@ module Swarm.Game.State (
   robotMap,
   robotsByLocation,
   robotsAtLocation,
+  robotsInArea,
   activeRobots,
   waitingRobots,
   availableRecipes,
   availableCommands,
+  messageNotifications,
   allDiscoveredEntities,
   gensym,
   randGen,
@@ -73,6 +75,7 @@ module Swarm.Game.State (
   classicGame0,
 
   -- * Utilities
+  manhattan,
   applyViewCenterRule,
   recalcViewCenter,
   modifyViewCenter,
@@ -88,7 +91,8 @@ module Swarm.Game.State (
   deleteRobot,
   activateRobot,
   toggleRunStatus,
-  messageNotifications,
+  messageIsRecent,
+  messageIsFromNearby,
 ) where
 
 import Control.Algebra (Has)
@@ -144,10 +148,14 @@ import Swarm.Language.Pipeline (ProcessedTerm)
 import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Syntax (Const, Term (TString), allConst)
 import Swarm.Language.Types
-import Swarm.Util (isRightOr, (<+=), (<<.=), (?))
+import Swarm.Util (isRightOr, uniq, (<+=), (<<.=), (?))
 import System.Clock qualified as Clock
 import System.Random (StdGen, mkStdGen, randomRIO)
 import Witch (into)
+
+-- $setup
+-- >>> import qualified Data.Map as M
+-- >>> import Linear.V2
 
 ------------------------------------------------------------
 -- Subsidiary data types
@@ -338,6 +346,51 @@ robotsAtLocation loc gs =
     . view robotsByLocation
     $ gs
 
+-- | Manhattan distance between world locations.
+manhattan :: V2 Int64 -> V2 Int64 -> Int64
+manhattan (V2 x1 y1) (V2 x2 y2) = abs (x1 - x2) + abs (y1 - y2)
+
+-- | Get elements that are in manhattan distance from location.
+--
+-- >>> v2s i = [(v, manhattan (V2 0 0) v) | x <- [-i..i], y <- [-i..i], let v = V2 x y]
+-- >>> v2s 0
+-- [(V2 0 0,0)]
+-- >>> map (\i -> length (getElemsInArea (V2 0 0) i (M.fromList $ v2s i))) [0..8]
+-- [1,5,13,25,41,61,85,113,145]
+--
+-- The last test is the sequence "Centered square numbers":
+-- https://oeis.org/A001844
+getElemsInArea :: V2 Int64 -> Int64 -> Map (V2 Int64) e -> [e]
+getElemsInArea o@(V2 x y) d m = M.elems sm'
+ where
+  -- to be more efficient we basically split on first coordinate
+  -- (which is logarithmic) and then we have to linearly filter
+  -- the second coordinate to get a square - this is how it looks:
+  --         ▲▲▲▲
+  --         ││││    the arrows mark points that are greater then A
+  --         ││s│                                 and lesser then B
+  --         │sssB (2,1)
+  --         ssoss   <-- o=(x=0,y=0) with d=2
+  -- (-2,-1) Asss│
+  --          │s││   the point o and all s are in manhattan
+  --          ││││                  distance 2 from point o
+  --          ▼▼▼▼
+  sm =
+    m
+      & M.split (V2 (x - d) (y - 1)) -- A
+      & snd -- A<
+      & M.split (V2 (x + d) (y + 1)) -- B
+      & fst -- B>
+  sm' = M.filterWithKey (const . (<= d) . manhattan o) sm
+
+-- | Get robots in manhattan distastance from location.
+robotsInArea :: V2 Int64 -> Int64 -> GameState -> [Robot]
+robotsInArea o d gs = map (rm IM.!) rids
+ where
+  rm = gs ^. robotMap
+  rl = gs ^. robotsByLocation
+  rids = concatMap IS.elems $ getElemsInArea o d rl
+
 -- | The list of entities that have been discovered.
 allDiscoveredEntities :: Lens' GameState Inventory
 
@@ -462,17 +515,31 @@ replWorking = to (\s -> matchesWorking $ s ^. replStatus)
   matchesWorking (REPLWorking _ _) = True
 
 -- | Get the notification list of messages from the point of view of focused robot.
-messageNotifications :: Getter GameState (Notifications (LogEntry, Bool))
+messageNotifications :: Getter GameState (Notifications LogEntry)
 messageNotifications = to getNotif
  where
-  getNotif gs = Notifications {_notificationsCount = newCount, _notificationsContent = toList allMessages}
+  getNotif gs = Notifications {_notificationsCount = length new, _notificationsContent = allUniq}
    where
+    allUniq = uniq $ toList allMessages
+    new = takeWhile (\l -> l ^. leTime > gs ^. lastSeenMessageTime) $ reverse allUniq
+    -- creative players and system robots just see all messages (and focused robots logs)
+    unchecked = gs ^. creativeMode || fromMaybe False (focusedRobot gs ^? _Just . systemRobot)
+    messages = (if unchecked then id else focusedOrLatestClose) (gs ^. messageQueue)
     allMessages = Seq.sort $ focusedLogs <> messages
-    focusedLogs = (,True) <$> maybe Empty (view robotLog) (focusedRobot gs)
-    messages = (,False) <$> (if gs ^. creativeMode then id else Seq.filter noOther) (gs ^. messageQueue)
-    noOther e = gs ^. focusedRobotID == e ^. leRobotID
-    newCount = max 0 $ Seq.length allMessages - fromMaybe 0 oldestSeen
-    oldestSeen = succ <$> Seq.findIndexR (\(l, _) -> l ^. leTime <= gs ^. lastSeenMessageTime) allMessages
+    focusedLogs = maybe Empty (view robotLog) (focusedRobot gs)
+    -- classic players only get to see messages that they said and a one message that they just heard
+    -- other they have to get from log
+    latestMsg = messageIsRecent gs
+    closeMsg = messageIsFromNearby gs
+    focusedOrLatestClose mq =
+      (Seq.take 1 . Seq.reverse . Seq.filter closeMsg $ Seq.takeWhileR latestMsg mq)
+        <> Seq.filter ((== gs ^. focusedRobotID) . view leRobotID) mq
+
+messageIsRecent :: GameState -> LogEntry -> Bool
+messageIsRecent gs e = e ^. leTime == (gs ^. ticks)
+
+messageIsFromNearby :: GameState -> LogEntry -> Bool
+messageIsFromNearby gs e = maybe False (\r -> manhattan (r ^. robotLocation) (e ^. leLocation) <= hearingDistance) (focusedRobot gs)
 
 -- | Given a current mapping from robot names to robots, apply a
 --   'ViewCenterRule' to derive the location it refers to.  The result

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -147,7 +147,7 @@ import Swarm.Language.Pipeline (ProcessedTerm)
 import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Syntax (Const, Term (TString), allConst)
 import Swarm.Language.Types
-import Swarm.Util (isRightOr, uniq, (<+=), (<<.=), (?), getElemsInArea, manhattan)
+import Swarm.Util (getElemsInArea, isRightOr, manhattan, uniq, (<+=), (<<.=), (?))
 import System.Clock qualified as Clock
 import System.Random (StdGen, mkStdGen, randomRIO)
 import Witch (into)

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -75,7 +75,6 @@ module Swarm.Game.State (
   classicGame0,
 
   -- * Utilities
-  manhattan,
   applyViewCenterRule,
   recalcViewCenter,
   modifyViewCenter,
@@ -148,14 +147,10 @@ import Swarm.Language.Pipeline (ProcessedTerm)
 import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Syntax (Const, Term (TString), allConst)
 import Swarm.Language.Types
-import Swarm.Util (isRightOr, uniq, (<+=), (<<.=), (?))
+import Swarm.Util (isRightOr, uniq, (<+=), (<<.=), (?), getElemsInArea, manhattan)
 import System.Clock qualified as Clock
 import System.Random (StdGen, mkStdGen, randomRIO)
 import Witch (into)
-
--- $setup
--- >>> import qualified Data.Map as M
--- >>> import Linear.V2
 
 ------------------------------------------------------------
 -- Subsidiary data types
@@ -345,43 +340,6 @@ robotsAtLocation loc gs =
     . M.lookup loc
     . view robotsByLocation
     $ gs
-
--- | Manhattan distance between world locations.
-manhattan :: V2 Int64 -> V2 Int64 -> Int64
-manhattan (V2 x1 y1) (V2 x2 y2) = abs (x1 - x2) + abs (y1 - y2)
-
--- | Get elements that are in manhattan distance from location.
---
--- >>> v2s i = [(v, manhattan (V2 0 0) v) | x <- [-i..i], y <- [-i..i], let v = V2 x y]
--- >>> v2s 0
--- [(V2 0 0,0)]
--- >>> map (\i -> length (getElemsInArea (V2 0 0) i (M.fromList $ v2s i))) [0..8]
--- [1,5,13,25,41,61,85,113,145]
---
--- The last test is the sequence "Centered square numbers":
--- https://oeis.org/A001844
-getElemsInArea :: V2 Int64 -> Int64 -> Map (V2 Int64) e -> [e]
-getElemsInArea o@(V2 x y) d m = M.elems sm'
- where
-  -- to be more efficient we basically split on first coordinate
-  -- (which is logarithmic) and then we have to linearly filter
-  -- the second coordinate to get a square - this is how it looks:
-  --         ▲▲▲▲
-  --         ││││    the arrows mark points that are greater then A
-  --         ││s│                                 and lesser then B
-  --         │sssB (2,1)
-  --         ssoss   <-- o=(x=0,y=0) with d=2
-  -- (-2,-1) Asss│
-  --          │s││   the point o and all s are in manhattan
-  --          ││││                  distance 2 from point o
-  --          ▼▼▼▼
-  sm =
-    m
-      & M.split (V2 (x - d) (y - 1)) -- A
-      & snd -- A<
-      & M.split (V2 (x + d) (y + 1)) -- B
-      & fst -- B>
-  sm' = M.filterWithKey (const . (<= d) . manhattan o) sm
 
 -- | Get robots in manhattan distastance from location.
 robotsInArea :: V2 Int64 -> Int64 -> GameState -> [Robot]

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -138,7 +138,7 @@ gameTick = do
               hid = view robotID h
               hn = view robotName h
               farAway = V2 maxBound maxBound
-          let m = LogEntry time hn hid farAway $ formatExn em exn
+          let m = LogEntry time False hn hid farAway $ formatExn em exn
           emitMessage m
         Right (VBool True) -> winCondition .= maybe (Won False) WinConditions (NE.nonEmpty objs)
         _ -> return ()
@@ -219,10 +219,6 @@ robotWithID rid = use (robotMap . at rid)
 robotWithName :: (Has (State GameState) sig m) => Text -> m (Maybe Robot)
 robotWithName rname = use (robotMap . to IM.elems . to (find $ \r -> r ^. robotName == rname))
 
--- | Manhattan distance between world locations.
-manhattan :: V2 Int64 -> V2 Int64 -> Int64
-manhattan (V2 x1 y1) (V2 x2 y2) = abs (x1 - x2) + abs (y1 - y2)
-
 -- | Generate a uniformly random number using the random generator in
 --   the game state.
 uniform :: (Has (State GameState) sig m, UniformRange a) => (a, a) -> m a
@@ -263,26 +259,28 @@ randomName = do
 -- Debugging
 ------------------------------------------------------------
 
--- | Create a log entry given current robot and game time in ticks.
-createLog :: (Has (State GameState) sig m, Has (State Robot) sig m) => Text -> m LogEntry
-createLog msg = do
+-- | Create a log entry given current robot and game time in ticks noting whether it has been said.
+--
+--   This is the more generic version used both for (recorded) said messages and normal logs.
+createLogEntry :: (Has (State GameState) sig m, Has (State Robot) sig m) => Bool -> Text -> m LogEntry
+createLogEntry isSaid msg = do
   rid <- use robotID
   rn <- use robotName
   time <- use ticks
   loc <- use robotLocation
-  pure $ LogEntry time rn rid loc msg
+  pure $ LogEntry time isSaid rn rid loc msg
 
 -- | Print some text via the robot's log.
-traceLog :: (Has (State GameState) sig m, Has (State Robot) sig m) => Text -> m ()
-traceLog msg = do
-  m <- createLog msg
+traceLog :: (Has (State GameState) sig m, Has (State Robot) sig m) => Bool -> Text -> m ()
+traceLog isSaid msg = do
+  m <- createLogEntry isSaid msg
   robotLog %= (Seq.|> m)
 
 -- | Print a showable value via the robot's log.
 --
 -- Useful for debugging.
 traceLogShow :: (Has (State GameState) sig m, Has (State Robot) sig m, Show a) => a -> m ()
-traceLogShow = traceLog . from . show
+traceLogShow = traceLog False . from . show
 
 ------------------------------------------------------------
 -- Exceptions and validation
@@ -1091,13 +1089,49 @@ execConst c vs s k = do
       _ -> badConst
     Say -> case vs of
       [VString msg] -> do
-        m <- createLog msg
+        creative <- use creativeMode
+        loc <- use robotLocation
+        m <- createLogEntry True msg
         emitMessage m
+        let addLatestClosest rl = \case
+              Seq.Empty -> Seq.Empty
+              es Seq.:|> e
+                | e ^. leTime < m ^. leTime -> es |> e |> m
+                | manhattan rl (e ^. leLocation) > manhattan rl (m ^. leLocation) -> es |> m
+                | otherwise -> es |> e
+        let addToRobotLog :: Has (State GameState) sgn m => Robot -> m ()
+            addToRobotLog r = do
+              r' <- execState r $ do
+                hasLog <- hasCapability CLog
+                hasListen <- hasCapability CListen
+                loc' <- use robotLocation
+                when (hasLog && hasListen) (robotLog %= addLatestClosest loc')
+              addRobot r'
+        robotsAround <-
+          if creative
+            then use $ robotMap . to IM.elems
+            else gets $ robotsInArea loc hearingDistance
+        mapM_ addToRobotLog robotsAround
         return $ Out VUnit s k
       _ -> badConst
+    Listen -> do
+      t <- use ticks
+      loc <- use robotLocation
+      creative <- use creativeMode
+      mq <- use messageQueue
+      let recentAndClose e = creative || e ^. leTime == t && manhattan loc (e ^. leLocation) <= hearingDistance
+          limitLast = \case
+            _s Seq.:|> l | l ^. leTime == t - 1 -> Just $ l ^. leText
+            _ -> Nothing
+          mm = limitLast $ Seq.takeWhileR recentAndClose mq
+      return $
+        maybe
+          (In (TConst Listen) mempty s (FExec : k)) -- continue listening
+          (\m -> Out (VString m) s k) -- return found message
+          mm
     Log -> case vs of
       [VString msg] -> do
-        traceLog msg
+        traceLog False msg
         return $ Out VUnit s k
       _ -> badConst
     View -> case vs of

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1116,14 +1116,14 @@ execConst c vs s k = do
         return $ Out VUnit s k
       _ -> badConst
     Listen -> do
-      t <- use ticks
+      gs <- get @GameState
       loc <- use robotLocation
       creative <- use creativeMode
       system <- use systemRobot
       mq <- use messageQueue
-      let recentAndClose e = system || creative || e ^. leTime == t && manhattan loc (e ^. leLocation) <= hearingDistance
+      let recentAndClose e = system || creative || messageIsRecent gs e && messageIsFromNearby loc e
           limitLast = \case
-            _s Seq.:|> l | l ^. leTime == t - 1 -> Just $ l ^. leText
+            _s Seq.:|> l -> Just $ l ^. leText
             _ -> Nothing
           mm = limitLast $ Seq.takeWhileR recentAndClose mq
       return $

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1090,6 +1090,7 @@ execConst c vs s k = do
     Say -> case vs of
       [VString msg] -> do
         creative <- use creativeMode
+        system <- use systemRobot
         loc <- use robotLocation
         m <- createLogEntry True msg
         emitMessage m
@@ -1108,7 +1109,7 @@ execConst c vs s k = do
                 when (hasLog && hasListen) (robotLog %= addLatestClosest loc')
               addRobot r'
         robotsAround <-
-          if creative
+          if creative || system
             then use $ robotMap . to IM.elems
             else gets $ robotsInArea loc hearingDistance
         mapM_ addToRobotLog robotsAround
@@ -1118,8 +1119,9 @@ execConst c vs s k = do
       t <- use ticks
       loc <- use robotLocation
       creative <- use creativeMode
+      system <- use systemRobot
       mq <- use messageQueue
-      let recentAndClose e = creative || e ^. leTime == t && manhattan loc (e ^. leLocation) <= hearingDistance
+      let recentAndClose e = system || creative || e ^. leTime == t && manhattan loc (e ^. leLocation) <= hearingDistance
           limitLast = \case
             _s Seq.:|> l | l ^. leTime == t - 1 -> Just $ l ^. leText
             _ -> Nothing

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -79,6 +79,8 @@ data Capability
     CAppear
   | -- | Execute the 'Create' command
     CCreate
+  | -- | Execute the 'Listen' command and passively log messages if also has 'CLog'
+    CListen
   | -- | Execute the 'Log' command
     CLog
   | -- | Don't drown in liquid
@@ -156,6 +158,7 @@ constCaps = \case
   Run -> Nothing
   -- ----------------------------------------------------------------
   -- Some straightforward ones.
+  Listen -> Just CListen
   Log -> Just CLog
   Selfdestruct -> Just CSelfdestruct
   Move -> Just CMove

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -241,6 +241,8 @@ data Const
     Reprogram
   | -- | Emit a message.
     Say
+  | -- | Listen for a message from other robots.
+    Listen
   | -- | Emit a log message.
     Log
   | -- | View a certain robot.
@@ -555,9 +557,20 @@ constInfo c = case c of
     command 0 long . doc "Deconstruct an old robot." $
       ["Salvaging a robot will give you its inventory, installed devices and log."]
   Say ->
-    command 1 short . doc "Emit a message." $ -- TODO: #513
-      [ "The message will be in a global log, which you can not currently view."
-      , "https://github.com/swarm-game/swarm/issues/513"
+    command 1 short . doc "Emit a message." $
+      [ "The message will be in the robots log (if it has one) and the global log."
+      , "You can view the message that would be picked by `listen` from the global log "
+          <> "in the messages panel, along with your own messages and logs."
+      , "This means that to see messages from other robots you have to be able to listen for them, "
+          <> "so once you have a listening device installed messages will be added to your log."
+      , "In creative mode, there is of course no such limitation."
+      ]
+  Listen ->
+    command 1 long . doc "Listen for a message from other robots." $
+      [ "It will take the first message said by the closest robot."
+      , "You do not need to actively listen for the message to be logged though, "
+          <> "that is done automatically once you have a listening device installed."
+      , "Note that you can see the messages either in your logger device or the message panel."
       ]
   Log -> command 1 Intangible "Log the string in the robot's logger."
   View -> command 1 short "View the given robot."

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -480,6 +480,7 @@ inferConst c = case c of
   Drill -> [tyQ| dir -> cmd () |]
   Salvage -> [tyQ| cmd () |]
   Say -> [tyQ| string -> cmd () |]
+  Listen -> [tyQ| cmd string |]
   Log -> [tyQ| string -> cmd () |]
   View -> [tyQ| robot -> cmd () |]
   Appear -> [tyQ| string -> cmd () |]

--- a/src/Swarm/TUI/Attr.hs
+++ b/src/Swarm/TUI/Attr.hs
@@ -132,6 +132,31 @@ sepAttr = "sep"
 infoAttr = "info"
 defAttr = "def"
 
+worldAttributes :: [AttrName]
+worldAttributes =
+  [ dirtAttr
+  , grassAttr
+  , stoneAttr
+  , waterAttr
+  , iceAttr
+  , robotAttr
+  , plantAttr
+  , flowerAttr
+  , copperAttr
+  , copperAttr'
+  , ironAttr
+  , ironAttr'
+  , quartzAttr
+  , silverAttr
+  , goldAttr
+  , snowAttr
+  , sandAttr
+  , fireAttr
+  , blueAttr
+  , rockAttr
+  , woodAttr
+  ]
+
 instance ToJSON AttrName where
   toJSON = toJSON . head . attrNameComponents
 

--- a/src/Swarm/TUI/Attr.hs
+++ b/src/Swarm/TUI/Attr.hs
@@ -12,15 +12,48 @@
 --
 -- Rendering attributes (/i.e./ foreground and background colors,
 -- styles, /etc./) used by the Swarm TUI.
-module Swarm.TUI.Attr where
+--
+-- We export constants only for those we use in the Haskell code
+-- and not those used in the world map, to avoid abusing attributes.
+-- For example using the robot attribute to highlight some text.
+--
+-- The few attributes that we use for drawing the logo are an exeption.
+module Swarm.TUI.Attr (
+  swarmAttrMap,
+  worldAttributes,
+  worldPrefix,
+
+  -- ** Terrain attributes
+  dirtAttr,
+  grassAttr,
+  stoneAttr,
+  waterAttr,
+  iceAttr,
+
+  -- ** Common attributes
+  entityAttr,
+  robotAttr,
+  rockAttr,
+  plantAttr,
+
+  -- ** Swarm TUI Attributes
+  highlightAttr,
+  notifAttr,
+  infoAttr,
+  yellowAttr,
+  blueAttr,
+  greenAttr,
+  redAttr,
+  defAttr,
+) where
 
 import Brick
 import Brick.Forms
 import Brick.Widgets.Dialog
 import Brick.Widgets.List
-import Graphics.Vty qualified as V
-
+import Data.Bifunctor (bimap)
 import Data.Yaml
+import Graphics.Vty qualified as V
 import Witch (from)
 
 -- | A mapping from the defined attribute names to TUI attributes.
@@ -28,134 +61,103 @@ swarmAttrMap :: AttrMap
 swarmAttrMap =
   attrMap
     V.defAttr
-    -- World rendering attributes
-    [ (robotAttr, fg V.white `V.withStyle` V.bold)
-    , (entityAttr, fg V.white)
-    , (plantAttr, fg V.green)
-    , (rockAttr, fg (V.rgbColor @Int 80 80 80))
-    , (woodAttr, fg (V.rgbColor @Int 139 69 19))
-    , (flowerAttr, fg (V.rgbColor @Int 200 0 200))
-    , (copperAttr, fg V.yellow)
-    , (copperAttr', fg (V.rgbColor @Int 78 117 102))
-    , (ironAttr, fg (V.rgbColor @Int 97 102 106))
-    , (ironAttr', fg (V.rgbColor @Int 183 65 14))
-    , (quartzAttr, fg V.white)
-    , (silverAttr, fg (V.rgbColor @Int 192 192 192))
-    , (goldAttr, fg (V.rgbColor @Int 255 215 0))
-    , (snowAttr, fg V.white)
-    , (sandAttr, fg (V.rgbColor @Int 194 178 128))
-    , (fireAttr, fg V.red `V.withStyle` V.bold)
-    , (redAttr, fg V.red)
-    , (notifAttr, fg V.yellow `V.withStyle` V.bold)
-    , (greenAttr, fg V.green)
-    , (blueAttr, fg V.blue)
-    , (deviceAttr, fg V.yellow `V.withStyle` V.bold)
-    , -- Terrain attributes
-      (dirtAttr, fg (V.rgbColor @Int 165 42 42))
-    , (grassAttr, fg (V.rgbColor @Int 0 32 0)) -- dark green
-    , (stoneAttr, fg (V.rgbColor @Int 32 32 32))
-    , (waterAttr, V.white `on` V.blue)
-    , (iceAttr, bg V.white)
-    , -- UI rendering attributes
-      (highlightAttr, fg V.cyan)
-    , (invalidFormInputAttr, fg V.red)
-    , (focusedFormInputAttr, V.defAttr)
-    , (listSelectedFocusedAttr, bg V.blue)
-    , (infoAttr, fg (V.rgbColor @Int 50 50 50))
-    , (buttonSelectedAttr, bg V.blue)
-    , -- Default attribute
-      (defAttr, V.defAttr)
-    ]
+    $ worldAttributes
+      <> [(waterAttr, V.white `on` V.blue)]
+      <> terrainAttr
+      <> [ -- Robot attribute
+           (robotAttr, fg V.white `V.withStyle` V.bold)
+         , -- UI rendering attributes
+           (highlightAttr, fg V.cyan)
+         , (invalidFormInputAttr, fg V.red)
+         , (focusedFormInputAttr, V.defAttr)
+         , (listSelectedFocusedAttr, bg V.blue)
+         , (infoAttr, fg (V.rgbColor @Int 50 50 50))
+         , (buttonSelectedAttr, bg V.blue)
+         , (notifAttr, fg V.yellow `V.withStyle` V.bold)
+         , -- Basic colors
+           (redAttr, fg V.red)
+         , (greenAttr, fg V.green)
+         , (blueAttr, fg V.blue)
+         , (yellowAttr, fg V.yellow)
+         , -- Default attribute
+           (defAttr, V.defAttr)
+         ]
+
+entityAttr :: AttrName
+entityAttr = fst $ head worldAttributes
+
+worldPrefix :: AttrName
+worldPrefix = "world"
+
+-- | Colors of entities in the world.
+--
+-- Also used to color messages, so water is special and excluded.
+worldAttributes :: [(AttrName, V.Attr)]
+worldAttributes =
+  bimap (worldPrefix <>) fg
+    <$> [ ("entity", V.white)
+        , ("device", V.brightYellow)
+        , ("plant", V.green)
+        , ("rock", V.rgbColor @Int 80 80 80)
+        , ("wood", V.rgbColor @Int 139 69 19)
+        , ("flower", V.rgbColor @Int 200 0 200)
+        , ("rubber", V.rgbColor @Int 245 224 179)
+        , ("copper", V.yellow)
+        , ("copper'", V.rgbColor @Int 78 117 102)
+        , ("iron", V.rgbColor @Int 97 102 106)
+        , ("iron'", V.rgbColor @Int 183 65 14)
+        , ("quartz", V.white)
+        , ("silver", V.rgbColor @Int 192 192 192)
+        , ("gold", V.rgbColor @Int 255 215 0)
+        , ("snow", V.white)
+        , ("sand", V.rgbColor @Int 194 178 128)
+        , ("fire", V.brightRed)
+        , ("red", V.red)
+        , ("green", V.green)
+        , ("blue", V.blue)
+        ]
+
+terrainPrefix :: AttrName
+terrainPrefix = "terrain"
+
+terrainAttr :: [(AttrName, V.Attr)]
+terrainAttr =
+  [ (dirtAttr, fg (V.rgbColor @Int 165 42 42))
+  , (grassAttr, fg (V.rgbColor @Int 0 32 0)) -- dark green
+  , (stoneAttr, fg (V.rgbColor @Int 32 32 32))
+  , (iceAttr, bg V.white)
+  ]
+
+-- | The default robot attribute.
+robotAttr :: AttrName
+robotAttr = "robot"
+
+dirtAttr, grassAttr, stoneAttr, iceAttr, waterAttr, rockAttr, plantAttr :: AttrName
+dirtAttr = terrainPrefix <> "dirt"
+grassAttr = terrainPrefix <> "grass"
+stoneAttr = terrainPrefix <> "stone"
+iceAttr = terrainPrefix <> "ice"
+waterAttr = worldPrefix <> "water"
+rockAttr = worldPrefix <> "rock"
+plantAttr = worldPrefix <> "plant"
 
 -- | Some defined attribute names used in the Swarm TUI.
-robotAttr
-  , entityAttr
-  , plantAttr
-  , flowerAttr
-  , copperAttr
-  , copperAttr'
-  , ironAttr
-  , ironAttr'
-  , quartzAttr
-  , silverAttr
-  , goldAttr
-  , snowAttr
-  , sandAttr
-  , rockAttr
-  , baseAttr
-  , fireAttr
-  , redAttr
+highlightAttr
   , notifAttr
-  , greenAttr
-  , blueAttr
-  , woodAttr
-  , deviceAttr
-  , dirtAttr
-  , grassAttr
-  , stoneAttr
-  , waterAttr
-  , iceAttr
-  , highlightAttr
-  , sepAttr
   , infoAttr
   , defAttr ::
     AttrName
-dirtAttr = "dirt"
-grassAttr = "grass"
-stoneAttr = "stone"
-waterAttr = "water"
-iceAttr = "ice"
-robotAttr = "robot"
-entityAttr = "entity"
-plantAttr = "plant"
-flowerAttr = "flower"
-copperAttr = "copper"
-copperAttr' = "copper'"
-ironAttr = "iron"
-ironAttr' = "iron'"
-quartzAttr = "quartz"
-silverAttr = "silver"
-goldAttr = "gold"
-snowAttr = "snow"
-sandAttr = "sand"
-fireAttr = "fire"
-redAttr = "red"
 highlightAttr = "highlight"
-greenAttr = "green"
-blueAttr = "blue"
-rockAttr = "rock"
-woodAttr = "wood"
-baseAttr = "base"
-deviceAttr = "device"
 notifAttr = "notif"
-sepAttr = "sep"
 infoAttr = "info"
 defAttr = "def"
 
-worldAttributes :: [AttrName]
-worldAttributes =
-  [ dirtAttr
-  , grassAttr
-  , stoneAttr
-  , waterAttr
-  , iceAttr
-  , robotAttr
-  , plantAttr
-  , flowerAttr
-  , copperAttr
-  , copperAttr'
-  , ironAttr
-  , ironAttr'
-  , quartzAttr
-  , silverAttr
-  , goldAttr
-  , snowAttr
-  , sandAttr
-  , fireAttr
-  , blueAttr
-  , rockAttr
-  , woodAttr
-  ]
+-- | Some basic colors used in TUI.
+redAttr, greenAttr, blueAttr, yellowAttr :: AttrName
+redAttr = "red"
+greenAttr = "green"
+blueAttr = "blue"
+yellowAttr = "yellow"
 
 instance ToJSON AttrName where
   toJSON = toJSON . head . attrNameComponents

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -233,7 +233,12 @@ handleMainEvent ev = do
     VtyEvent (V.EvResize _ _) -> invalidateCacheEntry WorldCache
     Key V.KEsc
       | isJust (s ^. uiState . uiError) -> uiState . uiError .= Nothing
-      | isJust (s ^. uiState . uiModal) -> maybeUnpause >> uiState . uiModal .= Nothing
+      | Just m <- s ^. uiState . uiModal -> do
+        safeAutoUnpause
+        uiState . uiModal .= Nothing
+        -- message modal is not autopaused, so update notifications when leaving it
+        when (m ^. modalType == MessagesModal) $ do
+          gameState . lastSeenMessageTime .= s ^. gameState . ticks
     FKey 1 -> toggleModal HelpModal
     FKey 2 -> toggleModal RobotsModal
     FKey 3 | not (null (s ^. gameState . availableRecipes . notificationsContent)) -> do
@@ -242,20 +247,16 @@ handleMainEvent ev = do
     FKey 4 | not (null (s ^. gameState . availableCommands . notificationsContent)) -> do
       toggleModal CommandsModal
       gameState . availableCommands . notificationsCount .= 0
+    FKey 5 | not (null (s ^. gameState . messageNotifications . notificationsContent)) -> do
+      toggleModal MessagesModal
+      gameState . lastSeenMessageTime .= s ^. gameState . ticks
     ControlKey 'g' -> case s ^. uiState . uiGoal of
       Just g | g /= [] -> toggleModal (GoalModal g)
       _ -> continueWithoutRedraw
     VtyEvent vev
       | isJust (s ^. uiState . uiModal) -> handleModalEvent vev
     -- pausing and stepping
-    ControlKey 'p' -> do
-      curTime <- liftIO $ getTime Monotonic
-      gameState . runStatus %= (\status -> if status == Running then ManualPause else Running)
-      -- Also reset the last frame time to now. If we are pausing, it
-      -- doesn't matter; if we are unpausing, this is critical to
-      -- ensure the next frame doesn't think it has to catch up from
-      -- whenever the game was paused!
-      uiState . lastFrameTime .= curTime
+    ControlKey 'p' -> safeTogglePause
     ControlKey 'o' -> do
       gameState . runStatus .= ManualPause
       runGameTickUI
@@ -318,20 +319,26 @@ mouseLocToWorldCoords (Brick.Location mouseLoc) = do
 setFocus :: Name -> EventM Name AppState ()
 setFocus name = uiState . uiFocusRing %= focusSetCurrent name
 
--- | Set the game to Running if it was auto paused
-maybeUnpause :: EventM Name AppState ()
-maybeUnpause = do
-  run <- use $ gameState . runStatus
-  when (run == AutoPause) $ do
-    curTime <- liftIO $ getTime Monotonic
-    resetLastFrameTime curTime
-    gameState . runStatus .= Running
- where
-  -- When unpausing, it is critical to ensure the next frame doesn't
-  -- catch up from the time spent in pause.
-  -- TODO: manage unpause more safely to also cover
-  -- the world event handler for the KChar 'p'.
-  resetLastFrameTime curTime = uiState . lastFrameTime .= curTime
+-- | Set the game to Running if it was (auto) paused otherwise to paused.
+--
+-- Also resets the last frame time to now. If we are pausing, it
+-- doesn't matter; if we are unpausing, this is critical to
+-- ensure the next frame doesn't think it has to catch up from
+-- whenever the game was paused!
+safeTogglePause :: EventM Name AppState ()
+safeTogglePause = do
+  curTime <- liftIO $ getTime Monotonic
+  uiState . lastFrameTime .= curTime
+  gameState . runStatus %= toggleRunStatus
+
+-- | Only unpause the game if leaving autopaused modal.
+--
+-- Note that the game could have been paused before opening
+-- the modal, in that case, leave the game paused.
+safeAutoUnpause :: EventM Name AppState ()
+safeAutoUnpause = do
+  runs <- use $ gameState . runStatus
+  when (runs == AutoPause) safeTogglePause
 
 toggleModal :: ModalType -> EventM Name AppState ()
 toggleModal mt = do
@@ -341,10 +348,10 @@ toggleModal mt = do
       newModal <- gets $ flip generateModal mt
       ensurePause
       uiState . uiModal ?= newModal
-    Just _ -> uiState . uiModal .= Nothing >> maybeUnpause
+    Just _ -> uiState . uiModal .= Nothing >> safeAutoUnpause
  where
   -- these modals do not pause the game
-  runningModals = [RobotsModal]
+  runningModals = [RobotsModal, MessagesModal]
   -- Set the game to AutoPause if needed
   ensurePause = do
     pause <- use $ gameState . paused

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -362,31 +362,31 @@ isRunningModal mt = mt `elem` [RobotsModal, MessagesModal]
 
 handleModalEvent :: V.Event -> EventM Name AppState ()
 handleModalEvent ev = do
- mt <- preuse $ uiState . uiModal . _Just . modalType
- let isRunning = maybe False isRunningModal mt
- case ev of
-  V.EvKey V.KEnter [] -> do
-    mdialog <- preuse $ uiState . uiModal . _Just . modalDialog
-    toggleModal QuitModal
-    case dialogSelection <$> mdialog of
-      Just (Just QuitButton) -> quitGame
-      Just (Just (NextButton scene)) -> startGame scene
-      _ -> return ()
-  -- TODO: copy pasted here from 'handleMainEvent'
-  -- pausing and stepping
-  V.EvKey (V.KChar 'p') [V.MCtrl] | isRunning -> safeTogglePause
-  V.EvKey (V.KChar 'o') [V.MCtrl] | isRunning -> do
-    gameState . runStatus .= ManualPause
-    runGameTickUI
-  -- speed controls
-  V.EvKey (V.KChar 'x') [V.MCtrl] | isRunning -> modify $ adjustTPS (+)
-  V.EvKey (V.KChar 'z') [V.MCtrl] | isRunning -> modify $ adjustTPS (-)
-  _ev -> do
-    Brick.zoom (uiState . uiModal . _Just . modalDialog) (handleDialogEvent ev)
-    modal <- preuse $ uiState . uiModal . _Just . modalType
-    case modal of
-      Just _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
-      _ -> return ()
+  mt <- preuse $ uiState . uiModal . _Just . modalType
+  let isRunning = maybe False isRunningModal mt
+  case ev of
+    V.EvKey V.KEnter [] -> do
+      mdialog <- preuse $ uiState . uiModal . _Just . modalDialog
+      toggleModal QuitModal
+      case dialogSelection <$> mdialog of
+        Just (Just QuitButton) -> quitGame
+        Just (Just (NextButton scene)) -> startGame scene
+        _ -> return ()
+    -- TODO: copy pasted here from 'handleMainEvent'
+    -- pausing and stepping
+    V.EvKey (V.KChar 'p') [V.MCtrl] | isRunning -> safeTogglePause
+    V.EvKey (V.KChar 'o') [V.MCtrl] | isRunning -> do
+      gameState . runStatus .= ManualPause
+      runGameTickUI
+    -- speed controls
+    V.EvKey (V.KChar 'x') [V.MCtrl] | isRunning -> modify $ adjustTPS (+)
+    V.EvKey (V.KChar 'z') [V.MCtrl] | isRunning -> modify $ adjustTPS (-)
+    _ev -> do
+      Brick.zoom (uiState . uiModal . _Just . modalDialog) (handleDialogEvent ev)
+      modal <- preuse $ uiState . uiModal . _Just . modalType
+      case modal of
+        Just _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
+        _ -> return ()
 
 -- | Quit a game.  Currently all it does is write out the updated REPL
 --   history to a @.swarm_history@ file, and return to the previous menu.

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -406,7 +406,7 @@ data ModalType
   | GoalModal [Text]
   deriving (Eq, Show)
 
-data ButtonSelection = PauseButton | CancelButton | QuitButton | NextButton Scenario
+data ButtonSelection = CancelButton | QuitButton | NextButton Scenario
 
 data Modal = Modal
   { _modalType :: ModalType

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -398,6 +398,7 @@ data ModalType
   = HelpModal
   | RecipesModal
   | CommandsModal
+  | MessagesModal
   | RobotsModal
   | WinModal
   | QuitModal
@@ -405,7 +406,7 @@ data ModalType
   | GoalModal [Text]
   deriving (Eq, Show)
 
-data ButtonSelection = CancelButton | QuitButton | NextButton Scenario
+data ButtonSelection = PauseButton | CancelButton | QuitButton | NextButton Scenario
 
 data Modal = Modal
   { _modalType :: ModalType

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -58,6 +58,7 @@ import Data.List.Split (chunksOf)
 import Data.Map qualified as M
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe, maybeToList)
 import Data.Semigroup (sconcat)
+import Data.Sequence qualified as Seq
 import Data.String (fromString)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -556,10 +557,10 @@ messagesWidget gs = widgetList
  where
   widgetList = focusNewest . map drawLogEntry' $ gs ^. messageNotifications . notificationsContent
   focusNewest = if gs ^. paused then id else over _last visible
-  drawLogEntry' (e, isLog) =
-    withAttr (if isLog then notifAttr else robotColor (e ^. leRobotID)) $
+  drawLogEntry' e =
+    withAttr (if not $ e ^. leSaid then notifAttr else robotColor (e ^. leRobotID)) $
       hBox
-        [ txt $ "[" <> view leRobotName e <> "] "
+        [ txt $ view leRobotName e <> (if e ^. leRobotID /= gs ^. focusedRobotID then " said" else "")
         , txtWrapWith indent2 (e ^. leText)
         ]
   -- color each robot message with different color of the world
@@ -931,7 +932,13 @@ drawRobotLog s =
     , vBox . imap drawEntry $ logEntries
     ]
  where
-  logEntries = s ^. gameState . to focusedRobot . _Just . robotLog . to F.toList
+  logEntries =
+    s
+      & view (gameState . to focusedRobot . _Just . robotLog)
+      & Seq.sort
+      & F.toList
+      & uniq
+
   rn = s ^? gameState . to focusedRobot . _Just . robotName
   n = length logEntries
 
@@ -943,9 +950,9 @@ drawRobotLog s =
 
 -- | Draw one log entry with an optional robot name first.
 drawLogEntry :: Bool -> LogEntry -> Widget a
-drawLogEntry addName e = txtWrapWith indent2 . (if addName then (name <>) else id) $ e ^. leText
+drawLogEntry addName e = txtWrapWith indent2 . (if addName then name else id) $ e ^. leText
  where
-  name = "[" <> view leRobotName e <> "] "
+  name t = view leRobotName e <> (if e ^. leSaid then " said " <> quote t else " " <> t)
 
 ------------------------------------------------------------
 -- REPL panel

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -92,12 +92,12 @@ drawUI :: AppState -> [Widget Name]
 drawUI s
   | s ^. uiState . uiPlaying = drawGameUI s
   | otherwise = case s ^. uiState . uiMenu of
-      -- We should never reach the NoMenu case if uiPlaying is false; we would have
-      -- quit the app instead.  But just in case, we display the main menu anyway.
-      NoMenu -> [drawMainMenuUI (s ^. uiState . appData . at "logo") (mainMenu NewGame)]
-      MainMenu l -> [drawMainMenuUI (s ^. uiState . appData . at "logo") l]
-      NewGameMenu stk -> [drawNewGameMenuUI stk]
-      AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
+    -- We should never reach the NoMenu case if uiPlaying is false; we would have
+    -- quit the app instead.  But just in case, we display the main menu anyway.
+    NoMenu -> [drawMainMenuUI (s ^. uiState . appData . at "logo") (mainMenu NewGame)]
+    MainMenu l -> [drawMainMenuUI (s ^. uiState . appData . at "logo") l]
+    NewGameMenu stk -> [drawNewGameMenuUI stk]
+    AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
 
 drawMainMenuUI :: Maybe Text -> BL.List Name MainMenuEntry -> Widget Name
 drawMainMenuUI logo l =
@@ -275,12 +275,12 @@ drawTPS s = hBox (tpsInfo : rateInfo)
 
   rateInfo
     | s ^. uiState . uiShowFPS =
-        [ txt " ("
-        , str (printf "%0.1f" (s ^. uiState . uiTPF))
-        , txt " tpf, "
-        , str (printf "%0.1f" (s ^. uiState . uiFPS))
-        , txt " fps)"
-        ]
+      [ txt " ("
+      , str (printf "%0.1f" (s ^. uiState . uiTPF))
+      , txt " tpf, "
+      , str (printf "%0.1f" (s ^. uiState . uiFPS))
+      , txt " fps)"
+      ]
     | otherwise = []
 
   l = s ^. uiState . lgTicksPerSecond
@@ -373,9 +373,9 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
             , Just
                 ( 0
                 , [(nextMsg, NextButton scene) | Just scene <- [s ^. uiState . uiNextScenario]]
-                    ++ [ (stopMsg, QuitButton)
-                       , (continueMsg, CancelButton)
-                       ]
+                  ++ [ (stopMsg, QuitButton)
+                     , (continueMsg, CancelButton)
+                     ]
                 )
             , sum (map length [nextMsg, stopMsg, continueMsg]) + 32
             )
@@ -523,8 +523,8 @@ mkAvailableList gs notifLens notifRender = map padRender news <> notifSep <> map
   (news, knowns) = splitAt count (gs ^. notifLens . notificationsContent)
   notifSep
     | count > 0 && not (null knowns) =
-        [ padBottom (Pad 1) (withAttr redAttr $ hBorderWithLabel (padLeftRight 1 (txt "new↑")))
-        ]
+      [ padBottom (Pad 1) (withAttr redAttr $ hBorderWithLabel (padLeftRight 1 (txt "new↑")))
+      ]
     | otherwise = []
 
 constHeader :: Widget Name
@@ -562,9 +562,9 @@ messagesWidget gs = widgetList
         [ txt $ "[" <> view leRobotName e <> "] "
         , txtWrapWith indent2 (e ^. leText)
         ]
-  -- color each robot message with different color of the world (except those with background)
+  -- color each robot message with different color of the world
   robotColor rid = fgCols !! (rid `mod` fgColLen)
-  fgCols = filter (`notElem` [waterAttr, iceAttr]) worldAttributes
+  fgCols = map fst worldAttributes
   fgColLen = length fgCols
 
 -- | Draw a menu explaining what key commands are available for the
@@ -597,10 +597,10 @@ drawKeyMenu s =
   notificationKey notifLens key name
     | null (s ^. gameState . notifLens . notificationsContent) = Nothing
     | otherwise =
-        let highlight
-              | s ^. gameState . notifLens . notificationsCount > 0 = Highlighted
-              | otherwise = NoHighlight
-         in Just (highlight, key, name)
+      let highlight
+            | s ^. gameState . notifLens . notificationsCount > 0 = Highlighted
+            | otherwise = NoHighlight
+       in Just (highlight, key, name)
 
   gameModeWidget =
     padLeft Max . padLeftRight 1
@@ -811,13 +811,13 @@ explainRecipes :: AppState -> Entity -> Widget Name
 explainRecipes s e
   | null recipes = emptyWidget
   | otherwise =
-      vBox
-        [ padBottom (Pad 1) (hBorderWithLabel (txt "Recipes"))
-        , padLeftRight 2 $
-            hCenter $
-              vBox $
-                map (hLimit widthLimit . padBottom (Pad 1) . drawRecipe (Just e) inv) recipes
-        ]
+    vBox
+      [ padBottom (Pad 1) (hBorderWithLabel (txt "Recipes"))
+      , padLeftRight 2 $
+          hCenter $
+            vBox $
+              map (hLimit widthLimit . padBottom (Pad 1) . drawRecipe (Just e) inv) recipes
+      ]
  where
   recipes = recipesWith s e
 
@@ -860,11 +860,11 @@ drawRecipe me inv (Recipe ins outs reqs time _weight) =
   connector
     | null reqs = hLimit 5 hBorder
     | otherwise =
-        hBox
-          [ hLimit 2 hBorder
-          , joinableBorder (Edges True False True True)
-          , hLimit 2 hBorder
-          ]
+      hBox
+        [ hLimit 2 hBorder
+        , joinableBorder (Edges True False True True)
+        , hLimit 2 hBorder
+        ]
   inLen = length ins + length times
   outLen = length outs
   times = [(fromIntegral time, timeE) | time /= 1]
@@ -902,8 +902,8 @@ drawRecipe me inv (Recipe ins outs reqs time _weight) =
   -- If it's the focused entity, draw it highlighted.
   -- If the robot doesn't have any, draw it in red.
   fmtEntityName missing ingr
-    | Just ingr == me = withAttr deviceAttr $ txtLines nm
-    | ingr == timeE = withAttr sandAttr $ txtLines nm
+    | Just ingr == me = withAttr highlightAttr $ txtLines nm
+    | ingr == timeE = withAttr yellowAttr $ txtLines nm
     | missing = withAttr invalidFormInputAttr $ txtLines nm
     | otherwise = txtLines nm
    where

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -56,7 +56,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.List.Split (chunksOf)
 import Data.Map qualified as M
-import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe, maybeToList)
 import Data.Semigroup (sconcat)
 import Data.String (fromString)
 import Data.Text (Text)
@@ -92,12 +92,12 @@ drawUI :: AppState -> [Widget Name]
 drawUI s
   | s ^. uiState . uiPlaying = drawGameUI s
   | otherwise = case s ^. uiState . uiMenu of
-    -- We should never reach the NoMenu case if uiPlaying is false; we would have
-    -- quit the app instead.  But just in case, we display the main menu anyway.
-    NoMenu -> [drawMainMenuUI (s ^. uiState . appData . at "logo") (mainMenu NewGame)]
-    MainMenu l -> [drawMainMenuUI (s ^. uiState . appData . at "logo") l]
-    NewGameMenu stk -> [drawNewGameMenuUI stk]
-    AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
+      -- We should never reach the NoMenu case if uiPlaying is false; we would have
+      -- quit the app instead.  But just in case, we display the main menu anyway.
+      NoMenu -> [drawMainMenuUI (s ^. uiState . appData . at "logo") (mainMenu NewGame)]
+      MainMenu l -> [drawMainMenuUI (s ^. uiState . appData . at "logo") l]
+      NewGameMenu stk -> [drawNewGameMenuUI stk]
+      AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
 
 drawMainMenuUI :: Maybe Text -> BL.List Name MainMenuEntry -> Widget Name
 drawMainMenuUI logo l =
@@ -275,12 +275,12 @@ drawTPS s = hBox (tpsInfo : rateInfo)
 
   rateInfo
     | s ^. uiState . uiShowFPS =
-      [ txt " ("
-      , str (printf "%0.1f" (s ^. uiState . uiTPF))
-      , txt " tpf, "
-      , str (printf "%0.1f" (s ^. uiState . uiFPS))
-      , txt " fps)"
-      ]
+        [ txt " ("
+        , str (printf "%0.1f" (s ^. uiState . uiTPF))
+        , txt " tpf, "
+        , str (printf "%0.1f" (s ^. uiState . uiFPS))
+        , txt " fps)"
+        ]
     | otherwise = []
 
   l = s ^. uiState . lgTicksPerSecond
@@ -337,6 +337,7 @@ drawModal s = \case
   RobotsModal -> robotsListWidget s
   RecipesModal -> availableListWidget (s ^. gameState) RecipeList
   CommandsModal -> availableListWidget (s ^. gameState) CommandList
+  MessagesModal -> availableListWidget (s ^. gameState) MessageList
   WinModal -> padBottom (Pad 1) $ hCenter $ txt "Congratulations!"
   DescriptionModal e -> descriptionWidget s e
   QuitModal -> padBottom (Pad 1) $ hCenter $ txt (quitMsg (s ^. uiState . uiMenu))
@@ -363,6 +364,7 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
       RobotsModal -> ("Robots", Nothing, descriptionWidth)
       RecipesModal -> ("Available Recipes", Nothing, descriptionWidth)
       CommandsModal -> ("Available Commands", Nothing, descriptionWidth)
+      MessagesModal -> ("Messages", Just (0, [("Toggle pause", PauseButton)]), descriptionWidth)
       WinModal ->
         let nextMsg = "Next challenge!"
             stopMsg = fromMaybe "Return to the menu" haltingMessage
@@ -371,9 +373,9 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
             , Just
                 ( 0
                 , [(nextMsg, NextButton scene) | Just scene <- [s ^. uiState . uiNextScenario]]
-                  ++ [ (stopMsg, QuitButton)
-                     , (continueMsg, CancelButton)
-                     ]
+                    ++ [ (stopMsg, QuitButton)
+                       , (continueMsg, CancelButton)
+                       ]
                 )
             , sum (map length [nextMsg, stopMsg, continueMsg]) + 32
             )
@@ -477,6 +479,7 @@ helpWidget = (helpKeys <=> fill ' ') <+> (helpCommands <=> fill ' ')
     , ("F2", "Robots list")
     , ("F3", "Available recipes")
     , ("F4", "Available commands")
+    , ("F5", "Messages")
     , ("Ctrl-g", "show goal")
     , ("Ctrl-q", "quit the game")
     , ("Meta-w", "focus on the world map")
@@ -499,14 +502,15 @@ helpWidget = (helpKeys <=> fill ' ') <+> (helpCommands <=> fill ' ')
     , ("has \"<item>\"", "Check for an item in the inventory")
     ]
 
-data NotificationList = RecipeList | CommandList
+data NotificationList = RecipeList | CommandList | MessageList
 
 availableListWidget :: GameState -> NotificationList -> Widget Name
-availableListWidget gs nl = padTop (Pad 1) $ vBox $ addHeader widgetList
+availableListWidget gs nl = padTop (Pad 1) $ vBox widgetList
  where
-  (widgetList, addHeader) = case nl of
-    RecipeList -> (mkAvailableList gs availableRecipes renderRecipe, id)
-    CommandList -> (mkAvailableList gs availableCommands renderCommand, (<> constWiki) . (padLeftRight 18 constHeader :))
+  widgetList = case nl of
+    RecipeList -> mkAvailableList gs availableRecipes renderRecipe
+    CommandList -> mkAvailableList gs availableCommands renderCommand & (<> constWiki) . (padLeftRight 18 constHeader :)
+    MessageList -> messagesWidget gs
   renderRecipe = padLeftRight 18 . drawRecipe Nothing (fromMaybe E.empty inv)
   inv = gs ^? to focusedRobot . _Just . robotInventory
   renderCommand = padLeftRight 18 . drawConst
@@ -519,8 +523,8 @@ mkAvailableList gs notifLens notifRender = map padRender news <> notifSep <> map
   (news, knowns) = splitAt count (gs ^. notifLens . notificationsContent)
   notifSep
     | count > 0 && not (null knowns) =
-      [ padBottom (Pad 1) (withAttr redAttr $ hBorderWithLabel (padLeftRight 1 (txt "new↑")))
-      ]
+        [ padBottom (Pad 1) (withAttr redAttr $ hBorderWithLabel (padLeftRight 1 (txt "new↑")))
+        ]
     | otherwise = []
 
 constHeader :: Widget Name
@@ -545,6 +549,23 @@ descriptionTitle e = " " ++ from @Text (e ^. entityName) ++ " "
 -- | Generate a pop-up widget to display the description of an entity.
 descriptionWidget :: AppState -> Entity -> Widget Name
 descriptionWidget s e = padLeftRight 1 (explainEntry s e)
+
+-- | Draw a widget with messages to the current robot.
+messagesWidget :: GameState -> [Widget Name]
+messagesWidget gs = widgetList
+ where
+  widgetList = focusNewest . map drawLogEntry' $ gs ^. messageNotifications . notificationsContent
+  focusNewest = if gs ^. paused then id else over _last visible
+  drawLogEntry' (e, isLog) =
+    withAttr (if isLog then notifAttr else robotColor (e ^. leRobotID)) $
+      hBox
+        [ txt $ "[" <> view leRobotName e <> "] "
+        , txtWrapWith indent2 (e ^. leText)
+        ]
+  -- color each robot message with different color of the world (except those with background)
+  robotColor rid = fgCols !! (rid `mod` fgColLen)
+  fgCols = filter (`notElem` [waterAttr, iceAttr]) worldAttributes
+  fgColLen = length fgCols
 
 -- | Draw a menu explaining what key commands are available for the
 --   current panel.  This menu is displayed as a single line in
@@ -572,14 +593,14 @@ drawKeyMenu s =
     _ -> False
   showZero = s ^. uiState . uiShowZero
 
-  notificationKey :: Lens' GameState (Notifications a) -> Text -> Text -> [(KeyHighlight, Text, Text)]
+  notificationKey :: Getter GameState (Notifications a) -> Text -> Text -> Maybe (KeyHighlight, Text, Text)
   notificationKey notifLens key name
-    | null (s ^. gameState . notifLens . notificationsContent) = []
+    | null (s ^. gameState . notifLens . notificationsContent) = Nothing
     | otherwise =
-      let highlight
-            | s ^. gameState . notifLens . notificationsCount > 0 = Highlighted
-            | otherwise = NoHighlight
-       in [(highlight, key, name)]
+        let highlight
+              | s ^. gameState . notifLens . notificationsCount > 0 = Highlighted
+              | otherwise = NoHighlight
+         in Just (highlight, key, name)
 
   gameModeWidget =
     padLeft Max . padLeftRight 1
@@ -589,14 +610,19 @@ drawKeyMenu s =
         False -> "Classic"
         True -> "Creative"
   globalKeyCmds =
-    [(NoHighlight, "F1", "help"), (NoHighlight, "F2", "robots")]
-      <> notificationKey availableRecipes "F3" "Recipes"
-      <> notificationKey availableCommands "F4" "Commands"
-      <> [(NoHighlight, "^v", "creative") | cheat]
-      <> [(NoHighlight, "^g", "goal") | goal]
-      <> [(NoHighlight, "^p", if isPaused then "unpause" else "pause")]
-      <> [(NoHighlight, "^o", "step")]
-      <> [(NoHighlight, "^zx", "speed")]
+    catMaybes
+      [ Just (NoHighlight, "F1", "help")
+      , Just (NoHighlight, "F2", "robots")
+      , notificationKey availableRecipes "F3" "Recipes"
+      , notificationKey availableCommands "F4" "Commands"
+      , notificationKey messageNotifications "F5" "Messages"
+      , may goal (NoHighlight, "^g", "goal")
+      , may cheat (NoHighlight, "^v", "creative")
+      , Just (NoHighlight, "^p", if isPaused then "unpause" else "pause")
+      , Just (NoHighlight, "^o", "step")
+      , Just (NoHighlight, "^zx", "speed")
+      ]
+  may b = if b then Just else const Nothing
 
   keyCmdsFor (Just REPLPanel) =
     [ ("↓↑", "history")
@@ -785,13 +811,13 @@ explainRecipes :: AppState -> Entity -> Widget Name
 explainRecipes s e
   | null recipes = emptyWidget
   | otherwise =
-    vBox
-      [ padBottom (Pad 1) (hBorderWithLabel (txt "Recipes"))
-      , padLeftRight 2 $
-          hCenter $
-            vBox $
-              map (hLimit widthLimit . padBottom (Pad 1) . drawRecipe (Just e) inv) recipes
-      ]
+      vBox
+        [ padBottom (Pad 1) (hBorderWithLabel (txt "Recipes"))
+        , padLeftRight 2 $
+            hCenter $
+              vBox $
+                map (hLimit widthLimit . padBottom (Pad 1) . drawRecipe (Just e) inv) recipes
+        ]
  where
   recipes = recipesWith s e
 
@@ -834,11 +860,11 @@ drawRecipe me inv (Recipe ins outs reqs time _weight) =
   connector
     | null reqs = hLimit 5 hBorder
     | otherwise =
-      hBox
-        [ hLimit 2 hBorder
-        , joinableBorder (Edges True False True True)
-        , hLimit 2 hBorder
-        ]
+        hBox
+          [ hLimit 2 hBorder
+          , joinableBorder (Edges True False True True)
+          , hLimit 2 hBorder
+          ]
   inLen = length ins + length times
   outLen = length outs
   times = [(fromIntegral time, timeE) | time /= 1]
@@ -912,9 +938,14 @@ drawRobotLog s =
   allMe = all ((== rn) . Just . view leRobotName) logEntries
 
   drawEntry i e =
-    (if i == n - 1 && s ^. uiState . uiScrollToEnd then visible else id)
-      . txtWrapWith indent2
-      $ (if allMe then e ^. leText else T.concat ["[", e ^. leRobotName, "] ", e ^. leText])
+    (if i == n - 1 && s ^. uiState . uiScrollToEnd then visible else id) $
+      drawLogEntry (not allMe) e
+
+-- | Draw one log entry with an optional robot name first.
+drawLogEntry :: Bool -> LogEntry -> Widget a
+drawLogEntry addName e = txtWrapWith indent2 . (if addName then (name <>) else id) $ e ^. leText
+ where
+  name = "[" <> view leRobotName e <> "] "
 
 ------------------------------------------------------------
 -- REPL panel

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -51,6 +51,7 @@ import Data.Array (range)
 import Data.Bits (shiftL, shiftR, (.&.))
 import Data.Foldable qualified as F
 import Data.IntMap qualified as IM
+import Data.List (intersperse)
 import Data.List qualified as L
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
@@ -86,7 +87,6 @@ import System.Clock (TimeSpec (..))
 import Text.Printf
 import Text.Wrap
 import Witch (from)
-import Data.List (intersperse)
 
 -- | The main entry point for drawing the entire UI.  Figures out
 --   which menu screen we should show (if any), or just the game itself.
@@ -243,7 +243,8 @@ drawClockDisplay gs = hBox . intersperse (txt " ") $ catMaybes [clockWidget, pau
   pauseWidget = if gs ^. paused then Just $ txt "(PAUSED)" else Nothing
 
 drawTime :: Integer -> Bool -> GameState -> Maybe (Widget n)
-drawTime t showTicks gs = justClock . str . mconcat $
+drawTime t showTicks gs =
+  justClock . str . mconcat $
     [ printf "%x" (t `shiftR` 20)
     , ":"
     , printf "%02x" ((t `shiftR` 12) .&. ((1 `shiftL` 8) - 1))

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -17,6 +17,7 @@ module Swarm.Util (
   maxOn,
   maximum0,
   cycleEnum,
+  uniq,
 
   -- * Directory utilities
   readFileMay,
@@ -133,6 +134,21 @@ cycleEnum :: (Eq e, Enum e, Bounded e) => e -> e
 cycleEnum e
   | e == maxBound = minBound
   | otherwise = succ e
+
+-- | Drop repeated elements that are adjacent to each other.
+--
+-- >>> uniq []
+-- []
+-- >>> uniq [1..5]
+-- [1,2,3,4,5]
+-- >>> uniq (replicate 10 'a')
+-- "a"
+-- >>> uniq "abbbccd"
+-- "abcd"
+uniq :: Eq a => [a] -> [a]
+uniq = \case
+  [] -> []
+  (x : xs) -> x : uniq (dropWhile (== x) xs)
 
 ------------------------------------------------------------
 -- Directory stuff

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -70,6 +70,7 @@ import Control.Effect.Throw (Throw, throwError)
 import Control.Exception (catch)
 import Control.Exception.Base (IOException)
 import Control.Lens (ASetter', Lens', LensLike, LensLike', Over, lens, (<>~))
+import Control.Lens.Lens ((&))
 import Control.Monad (forM, unless, when)
 import Data.Aeson (FromJSONKey, ToJSONKey)
 import Data.Bifunctor (first)
@@ -106,7 +107,6 @@ import System.FilePath
 import System.IO
 import System.IO.Error (catchIOError)
 import Witch
-import Control.Lens.Lens ((&))
 
 -- $setup
 -- >>> import qualified Data.Map as M

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -30,6 +30,7 @@ import Swarm.Game.State (
   WinCondition (Won),
   activeRobots,
   initGameStateForScenario,
+  messageQueue,
   robotMap,
   ticks,
   waitingRobots,
@@ -238,9 +239,11 @@ noBadErrors g = do
 badErrorsInLogs :: GameState -> [Text]
 badErrorsInLogs g =
   concatMap
-    (\r -> filter isBad (view leText <$> toList (r ^. robotLog)))
+    (\r -> filter isBad (seqToTexts $ r ^. robotLog))
     (g ^. robotMap)
+    <> filter isBad (seqToTexts $ g ^. messageQueue)
  where
+  seqToTexts = map (view leText) . toList
   isBad m = "Fatal error:" `T.isInfixOf` m || "swarm/issues" `T.isInfixOf` m
 
 printAllLogs :: GameState -> IO ()

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -5,7 +5,7 @@
 -- | Swarm unit tests
 module Main where
 
-import Control.Lens (Getter, Ixed (ix), to, use, view, (&), (.~), (^.), (^?), (^?!), _1, _3)
+import Control.Lens (Getter, Ixed (ix), to, use, view, (&), (.~), (^.), (^?), (^?!), _3)
 import Control.Monad.Except
 import Control.Monad.State
 import Data.Aeson (eitherDecode, encode)
@@ -819,14 +819,14 @@ testNotification gs =
         assertNew gs' 2 "messages" messageNotifications
     , testCase "one new message and one old message" $ do
         gs' <- goodPlay "say \"Hello!\"; say \"Goodbye!\""
-        assertEqual "There should be two messages in queue" [0, 1] (view (_1 . leTime) <$> gs' ^. messageNotifications . notificationsContent)
+        assertEqual "There should be two messages in queue" [0, 1] (view leTime <$> gs' ^. messageNotifications . notificationsContent)
         assertNew (gs' & lastSeenMessageTime .~ 0) 1 "message" messageNotifications
     , testCase "new message after log" $ do
         gs' <- goodPlay "create \"logger\"; install self \"logger\"; log \"Hello world!\""
         let r = gs' ^?! robotMap . ix (-1)
         assertBool "There should be one log entry in robots log" (length (r ^. robotLog) == 1)
         assertEqual "The hypothetical robot should be in focus" (Just (r ^. robotID)) (view robotID <$> focusedRobot gs')
-        assertEqual "There should be one log notification" [2] (view (_1 . leTime) <$> gs' ^. messageNotifications . notificationsContent)
+        assertEqual "There should be one log notification" [2] (view leTime <$> gs' ^. messageNotifications . notificationsContent)
         assertNew gs' 1 "message" messageNotifications
     , testCase "new message after build say" $ do
         gs' <- goodPlay "build {say \"Hello world!\"}; turn back; turn back;"

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -5,7 +5,7 @@
 -- | Swarm unit tests
 module Main where
 
-import Control.Lens ((&), (.~), (^.))
+import Control.Lens (Getter, Ixed (ix), to, use, view, (&), (.~), (^.), (^?), (^?!), _1, _3)
 import Control.Monad.Except
 import Control.Monad.State
 import Data.Aeson (eitherDecode, encode)
@@ -19,22 +19,13 @@ import Data.String (fromString)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
-import Linear
-import Test.QuickCheck qualified as QC
-import Test.QuickCheck.Poly qualified as QC
-import Test.Tasty
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck
-import Witch (from)
-
 import Swarm.Game.CESK
 import Swarm.Game.Display
-import Swarm.Game.Entity (EntityMap)
 import Swarm.Game.Entity qualified as E
 import Swarm.Game.Exception
 import Swarm.Game.Robot
 import Swarm.Game.State
-import Swarm.Game.Step (stepCESK)
+import Swarm.Game.Step (gameTick, hypotheticalRobot, stepCESK)
 import Swarm.Game.Value
 import Swarm.Language.Context
 import Swarm.Language.Pipeline (ProcessedTerm (..), processTerm)
@@ -42,6 +33,12 @@ import Swarm.Language.Pretty
 import Swarm.Language.Syntax hiding (mkOp)
 import Swarm.TUI.Model
 import Swarm.Util
+import Test.QuickCheck qualified as QC
+import Test.QuickCheck.Poly qualified as QC
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+import Witch (from)
 
 main :: IO ()
 main = do
@@ -51,10 +48,20 @@ main = do
     Right g -> defaultMain (tests g)
 
 tests :: GameState -> TestTree
-tests g = testGroup "Tests" [parser, prettyConst, eval g, testModel, inventory, misc]
+tests g =
+  testGroup
+    "Tests"
+    [ testParser
+    , testPrettyConst
+    , testEval g
+    , testModel
+    , testInventory
+    , testNotification g
+    , testMisc
+    ]
 
-parser :: TestTree
-parser =
+testParser :: TestTree
+testParser =
   testGroup
     "Language - pipeline"
     [ testCase "end semicolon #79" (valid "def a = 41 end def b = a + 1 end def c = b + 2 end")
@@ -292,8 +299,8 @@ parser =
       | expect == "" -> pure ()
       | otherwise -> error "Unexpected success"
 
-prettyConst :: TestTree
-prettyConst =
+testPrettyConst :: TestTree
+testPrettyConst =
   testGroup
     "Language - pretty"
     [ testCase
@@ -371,8 +378,8 @@ binOp a op b = from @String (p (show a) ++ op ++ p (show b))
  where
   p x = "(" ++ x ++ ")"
 
-eval :: GameState -> TestTree
-eval g =
+testEval :: GameState -> TestTree
+testEval g =
   testGroup
     "Language - evaluation"
     [ testGroup
@@ -612,30 +619,8 @@ eval g =
         assertEqual "" val v
         assertBool ("Took more than " ++ show maxSteps ++ " steps!") (steps <= maxSteps)
 
-  processTerm1 :: Text -> Either Text ProcessedTerm
-  processTerm1 txt = processTerm txt >>= maybe wsErr Right
-   where
-    wsErr = Left "expecting a term, but got only whitespace"
-
   evaluate :: Text -> IO (Either Text (Value, Int))
-  evaluate = either (return . Left) evalPT . processTerm1
-
-  evalPT :: ProcessedTerm -> IO (Either Text (Value, Int))
-  evalPT t = evaluateCESK (initMachine t empty emptyStore)
-
-  evaluateCESK :: CESK -> IO (Either Text (Value, Int))
-  evaluateCESK cesk = flip evalStateT (g & creativeMode .~ True) . flip evalStateT r . runCESK 0 $ cesk
-   where
-    r = mkRobot (-1) Nothing "" [] zero zero defaultRobotDisplay cesk [] [] False False 0
-
-  entMap :: EntityMap
-  entMap = g ^. entityMap
-
-  runCESK :: Int -> CESK -> StateT Robot (StateT GameState IO) (Either Text (Value, Int))
-  runCESK _ (Up exn _ []) = return (Left (formatExn entMap exn))
-  runCESK !steps cesk = case finalValue cesk of
-    Just (v, _) -> return (Right (v, steps))
-    Nothing -> stepCESK cesk >>= runCESK (steps + 1)
+  evaluate = fmap (^. _3) . eval g
 
 testModel :: TestTree
 testModel =
@@ -715,8 +700,8 @@ testModel =
   addInOutInt :: Int -> REPLHistory -> REPLHistory
   addInOutInt i = addREPLItem (REPLOutput $ toT i <> ":int") . addREPLItem (REPLEntry $ toT i)
 
-inventory :: TestTree
-inventory =
+testInventory :: TestTree
+testInventory =
   testGroup
     "Inventory"
     [ testCase
@@ -815,8 +800,55 @@ inventory =
   y = E.mkEntity (defaultEntityDisplay 'Y') "fooY" [] [] []
   z = E.mkEntity (defaultEntityDisplay 'Z') "fooZ" [] [] []
 
-misc :: TestTree
-misc =
+testNotification :: GameState -> TestTree
+testNotification gs =
+  testGroup
+    "Notifications"
+    [ testCase "notifications at start" $ do
+        assertBool "There should be no messages in queue" (null (gs ^. messageQueue))
+        assertNew gs 0 "messages at game start" messageNotifications
+        assertNew gs 0 "recipes at game start" availableRecipes
+        assertNew gs 0 "commands at game start" availableCommands
+    , testCase "new message after say" $ do
+        gs' <- goodPlay "say \"Hello world!\""
+        assertBool "There should be one message in queue" (length (gs' ^. messageQueue) == 1)
+        assertNew gs' 1 "message" messageNotifications
+    , testCase "two new messages after say twice" $ do
+        gs' <- goodPlay "say \"Hello!\"; say \"Goodbye!\""
+        assertBool "There should be two messages in queue" (length (gs' ^. messageQueue) == 2)
+        assertNew gs' 2 "messages" messageNotifications
+    , testCase "one new message and one old message" $ do
+        gs' <- goodPlay "say \"Hello!\"; say \"Goodbye!\""
+        assertEqual "There should be two messages in queue" [0, 1] (view (_1 . leTime) <$> gs' ^. messageNotifications . notificationsContent)
+        assertNew (gs' & lastSeenMessageTime .~ 0) 1 "message" messageNotifications
+    , testCase "new message after log" $ do
+        gs' <- goodPlay "create \"logger\"; install self \"logger\"; log \"Hello world!\""
+        let r = gs' ^?! robotMap . ix (-1)
+        assertBool "There should be one log entry in robots log" (length (r ^. robotLog) == 1)
+        assertEqual "The hypothetical robot should be in focus" (Just (r ^. robotID)) (view robotID <$> focusedRobot gs')
+        assertEqual "There should be one log notification" [2] (view (_1 . leTime) <$> gs' ^. messageNotifications . notificationsContent)
+        assertNew gs' 1 "message" messageNotifications
+    , testCase "new message after build say" $ do
+        gs' <- goodPlay "build {say \"Hello world!\"}; turn back; turn back;"
+        assertBool "There should be one message in queue" (length (gs' ^. messageQueue) == 1)
+        assertNew gs' 1 "message" messageNotifications
+    , testCase "no new message after build log" $ do
+        gs' <- goodPlay "build {log \"Hello world!\"}; turn back; turn back;"
+        assertNew gs' 0 "message" messageNotifications
+    ]
+ where
+  goodPlay :: Text -> IO GameState
+  goodPlay t = do
+    (e, g) <- play gs t
+    either (assertFailure . T.unpack) pure e
+    return g
+  assertNew :: s -> Int -> String -> Getter s (Notifications a) -> Assertion
+  assertNew g n what l =
+    let c = g ^. l . notificationsCount
+     in assertEqual ("There should be exactly " <> show n <> " new " <> what) n c
+
+testMisc :: TestTree
+testMisc =
   testGroup
     "Miscellaneous"
     [ testProperty
@@ -849,3 +881,58 @@ data El = AA | BB | CC | DD | EE | FF
 
 instance QC.Arbitrary El where
   arbitrary = QC.arbitraryBoundedEnum
+
+-- ----------------------------------------------------------------------------
+-- Utility functions
+-- ----------------------------------------------------------------------------
+
+eval :: GameState -> Text -> IO (GameState, Robot, Either Text (Value, Int))
+eval g = either (return . (g,hypotheticalRobot undefined 0,) . Left) (evalPT g) . processTerm1
+
+processTerm1 :: Text -> Either Text ProcessedTerm
+processTerm1 txt = processTerm txt >>= maybe wsErr Right
+ where
+  wsErr = Left "expecting a term, but got only whitespace"
+
+evalPT :: GameState -> ProcessedTerm -> IO (GameState, Robot, Either Text (Value, Int))
+evalPT g t = evalCESK g (initMachine t empty emptyStore)
+
+evalCESK :: GameState -> CESK -> IO (GameState, Robot, Either Text (Value, Int))
+evalCESK g cesk =
+  runCESK 0 cesk
+    & flip runStateT r
+    & flip runStateT (g & creativeMode .~ True)
+    & fmap orderResult
+ where
+  r = hypotheticalRobot cesk 0
+  orderResult ((res, rr), rg) = (rg, rr, res)
+
+runCESK :: Int -> CESK -> StateT Robot (StateT GameState IO) (Either Text (Value, Int))
+runCESK _ (Up exn _ []) = Left . flip formatExn exn <$> lift (use entityMap)
+runCESK !steps cesk = case finalValue cesk of
+  Just (v, _) -> return (Right (v, steps))
+  Nothing -> stepCESK cesk >>= runCESK (steps + 1)
+
+play :: GameState -> Text -> IO (Either Text (), GameState)
+play g = either (return . (,g) . Left) playPT . processTerm1
+ where
+  playPT pt = runStateT (playUntilDone (hr ^. robotID)) gs
+   where
+    cesk = initMachine pt empty emptyStore
+    hr = hypotheticalRobot cesk 0
+    hid = hr ^. robotID
+    gs =
+      g
+        & execState (addRobot hr)
+        & viewCenterRule .~ VCRobot hid
+        & creativeMode .~ True
+
+playUntilDone :: RID -> StateT GameState IO (Either Text ())
+playUntilDone rid = do
+  w <- use robotMap
+  case w ^? ix rid . to isActive of
+    Just True -> do
+      gameTick
+      playUntilDone rid
+    Just False -> return $ Right ()
+    Nothing -> return $ Left . T.pack $ "The robot with ID " <> show rid <> " is nowhere to be found!"


### PR DESCRIPTION
- use `LogEntry` for said messages
- add fields to log entries for sorting
- add a messages panel that also shows logs (logger required)
  - colour messages (also in logger)
    - logs bold, message colour per robot and exceptions red
  - show message time
- test notifications for new messages
- add `listen` command and capability
  - add a hearing aid device that provides the capability
- move the F-key modal hints to the top left world corner
- close #513 
- close #512
- close #577 