### PR TITLE
Persist the type of the last expression in the REPL UI

### DIFF
--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -846,7 +846,6 @@ buildWorld em WorldDescription {..} = (robots, first fromEnum . wf)
             let robotWithLoc = trobotLocation ?~ W.coordsToLoc (Coords (ulr + r, ulc + c))
              in map robotWithLoc robotList
         )
-      
 
 -- | Create an initial game state for a specific scenario.
 initGameStateForScenario :: String -> Maybe Seed -> Maybe String -> ExceptT Text IO GameState

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -62,6 +62,7 @@ module Swarm.Game.State (
   needsRedraw,
   replStatus,
   replWorking,
+  replActiveType,
   messageQueue,
   lastSeenMessageTime,
   focusedRobotID,
@@ -176,7 +177,8 @@ makePrisms ''ViewCenterRule
 -- | A data type to represent the current status of the REPL.
 data REPLStatus
   = -- | The REPL is not doing anything actively at the moment.
-    REPLDone
+    --   We persist the last value and its type though.
+    REPLDone (Maybe (Polytype, Value))
   | -- | A command entered at the REPL is currently being run.  The
     --   'Polytype' represents the type of the expression that was
     --   entered.  The @Maybe Value@ starts out as @Nothing@ and gets
@@ -496,8 +498,16 @@ viewCenterRule = lens getter setter
 replWorking :: Getter GameState Bool
 replWorking = to (\s -> matchesWorking $ s ^. replStatus)
  where
-  matchesWorking REPLDone = False
+  matchesWorking (REPLDone _) = False
   matchesWorking (REPLWorking _ _) = True
+
+-- | Either the type of the command being executed, or of the last command
+replActiveType :: Getter REPLStatus (Maybe Polytype)
+replActiveType = to getter
+ where
+  getter (REPLDone (Just (typ, _))) = Just typ
+  getter (REPLWorking typ _) = Just typ
+  getter _ = Nothing
 
 -- | Get the notification list of messages from the point of view of focused robot.
 messageNotifications :: Getter GameState (Notifications LogEntry)
@@ -703,7 +713,7 @@ initGameState = do
       , _viewCenterRule = VCRobot 0
       , _viewCenter = V2 0 0
       , _needsRedraw = False
-      , _replStatus = REPLDone
+      , _replStatus = REPLDone Nothing
       , _messageQueue = Empty
       , _lastSeenMessageTime = -1
       , _focusedRobotID = 0
@@ -753,8 +763,8 @@ scenarioToGameState scenario userSeed toRun g = do
       , -- When starting base with the run flag, REPL status must be set to working,
         -- otherwise the store of definition cells is not saved (see #333)
         _replStatus = case toRun of
-          Nothing -> REPLDone
-          Just _ -> REPLWorking (Forall [] (TyCmd TyUnit)) Nothing
+          Nothing -> REPLDone Nothing
+          Just _ -> REPLWorking PolyUnit Nothing
       , _messageQueue = Empty
       , _focusedRobotID = baseID
       , _ticks = 0
@@ -836,6 +846,7 @@ buildWorld em WorldDescription {..} = (robots, first fromEnum . wf)
             let robotWithLoc = trobotLocation ?~ W.coordsToLoc (Coords (ulr + r, ulc + c))
              in map robotWithLoc robotList
         )
+      
 
 -- | Create an initial game state for a specific scenario.
 initGameStateForScenario :: String -> Maybe Seed -> Maybe String -> ExceptT Text IO GameState

--- a/src/Swarm/Language/Types.hs
+++ b/src/Swarm/Language/Types.hs
@@ -158,7 +158,6 @@ type UType = UTerm TypeF IntVar
 -- The derived Data instances are so we can make a quasiquoter for
 -- types.
 deriving instance Data UType
-
 deriving instance Data IntVar
 
 -- | A generic /fold/ for things defined via 'UTerm' (including, in
@@ -374,7 +373,5 @@ pattern PolyUnit = Forall [] (TyCmd TyUnit)
 
 -- Derive aeson instances for type serialization
 deriving instance Generic Type
-
 deriving instance ToJSON Type
-
 deriving instance FromJSON Type

--- a/src/Swarm/Language/Types.hs
+++ b/src/Swarm/Language/Types.hs
@@ -58,6 +58,7 @@ module Swarm.Language.Types (
   -- * Polytypes
   Poly (..),
   Polytype,
+  pattern PolyUnit,
   UPolytype,
 
   -- * Contexts
@@ -157,6 +158,7 @@ type UType = UTerm TypeF IntVar
 -- The derived Data instances are so we can make a quasiquoter for
 -- types.
 deriving instance Data UType
+
 deriving instance Data IntVar
 
 -- | A generic /fold/ for things defined via 'UTerm' (including, in
@@ -367,7 +369,12 @@ pattern UTyCmd ty1 = UTerm (TyCmdF ty1)
 pattern UTyDelay :: UType -> UType
 pattern UTyDelay ty1 = UTerm (TyDelayF ty1)
 
+pattern PolyUnit :: Polytype
+pattern PolyUnit = Forall [] (TyCmd TyUnit)
+
 -- Derive aeson instances for type serialization
 deriving instance Generic Type
+
 deriving instance ToJSON Type
+
 deriving instance FromJSON Type

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -208,8 +208,7 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
 
 exitNewGameMenu :: NonEmpty (BL.List Name ScenarioItem) -> EventM Name AppState ()
 exitNewGameMenu stk = do
-  uiState
-    . uiMenu
+  uiState . uiMenu
     .= case snd (NE.uncons stk) of
       Nothing -> MainMenu (mainMenu NewGame)
       Just stk' -> NewGameMenu stk'
@@ -791,8 +790,7 @@ validateREPLForm s =
           theType = case result of
             Right (Just (ProcessedTerm _ (Module ty _) _ _)) -> Just ty
             _ -> Nothing
-       in s
-            & uiState . uiReplForm %~ validate result
+       in s & uiState . uiReplForm %~ validate result
             & uiState . uiReplType .~ theType
     SearchPrompt _ _ -> s
  where

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -237,11 +237,11 @@ handleMainEvent ev = do
     Key V.KEsc
       | isJust (s ^. uiState . uiError) -> uiState . uiError .= Nothing
       | Just m <- s ^. uiState . uiModal -> do
-          safeAutoUnpause
-          uiState . uiModal .= Nothing
-          -- message modal is not autopaused, so update notifications when leaving it
-          when (m ^. modalType == MessagesModal) $ do
-            gameState . lastSeenMessageTime .= s ^. gameState . ticks
+        safeAutoUnpause
+        uiState . uiModal .= Nothing
+        -- message modal is not autopaused, so update notifications when leaving it
+        when (m ^. modalType == MessagesModal) $ do
+          gameState . lastSeenMessageTime .= s ^. gameState . ticks
     FKey 1 -> toggleModal HelpModal
     FKey 2 -> toggleModal RobotsModal
     FKey 3 | not (null (s ^. gameState . availableRecipes . notificationsContent)) -> do
@@ -721,8 +721,8 @@ handleREPLEvent = \case
             Just found
               | T.null t -> uiState %= resetWithREPLForm (mkReplForm $ mkCmdPrompt "")
               | otherwise -> do
-                  uiState %= resetWithREPLForm (mkReplForm $ mkCmdPrompt found)
-                  modify validateREPLForm
+                uiState %= resetWithREPLForm (mkReplForm $ mkCmdPrompt found)
+                modify validateREPLForm
       else continueWithoutRedraw
   Key V.KUp -> modify $ adjReplHistIndex Older
   Key V.KDown -> modify $ adjReplHistIndex Newer
@@ -768,9 +768,9 @@ tabComplete s (CmdPrompt t mms)
   | (m : ms) <- mms = CmdPrompt (replaceLast m t) (ms ++ [m])
   | T.null lastWord = CmdPrompt t []
   | otherwise = case matches of
-      [] -> CmdPrompt t []
-      [m] -> CmdPrompt (completeWith m) []
-      (m : ms) -> CmdPrompt (completeWith m) (ms ++ [m])
+    [] -> CmdPrompt t []
+    [m] -> CmdPrompt (completeWith m) []
+    (m : ms) -> CmdPrompt (completeWith m) (ms ++ [m])
  where
   completeWith m = T.append t (T.drop (T.length lastWord) m)
   lastWord = T.takeWhileEnd isIdentChar t

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -904,7 +904,6 @@ populateInventoryList (Just r) = do
 resetWithREPLForm :: Form REPLPrompt AppEvent Name -> UIState -> UIState
 resetWithREPLForm f =
   (uiReplForm .~ f)
-    . (uiReplType .~ Nothing)
     . (uiError .~ Nothing)
 
 ------------------------------------------------------------


### PR DESCRIPTION
- adds `PolyUnit` pattern (just seemed useful?)
- persists the last type/value into the `REPLDone (Maybe (Polytype, Value))` constructor
    - `value` is not needed right now, but I'm thinking about using it for #304
    - I'm also considering if pretty-printing the last value in that cozy corner could also be a good idea
- notion of the "active" type (last or currently-executing) and the corresponding `Getter`: `replActiveType`
- show this active type in the REPL UI (fixes #692)