### PR TITLE
Lower the maximum modal height

### DIFF
--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -321,7 +321,7 @@ maybeScroll :: (Ord n, Show n) => n -> Widget n -> Widget n
 maybeScroll vpName contents =
   Widget Greedy Greedy $ do
     ctx <- getContext
-    result <- withReaderT (availHeightL .~ 1000000) (render contents)
+    result <- withReaderT (availHeightL .~ 10000) (render contents)
     if V.imageHeight (result ^. imageL) <= ctx ^. availHeightL
       then return result
       else

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -466,7 +466,7 @@ robotsListWidget s = hCenter table
   g = s ^. gameState
 
 helpWidget :: Widget Name
-helpWidget = (helpKeys <=> fill ' ') <+> (helpCommands <=> fill ' ')
+helpWidget = helpKeys <+> helpCommands
  where
   helpKeys =
     vBox


### PR DESCRIPTION
- lower the maximum height for scrolling to 10 000
  - one million was too slow to scroll and load when filled by greedy widgets
- make the Help widget less greedy
  - `<+> fill ' '` literally fills the rest with space, thanks for spotting that @byorgey :)
- closes #626