### PR TITLE
Improve help modal

### DIFF
--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -40,8 +40,8 @@ app eventHandler =
 -- | The main @IO@ computation which initializes the state, sets up
 --   some communication channels, and runs the UI.
 appMain :: Maybe Port -> Maybe Seed -> Maybe String -> Maybe String -> Bool -> IO ()
-appMain port seed scenario toRun cheat = do
-  res <- runExceptT $ initAppState seed scenario toRun cheat
+appMain port mseed scenario toRun cheat = do
+  res <- runExceptT $ initAppState mseed scenario toRun cheat
   case res of
     Left errMsg -> T.putStrLn errMsg
     Right s -> do

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -41,7 +41,7 @@ app eventHandler =
 --   some communication channels, and runs the UI.
 appMain :: Maybe Port -> Maybe Seed -> Maybe String -> Maybe String -> Bool -> IO ()
 appMain port mseed scenario toRun cheat = do
-  res <- runExceptT $ initAppState mseed scenario toRun cheat
+  res <- runExceptT $ initAppState port mseed scenario toRun cheat
   case res of
     Left errMsg -> T.putStrLn errMsg
     Right s -> do
@@ -85,12 +85,13 @@ appMain port mseed scenario toRun cheat = do
 -- This is useful to live update the code using `ghcid -W --test "Swarm.App.demoWeb"`
 demoWeb :: IO ()
 demoWeb = do
-  res <- runExceptT $ initAppState Nothing demoScenario Nothing True
+  let demoPort = 8080
+  res <- runExceptT $ initAppState (Just demoPort) Nothing demoScenario Nothing True
   case res of
     Left errMsg -> T.putStrLn errMsg
     Right s -> do
       gsRef <- newIORef (s ^. gameState)
-      webMain Nothing 8080 gsRef
+      webMain Nothing demoPort gsRef
  where
   demoScenario = Just "./data/scenarios/Testing/475-wait-one.yaml"
 

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -11,7 +11,7 @@ module Swarm.App where
 import Brick
 import Brick.BChan
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Lens ((^.))
+import Control.Lens ((&), (.~), (^.))
 import Control.Monad.Except
 import Data.IORef (newIORef, writeIORef)
 import Data.Text.IO qualified as T
@@ -41,7 +41,7 @@ app eventHandler =
 --   some communication channels, and runs the UI.
 appMain :: Maybe Port -> Maybe Seed -> Maybe String -> Maybe String -> Bool -> IO ()
 appMain port mseed scenario toRun cheat = do
-  res <- runExceptT $ initAppState port mseed scenario toRun cheat
+  res <- runExceptT $ initAppState mseed scenario toRun cheat
   case res of
     Left errMsg -> T.putStrLn errMsg
     Right s -> do
@@ -67,26 +67,28 @@ appMain port mseed scenario toRun cheat = do
 
       -- Start the web service with a reference to the game state
       gsRef <- newIORef (s ^. gameState)
-      Swarm.Web.startWebThread port gsRef
+      mport <- Swarm.Web.startWebThread port gsRef
+
+      let s' = s & uiState . uiPort .~ mport
 
       -- Update the reference for every event
       let eventHandler e = do
