### PR TITLE
Fix robot display

### DIFF
--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -25,7 +25,6 @@ module Swarm.Game.Entity (
   -- * Entities
   Entity,
   mkEntity,
-  displayEntity,
 
   -- ** Lenses
   -- $lenses
@@ -80,7 +79,6 @@ module Swarm.Game.Entity (
   difference,
 ) where
 
-import Brick (Widget)
 import Control.Arrow ((&&&))
 import Control.Lens (Getter, Lens', lens, to, view, (^.))
 import Control.Monad.IO.Class
@@ -445,10 +443,6 @@ entityCapabilities = hashedLens _entityCapabilities (\e x -> e {_entityCapabilit
 -- | The inventory of other entities carried by this entity.
 entityInventory :: Lens' Entity Inventory
 entityInventory = hashedLens _entityInventory (\e x -> e {_entityInventory = x})
-
--- | Display an entity as a single character.
-displayEntity :: Entity -> Widget n
-displayEntity e = renderDisplay (e ^. entityDisplay)
 
 ------------------------------------------------------------
 -- Inventory

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -724,7 +724,7 @@ drawItem _ _ _ (InstalledEntry e) = drawLabelledEntityName e <+> padLeft Max (st
 drawLabelledEntityName :: Entity -> Widget Name
 drawLabelledEntityName e =
   hBox
-    [ padRight (Pad 2) (displayEntity e)
+    [ padRight (Pad 2) (renderDisplay (e ^. entityDisplay))
     , txt (e ^. entityName)
     ]
 

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -414,7 +414,7 @@ robotsListWidget s = viewport RobotsViewport Vertical (hCenter table)
     , txt rLog
     ]
    where
-    nameWidget = hBox [displayEntity (robot ^. robotEntity), higlightSystem . txt $ " " <> robot ^. robotName]
+    nameWidget = hBox [renderDisplay (robot ^. robotDisplay), higlightSystem . txt $ " " <> robot ^. robotName]
     higlightSystem = if robot ^. systemRobot then withAttr highlightAttr else id
 
     ageStr
@@ -688,7 +688,7 @@ drawRobotPanel s = case (s ^. gameState . to focusedRobot, s ^. uiState . uiInve
                 hBox
                   [ txt (r ^. robotName)
                   , padLeft (Pad 2) $ str (printf "(%d, %d)" x y)
-                  , padLeft (Pad 2) $ displayEntity (r ^. robotEntity)
+                  , padLeft (Pad 2) $ renderDisplay (r ^. robotDisplay)
                   ]
             , padAll 1 (BL.renderListWithIndex drawClickableItem True lst)
             ]


### PR DESCRIPTION
Use `renderDisplay (r ^. robotDisplay)` instead of `displayEntity (r ^. robotEntity)`, since the latter no longer takes into account the robot's direction.  Also get rid of the `displayEntity` function since it's unnecessary and tempting to use in this incorrect way.