### PR TITLE
Add cotton, strings, and nets

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -323,8 +323,17 @@
     char: '~'
   description:
   - A long, flexible device for transferring either force or
-    information, made of twisted cotton fibers.
+    information, made of twisted cotton fibers.  Multiple strings can
+    also be woven into larger configurations such as cloth or nets.
+  - |
+    A string device enables two commands: the first, `format : a ->
+    text`, can turn any value into a suitable text representation.
+    The second is the infix operator `++ : text -> text -> text`
+    which can be used to concatenate two text values.  For example,
+  - |
+    "Number of widgets: " ++ format numWidgets
   properties: [portable]
+  capabilities: [text]
 
 - name: lambda
   display:

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -317,6 +317,15 @@
   properties: [portable, growable]
   growth: [100, 800]
 
+- name: string
+  display:
+    attr: silver
+    char: '~'
+  description:
+  - A long, flexible device for transferring either force or
+    information, made of twisted cotton fibers.
+  properties: [portable]
+
 - name: lambda
   display:
     attr: flower
@@ -933,3 +942,17 @@
 
   properties: [portable]
   capabilities: [atomic]
+
+- name: net
+  display:
+    attr: silver
+    char: '#'
+  description:
+  - A net is a device woven out of many strings.  With a net
+    installed, you can use the `try` command to catch errors. For example,
+  - |
+    `try {move} {turn left}`
+  - will attempt to move, but if that fails, turn left instead.
+  properties: [portable]
+  capabilities: [try]
+

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -306,6 +306,17 @@
   properties: [portable, growable]
   growth: [30, 50]
 
+- name: cotton
+  display:
+    attr: silver
+    char: 'i'
+  description:
+  - A plant with tufts of soft fibers that can be harvested and used
+    to make things, including sheets of material that the local
+    aliens like to drape over their bodies.
+  properties: [portable, growable]
+  growth: [100, 800]
+
 - name: lambda
   display:
     attr: flower

--- a/data/recipes.yaml
+++ b/data/recipes.yaml
@@ -667,3 +667,19 @@
   - [1, strange loop]
   out:
   - [1, rubber band]
+
+#########################################
+##                COTTON               ##
+#########################################
+
+- in:
+  - [4, cotton]
+  out:
+  - [1, string]
+  required:
+  - [1, small motor]
+
+- in:
+  - [256, string]
+  out:
+  - [1, net]

--- a/data/scenarios/Testing/508-capability-subset.yaml
+++ b/data/scenarios/Testing/508-capability-subset.yaml
@@ -13,16 +13,22 @@ objectives:
       } { return false }
 solution: |
   log "Hi, I can build teleporting robots!";
-  build {log "Hi, I can teleport!"; teleport self (5,0); p <- whereami; log $ "I am at " ++ format p}
+  try {
+    build {log "Hi, I can teleport!"; teleport self (5,0); p <- whereami; log $ "I am at " ++ format p}
+  } {
+    fail "Fatal error: BASE: I could not build my robot! What happened?!"
+  }
 robots:
   - name: base
     loc: [0,0]
     dir: [1,0]
     devices:
       - logger
+      - net
       - 3D printer
     inventory:
       - [1, mirror]
+      - [1, string]
       - [1, GPS]
       - [1, Tardis]
       - [1, logger]

--- a/data/scenarios/Tutorials/bind.yaml
+++ b/data/scenarios/Tutorials/bind.yaml
@@ -12,8 +12,8 @@ objectives:
       - |
         Other commands do return a nontrivial value after executing.
         For example, `grab` has type
-        `cmd string`, and returns the name of the
-        grabbed entity as a string. Try it:
+        `cmd text`, and returns the name of the
+        grabbed entity as a text value. Try it:
       - |
         move; grab
       - |

--- a/data/scenarios/Tutorials/conditionals.yaml
+++ b/data/scenarios/Tutorials/conditionals.yaml
@@ -12,7 +12,7 @@ objectives:
         to sweep over the entire 4x4 square and pick up a `very small
         rock` any time you detect one.
       - |
-        The `ishere` command, with type `string -> cmd bool`, can be used
+        The `ishere` command, with type `text -> cmd bool`, can be used
         for detecting the presence of a specific item such as a `very small rock`.
         What we need is a way to take the `bool` output from `ishere`
         and use it to decide whether to `grab` a rock or not.
@@ -45,7 +45,7 @@ objectives:
       - |
         TIP: the two branches of an `if` must have the same type. In particular,
         `if ... {grab} {}` is not
