### PR TITLE
Use lazy event state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,7 +5,7 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/jtdaugherty/brick
-  tag: dee90efa8cde1755f435c1f7dd9b6828b1bd0089
+  location: https://github.com/xsebek/brick.git
+  tag: 757123f5b89c4d07a72851fb24f499bcf2efd979
 
 packages: .


### PR DESCRIPTION
This is the lazy version of the state in `brick`'s new `EventM`.

Let's compare how it fares with `-O0` against:
- 0150b8a9 (refactor to `EventM` with strict state)
- 35ff8352 (just before refactor but with latest `brick`)