### PR TITLE
Add debug web service

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,6 +12,7 @@ import Swarm.App (appMain)
 import Swarm.DocGen (EditorType (..), GenerateDocs (..), SheetType (..), generateDocs)
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Pipeline (processTerm)
+import Swarm.Web (defaultPort)
 import System.Exit (exitFailure, exitSuccess)
 
 data CLI
@@ -57,7 +58,14 @@ cliParser =
   seed :: Parser (Maybe Int)
   seed = optional $ option auto (long "seed" <> short 's' <> metavar "INT" <> help "Seed to use for world generation")
   webPort :: Parser (Maybe Int)
-  webPort = optional $ option auto (long "web" <> metavar "PORT" <> help "Start the web interface")
+  webPort =
+    optional $
+      option
+        auto
+        ( long "web"
+            <> metavar "PORT"
+            <> help ("Set the web service port (or disable it with 0). Default to " <> show defaultPort <> ".")
+        )
   scenario :: Parser (Maybe String)
   scenario = optional $ strOption (long "scenario" <> short 'c' <> metavar "FILE" <> help "Name of a scenario to load")
   run :: Parser (Maybe String)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -57,7 +57,7 @@ cliParser =
   seed :: Parser (Maybe Int)
   seed = optional $ option auto (long "seed" <> short 's' <> metavar "INT" <> help "Seed to use for world generation")
   webPort :: Parser (Maybe Int)
-  webPort = optional $ option auto (long "web" <> metavar "INT" <> help "Start the web interface")
+  webPort = optional $ option auto (long "web" <> metavar "PORT" <> help "Start the web interface")
   scenario :: Parser (Maybe String)
   scenario = optional $ strOption (long "scenario" <> short 'c' <> metavar "FILE" <> help "Name of a scenario to load")
   run :: Parser (Maybe String)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,6 +20,7 @@ data CLI
       (Maybe FilePath) -- scenario
       (Maybe FilePath) -- file to run
       Bool -- cheat mode
+      (Maybe Int) -- web port
   | Format Input
   | DocGen GenerateDocs
   | LSP
@@ -33,7 +34,7 @@ cliParser =
         , command "generate" (info (DocGen <$> docgen <**> helper) (progDesc "Generate docs"))
         ]
     )
-    <|> Run <$> seed <*> scenario <*> run <*> cheat
+    <|> Run <$> seed <*> scenario <*> run <*> cheat <*> webPort
  where
   format :: Parser CLI
   format =
@@ -55,6 +56,8 @@ cliParser =
       ]
   seed :: Parser (Maybe Int)
   seed = optional $ option auto (long "seed" <> short 's' <> metavar "INT" <> help "Seed to use for world generation")
+  webPort :: Parser (Maybe Int)
+  webPort = optional $ option auto (long "web" <> metavar "INT" <> help "Start the web interface")
   scenario :: Parser (Maybe String)
   scenario = optional $ strOption (long "scenario" <> short 'c' <> metavar "FILE" <> help "Name of a scenario to load")
   run :: Parser (Maybe String)
@@ -102,7 +105,7 @@ main :: IO ()
 main = do
   cli <- execParser cliInfo
   case cli of
-    Run seed scenario toRun cheat -> appMain seed scenario toRun cheat
+    Run seed scenario toRun cheat webPort -> appMain webPort seed scenario toRun cheat
     Format fo -> formatFile fo
     DocGen g -> generateDocs g
     LSP -> lspMain

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -70,7 +70,7 @@ appMain port seed scenario toRun cheat = do
         Just port' -> do
           -- Share a reference to the state with the web ui
           gsRef <- newIORef (s ^. gameState)
