### PR TITLE
Add `time` command and UI clock

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -849,6 +849,7 @@
   description:
   - A clock is a device for keeping track of time.
   properties: [portable]
+  capabilities: [time]
 
 - name: comparator
   display:

--- a/data/scenarios/Challenges/teleport.yaml
+++ b/data/scenarios/Challenges/teleport.yaml
@@ -10,7 +10,9 @@ win: |
     as base {has "lambda"}
   } { return false }
 solution: |
-  turn back; move;move;move; wait 10; move;move;move; grab
+  def w2 = turn back; turn back end;
+  def w10 = w2; w2; w2; w2; w2 end;
+  turn back; move;move;move; w10; move;move;move; grab
 robots:
   - name: base
     loc: [3,0]
@@ -19,6 +21,7 @@ robots:
       - treads
       - logger
       - grabber
+      - dictionary
     inventory:
       - [0, lambda]
   - name: portkey1

--- a/data/scenarios/Testing/201-require/533-reprogram-simple.yaml
+++ b/data/scenarios/Testing/201-require/533-reprogram-simple.yaml
@@ -35,6 +35,7 @@ robots:
       - 3D printer
       - logger
       - flash memory
+      - clock
     inventory:
       - [2, boat]
       - [2, solar panel]

--- a/data/scenarios/Testing/201-require/533-reprogram.yaml
+++ b/data/scenarios/Testing/201-require/533-reprogram.yaml
@@ -35,6 +35,7 @@ robots:
       - 3D printer
       - logger
       - flash memory
+      - clock
     inventory:
       - [2, boat]
       - [2, solar panel]

--- a/data/scenarios/Testing/475-wait-one.yaml
+++ b/data/scenarios/Testing/475-wait-one.yaml
@@ -26,6 +26,7 @@ robots:
     dir: [1,0]
     devices:
       - logger
+      - clock
     program: |
       log "I shall sleep"; wait 1; log "I have awoken"
 world:

--- a/data/scenarios/Tutorials/crash.yaml
+++ b/data/scenarios/Tutorials/crash.yaml
@@ -68,6 +68,7 @@ robots:
     devices:
       - logger
       - 3D printer
+      - clock
     inventory:
       - [10, logger]
       - [10, compass]

--- a/data/scenarios/Tutorials/place.yaml
+++ b/data/scenarios/Tutorials/place.yaml
@@ -45,9 +45,14 @@ win: |
 solution: |
   def t = move; place "spruce"; harvest; end;
   def h = harvest; move end;
+  // wait without needing a clock: literally spin our wheels
+  def w4 = turn left; turn left; turn left; turn left end;
+  def w16 = w4; w4; w4; w4 end;
+  def w64 = w16; w16; w16; w16 end;
+  def w256 = w64; w64; w64; w64 end;
   move;
   move; harvest; t; t; t; t; t;
-  wait 256;
+  w256;
   turn back; h; h; h; h; h; h;
 robots:
   - name: base

--- a/data/scenarios/classic.yaml
+++ b/data/scenarios/classic.yaml
@@ -16,6 +16,7 @@ robots:
       - toolkit
       - solar panel
       - workbench
+      - clock
     inventory:
       - [5, 3D printer]
       - [100, treads]

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -68,6 +68,7 @@
                "view"
                "appear"
                "create"
+               "time"
                "whereami"
                "blocked"
                "scan"

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -99,7 +99,7 @@
 			"patterns": [
 				{
 				"name": "constant.numeric",
-				"match": "[0-9]"
+				"match": "([0-9]*|0b[01]*|0o[0-8]*|0x\\x*)"
 				}
 			]
 		}

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -56,7 +56,7 @@
 				},
 				{
 				"name": "keyword.other",
-				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|install|make|has|installed|count|drill|build|salvage|reprogram|say|log|view|appear|create|whereami|blocked|scan|upload|ishere|whoami|setname|random|run|return|try|atomic|teleport|as|robotnamed|robotnumbered|knows)\\b"
+				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|install|make|has|installed|count|drill|build|salvage|reprogram|say|log|view|appear|create|time|whereami|blocked|scan|upload|ishere|whoami|setname|random|run|return|try|atomic|teleport|as|robotnamed|robotnumbered|knows)\\b"
 				}
 			]
 			},

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -928,6 +928,9 @@ execConst c vs s k = do
     Whereami -> do
       V2 x y <- use robotLocation
       return $ Out (VPair (VInt (fromIntegral x)) (VInt (fromIntegral y))) s k
