### PR TITLE
Update editors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -14,7 +14,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Disco team nor the names of other
+    * Neither the name of Swarm team nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -27,7 +27,7 @@
       (let* (
              ;; Generate the current keywords with:
              ;; cabal run swarm:swarm -- generate editors --emacs
-             (x-keywords '("def" "end"))
+             (x-keywords '("def" "end" "let" "in" "require"))
              (x-builtins '(
                "self"
                "parent"

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the "swarm-language" extension will be documented in this file.
 
+## version 0.0.5
+- [Highlighter] added the `atomic`, `installed` and `time` constants
+- [Highlighter] added `require` syntax (checking what follows it is left to typechecker)
+- [Highlighter] changed the syntax for numbers to allow octal, binary and hexadecimal
+- hopefully fixed the image link, so that it can render in editor and on the extension webpage
+
+## version 0.0.4
+- [Highlighter] Automatically generated the list of keywords (many new ones and few renamed)
+
 ## version 0.0.3
 
 - [Highlighter] Update reserved word list (include `drill`, `has`, etc.)

--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -14,7 +14,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of Disco team nor the names of other
+    * Neither the name of Swarm team nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -1,0 +1,31 @@
+Copyright Brent Yorgey 2021-2022
+SPDX-License-Identifier: BSD-3-Clause
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Disco team nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -2,7 +2,7 @@
 
 This VSCode extension provides a basic highlighting and LSP client for the swarm programming language.
 
-![VSCode screenshot](https://github.com/swarm-game/swarm/blob/main/editors/vscode/images/editor_debug.png)
+![VSCode screenshot](https://raw.githubusercontent.com/swarm-game/swarm/main/editors/vscode/images/editor_debug.png)
 
 ## Extension Settings
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -2,7 +2,7 @@
 
 This VSCode extension provides a basic highlighting and LSP client for the swarm programming language.
 
-![VSCode screenshot](images/editor_debug.png)
+![VSCode screenshot](https://github.com/swarm-game/swarm/blob/main/editors/vscode/images/editor_debug.png)
 
 ## Extension Settings
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "swarm-language",
     "displayName": "swarm-language",
     "description": "VSCode support for swarm (the game) programming language.",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "icon": "images/swarm-logo.png",
     "publisher": "xsebek",
     "repository": {

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -30,8 +30,8 @@
 				},
 				{
 				"name": "keyword.control.dictionary.let",
-				"begin": "let\\s+(\\w+)\\s*(:((\\s*(cmd|dir|string|int|\\(|\\)|(\\*|\\+|->)|[a-z]\\w*|forall ([a-z]\\w*\\s*)+.)\\s*)+))?=",
-				"end": "in",
+				"begin": "\\s*let\\s+(\\w+)\\s*(:((\\s*(cmd|dir|string|int|\\(|\\)|\\{|\\}|(\\*|\\+|->)|[a-z]\\w*|forall ([a-z]\\w*\\s*)+.)\\s*)+))?=",
+				"end": "\\s*in",
 				"beginCaptures": {
 					"1": {"name": "variable.other"},
 					"3": {"name": "storage.type"},

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -46,6 +46,10 @@
 				]
 				},
 				{
+				"name": "keyword.control.require",
+				"match": "require"
+				},
+				{
 				"name": "keyword.operator",
 				"match": "-|==|!=|<|>|<=|>=|\\|\\||&&|\\+|-|\\*|/(?![/|*])|\\^|\\+\\+|\\$"
 				},


### PR DESCRIPTION
- update the highlighting for `require` in editors
- bump VSCode plugin version to 0.0.5
- update VSCode plugin changelog
- update the VSCode plugin image link
- copy LICENSE to the VSCode folder (`vsce` was complaining about it)
- rename the team in LICENSE file to Swarm
- closes #548