### PR TITLE
preserve the focused scenario when rebuilding the NewGameMenu

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -175,7 +175,7 @@ getTutorials sc = case M.lookup "Tutorials" (scMap sc) of
 
 -- | If we are in a New Game menu, advance the menu to the next item in order.
 advanceMenu :: Menu -> Menu
-advanceMenu = _NewGameMenu . neHead %~ BL.listMoveDown
+advanceMenu = _NewGameMenu . ix 0 %~ BL.listMoveDown
 
 handleMainMessagesEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleMainMessagesEvent = \case
@@ -402,7 +402,7 @@ saveScenarioInfoOnQuit = do
         -- See what scenario is currently focused in the menu.  Depending on how the
         -- previous scenario ended (via quit vs. via win), it might be the same as
         -- currentScenarioPath or it might be different.
-        curPath <- preuse $ uiState . uiMenu . _NewGameMenu . neHead . BL.listSelectedElementL . _SISingle . _2 . scenarioPath
+        curPath <- preuse $ uiState . uiMenu . _NewGameMenu . ix 0 . BL.listSelectedElementL . _SISingle . _2 . scenarioPath
         -- Now rebuild the NewGameMenu so it gets the updated ScenarioInfo,
         -- being sure to preserve the same focused scenario.
         sc <- use $ gameState . scenarios

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -60,6 +60,7 @@ module Swarm.Util (
   (<<.=),
   (<>=),
   _NonEmpty,
+  neHead,
 
   -- * Utilities for NP-hard approximation
   smallHittingSet,
@@ -80,6 +81,7 @@ import Data.Either.Validation
 import Data.Int (Int64)
 import Data.List (maximumBy, partition)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -412,6 +414,9 @@ l <>= a = modify (l <>~ a)
 
 _NonEmpty :: Lens' (NonEmpty a) (a, [a])
 _NonEmpty = lens (\(x :| xs) -> (x, xs)) (const (uncurry (:|)))
+
+neHead :: Lens' (NonEmpty a) a
+neHead = lens NE.head (\(_ :| t) a -> a :| t)
 
 ------------------------------------------------------------
 -- Some utilities for NP-hard approximation

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -60,7 +60,6 @@ module Swarm.Util (
   (<<.=),
   (<>=),
   _NonEmpty,
-  neHead,
 
   -- * Utilities for NP-hard approximation
   smallHittingSet,
@@ -81,7 +80,6 @@ import Data.Either.Validation
 import Data.Int (Int64)
 import Data.List (maximumBy, partition)
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -414,9 +412,6 @@ l <>= a = modify (l <>~ a)
 
 _NonEmpty :: Lens' (NonEmpty a) (a, [a])
 _NonEmpty = lens (\(x :| xs) -> (x, xs)) (const (uncurry (:|)))
-
-neHead :: Lens' (NonEmpty a) a
-neHead = lens NE.head (\(_ :| t) a -> a :| t)
 
 ------------------------------------------------------------
 -- Some utilities for NP-hard approximation


### PR DESCRIPTION
Fixes #682.

I still don't understand why it was doing the thing before where it repeated each challenge twice, instead of just repeating the same challenge over and over again.  So that has me a little worried.  But I do understand why there was a problem --- because when we win a scenario, the menu automatically advances to the next one, but the `currentScenarioPath` is still the one we just won, as it should be so we can save the updated `ScenarioInfo` associated to the correct scenario.  But then the menu is rebuilt in order to get all the updated `ScenarioInfo` --- so we must be sure to carefully preserve whatever scenario the menu is focused on, which may or may not be the same as the one we just exited, depending on whether we won or just quit.