### PR TITLE
Catch release query errors

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -82,9 +82,9 @@ import Swarm.TUI.List
 import Swarm.TUI.Model
 import Swarm.TUI.View (generateModal)
 import Swarm.Util hiding ((<<.=))
+import Swarm.Version (NewReleaseFailure (..))
 import System.Clock
 import Witch (into)
-import Swarm.Version (NewReleaseFailure(..))
 
 -- | Pattern synonyms to simplify brick event handler
 pattern Key :: V.Key -> BrickEvent n e

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -84,6 +84,7 @@ import Swarm.TUI.View (generateModal)
 import Swarm.Util hiding ((<<.=))
 import System.Clock
 import Witch (into)
+import Swarm.Version (NewReleaseFailure(..))
 
 -- | Pattern synonyms to simplify brick event handler
 pattern Key :: V.Key -> BrickEvent n e
@@ -105,8 +106,10 @@ handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleEvent = \case
   -- the query for upstream version could finish at any time, so we have to handle it here
   AppEvent (UpstreamVersion ev) -> do
+    let logReleaseEvent l e = runtimeState . eventLog %= logEvent l ("Release", -7) (T.pack $ show e)
     case ev of
-      Left e -> runtimeState . eventLog %= logEvent Said ("Release", -7) (T.pack $ show e)
+      Left e@(FailedReleaseQuery _e) -> logReleaseEvent ErrorTrace e
+      Left e -> logReleaseEvent Said e
       Right _ -> pure ()
     runtimeState . upstreamRelease .= ev
   e -> do

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -184,7 +184,7 @@ import Swarm.Game.State
 import Swarm.Game.World qualified as W
 import Swarm.Language.Types
 import Swarm.Util
-import Swarm.Version (NewReleaseFailure (NoUpstreamRelease))
+import Swarm.Version (NewReleaseFailure (NoMainUpstreamRelease))
 import System.Clock
 import System.FilePath (dropTrailingPathSeparator, splitPath, takeFileName)
 import Witch (into)
@@ -708,7 +708,7 @@ initRuntimeState :: RuntimeState
 initRuntimeState =
   RuntimeState
     { _webPort = Nothing
-    , _upstreamRelease = Left NoUpstreamRelease
+    , _upstreamRelease = Left (NoMainUpstreamRelease [])
     , _eventLog = mempty
     }
 

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -140,7 +140,8 @@ newVersionWidget :: Either NewReleaseFailure String -> Maybe (Widget n)
 newVersionWidget = \case
   Right ver -> Just . txt $ "New version " <> T.pack ver <> " is available!"
   Left (OnDevelopmentBranch _b) -> Just . txt $ "Good luck developing!"
-  Left NoUpstreamRelease -> Nothing
+  Left (FailedReleaseQuery _f) -> Nothing
+  Left (NoMainUpstreamRelease _fails) -> Nothing
   Left (OldUpstreamRelease _up _my) -> Nothing
 
 drawLogo :: Text -> Widget Name


### PR DESCRIPTION
- catch `HttpException` thrown when the query to GitHub API fails
- refactor the version error handling