### PR TITLE
Update stack build for new EventM API (#583)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,15 @@
 extra-deps:
-- brick-0.69
 - word-wrap-0.5
 - hashable-1.3.5.0
 - base-orphans-0.8.6
 - git: https://github.com/colinhect/hsnoise
   commit: 4ccff11dea7e8d94e6a5fcaf8f43857bd65bd72d
+- git: https://github.com/jtdaugherty/brick
+  commit: dee90efa8cde1755f435c1f7dd9b6828b1bd0089
 - simple-enumeration-0.2.1@sha256:8625b269c1650d3dd0e3887351c153049f4369853e0d525219e07480ea004b9f,1178
 - fused-effects-1.1.1.1@sha256:c029c5fb0b2154281221a71ff25709d2a11347fe061fa8c2398e7fe52a16008d,4932
 - fused-effects-lens-1.2.0.1@sha256:675fddf183215b6f3c1f2a0823359a648756435fd1966284e61830ec28ad61fa,1466
+- text-zipper-0.12@sha256:e96110598fc25e57a99ffcd8e583351af8b325b813aa5e3bd0adc627e3e02b6b,1472
+- vty-5.36@sha256:dfbb78ea924ad0ef66cff4bc223918240234508c3de139b34780038dafb5fc53,20859
 resolver: lts-19.8
 


### PR DESCRIPTION
Allows building with `stack` as well as `cabal`.