-            s' <- get
-            liftIO $ writeIORef gsRef (s' ^. gameState)
+            curSt <- get
+            liftIO $ writeIORef gsRef (curSt ^. gameState)
             handleEvent e
 
       -- Run the app.
       let buildVty = V.mkVty V.defaultConfig
       initialVty <- buildVty
       V.setMode (V.outputIface initialVty) V.Mouse True
-      void $ customMain initialVty buildVty (Just chan) (app eventHandler) s
+      void $ customMain initialVty buildVty (Just chan) (app eventHandler) s'
 
 -- | A demo program to run the web service directly, without the terminal application.
 -- This is useful to live update the code using `ghcid -W --test "Swarm.App.demoWeb"`
 demoWeb :: IO ()
 demoWeb = do
   let demoPort = 8080
-  res <- runExceptT $ initAppState (Just demoPort) Nothing demoScenario Nothing True
+  res <- runExceptT $ initAppState Nothing demoScenario Nothing True
   case res of
     Left errMsg -> T.putStrLn errMsg
     Right s -> do

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -702,15 +702,15 @@ initLgTicksPerSecond = 4 -- 2^4 = 16 ticks / second
 --   time, and loading text files from the data directory.  The @Bool@
 --   parameter indicates whether we should start off by showing the
 --   main menu.
-initUIState :: Maybe Port -> Bool -> Bool -> ExceptT Text IO UIState
-initUIState port showMainMenu cheatMode = liftIO $ do
+initUIState :: Bool -> Bool -> ExceptT Text IO UIState
+initUIState showMainMenu cheatMode = liftIO $ do
   historyT <- readFileMayT =<< getSwarmHistoryPath False
   appDataMap <- readAppData
   let history = maybe [] (map REPLEntry . T.lines) historyT
   startTime <- getTime Monotonic
   return $
     UIState
-      { _uiPort = port
+      { _uiPort = Nothing
       , _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
       , _uiPlaying = not showMainMenu
       , _uiNextScenario = Nothing
@@ -807,11 +807,11 @@ resetWithREPLForm f =
 ------------------------------------------------------------
 
 -- | Initialize the 'AppState'.
-initAppState :: Maybe Port -> Maybe Seed -> Maybe String -> Maybe String -> Bool -> ExceptT Text IO AppState
-initAppState port userSeed scenarioName toRun cheatMode = do
+initAppState :: Maybe Seed -> Maybe String -> Maybe String -> Bool -> ExceptT Text IO AppState
+initAppState userSeed scenarioName toRun cheatMode = do
   let skipMenu = isJust scenarioName || isJust toRun || isJust userSeed
   gs <- initGameState
-  ui <- initUIState port (not skipMenu) cheatMode
+  ui <- initUIState (not skipMenu) cheatMode
   case skipMenu of
     False -> return $ AppState gs ui
     True -> do

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -66,6 +66,7 @@ module Swarm.TUI.Model (
 
   -- ** UI Model
   UIState,
+  uiPort,
   uiMenu,
   uiPlaying,
   uiNextScenario,
@@ -147,6 +148,7 @@ import Data.Sequence qualified as Seq
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Vector qualified as V
+import Network.Wai.Handler.Warp (Port)
 import Swarm.Game.Entity as E
 import Swarm.Game.Robot
 import Swarm.Game.Scenario (Scenario, ScenarioItem, loadScenario)
@@ -451,7 +453,8 @@ makePrisms ''InventoryListEntry
 -- | The main record holding the UI state.  For access to the fields,
 -- see the lenses below.
 data UIState = UIState
-  { _uiMenu :: Menu
+  { _uiPort :: Maybe Port
+  , _uiMenu :: Menu
   , _uiPlaying :: Bool
   , _uiNextScenario :: Maybe Scenario
   , _uiCheatMode :: Bool
@@ -500,6 +503,9 @@ let exclude = ['_lgTicksPerSecond]
             if n `elem` exclude then [] else fn n
       )
       ''UIState
+
+-- | The port on which the HTTP debug service is running.
+uiPort :: Lens' UIState (Maybe Port)
 
 -- | The current menu state.
 uiMenu :: Lens' UIState Menu
@@ -696,15 +702,16 @@ initLgTicksPerSecond = 4 -- 2^4 = 16 ticks / second
 --   time, and loading text files from the data directory.  The @Bool@
 --   parameter indicates whether we should start off by showing the
 --   main menu.
-initUIState :: Bool -> Bool -> ExceptT Text IO UIState
-initUIState showMainMenu cheatMode = liftIO $ do
+initUIState :: Maybe Port -> Bool -> Bool -> ExceptT Text IO UIState
+initUIState port showMainMenu cheatMode = liftIO $ do
   historyT <- readFileMayT =<< getSwarmHistoryPath False
   appDataMap <- readAppData
   let history = maybe [] (map REPLEntry . T.lines) historyT
   startTime <- getTime Monotonic
   return $
     UIState
-      { _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
+      { _uiPort = port
+      , _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
       , _uiPlaying = not showMainMenu
       , _uiNextScenario = Nothing
       , _uiCheatMode = cheatMode
@@ -800,11 +807,11 @@ resetWithREPLForm f =
 ------------------------------------------------------------
 
 -- | Initialize the 'AppState'.
-initAppState :: Maybe Seed -> Maybe String -> Maybe String -> Bool -> ExceptT Text IO AppState
-initAppState userSeed scenarioName toRun cheatMode = do
+initAppState :: Maybe Port -> Maybe Seed -> Maybe String -> Maybe String -> Bool -> ExceptT Text IO AppState
+initAppState port userSeed scenarioName toRun cheatMode = do
   let skipMenu = isJust scenarioName || isJust toRun || isJust userSeed
   gs <- initGameState
-  ui <- initUIState (not skipMenu) cheatMode
+  ui <- initUIState port (not skipMenu) cheatMode
   case skipMenu of
     False -> return $ AppState gs ui
     True -> do

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -335,7 +335,7 @@ maybeScroll vpName contents =
 -- | Draw one of the various types of modal dialog.
 drawModal :: AppState -> ModalType -> Widget Name
 drawModal s = \case
-  HelpModal -> helpWidget Nothing Nothing -- XXX save seed & port
+  HelpModal -> helpWidget (s ^. gameState . seed) Nothing -- XXX save port
   RobotsModal -> robotsListWidget s
   RecipesModal -> availableListWidget (s ^. gameState) RecipeList
   CommandsModal -> availableListWidget (s ^. gameState) CommandList
@@ -466,8 +466,8 @@ robotsListWidget s = hCenter table
   debugging = creative && cheat
   g = s ^. gameState
 
-helpWidget :: Maybe Seed -> Maybe Port -> Widget Name
-helpWidget mseed mport =
+helpWidget :: Seed -> Maybe Port -> Widget Name
+helpWidget theSeed mport =
   padTop (Pad 1) $
     hBox . map (padLeftRight 2) $
       [helpKeys, tips <=> padTop (Pad 1) info]
@@ -481,8 +481,8 @@ helpWidget mseed mport =
       ]
   info =
     vBox $
-      [txt $ "Current seed: " <> into @Text (show seed) | Just seed <- [mseed]]
-      ++ [txt $ "Web server running on port: " <> into @Text (show port) | Just port <- [mport]]
+      txt ("Current seed: " <> into @Text (show theSeed)) :
+        [txt $ "Web server running on port: " <> into @Text (show port) | Just port <- [mport]]
   helpKeys =
     vBox
       [ txt "Global Keybindings"

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -335,7 +335,7 @@ maybeScroll vpName contents =
 -- | Draw one of the various types of modal dialog.
 drawModal :: AppState -> ModalType -> Widget Name
 drawModal s = \case
-  HelpModal -> helpWidget (s ^. gameState . seed) Nothing -- XXX save port
+  HelpModal -> helpWidget (s ^. gameState . seed) (s ^. uiState . uiPort)
   RobotsModal -> robotsListWidget s
   RecipesModal -> availableListWidget (s ^. gameState) RecipeList
   CommandsModal -> availableListWidget (s ^. gameState) CommandList
@@ -481,8 +481,11 @@ helpWidget theSeed mport =
       ]
   info =
     vBox $
-      txt ("Current seed: " <> into @Text (show theSeed)) :
-        [txt $ "Web server running on port: " <> into @Text (show port) | Just port <- [mport]]
+      [ txt ("Current seed: " <> into @Text (show theSeed))
+      , txt $ case mport of
+          Nothing -> "The web server is not running."
+          Just port -> "Web server running on port " <> into @Text (show port)
+      ]
   helpKeys =
     vBox
       [ txt "Global Keybindings"

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -480,7 +480,7 @@ helpWidget theSeed mport =
       , txt "  - The #swarm IRC channel on Libera.Chat"
       ]
   info =
-    vBox $
+    vBox
       [ txt ("Current seed: " <> into @Text (show theSeed))
       , txt $ case mport of
           Nothing -> "The web server is not running."

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -360,9 +360,10 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
     NoMenu -> Just "Quit"
     _ -> Nothing
   descriptionWidth = 100
+  helpWidth = 80
   (title, buttons, requiredWidth) =
     case mt of
-      HelpModal -> (" Help ", Nothing, maxModalWindowWidth)
+      HelpModal -> (" Help ", Nothing, helpWidth)
       RobotsModal -> ("Robots", Nothing, descriptionWidth)
       RecipesModal -> ("Available Recipes", Nothing, descriptionWidth)
       CommandsModal -> ("Available Commands", Nothing, descriptionWidth)
@@ -469,8 +470,8 @@ robotsListWidget s = hCenter table
 helpWidget :: Seed -> Maybe Port -> Widget Name
 helpWidget theSeed mport =
   padTop (Pad 1) $
-    hBox . map (padLeftRight 2) $
-      [helpKeys, tips <=> padTop (Pad 1) info]
+    (hBox . map (padLeftRight 2) $ [helpKeys, info])
+      <=> padTop (Pad 1) (hCenter tips)
  where
   tips =
     vBox
@@ -481,14 +482,14 @@ helpWidget theSeed mport =
       ]
   info =
     vBox
-      [ txt ("Current seed: " <> into @Text (show theSeed))
-      , txt $ case mport of
-          Nothing -> "The web server is not running."
-          Just port -> "Web server running on port " <> into @Text (show port)
+      [ txt "Configuration"
+      , txt " "
+      , txt ("Seed: " <> into @Text (show theSeed))
+      , txt ("Web server port: " <> maybe "none" (into @Text . show) mport)
       ]
   helpKeys =
     vBox
-      [ txt "Global Keybindings"
+      [ txt "Keybindings"
       , txt " "
       , mkTable glKeyBindings
       ]

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -56,9 +56,7 @@ webMain baton port gsRef = do
   Warp.runSettings settings app
  where
   onReady = case baton of
-    Just mv -> Warp.setBeforeMainLoop $ do
-      putStrLn $ "Web interface listening on :" <> show port
-      putMVar mv ()
+    Just mv -> Warp.setBeforeMainLoop $ putMVar mv ()
     Nothing -> id
   app :: Network.Wai.Application
   app = Servant.serve (Proxy @SwarmApi) (mkApp gsRef)

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -26,6 +26,7 @@ import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Data.IORef (IORef, readIORef)
 import Data.IntMap qualified as IM
+import Data.Maybe (fromMaybe)
 import Network.Wai qualified
 import Network.Wai.Handler.Warp qualified as Warp
 import Servant
@@ -65,21 +66,22 @@ webMain baton port gsRef = do
 defaultPort :: Warp.Port
 defaultPort = 5357
 
-startWebThread :: Maybe Warp.Port -> IORef GameState -> IO ()
+-- | Attempt to start a web thread on the requested port, or a default
+--   one if none is requested (or don't start a web thread if the
+--   requested port is 0).  If an explicit port was requested, fail if
+--   startup doesn't work.  Otherwise, ignore the failure.  In any
+--   case, return a @Maybe Port@ value representing whether a web
+--   server is actually running, and if so, what port it is on.
+startWebThread :: Maybe Warp.Port -> IORef GameState -> IO (Maybe Warp.Port)
+-- User explicitly provided port '0': don't run the web server
+startWebThread (Just 0) _ = pure Nothing
 startWebThread portM gsRef = do
-  res <- go
-  case res of
-    Nothing -> fail "Fail to start the web api"
-    Just _ -> pure ()
- where
-  go = case portM of
-    Just 0 -> pure (Just ())
-    Just port -> do
-      -- The user provided a port, so we ensure the api does starts
-      baton <- newEmptyMVar
-      void $ forkIO $ webMain (Just baton) port gsRef
-      timeout 500_000 (takeMVar baton)
-    Nothing -> do
-      -- No port was given, the api may fail to start
-      void $ forkIO $ webMain Nothing defaultPort gsRef
-      pure (Just ())
+  baton <- newEmptyMVar
+  let port = fromMaybe defaultPort portM
+  void $ forkIO $ webMain (Just baton) port gsRef
+  res <- timeout 500_000 (takeMVar baton)
+  case (portM, res) of
+    -- User requested explicit port but server didn't start: fail
+    (Just _, Nothing) -> fail $ "Failed to start the web API  on :" <> show port
+    -- Otherwise, just report whether the server is running, and if so, on what port
+    _ -> return (port <$ res)


### PR DESCRIPTION
Improve the Help (F1) modal dialog.

- Get rid of the list of commands; they are now available in Commands modal
- Improve formatting of keybindings list, and add more global keybindings to the list
- Add some text with pointers to the wiki and IRC
- Display current seed (closes #359)
- Display current web API port