-        allowed, because `{grab}` has type `{cmd string}` whereas `{}` has type `{cmd ()}`.
+        allowed, because `{grab}` has type `{cmd text}` whereas `{}` has type `{cmd ()}`.
         In this case `{grab; return ()}` has the right type.
     condition: |
       try {

--- a/data/scenarios/Tutorials/crash-secret.sw
+++ b/data/scenarios/Tutorials/crash-secret.sw
@@ -21,7 +21,7 @@ end;
 
 // Try to give a robot a Win, filtering out those that were already given a Win.
 // The robot will also receive instructions, so it **must have a logger!**
-def tryGive: string -> (robot -> bool) -> int -> cmd (robot -> bool) = \msg.\f.\i.
+def tryGive: text -> (robot -> bool) -> int -> cmd (robot -> bool) = \msg.\f.\i.
   r <- try {
     robotNumbered i;
   } {

--- a/data/scenarios/Tutorials/farming.sw
+++ b/data/scenarios/Tutorials/farming.sw
@@ -11,7 +11,7 @@ end;
 def while : cmd bool -> {cmd a} -> cmd () = \test. \body.
   ifC test {force body ; while test body} {}
 end;
-def giveall : robot -> string -> cmd () = \r. \thing.
+def giveall : robot -> text -> cmd () = \r. \thing.
   while (has thing) {give r thing}
 end;
 def x4 = \c. c; c; c; c end;
@@ -19,14 +19,14 @@ def m4 = x4 move end;
 def x12 = \c. x4 (c;c;c) end;
 def m12 = x12 move end;
 def next_row = tB; m12; tL; move; tL end;
-def plant_field : string -> cmd () = \thing.
+def plant_field : text -> cmd () = \thing.
   log "planting";
   x4 (
     x12 (move; place thing; harvest);
     next_row
   )
 end;
-def harvest_field : string -> cmd () = \thing.
+def harvest_field : text -> cmd () = \thing.
   x4 (
     x12 (move; ifC (ishere thing) {harvest; return ()} {});
     next_row

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -97,7 +97,7 @@
                "west"
                "down"
              ))
-             (x-types '("int" "string" "dir" "bool" "cmd"))
+             (x-types '("int" "text" "dir" "bool" "cmd"))
 
              (x-keywords-regexp (regexp-opt x-keywords 'words))
              (x-builtins-regexp (regexp-opt x-builtins 'words))

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -152,7 +152,7 @@ import Swarm.Language.Capability (constCaps)
 import Swarm.Language.Context qualified as Ctx
 import Swarm.Language.Pipeline (ProcessedTerm)
 import Swarm.Language.Pipeline.QQ (tmQ)
-import Swarm.Language.Syntax (Const, Term (TString), allConst)
+import Swarm.Language.Syntax (Const, Term (TText), allConst)
 import Swarm.Language.Types
 import Swarm.Util (getElemsInArea, isRightOr, manhattan, uniq, (<+=), (<<.=), (?))
 import System.Clock qualified as Clock

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -567,7 +567,7 @@ viewingRegion :: GameState -> (Int64, Int64) -> (W.Coords, W.Coords)
 viewingRegion g (w, h) = (W.Coords (rmin, cmin), W.Coords (rmax, cmax))
  where
   V2 cx cy = g ^. viewCenter
-  (rmin, rmax) = over both (+ (- cy - h `div` 2)) (0, h - 1)
+  (rmin, rmax) = over both (+ (-cy - h `div` 2)) (0, h - 1)
   (cmin, cmax) = over both (+ (cx - w `div` 2)) (0, w - 1)
 
 -- | Find out which robot has been last specified by the

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1435,7 +1435,7 @@ execConst c vs s k = do
       [VBool b] -> return $ Out (VBool (not b)) s k
       _ -> badConst
     Neg -> case vs of
-      [VInt n] -> return $ Out (VInt (- n)) s k
+      [VInt n] -> return $ Out (VInt (-n)) s k
       _ -> badConst
     Eq -> returnEvalCmp
     Neq -> returnEvalCmp

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -407,10 +407,10 @@ stepCESK cesk = case cesk of
   In TUnit _ s k -> return $ Out VUnit s k
   In (TDir d) _ s k -> return $ Out (VDir d) s k
   In (TInt n) _ s k -> return $ Out (VInt n) s k
-  In (TString str) _ s k -> return $ Out (VString str) s k
+  In (TText str) _ s k -> return $ Out (VText str) s k
   In (TBool b) _ s k -> return $ Out (VBool b) s k
   -- There should not be any antiquoted variables left at this point.
-  In (TAntiString v) _ s k ->
+  In (TAntiText v) _ s k ->
     return $ Up (Fatal (T.append "Antiquoted variable found at runtime: $str:" v)) s k
   In (TAntiInt v) _ s k ->
     return $ Up (Fatal (T.append "Antiquoted variable found at runtime: $int:" v)) s k
@@ -785,7 +785,7 @@ execConst c vs s k = do
         return $ Out VUnit s k
       _ -> badConst
     Place -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         inv <- use robotInventory
         loc <- use robotLocation
 
@@ -809,7 +809,7 @@ execConst c vs s k = do
         return $ Out VUnit s k
       _ -> badConst
     Give -> case vs of
-      [VRobot otherID, VString itemName] -> do
+      [VRobot otherID, VText itemName] -> do
         -- Make sure the other robot exists and is close
         _other <- getRobotWithinTouch otherID
 
@@ -834,7 +834,7 @@ execConst c vs s k = do
         return $ Out VUnit s k
       _ -> badConst
     Install -> case vs of
-      [VRobot otherID, VString itemName] -> do
+      [VRobot otherID, VText itemName] -> do
         -- Make sure the other robot exists and is close
         _other <- getRobotWithinTouch otherID
 
@@ -868,7 +868,7 @@ execConst c vs s k = do
         return $ Out VUnit s k
       _ -> badConst
     Make -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         inv <- use robotInventory
         ins <- use installedDevices
         em <- use entityMap
@@ -915,17 +915,17 @@ execConst c vs s k = do
         finishCookingRecipe recipe (WorldUpdate Right) (RobotUpdate changeInv)
       _ -> badConst
     Has -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         inv <- use robotInventory
         return $ Out (VBool ((> 0) $ countByName name inv)) s k
       _ -> badConst
     Installed -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         inv <- use installedDevices
         return $ Out (VBool ((> 0) $ countByName name inv)) s k
       _ -> badConst
     Count -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         inv <- use robotInventory
         return $ Out (VInt (fromIntegral $ countByName name inv)) s k
       _ -> badConst
@@ -996,12 +996,12 @@ execConst c vs s k = do
           Just e -> do
             robotInventory %= insertCount 0 e
             updateDiscoveredEntities e
-            return $ VInj True (VString (e ^. entityName))
+            return $ VInj True (VText (e ^. entityName))
 
         return $ Out res s k
       _ -> badConst
     Knows -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         inv <- use robotInventory
         ins <- use installedDevices
         let allKnown = inv `E.union` ins
@@ -1060,7 +1060,7 @@ execConst c vs s k = do
         return $ Out v s k
       _ -> badConst
     RobotNamed -> case vs of
-      [VString rname] -> do
+      [VText rname] -> do
         r <- robotWithName rname >>= (`isJustOrFail` ["There is no robot named", rname])
         let robotValue = VRobot (r ^. robotID)
         return $ Out robotValue s k
@@ -1074,7 +1074,7 @@ execConst c vs s k = do
         return $ Out robotValue s k
       _ -> badConst
     Say -> case vs of
-      [VString msg] -> do
+      [VText msg] -> do
         creative <- use creativeMode
         system <- use systemRobot
         loc <- use robotLocation
@@ -1115,10 +1115,10 @@ execConst c vs s k = do
       return $
         maybe
           (In (TConst Listen) mempty s (FExec : k)) -- continue listening
-          (\m -> Out (VString m) s k) -- return found message
+          (\m -> Out (VText m) s k) -- return found message
           mm
     Log -> case vs of
-      [VString msg] -> do
+      [VText msg] -> do
         void $ traceLog Logged msg
         return $ Out VUnit s k
       _ -> badConst
@@ -1137,7 +1137,7 @@ execConst c vs s k = do
         return $ Out VUnit s k
       _ -> badConst
     Appear -> case vs of
-      [VString app] -> do
+      [VText app] -> do
         flagRedraw
         case into @String app of
           [dc] -> do
@@ -1154,7 +1154,7 @@ execConst c vs s k = do
           _other -> raise Appear [quote app, "is not a valid appearance string. 'appear' must be given a string with exactly 1 or 5 characters."]
       _ -> badConst
     Create -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         em <- use entityMap
         e <-
           lookupEntityName name em
@@ -1166,7 +1166,7 @@ execConst c vs s k = do
         return $ Out VUnit s k
       _ -> badConst
     Ishere -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         loc <- use robotLocation
         me <- entityAt loc
         case me of
@@ -1184,10 +1184,10 @@ execConst c vs s k = do
     Whoami -> case vs of
       [] -> do
         name <- use robotName
-        return $ Out (VString name) s k
+        return $ Out (VText name) s k
       _ -> badConst
     Setname -> case vs of
-      [VString name] -> do
+      [VText name] -> do
         robotName .= name
         return $ Out VUnit s k
       _ -> badConst
@@ -1245,7 +1245,7 @@ execConst c vs s k = do
       _ -> badConst
     Undefined -> return $ Up (User "undefined") s k
     Fail -> case vs of
-      [VString msg] -> return $ Up (User msg) s k
+      [VText msg] -> return $ Up (User msg) s k
       _ -> badConst
     Reprogram -> case vs of
       [VRobot childRobotID, VDelay cmd e] -> do
@@ -1403,7 +1403,7 @@ execConst c vs s k = do
             -- The program for the salvaged robot to run
             let giveInventory =
                   foldr (TBind Nothing . giveItem) (TConst Selfdestruct) salvageItems
-                giveItem item = TApp (TApp (TConst Give) (TRobot ourID)) (TString item)
+                giveItem item = TApp (TApp (TConst Give) (TRobot ourID)) (TText item)
 
             -- Reprogram and activate the salvaged robot
             robotMap . at (target ^. robotID) . traverse . machine
@@ -1418,7 +1418,7 @@ execConst c vs s k = do
     -- with and without file extension as in
     -- "./path/to/file.sw" and "./path/to/file"
     Run -> case vs of
-      [VString fileName] -> do
+      [VText fileName] -> do
         mf <- sendIO $ mapM readFileMay [into fileName, into $ fileName <> ".sw"]
 
         f <- msum mf `isJustOrFail` ["File not found:", fileName]
@@ -1455,10 +1455,10 @@ execConst c vs s k = do
     Div -> returnEvalArith
     Exp -> returnEvalArith
     Format -> case vs of
-      [v] -> return $ Out (VString (prettyValue v)) s k
+      [v] -> return $ Out (VText (prettyValue v)) s k
       _ -> badConst
     Concat -> case vs of
-      [VString v1, VString v2] -> return $ Out (VString (v1 <> v2)) s k
+      [VText v1, VText v2] -> return $ Out (VText (v1 <> v2)) s k
       _ -> badConst
     AppF ->
       let msg = "The operator '$' should only be a syntactic sugar and removed in elaboration:\n"
@@ -1744,7 +1744,7 @@ execConst c vs s k = do
     updateDiscoveredEntities e'
 
     -- Return the name of the item obtained.
-    return $ Out (VString (e' ^. entityName)) s k
+    return $ Out (VText (e' ^. entityName)) s k
 
 ------------------------------------------------------------
 -- Some utility functions
@@ -1847,7 +1847,7 @@ compareValues :: Has (Throw Exn) sig m => Value -> Value -> m Ordering
 compareValues v1 = case v1 of
   VUnit -> \case VUnit -> return EQ; v2 -> incompatCmp VUnit v2
   VInt n1 -> \case VInt n2 -> return (compare n1 n2); v2 -> incompatCmp v1 v2
-  VString t1 -> \case VString t2 -> return (compare t1 t2); v2 -> incompatCmp v1 v2
+  VText t1 -> \case VText t2 -> return (compare t1 t2); v2 -> incompatCmp v1 v2
   VDir d1 -> \case VDir d2 -> return (compare d1 d2); v2 -> incompatCmp v1 v2
   VBool b1 -> \case VBool b2 -> return (compare b1 b2); v2 -> incompatCmp v1 v2
   VRobot r1 -> \case VRobot r2 -> return (compare r1 r2); v2 -> incompatCmp v1 v2

--- a/src/Swarm/Game/Value.hs
+++ b/src/Swarm/Game/Value.hs
@@ -40,8 +40,8 @@ data Value where
   VUnit :: Value
   -- | An integer.
   VInt :: Integer -> Value
-  -- | A literal string.
-  VString :: Text -> Value
+  -- | Literal text.
+  VText :: Text -> Value
   -- | A direction.
   VDir :: Direction -> Value
   -- | A boolean.
@@ -95,7 +95,7 @@ prettyValue = prettyText . valueToTerm
 valueToTerm :: Value -> Term
 valueToTerm VUnit = TUnit
 valueToTerm (VInt n) = TInt n
-valueToTerm (VString s) = TString s
+valueToTerm (VText s) = TText s
 valueToTerm (VDir d) = TDir d
 valueToTerm (VBool b) = TBool b
 valueToTerm (VRobot r) = TRobot r

--- a/src/Swarm/Game/WorldGen.hs
+++ b/src/Swarm/Game/WorldGen.hs
@@ -111,7 +111,8 @@ testWorld2 em baseSeed = second (readEntity em) (WF tw2)
       | even (r + c) = (DirtT, Just "wavy water")
       | otherwise = (DirtT, Just "water")
     genBiome Small Soft Natural
-      | h `mod` 10 == 0 = (GrassT, Just "flower")
+      | h `mod` 20 == 0 = (GrassT, Just "flower")
+      | h `mod` 20 == 10 = (GrassT, Just "cotton")
       | otherwise = (GrassT, Nothing)
     genBiome Small Soft Artificial
       | h `mod` 10 == 0 = (GrassT, Just (T.concat ["bit (", from (show ((r + c) `mod` 2)), ")"]))

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -112,6 +112,8 @@ data Capability
   | -- | Capabiltiy to do time-related things, like `wait` and get the
     --   current time.
     CTime
+  | -- | Capability to execute `try`.
+    CTry
   | -- | God-like capabilities.  For e.g. commands intended only for
     --   checking challenge mode win conditions, and not for use by
     --   players.
@@ -212,6 +214,9 @@ constCaps = \case
   Or -> Just CCond
   Not -> Just CNegation
   -- ----------------------------------------------------------------
+  -- exceptions
+  Try -> Just CTry
+  -- ----------------------------------------------------------------
   -- Some additional straightforward ones, which however currently
   -- cannot be used in classic mode since there is no craftable item
   -- which conveys their capability. TODO: #26
@@ -228,5 +233,4 @@ constCaps = \case
   Case -> Nothing
   Fst -> Nothing -- XXX should require cap for pairs
   Snd -> Nothing
-  Try -> Nothing -- XXX these definitely need to require something.
   Knows -> Nothing

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -81,6 +81,8 @@ data Capability
     CListen
   | -- | Execute the 'Log' command
     CLog
+  | -- | Manipulate text values
+    CText
   | -- | Don't drown in liquid
     CFloat
   | -- | Evaluate conditional expressions
@@ -191,9 +193,9 @@ constCaps = \case
   Time -> Just CTime
   Wait -> Just CTime
   -- ----------------------------------------------------------------
-  -- String operations
-  Format -> Just CLog
-  Concat -> Just CLog
+  -- Text operations
+  Format -> Just CText
+  Concat -> Just CText
   -- ----------------------------------------------------------------
   -- Some God-like abilities.
   As -> Just CGod

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -82,7 +82,7 @@ reservedWords =
   map (syntax . constInfo) (filter isUserFunc allConst)
     ++ map (dirSyntax . dirInfo) allDirs
     ++ [ "int"
-       , "string"
+       , "text"
        , "dir"
        , "bool"
        , "robot"
@@ -137,9 +137,9 @@ identifier = (lexeme . try) (p >>= check) <?> "variable name"
    where
     t = into @Text s
 
--- | Parse a string literal (including escape sequences) in double quotes.
-stringLiteral :: Parser Text
-stringLiteral = into <$> lexeme (char '"' >> manyTill L.charLiteral (char '"'))
+-- | Parse a text literal (including escape sequences) in double quotes.
+textLiteral :: Parser Text
+textLiteral = into <$> lexeme (char '"' >> manyTill L.charLiteral (char '"'))
 
 -- | Parse a positive integer literal token, in decimal, binary,
 --   octal, or hexadecimal notation.  Note that negation is handled as
@@ -206,7 +206,7 @@ parseTypeAtom =
   TyUnit <$ symbol "()"
     <|> TyVar <$> identifier
     <|> TyInt <$ reserved "int"
-    <|> TyString <$ reserved "string"
+    <|> TyText <$ reserved "text"
     <|> TyDir <$ reserved "dir"
     <|> TyBool <$ reserved "bool"
     <|> TyRobot <$ reserved "robot"
@@ -246,14 +246,14 @@ parseTermAtom =
         <|> TVar <$> identifier
         <|> TDir <$> parseDirection
         <|> TInt <$> integer
-        <|> TString <$> stringLiteral
+        <|> TText <$> textLiteral
         <|> TBool <$> ((True <$ reserved "true") <|> (False <$ reserved "false"))
         <|> reserved "require"
           *> ( ( TRequireDevice
-                  <$> (stringLiteral <?> "device name in double quotes")
+                  <$> (textLiteral <?> "device name in double quotes")
                )
                 <|> ( TRequire <$> (fromIntegral <$> integer)
-                        <*> (stringLiteral <?> "entity name in double quotes")
+                        <*> (textLiteral <?> "entity name in double quotes")
                     )
              )
         <|> SLam <$> (symbol "\\" *> identifier)
@@ -295,7 +295,7 @@ sDef x ty t = SDef (x `S.member` setOf fv (sTerm t)) x ty t
 
 parseAntiquotation :: Parser Term
 parseAntiquotation =
-  TAntiString <$> (lexeme . try) (symbol "$str:" *> identifier)
+  TAntiText <$> (lexeme . try) (symbol "$str:" *> identifier)
     <|> TAntiInt <$> (lexeme . try) (symbol "$int:" *> identifier)
 
 -- | Parse a Swarm language term.

--- a/src/Swarm/Language/Pipeline/QQ.hs
+++ b/src/Swarm/Language/Pipeline/QQ.hs
@@ -49,12 +49,12 @@ quoteTermExp s = do
     Right ptm -> dataToExpQ ((fmap liftText . cast) `extQ` antiTermExp) ptm
 
 antiTermExp :: Term -> Maybe TH.ExpQ
-antiTermExp (TAntiString v) =
-  Just $ TH.appE (TH.conE (TH.mkName "TString")) (TH.varE (TH.mkName (from v)))
+antiTermExp (TAntiText v) =
+  Just $ TH.appE (TH.conE (TH.mkName "TText")) (TH.varE (TH.mkName (from v)))
 antiTermExp (TAntiInt v) =
   Just $ TH.appE (TH.conE (TH.mkName "TInt")) (TH.varE (TH.mkName (from v)))
 antiTermExp _ = Nothing
 
--- At the moment, only antiquotation of literal strings and ints are
+-- At the moment, only antiquotation of literal text and ints are
 -- supported, because that's what we need for the seedProgram.  But
 -- we can easily add more in the future.

--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -58,7 +58,7 @@ instance PrettyPrec BaseTy where
   prettyPrec _ BUnit = "()"
   prettyPrec _ BInt = "int"
   prettyPrec _ BDir = "dir"
-  prettyPrec _ BString = "string"
+  prettyPrec _ BText = "text"
   prettyPrec _ BBool = "bool"
   prettyPrec _ BRobot = "robot"
 
@@ -116,13 +116,13 @@ instance PrettyPrec Term where
   prettyPrec _ (TDir d) = ppr d
   prettyPrec _ (TInt n) = pretty n
   prettyPrec _ (TAntiInt v) = "$int:" <> pretty v
-  prettyPrec _ (TString s) = fromString (show s)
-  prettyPrec _ (TAntiString v) = "$str:" <> pretty v
+  prettyPrec _ (TText s) = fromString (show s)
+  prettyPrec _ (TAntiText v) = "$str:" <> pretty v
   prettyPrec _ (TBool b) = bool "false" "true" b
   prettyPrec _ (TRobot r) = "<r" <> pretty r <> ">"
   prettyPrec _ (TRef r) = "@" <> pretty r
-  prettyPrec p (TRequireDevice d) = pparens (p > 10) $ "require" <+> ppr (TString d)
-  prettyPrec p (TRequire n e) = pparens (p > 10) $ "require" <+> pretty n <+> ppr (TString e)
+  prettyPrec p (TRequireDevice d) = pparens (p > 10) $ "require" <+> ppr (TText d)
+  prettyPrec p (TRequire n e) = pparens (p > 10) $ "require" <+> pretty n <+> ppr (TText e)
   prettyPrec _ (TVar s) = pretty s
   prettyPrec _ (TDelay _ t) = braces $ ppr t
   prettyPrec _ t@TPair {} = prettyTuple t

--- a/src/Swarm/Language/Requirement.hs
+++ b/src/Swarm/Language/Requirement.hs
@@ -187,8 +187,8 @@ requirements' = go
     TDir d -> if isCardinal d then singletonCap COrient else mempty
     TInt _ -> mempty
     TAntiInt _ -> mempty
-    TString _ -> mempty
-    TAntiString _ -> mempty
+    TText _ -> mempty
+    TAntiText _ -> mempty
     TBool _ -> mempty
     -- Look up the capabilities required by a function/command
     -- constants using 'constCaps'.

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -757,7 +757,7 @@ pattern TDelay :: DelayType -> Term -> Term
 pattern TDelay m t = SDelay m (STerm t)
 
 -- | COMPLETE pragma tells GHC using this set of pattern is complete for Term
-{-# COMPLETE TUnit, TConst, TDir, TInt, TAntiInt, TString, TAntiString, TBool, TRequireDevice, TRequire, TVar, TPair, TLam, TApp, TLet, TDef, TBind, TDelay #-}
+{-# COMPLETE TUnit, TConst, TDir, TInt, TAntiInt, TText, TAntiText, TBool, TRequireDevice, TRequire, TVar, TPair, TLam, TApp, TLet, TDef, TBind, TDelay #-}
 
 ------------------------------------------------------------
 -- Terms
@@ -791,10 +791,10 @@ data Term
     TInt Integer
   | -- | An antiquoted Haskell variable name of type Integer.
     TAntiInt Text
-  | -- | A string literal.
-    TString Text
+  | -- | A text literal.
+    TText Text
   | -- | An antiquoted Haskell variable name of type Text.
-    TAntiString Text
+    TAntiText Text
   | -- | A Boolean literal.
     TBool Bool
   | -- | A robot value.  These never show up in surface syntax, but are
@@ -851,8 +851,8 @@ fvT f = go S.empty
     TDir {} -> pure t
     TInt {} -> pure t
     TAntiInt {} -> pure t
-    TString {} -> pure t
-    TAntiString {} -> pure t
+    TText {} -> pure t
+    TAntiText {} -> pure t
     TBool {} -> pure t
     TRobot {} -> pure t
     TRef {} -> pure t

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -117,9 +117,9 @@ allDirs = [minBound .. maxBound]
 -- | Information about all directions
 dirInfo :: Direction -> DirInfo
 dirInfo d = case d of
-  DLeft -> relative (\(V2 x y) -> V2 (- y) x)
-  DRight -> relative (\(V2 x y) -> V2 y (- x))
-  DBack -> relative (\(V2 x y) -> V2 (- x) (- y))
+  DLeft -> relative (\(V2 x y) -> V2 (-y) x)
+  DRight -> relative (\(V2 x y) -> V2 y (-x))
+  DBack -> relative (\(V2 x y) -> V2 (-x) (-y))
   DDown -> relative (const down)
   DForward -> relative id
   DNorth -> cardinal north

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -332,8 +332,8 @@ infer s@(Syntax l t) = (`catchError` addLocToTypeErr s) $ case t of
   TDir _ -> return UTyDir
   TInt _ -> return UTyInt
   TAntiInt _ -> return UTyInt
-  TString _ -> return UTyString
-  TAntiString _ -> return UTyString
+  TText _ -> return UTyText
+  TAntiText _ -> return UTyText
   TBool _ -> return UTyBool
   TRobot _ -> return UTyRobot
   -- We should never encounter a TRef since they do not show up in
@@ -464,38 +464,38 @@ inferConst c = case c of
   Selfdestruct -> [tyQ| cmd () |]
   Move -> [tyQ| cmd () |]
   Turn -> [tyQ| dir -> cmd () |]
-  Grab -> [tyQ| cmd string |]
-  Harvest -> [tyQ| cmd string |]
-  Place -> [tyQ| string -> cmd () |]
-  Give -> [tyQ| robot -> string -> cmd () |]
-  Install -> [tyQ| robot -> string -> cmd () |]
-  Make -> [tyQ| string -> cmd () |]
-  Has -> [tyQ| string -> cmd bool |]
-  Installed -> [tyQ| string -> cmd bool |]
-  Count -> [tyQ| string -> cmd int |]
+  Grab -> [tyQ| cmd text |]
+  Harvest -> [tyQ| cmd text |]
+  Place -> [tyQ| text -> cmd () |]
+  Give -> [tyQ| robot -> text -> cmd () |]
+  Install -> [tyQ| robot -> text -> cmd () |]
+  Make -> [tyQ| text -> cmd () |]
+  Has -> [tyQ| text -> cmd bool |]
+  Installed -> [tyQ| text -> cmd bool |]
+  Count -> [tyQ| text -> cmd int |]
   Reprogram -> [tyQ| robot -> {cmd a} -> cmd () |]
   Build -> [tyQ| {cmd a} -> cmd robot |]
   Drill -> [tyQ| dir -> cmd () |]
   Salvage -> [tyQ| cmd () |]
-  Say -> [tyQ| string -> cmd () |]
-  Listen -> [tyQ| cmd string |]
-  Log -> [tyQ| string -> cmd () |]
+  Say -> [tyQ| text -> cmd () |]
+  Listen -> [tyQ| cmd text |]
+  Log -> [tyQ| text -> cmd () |]
   View -> [tyQ| robot -> cmd () |]
-  Appear -> [tyQ| string -> cmd () |]
-  Create -> [tyQ| string -> cmd () |]
+  Appear -> [tyQ| text -> cmd () |]
+  Create -> [tyQ| text -> cmd () |]
   Time -> [tyQ| cmd int |]
   Whereami -> [tyQ| cmd (int * int) |]
   Blocked -> [tyQ| cmd bool |]
-  Scan -> [tyQ| dir -> cmd (() + string) |]
+  Scan -> [tyQ| dir -> cmd (() + text) |]
   Upload -> [tyQ| robot -> cmd () |]
-  Ishere -> [tyQ| string -> cmd bool |]
+  Ishere -> [tyQ| text -> cmd bool |]
   Self -> [tyQ| robot |]
   Parent -> [tyQ| robot |]
   Base -> [tyQ| robot |]
-  Whoami -> [tyQ| cmd string |]
-  Setname -> [tyQ| string -> cmd () |]
+  Whoami -> [tyQ| cmd text |]
+  Setname -> [tyQ| text -> cmd () |]
   Random -> [tyQ| int -> cmd int |]
-  Run -> [tyQ| string -> cmd () |]
+  Run -> [tyQ| text -> cmd () |]
   If -> [tyQ| bool -> {a} -> {a} -> a |]
   Inl -> [tyQ| a -> a + b |]
   Inr -> [tyQ| b -> a + b |]
@@ -506,7 +506,7 @@ inferConst c = case c of
   Return -> [tyQ| a -> cmd a |]
   Try -> [tyQ| {cmd a} -> {cmd a} -> cmd a |]
   Undefined -> [tyQ| a |]
-  Fail -> [tyQ| string -> a |]
+  Fail -> [tyQ| text -> a |]
   Not -> [tyQ| bool -> bool |]
   Neg -> [tyQ| int -> int |]
   Eq -> cmpBinT
@@ -522,15 +522,15 @@ inferConst c = case c of
   Mul -> arithBinT
   Div -> arithBinT
   Exp -> arithBinT
-  Format -> [tyQ| a -> string |]
-  Concat -> [tyQ| string -> string -> string |]
+  Format -> [tyQ| a -> text |]
+  Concat -> [tyQ| text -> text -> text |]
   AppF -> [tyQ| (a -> b) -> a -> b |]
   Atomic -> [tyQ| cmd a -> cmd a |]
   Teleport -> [tyQ| robot -> (int * int) -> cmd () |]
   As -> [tyQ| robot -> {cmd a} -> cmd a |]
-  RobotNamed -> [tyQ| string -> cmd robot |]
+  RobotNamed -> [tyQ| text -> cmd robot |]
   RobotNumbered -> [tyQ| int -> cmd robot |]
-  Knows -> [tyQ| string -> cmd bool |]
+  Knows -> [tyQ| text -> cmd bool |]
  where
   cmpBinT = [tyQ| a -> a -> bool |]
   arithBinT = [tyQ| int -> int -> int |]
@@ -545,7 +545,7 @@ check t ty = do
 -- | Ensure a term is a valid argument to @atomic@.  Valid arguments
 --   may not contain @def@, @let@, or lambda. Any variables which are
 --   referenced must have a primitive, first-order type such as
---   @string@ or @int@ (in particular, no functions, @cmd@, or
+--   @text@ or @int@ (in particular, no functions, @cmd@, or
 --   @delay@).  We simply assume that any locally bound variables are
 --   OK without checking their type: the only way to bind a variable
 --   locally is with a binder of the form @x <- c1; c2@, where @c1@ is
@@ -583,8 +583,8 @@ analyzeAtomic locals (Syntax l t) = case t of
   TDir {} -> return 0
   TInt {} -> return 0
   TAntiInt {} -> return 0
-  TString {} -> return 0
-  TAntiString {} -> return 0
+  TText {} -> return 0
+  TAntiText {} -> return 0
   TBool {} -> return 0
   TRobot {} -> return 0
   TRequireDevice {} -> return 0

--- a/src/Swarm/Language/Types.hs
+++ b/src/Swarm/Language/Types.hs
@@ -25,7 +25,7 @@ module Swarm.Language.Types (
   pattern TyVar,
   pattern TyUnit,
   pattern TyInt,
-  pattern TyString,
+  pattern TyText,
   pattern TyDir,
   pattern TyBool,
   pattern TyRobot,
@@ -41,7 +41,7 @@ module Swarm.Language.Types (
   pattern UTyVar,
   pattern UTyUnit,
   pattern UTyInt,
-  pattern UTyString,
+  pattern UTyText,
   pattern UTyDir,
   pattern UTyBool,
   pattern UTyRobot,
@@ -101,7 +101,7 @@ data BaseTy
   | -- | Signed, arbitrary-size integers.
     BInt
   | -- | Unicode strings.
-    BString
+    BText
   | -- | Directions.
     BDir
   | -- | Booleans.
@@ -295,8 +295,8 @@ pattern TyUnit = Fix (TyBaseF BUnit)
 pattern TyInt :: Type
 pattern TyInt = Fix (TyBaseF BInt)
 
-pattern TyString :: Type
-pattern TyString = Fix (TyBaseF BString)
+pattern TyText :: Type
+pattern TyText = Fix (TyBaseF BText)
 
 pattern TyDir :: Type
 pattern TyDir = Fix (TyBaseF BDir)
@@ -340,8 +340,8 @@ pattern UTyUnit = UTerm (TyBaseF BUnit)
 pattern UTyInt :: UType
 pattern UTyInt = UTerm (TyBaseF BInt)
 
-pattern UTyString :: UType
-pattern UTyString = UTerm (TyBaseF BString)
+pattern UTyText :: UType
+pattern UTyText = UTerm (TyBaseF BText)
 
 pattern UTyDir :: UType
 pattern UTyDir = UTerm (TyBaseF BDir)

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -880,7 +880,7 @@ makeEntity :: Entity -> EventM Name AppState ()
 makeEntity e = do
   s <- get
   let mkTy = Forall [] $ TyCmd TyUnit
-      mkProg = TApp (TConst Make) (TString (e ^. entityName))
+      mkProg = TApp (TConst Make) (TText (e ^. entityName))
       mkPT = ProcessedTerm mkProg (Module mkTy empty) (R.singletonCap CMake) empty
       topStore =
         fromMaybe emptyStore $

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -95,7 +95,7 @@ testEval g =
             ("inl 3" `evaluatesTo` VInj False (VInt 3))
         , testCase
             "inr"
-            ("inr \"hi\"" `evaluatesTo` VInj True (VString "hi"))
+            ("inr \"hi\"" `evaluatesTo` VInj True (VText "hi"))
         , testCase
             "inl a < inl b"
             ("inl 3 < inl 4" `evaluatesTo` VBool True)
@@ -128,13 +128,13 @@ testEval g =
             ("case (inr 2) (\\x. x + 1) (\\y. y * 17)" `evaluatesTo` VInt 34)
         , testCase
             "nested 1"
-            ("(\\x : int + bool + string. case x (\\q. 1) (\\s. case s (\\y. 2) (\\z. 3))) (inl 3)" `evaluatesTo` VInt 1)
+            ("(\\x : int + bool + text. case x (\\q. 1) (\\s. case s (\\y. 2) (\\z. 3))) (inl 3)" `evaluatesTo` VInt 1)
         , testCase
             "nested 2"
-            ("(\\x : int + bool + string. case x (\\q. 1) (\\s. case s (\\y. 2) (\\z. 3))) (inr (inl false))" `evaluatesTo` VInt 2)
+            ("(\\x : int + bool + text. case x (\\q. 1) (\\s. case s (\\y. 2) (\\z. 3))) (inr (inl false))" `evaluatesTo` VInt 2)
         , testCase
             "nested 2"
-            ("(\\x : int + bool + string. case x (\\q. 1) (\\s. case s (\\y. 2) (\\z. 3))) (inr (inr \"hi\"))" `evaluatesTo` VInt 3)
+            ("(\\x : int + bool + text. case x (\\q. 1) (\\s. case s (\\y. 2) (\\z. 3))) (inr (inr \"hi\"))" `evaluatesTo` VInt 3)
         ]
     , testGroup
         "operator evaluation"
@@ -212,19 +212,19 @@ testEval g =
             ("try {return (1/0)} {return 3}" `evaluatesTo` VInt 3)
         ]
     , testGroup
-        "strings"
+        "text"
         [ testCase
             "format int"
-            ("format 1" `evaluatesTo` VString "1")
+            ("format 1" `evaluatesTo` VText "1")
         , testCase
             "format sum"
-            ("format (inl 1)" `evaluatesTo` VString "inl 1")
+            ("format (inl 1)" `evaluatesTo` VText "inl 1")
         , testCase
             "format function"
-            ("format (\\x. x + 1)" `evaluatesTo` VString "\\x. x + 1")
+            ("format (\\x. x + 1)" `evaluatesTo` VText "\\x. x + 1")
         , testCase
             "concat"
-            ("\"x = \" ++ format (2+3) ++ \"!\"" `evaluatesTo` VString "x = 5!")
+            ("\"x = \" ++ format (2+3) ++ \"!\"" `evaluatesTo` VText "x = 5!")
         ]
     ]
  where

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -159,10 +159,10 @@ testLanguagePipeline =
             )
         , testCase
             "grabif"
-            (valid "def grabif : string -> cmd () = \\x. atomic (b <- ishere x; if b {grab; return ()} {}) end")
+            (valid "def grabif : text -> cmd () = \\x. atomic (b <- ishere x; if b {grab; return ()} {}) end")
         , testCase
             "placeif"
-            (valid "def placeif : string -> cmd bool = \\thing. atomic (res <- scan down; if (res == inl ()) {place thing; return true} {return false}) end")
+            (valid "def placeif : text -> cmd bool = \\thing. atomic (res <- scan down; if (res == inl ()) {place thing; return true} {return false}) end")
         , testCase
             "atomic move+move"
             ( process

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -81,7 +81,7 @@ testLanguagePipeline =
             "located type error"
             ( process
                 "def a =\n 42 + \"oops\"\nend"
-                "2: Can't unify int and string"
+                "2: Can't unify int and text"
             )
         , testCase
             "failure inside bind chain"


### PR DESCRIPTION
* Add a `cotton` entity that grows in some of the places there used to be flowers
* 4 `cotton` make one `string`, with a `small motor` catalyst.  Currently, `string` serves no purpose except being an ingredient for `net`, but I imagine we can find other fun things to do with `string`s.
* 256 `string` make one `net`.
* A `net` is a device that enables the `try` command.

This is intentionally a bit on the harder side to construct.  You need to set up some good automation to be able to crank out the nets if you want to be able to use `try` on your robots.

Closes #132.