### PR TITLE
WIP: Infinite count

### DIFF
--- a/src/Swarm/DocGen.hs
+++ b/src/Swarm/DocGen.hs
@@ -33,7 +33,7 @@ import Data.Text (Text, unpack)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Tuple (swap)
-import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityName, loadEntities)
+import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityName, loadEntities, Count)
 import Swarm.Game.Entity qualified as E
 import Swarm.Game.Recipe (Recipe, loadRecipes, recipeInputs, recipeOutputs, recipeRequirements)
 import Swarm.Game.Robot (installedDevices, instantiateRobot, robotInventory)
@@ -365,7 +365,7 @@ classicScenario = do
 startingDevices :: Scenario -> Set Entity
 startingDevices = Set.fromList . map snd . E.elems . view installedDevices . instantiateRobot 0 . head . view scenarioRobots
 
-startingInventory :: Scenario -> Map Entity Int
+startingInventory :: Scenario -> Map Entity Count
 startingInventory = Map.fromList . map swap . E.elems . view robotInventory . instantiateRobot 0 . head . view scenarioRobots
 
 -- | Ignore utility entites that are just used for tutorials and challenges.

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -116,7 +116,6 @@ import Data.IntMap qualified as IM
 import Data.IntSet (IntSet)
 import Data.IntSet qualified as IS
 import Data.IntSet.Lens (setOf)
-import Data.List (partition)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
@@ -764,7 +763,8 @@ scenarioToGameState scenario userSeed toRun g = do
   em = g ^. entityMap <> scenario ^. scenarioEntities
 
   baseID = 0
-  (things, devices) = partition (null . view entityCapabilities) (M.elems (entitiesByName em))
+  entities = M.elems (entitiesByName em)
+  devices = filter (not . null . view entityCapabilities) entities
   -- Keep only robots from the robot list with a concrete location;
   -- the others existed only to serve as a template for robots drawn
   -- in the world map
@@ -781,7 +781,7 @@ scenarioToGameState scenario userSeed toRun g = do
       & ix baseID . robotInventory
         %~ case scenario ^. scenarioCreative of
           False -> id
-          True -> union (fromElems (map (0,) things))
+          True -> union (fromElems (map (Infinity,) entities))
       & ix baseID . installedDevices
         %~ case scenario ^. scenarioCreative of
           False -> id

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -48,8 +48,8 @@ import Data.Tuple (swap)
 import Linear (V2 (..), zero, (^+^))
 import Swarm.Game.CESK
 import Swarm.Game.Display
-import Swarm.Game.Entity hiding (empty, lookup, singleton, union)
-import Swarm.Game.Entity qualified as E
+import Swarm.Game.Entity hiding (empty, lookup, singleton, union, Count)
+import Swarm.Game.Entity qualified as E 
 import Swarm.Game.Exception
 import Swarm.Game.Recipe
 import Swarm.Game.Robot
@@ -927,7 +927,10 @@ execConst c vs s k = do
     Count -> case vs of
       [VString name] -> do
         inv <- use robotInventory
-        return $ Out (VInt (fromIntegral $ countByName name inv)) s k
+        let n = case countByName name inv of
+              E.Count x -> x
+              E.Infinity -> 42
+        return $ Out (VInt $ fromIntegral n) s k
       _ -> badConst
     Whereami -> do
       V2 x y <- use robotLocation
@@ -1375,22 +1378,22 @@ execConst c vs s k = do
             let salvageInventory = E.union (target ^. robotInventory) (target ^. installedDevices)
             robotMap . at (target ^. robotID) . traverse . robotInventory .= salvageInventory
 
-            let salvageItems = concatMap (\(n, e) -> replicate n (e ^. entityName)) (E.elems salvageInventory)
-                numItems = length salvageItems
 
             -- Copy over the salvaged robot's log, if we have one
             inst <- use installedDevices
             em <- use entityMap
             creative <- use creativeMode