+    Time -> do
+      t <- use ticks
+      return $ Out (VInt t) s k
     Drill -> case vs of
       [VDir d] -> do
         rname <- use robotName

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -105,6 +105,9 @@ data Capability
     CTeleport
   | -- | Capability to run commands atomically
     CAtomic
+  | -- | Capabiltiy to do time-related things, like `wait` and get the
+    --   current time.
+    CTime
   | -- | God-like capabilities.  For e.g. commands intended only for
     --   checking challenge mode win conditions, and not for use by
     --   players.

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -132,7 +132,6 @@ instance FromJSON Capability where
 constCaps :: Const -> Maybe Capability
 constCaps = \case
   -- Some built-in constants that don't require any special capability.
-  Wait -> Nothing
   Noop -> Nothing
   AppF -> Nothing
   Force -> Nothing
@@ -175,6 +174,7 @@ constCaps = \case
   Self -> Just CWhoami
   Atomic -> Just CAtomic
   Time -> Just CTime
+  Wait -> Just CTime
   -- Some God-like abilities.
   As -> Just CGod
   RobotNamed -> Just CGod

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -174,6 +174,7 @@ constCaps = \case
   Whoami -> Just CWhoami
   Self -> Just CWhoami
   Atomic -> Just CAtomic
+  Time -> Just CTime
   -- Some God-like abilities.
   As -> Just CGod
   RobotNamed -> Just CGod

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -143,10 +143,20 @@ identifier = (lexeme . try) (p >>= check) <?> "variable name"
 stringLiteral :: Parser Text
 stringLiteral = into <$> lexeme (char '"' >> manyTill L.charLiteral (char '"'))
 
--- | Parse a positive integer literal token.  Note that negation is
---   handled as a separate operator.
+-- | Parse a positive integer literal token, in decimal, binary,
+--   octal, or hexadecimal notation.  Note that negation is handled as
+--   a separate operator.
 integer :: Parser Integer
-integer = lexeme L.decimal
+integer =
+  label "integer literal" $
+    lexeme $ do
+      n <-
+        try (string "0b" *> L.binary)
+          <|> try (string "0o" *> L.octal)
+          <|> try (string "0x" *> L.hexadecimal)
+          <|> L.decimal
+      notFollowedBy alphaNumChar
+      return n
 
 braces :: Parser a -> Parser a
 braces = between (symbol "{") (symbol "}")

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -151,9 +151,9 @@ integer =
   label "integer literal" $
     lexeme $ do
       n <-
-        try (string "0b" *> L.binary)
-          <|> try (string "0o" *> L.octal)
-          <|> try (string "0x" *> L.hexadecimal)
+        string "0b" *> L.binary
+          <|> string "0o" *> L.octal
+          <|> string "0x" *> L.hexadecimal
           <|> L.decimal
       notFollowedBy alphaNumChar
       return n

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -161,9 +161,6 @@ integer =
 braces :: Parser a -> Parser a
 braces = between (symbol "{") (symbol "}")
 
--- dbraces :: Parser a -> Parser a
--- dbraces = between (symbol "{{") (symbol "}}")
-
 parens :: Parser a -> Parser a
 parens = between (symbol "(") (symbol ")")
 

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -252,7 +252,9 @@ data Const
     Create
   | -- Sensing / generation
 
-    -- | Get the current x, y coordinates
+    -- | Get current time
+    Time
+  | -- | Get the current x, y coordinates
     Whereami
   | -- | See if we can move forward or not.
     Blocked
@@ -567,6 +569,7 @@ constInfo c = case c of
   Create ->
     command 1 short . doc "Create an item out of thin air." $
       ["Only available in creative mode."]
+  Time -> command 0 Intangible "Get the current time."
   Whereami -> command 0 Intangible "Get the current x and y coordinates."
   Blocked -> command 0 Intangible "See if the robot can move forward."
   Scan ->

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -484,6 +484,7 @@ inferConst c = case c of
   View -> [tyQ| robot -> cmd () |]
   Appear -> [tyQ| string -> cmd () |]
   Create -> [tyQ| string -> cmd () |]
+  Time -> [tyQ| cmd int |]
   Whereami -> [tyQ| cmd (int * int) |]
   Blocked -> [tyQ| cmd bool |]
   Scan -> [tyQ| dir -> cmd (() + string) |]

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -734,7 +734,7 @@ initReplForm =
 
 -- | The initial tick speed.
 initLgTicksPerSecond :: Int
