### PR TITLE
start the base out with 50 clocks in classic mode

### DIFF
--- a/data/scenarios/classic.yaml
+++ b/data/scenarios/classic.yaml
@@ -24,6 +24,7 @@ robots:
       - [70, grabber]
       - [100, solar panel]
       - [50, scanner]
+      - [50, clock]
       - [5, toolkit]
 world:
   seed: null


### PR DESCRIPTION
Clocks are somewhat difficult to build, and it's useful to be able to use `wait` early in the game.