-          void $ forkIO $ webMain port' gsRef
+          Swarm.Web.startWebThread port' gsRef
           pure $ \e -> do
             s' <- get
             liftIO $ writeIORef gsRef (s' ^. gameState)
@@ -91,7 +91,7 @@ demoWeb = do
     Left errMsg -> T.putStrLn errMsg
     Right s -> do
       gsRef <- newIORef (s ^. gameState)
-      webMain 8080 gsRef
+      webMain Nothing 8080 gsRef
  where
   demoScenario = Just "./data/scenarios/Testing/475-wait-one.yaml"
 

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -65,13 +65,12 @@ appMain port seed scenario toRun cheat = do
           threadDelay 33_333 -- cap maximum framerate at 30 FPS
           writeBChan chan Frame
 
-      eventHandler <- case port of
-        Nothing -> pure handleEvent
-        Just port' -> do
-          -- Share a reference to the state with the web ui
-          gsRef <- newIORef (s ^. gameState)
-          Swarm.Web.startWebThread port' gsRef
-          pure $ \e -> do
+      -- Start the web service with a reference to the game state
+      gsRef <- newIORef (s ^. gameState)
+      Swarm.Web.startWebThread port gsRef
+
+      -- Update the reference for every event
+      let eventHandler e = do
             s' <- get
             liftIO $ writeIORef gsRef (s' ^. gameState)
             handleEvent e

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -110,18 +110,18 @@ import System.Clock (TimeSpec)
 -- | A record that stores the information
 --   for all defintions stored in a 'Robot'
 data RobotContext = RobotContext
-  { _defTypes :: TCtx
-  -- ^ Map definition names to their types.
-  , _defReqs :: ReqCtx
-  -- ^ Map defintion names to the capabilities
-  --   required to evaluate/execute them.
-  , _defVals :: Env
-  -- ^ Map defintion names to their values. Note that since
-  --   definitions are delayed, the values will just consist of
-  --   'VRef's pointing into the store.
-  , _defStore :: Store
-  -- ^ A store containing memory cells allocated to hold
-  --   definitions.
+  { -- | Map definition names to their types.
+    _defTypes :: TCtx
+  , -- | Map defintion names to the capabilities
+    --   required to evaluate/execute them.
+    _defReqs :: ReqCtx
+  , -- | Map defintion names to their values. Note that since
+    --   definitions are delayed, the values will just consist of
+    --   'VRef's pointing into the store.
+    _defVals :: Env
+  , -- | A store containing memory cells allocated to hold
+    --   definitions.
+    _defStore :: Store
   }
   deriving (Show, Generic, FromJSON, ToJSON)
 
@@ -132,19 +132,19 @@ data LogSource = Said | Logged | ErrorTrace
 
 -- | An entry in a robot's log.
 data LogEntry = LogEntry
-  { _leTime :: Integer
-  -- ^ The time at which the entry was created.
-  --   Note that this is the first field we sort on.
-  , _leSaid :: LogSource
-  -- ^ Whether this log records a said message.
-  , _leRobotName :: Text
-  -- ^ The name of the robot that generated the entry.
-  , _leRobotID :: Int
-  -- ^ The ID of the robot that generated the entry.
-  , _leLocation :: V2 Int64
-  -- ^ Location of the robot at log entry creation.
-  , _leText :: Text
-  -- ^ The text of the log entry.
+  { -- | The time at which the entry was created.
+    --   Note that this is the first field we sort on.
+    _leTime :: Integer
+  , -- | Whether this log records a said message.
+    _leSaid :: LogSource
+  , -- | The name of the robot that generated the entry.
+    _leRobotName :: Text
+  , -- | The ID of the robot that generated the entry.
+    _leRobotID :: Int
+  , -- | Location of the robot at log entry creation.
+    _leLocation :: V2 Int64
+  , -- | The text of the log entry.
+    _leText :: Text
   }
   deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
@@ -179,9 +179,9 @@ type family RobotID (phase :: RobotPhase) :: * where
 data RobotR (phase :: RobotPhase) = RobotR
   { _robotEntity :: Entity
   , _installedDevices :: Inventory
-  , _robotCapabilities :: Set Capability
-  -- ^ A cached view of the capabilities this robot has.
-  --   Automatically generated from '_installedDevices'.
+  , -- | A cached view of the capabilities this robot has.
+    --   Automatically generated from '_installedDevices'.
+    _robotCapabilities :: Set Capability
   , _robotLog :: Seq LogEntry
   , _robotLogUpdated :: Bool
   , _robotLocation :: RobotLocation phase

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -110,18 +110,18 @@ import System.Clock (TimeSpec)
 -- | A record that stores the information
 --   for all defintions stored in a 'Robot'
 data RobotContext = RobotContext
-  { -- | Map definition names to their types.
-    _defTypes :: TCtx
-  , -- | Map defintion names to the capabilities
-    --   required to evaluate/execute them.
-    _defReqs :: ReqCtx
-  , -- | Map defintion names to their values. Note that since
-    --   definitions are delayed, the values will just consist of
-    --   'VRef's pointing into the store.
-    _defVals :: Env
-  , -- | A store containing memory cells allocated to hold
-    --   definitions.
-    _defStore :: Store
+  { _defTypes :: TCtx
+  -- ^ Map definition names to their types.
+  , _defReqs :: ReqCtx
+  -- ^ Map defintion names to the capabilities
+  --   required to evaluate/execute them.
+  , _defVals :: Env
+  -- ^ Map defintion names to their values. Note that since
+  --   definitions are delayed, the values will just consist of
+  --   'VRef's pointing into the store.
+  , _defStore :: Store
+  -- ^ A store containing memory cells allocated to hold
+  --   definitions.
   }
   deriving (Show, Generic, FromJSON, ToJSON)
 
@@ -132,19 +132,19 @@ data LogSource = Said | Logged | ErrorTrace
 
 -- | An entry in a robot's log.
 data LogEntry = LogEntry
-  { -- | The time at which the entry was created.
-    --   Note that this is the first field we sort on.
-    _leTime :: Integer
-  , -- | Whether this log records a said message.
-    _leSaid :: LogSource
-  , -- | The name of the robot that generated the entry.
-    _leRobotName :: Text
-  , -- | The ID of the robot that generated the entry.
-    _leRobotID :: Int
-  , -- | Location of the robot at log entry creation.
-    _leLocation :: V2 Int64
-  , -- | The text of the log entry.
-    _leText :: Text
+  { _leTime :: Integer
+  -- ^ The time at which the entry was created.
+  --   Note that this is the first field we sort on.
+  , _leSaid :: LogSource
+  -- ^ Whether this log records a said message.
+  , _leRobotName :: Text
+  -- ^ The name of the robot that generated the entry.
+  , _leRobotID :: Int
+  -- ^ The ID of the robot that generated the entry.
+  , _leLocation :: V2 Int64
+  -- ^ Location of the robot at log entry creation.
+  , _leText :: Text
+  -- ^ The text of the log entry.
   }
   deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
@@ -179,9 +179,9 @@ type family RobotID (phase :: RobotPhase) :: * where
 data RobotR (phase :: RobotPhase) = RobotR
   { _robotEntity :: Entity
   , _installedDevices :: Inventory
-  , -- | A cached view of the capabilities this robot has.
-    --   Automatically generated from '_installedDevices'.
-    _robotCapabilities :: Set Capability
+  , _robotCapabilities :: Set Capability
+  -- ^ A cached view of the capabilities this robot has.
+  --   Automatically generated from '_installedDevices'.
   , _robotLog :: Seq LogEntry
   , _robotLogUpdated :: Bool
   , _robotLocation :: RobotLocation phase
@@ -199,6 +199,8 @@ data RobotR (phase :: RobotPhase) = RobotR
   deriving (Generic)
 
 deriving instance (Show (RobotLocation phase), Show (RobotID phase)) => Show (RobotR phase)
+
+deriving instance (ToJSON (RobotLocation phase), ToJSON (RobotID phase)) => ToJSON (RobotR phase)
 
 -- See https://byorgey.wordpress.com/2021/09/17/automatically-updated-cached-views-with-lens/
 -- for the approach used here with lenses.

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -2,6 +2,21 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
+-- |
+-- A web service for Swarm.
+--
+-- The service can be started using the `--port 8080` command line argument,
+-- or through the REPL by calling `Swarm.App.demoWeb`.
+--
+-- Once running, here are the available endpoints:
+--
+--   * /robots : return the list of robots
+--   * /robot/ID : return a single robot identified by its id
+--
+-- Missing endpoints:
+--
+--   * TODO: #625 run endpoint to load definitions
+--   * TODO: #493 export the whole game state
 module Swarm.Web where
 
 import Control.Lens ((^.))

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -8,7 +8,6 @@ import Control.Lens ((^.))
 import Control.Monad.IO.Class (liftIO)
 import Data.IORef (IORef, readIORef)
 import Data.IntMap qualified as IM
-import Data.Maybe (fromMaybe)
 import Network.Wai qualified
 import Network.Wai.Handler.Warp (Port)
 import Network.Wai.Handler.Warp qualified
@@ -18,7 +17,7 @@ import Swarm.Game.State
 
 type SwarmApi =
   "robots" :> Get '[JSON] [Robot]
-    :<|> "robot" :> Capture "id" Int :> Get '[JSON] Robot
+    :<|> "robot" :> Capture "id" Int :> Get '[JSON] (Maybe Robot)
 
 mkApp :: IORef GameState -> Servant.Server SwarmApi
 mkApp gsRef =
@@ -30,7 +29,7 @@ mkApp gsRef =
     pure $ IM.elems $ g ^. robotMap
   robotHandler rid = do
     g <- liftIO (readIORef gsRef)
-    pure $ fromMaybe (error "Unknown robot") (IM.lookup rid (g ^. robotMap))
+    pure $ IM.lookup rid (g ^. robotMap)
 
 webMain :: Port -> IORef GameState -> IO ()
 webMain port gsRef = do

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Swarm.Web where
+
+import Control.Lens ((^.))
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef (IORef, readIORef)
+import Data.IntMap qualified as IM
+import Data.Maybe (fromMaybe)
+import Network.Wai qualified
+import Network.Wai.Handler.Warp (Port)
+import Network.Wai.Handler.Warp qualified
+import Servant
+import Swarm.Game.Robot
+import Swarm.Game.State
+
+type SwarmApi =
+  "robots" :> Get '[JSON] [Robot]
+    :<|> "robot" :> Capture "id" Int :> Get '[JSON] Robot
+
+mkApp :: IORef GameState -> Servant.Server SwarmApi
+mkApp gsRef =
+  robotsHandler
+    :<|> robotHandler
+  where
+    robotsHandler = do
+      g <- liftIO (readIORef gsRef)
+      pure $ IM.elems $ g ^. robotMap
+    robotHandler rid = do
+      g <- liftIO (readIORef gsRef)
+      pure $ fromMaybe (error "Unknown robot") (IM.lookup rid (g ^. robotMap))
+
+webMain :: Port -> IORef GameState -> IO ()
+webMain port gsRef = do
+  putStrLn $ "Web interface listening on :" <> show port
+  Network.Wai.Handler.Warp.run port app
+  where
+    app :: Network.Wai.Application
+    app = Servant.serve (Proxy @SwarmApi) (mkApp gsRef)

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -24,18 +24,18 @@ mkApp :: IORef GameState -> Servant.Server SwarmApi
 mkApp gsRef =
   robotsHandler
     :<|> robotHandler
-  where
-    robotsHandler = do
-      g <- liftIO (readIORef gsRef)
-      pure $ IM.elems $ g ^. robotMap
-    robotHandler rid = do
-      g <- liftIO (readIORef gsRef)
-      pure $ fromMaybe (error "Unknown robot") (IM.lookup rid (g ^. robotMap))
+ where
+  robotsHandler = do
+    g <- liftIO (readIORef gsRef)
+    pure $ IM.elems $ g ^. robotMap
+  robotHandler rid = do
+    g <- liftIO (readIORef gsRef)
+    pure $ fromMaybe (error "Unknown robot") (IM.lookup rid (g ^. robotMap))
 
 webMain :: Port -> IORef GameState -> IO ()
 webMain port gsRef = do
   putStrLn $ "Web interface listening on :" <> show port
   Network.Wai.Handler.Warp.run port app
-  where
-    app :: Network.Wai.Application
-    app = Servant.serve (Proxy @SwarmApi) (mkApp gsRef)
+ where
+  app :: Network.Wai.Application
+  app = Servant.serve (Proxy @SwarmApi) (mkApp gsRef)

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -115,6 +115,7 @@ library
                       Swarm.TUI.View
                       Swarm.TUI.Controller
                       Swarm.App
+                      Swarm.Web
                       Swarm.Util
                       Swarm.DocGen
                       Swarm.Util.Yaml
@@ -145,6 +146,8 @@ library
                       parser-combinators            >= 1.2 && < 1.4,
                       prettyprinter                 >= 1.7.0 && < 1.8,
                       random                        >= 1.2.0 && < 1.3,
+                      servant                       >= 0.19,
+                      servant-server                >= 0.19,
                       simple-enumeration            >= 0.2 && < 0.3,
                       split                         >= 0.2.3 && < 0.3,
                       stm                           >= 2.5.0 && < 2.6,
@@ -155,6 +158,8 @@ library
                       unordered-containers          >= 0.2.14 && < 0.3,
                       vector                        >= 0.12 && < 0.13,
                       vty                           >= 5.33 && < 5.37,
+                      warp                          >= 3.2,
+                      wai                           >= 3.2,
                       witch                         >= 0.3.4 && < 1.1,
                       word-wrap                     >= 0.5 && < 0.6,
                       yaml                          >= 0.11 && < 0.12,


### PR DESCRIPTION
This change introduce a new web API for the game.
The initial goal is to expose the internal state using the
`/robots` and `/robot/$id` endpoint to query the json representation
of the robots.

A new command line argument is added:
- When `--port 0` is set, the web service is disabled.
- When `--web port` is set, the game won't start if the web service fail to bind the port.
- Otherwise, when `--web` is not set, the service may start on 5357 if the port is available.

Example usage:

```
 swarm --web 5357
 curl localhost:5357/robots | jq
```

Future improvement may include:

- Ability to load program to the base (to send command from external text editor)
- Serve a html interface for alternative visualization