### PR TITLE
add recipe for turning iron into a lodestone

### DIFF
--- a/data/recipes.yaml
+++ b/data/recipes.yaml
@@ -132,6 +132,14 @@
 #########################################
 
 - in:
+  - [1, rock]
+  out:
+  - [1, lodestone]
+  required:
+  - [1, lodestone]
+  time: 64
+
+- in:
   - [1, boulder]
   out:
   - [3, rock]

--- a/data/recipes.yaml
+++ b/data/recipes.yaml
@@ -132,14 +132,6 @@
 #########################################
 
 - in:
-  - [1, rock]
-  out:
-  - [1, lodestone]
-  required:
-  - [1, lodestone]
-  time: 64
-
-- in:
   - [1, boulder]
   out:
   - [3, rock]
@@ -396,6 +388,14 @@
   - [2, iron plate]
   required:
   - [1, big furnace]
+
+- in:
+  - [1, iron plate]
+  out:
+  - [1, lodestone]
+  required:
+  - [2, lodestone]
+  time: 64
 
 ## TOOLS
 


### PR DESCRIPTION
If you rub some iron with a lodestone for a long time, the iron turns into another lodestone.

While playing the game it felt like lodestones were too scarce, given the fact that they are needed to evaluate `not`, which ends up getting used frequently.  This way lodestones are actually renewable.