### PR TITLE
Shorten craft tutorial name

### DIFF
--- a/data/scenarios/Tutorials/craft.yaml
+++ b/data/scenarios/Tutorials/craft.yaml
@@ -1,4 +1,4 @@
-name: Crafting, part 1
+name: Crafting
 description: |
   Learn how to make new things using recipes.
 #


### PR DESCRIPTION
- there is no crafting part two tutorial (at least so far) so we can do without the suffix