+            system <- use systemRobot
             logger <-
               lookupEntityName "logger" em
                 `isJustOr` Fatal "While executing 'salvage': there's no such thing as a logger!?"
             when (creative || inst `E.contains` logger) $ robotLog <>= target ^. robotLog
 
             -- Immediately copy over any items the robot knows about
-            -- but has 0 of
-            let knownItems = map snd . filter ((== 0) . fst) . elems $ salvageInventory
-            robotInventory %= \i -> foldr (insertCount 0) i knownItems
+            -- but has 0 of and in creative mode just get everything now.
+            let immediate = if system || creative then id else filter ((== 0) . fst)
+            let immediateItems = map snd . immediate . elems $ salvageInventory
+            robotInventory %= \i -> foldr (insertCount 0) i immediateItems
 
             -- Now reprogram the robot being salvaged to 'give' each
             -- item in its inventory to us, one at a time, then
@@ -1399,6 +1402,13 @@ execConst c vs s k = do
             robotMap . at (target ^. robotID) . traverse . systemRobot .= True
 
             ourID <- use @Robot robotID
+            let salvageItems = if system || creative
+                  then []
+                  else concatMap (uncurry replicateCount) (E.elems salvageInventory)
+                numItems = length salvageItems
+                replicateCount n e = e ^. entityName & case n of
+                  E.Count x -> replicate (fromIntegral x)
+                  E.Infinity -> replicate 42
 
             -- The program for the salvaged robot to run
             let giveInventory =

--- a/src/Swarm/Language/Requirement.hs
+++ b/src/Swarm/Language/Requirement.hs
@@ -40,7 +40,8 @@ import GHC.Generics (Generic)
 import Swarm.Language.Capability (Capability (..), constCaps)
 import Swarm.Language.Context (Ctx)
 import Swarm.Language.Context qualified as Ctx
-import Swarm.Language.Syntax
+import Swarm.Language.Syntax hiding (Count)
+import Swarm.Game.Entity (Count(..))
 
 -- | A /requirement/ is something a robot must have when it is
 --   built. There are three types:
@@ -84,7 +85,7 @@ data Requirement
 data Requirements = Requirements
   { capReqs :: Set Capability
   , devReqs :: Set Text
-  , invReqs :: Map Text Int
+  , invReqs :: Map Text Count
   }
   deriving (Eq, Ord, Show, Data, Generic, FromJSON, ToJSON)
 
@@ -99,7 +100,7 @@ instance Monoid Requirements where
 singleton :: Requirement -> Requirements
 singleton (ReqCap c) = Requirements (S.singleton c) S.empty M.empty
 singleton (ReqDev d) = Requirements S.empty (S.singleton d) M.empty
-singleton (ReqInv n e) = Requirements S.empty S.empty (M.singleton e n)
+singleton (ReqInv n e) = Requirements S.empty S.empty (M.singleton e (Count $ fromIntegral n))
 
 -- | For convenience, create a 'Requirements' set with a single
 --   'Capability' requirement.

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -847,7 +847,10 @@ drawItem sel i _ (Separator l) =
   (if sel == Just (i + 1) then visible else id) $ hBorderWithLabel (txt l)
 drawItem _ _ _ (InventoryEntry n e) = drawLabelledEntityName e <+> showCount n
  where
-  showCount = padLeft Max . str . show
+  showCount = padLeft Max . str . prettyCount
+  prettyCount = \case
+    E.Count a -> show a
+    E.Infinity -> "∞"
 drawItem _ _ _ (InstalledEntry e) = drawLabelledEntityName e <+> padLeft Max (str " ")
 
 -- | Draw the name of an entity, labelled with its visual


### PR DESCRIPTION
This approach is buggy in two ways:
- it can **crash** because [`Natural`](https://hackage.haskell.org/package/base-4.14.1.0/docs/GHC-Natural.html#t:Natural) is too strict
- it breaks the fragile hashing laws for inventory

A better approach would be to either do without a `Num` instance and handle every usage carefully or add _negative infinity_ too and use integers.

In that case, we might as well add them to the number values in-game.
We can handle adding infinities together with a `safeAdd` function and they would only become available in creative mode or special scenarios anyway.

- closes #621 