### PR TITLE
improved recipe lists

### DIFF
--- a/src/Swarm/Game/Recipe.hs
+++ b/src/Swarm/Game/Recipe.hs
@@ -25,6 +25,7 @@ module Swarm.Game.Recipe (
   loadRecipes,
   outRecipeMap,
   inRecipeMap,
+  reqRecipeMap,
 
   -- * Looking up recipes
   MissingIngredient (..),
@@ -164,16 +165,20 @@ buildRecipeMap select recipeList =
 outRecipeMap :: [Recipe Entity] -> IntMap [Recipe Entity]
 outRecipeMap = buildRecipeMap recipeOutputs
 
+-- | Build a map of recipes indexed by input ingredients.
+inRecipeMap :: [Recipe Entity] -> IntMap [Recipe Entity]
+inRecipeMap = buildRecipeMap recipeInputs
+
+-- | Build a map of recipes indexed by requirements.
+reqRecipeMap :: [Recipe Entity] -> IntMap [Recipe Entity]
+reqRecipeMap = buildRecipeMap recipeRequirements
+
 -- | Get a list of all the recipes for the given entity.  Look up an
 --   entity in either an 'inRecipeMap' or 'outRecipeMap' depending on
 --   whether you want to know recipes that consume or produce the
 --   given entity, respectively.
 recipesFor :: IntMap [Recipe Entity] -> Entity -> [Recipe Entity]
 recipesFor rm e = fromMaybe [] $ IM.lookup (e ^. entityHash) rm
-
--- | Build a map of recipes indexed by input ingredients.
-inRecipeMap :: [Recipe Entity] -> IntMap [Recipe Entity]
-inRecipeMap = buildRecipeMap recipeInputs
 
 data MissingIngredient = MissingIngredient MissingType Count Entity
   deriving (Show, Eq)

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -51,6 +51,7 @@ module Swarm.Game.State (
   entityMap,
   recipesOut,
   recipesIn,
+  recipesReq,
   scenarios,
   knownEntities,
   world,
@@ -135,6 +136,7 @@ import Swarm.Game.Recipe (
   inRecipeMap,
   loadRecipes,
   outRecipeMap,
+  reqRecipeMap,
  )
 import Swarm.Game.Robot
 import Swarm.Game.Scenario
@@ -270,6 +272,7 @@ data GameState = GameState
   , _entityMap :: EntityMap
   , _recipesOut :: IntMap [Recipe Entity]
   , _recipesIn :: IntMap [Recipe Entity]
+  , _recipesReq :: IntMap [Recipe Entity]
   , _scenarios :: ScenarioCollection
   , _knownEntities :: [Text]
   , _world :: W.World Int Entity
@@ -398,6 +401,9 @@ recipesOut :: Lens' GameState (IntMap [Recipe Entity])
 
 -- | All recipes the game knows about, indexed by inputs.
 recipesIn :: Lens' GameState (IntMap [Recipe Entity])
+
+-- | All recipes the game knows about, indexed by requirement/catalyst.
+recipesReq :: Lens' GameState (IntMap [Recipe Entity])
 
 -- | The collection of scenarios that comes with the game.
 scenarios :: Lens' GameState ScenarioCollection
@@ -679,6 +685,7 @@ initGameState = do
       , _entityMap = entities
       , _recipesOut = outRecipeMap recipes
       , _recipesIn = inRecipeMap recipes
+      , _recipesReq = reqRecipeMap recipes
       , _scenarios = loadedScenarios
       , _knownEntities = []
       , _world = W.emptyWorld (fromEnum StoneT)
@@ -726,6 +733,7 @@ scenarioToGameState scenario userSeed toRun g = do
       , _entityMap = em
       , _recipesOut = addRecipesWith outRecipeMap recipesOut
       , _recipesIn = addRecipesWith inRecipeMap recipesIn
+      , _recipesReq = addRecipesWith reqRecipeMap recipesReq
       , _knownEntities = scenario ^. scenarioKnown
       , _world = theWorld theSeed
       , _viewCenterRule = VCRobot baseID

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -870,10 +870,22 @@ explainRecipes s e
       maximumOf (traverse . recipeOutputs . traverse . to width) recipes
   widthLimit = 2 * max maxInputWidth maxOutputWidth + 11
 
+-- | Return all recipes that involve a given entity.
 recipesWith :: AppState -> Entity -> [Recipe Entity]
 recipesWith s e =
   let getRecipes select = recipesFor (s ^. gameState . select) e
-   in L.nub $ getRecipes recipesOut ++ getRecipes recipesIn
+   in -- The order here is chosen intentionally.  See https://github.com/swarm-game/swarm/issues/418.
+      --
+      --   1. Recipes where the entity is an input --- these should go
+      --     first since the first thing you will want to know when you
+      --     obtain a new entity is what you can do with it.
+      --
+      --   2. Recipes where it serves as a catalyst --- for the same reason.
+      --
+      --   3. Recipes where it is an output --- these should go last,
+      --      since if you have it, you probably already figured out how
+      --      to make it.
+      L.nub $ getRecipes recipesIn ++ getRecipes recipesReq ++ getRecipes recipesOut
 
 -- | Draw an ASCII art representation of a recipe.  For now, the
 --   weight is not shown.


### PR DESCRIPTION
- Add recipes where the entity is a catalyst to the recipes shown for
  an entity
- Order recipes so we get recipes where the entity is a (1) input (2)
  catalyst (3) output, in that order.

Closes #418.