-initLgTicksPerSecond = 3 -- 2^3 = 8 ticks / second
+initLgTicksPerSecond = 4 -- 2^4 = 16 ticks / second
 
 -- | Initialize the UI state.  This needs to be in the IO monad since
 --   it involves reading a REPL history file, getting the current

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -238,6 +238,8 @@ drawGameUI s =
   addCursorPos = case s ^. uiState . uiWorldCursor of
     Just coord -> topLabels . rightLabel ?~ padLeftRight 1 (drawWorldCursorInfo (s ^. gameState) coord)
     Nothing -> id
+  -- Add clock display in bottom left of the world view if focused robot
+  -- has a clock installed
   addClock = case s ^. gameState . to focusedRobot of
     Nothing -> id
     Just r

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -236,11 +236,11 @@ drawGameUI s =
   ]
  where
   addCursorPos = case s ^. uiState . uiWorldCursor of
-    Just coord -> topLabels . rightLabel ?~ padLeftRight 1 (drawWorldCursorInfo (s ^. gameState) coord)
+    Just coord -> bottomLabels . leftLabel ?~ padLeftRight 1 (drawWorldCursorInfo (s ^. gameState) coord)
     Nothing -> id
-  -- Add clock display in bottom left of the world view if focused robot
+  -- Add clock display in top right of the world view if focused robot
   -- has a clock installed
-  addClock = bottomLabels . leftLabel ?~ padLeftRight 1 (drawClockDisplay s)
+  addClock = topLabels . rightLabel ?~ padLeftRight 1 (drawClockDisplay s)
   fr = s ^. uiState . uiFocusRing
   moreTop = s ^. uiState . uiMoreInfoTop
   moreBot = s ^. uiState . uiMoreInfoBot

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -260,11 +260,11 @@ drawClock :: Integer -> Widget n
 drawClock t =
   str $
     mconcat
-      [ printf "%x" (t `shiftR` 19)
+      [ printf "%x" (t `shiftR` 20)
       , ":"
-      , printf "%02x" ((t `shiftR` 11) .&. ((1 `shiftL` 8) - 1))
+      , printf "%02x" ((t `shiftR` 12) .&. ((1 `shiftL` 8) - 1))
       , ":"
-      , printf "%02x" ((t `shiftR` 3) .&. ((1 `shiftL` 8) - 1))
+      , printf "%02x" ((t `shiftR` 4) .&. ((1 `shiftL` 8) - 1))
       ]
 
 -- | Render the type of the current REPL input to be shown to the user.

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -166,7 +166,7 @@ parser =
                     , "1 | require x"
                     , "  |         ^"
                     , "unexpected 'x'"
-                    , "expecting device name in double quotes or integer"
+                    , "expecting device name in double quotes or integer literal"
                     ]
                 )
             )
@@ -250,6 +250,27 @@ parser =
                 "atomic (salvage)"
                 "1: Invalid atomic block: commands that can take multiple ticks to execute are not allowed: salvage"
             )
+        ]
+    , testGroup
+        "integer literals"
+        [ testCase
+            "binary literal"
+            (valid "0b1011011101")
+        , testCase
+            "invalid binary literal"
+            (process "0b101201" "1:6:\n  |\n1 | 0b101201\n  |      ^\nunexpected '2'\n")
+        , testCase
+            "octal literal"
+            (valid "0o3726")
+        , testCase
+            "invalid octal literal"
+            (process "0o3826" "1:4:\n  |\n1 | 0o3826\n  |    ^\nunexpected '8'\n")
+        , testCase
+            "hex literal"
+            (valid "0xabcD6F")
+        , testCase
+            "invalid hex literal"
+            (process "0xabcD6G2" "1:8:\n  |\n1 | 0xabcD6G2\n  |        ^\nunexpected 'G'\n")
         ]
     ]
  where


### PR DESCRIPTION
Add `time` capability and related things:
- Add a new constant `time : cmd int`
- Make `clock` device provide `time` capability
- If the focused robot has a `clock` device installed (`base` has one by default in classic mode), display hexadecimal time in bottom left of the world panel.
- Add binary, octal, and hexadecimal integer literal syntax to the language.
- Make 16 ticks/s the default speed
    - The old default, 8 ticks/s, was annoyingly slow
    - Now you can simply type in `0x` followed by all the digits in the clock display, followed by a single trailing 0, to get the `time` in ticks

#402 discussed the possibility of having the `wait` command also require the `time` capability.  This breaks a number of tests which rely on the `wait` command.  I can fix the tests of course, but I'd like some feedback on whether requiring a `clock` in order to `wait` is a good idea.

Closes #402.
Closes #559.