### PR TITLE
bug fix: don't `continueWithoutRedraw` from modal scroll handler

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -894,4 +894,4 @@ handleInfoPanelEvent vs = \case
   Key V.KPageUp -> vScrollPage vs Brick.Up
   Key V.KHome -> vScrollToBeginning vs
   Key V.KEnd -> vScrollToEnd vs
-  _ -> continueWithoutRedraw
+  _ -> return ()


### PR DESCRIPTION
The problem is that we pass along events to *both* the dialog (for
e.g. switching between dialog buttons) *and* to the viewport (for e.g.
scrolling up and down).  If we hit Tab the dialog handles it, but then
the viewport handler used to say `continueWithoutRedraw` so the screen
didn't update to reflect the moved button focus.