### PR TITLE
Move TH GitInfo back to Main

### DIFF
--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -70,7 +70,7 @@ appMain opts = do
           writeBChan chan Frame
 
       _ <- forkIO $ do
-        upRel <- getNewerReleaseVersion
+        upRel <- getNewerReleaseVersion (repoGitInfo opts)
         writeBChan chan (UpstreamVersion upRel)
 
       -- Start the web service with a reference to the game state
@@ -111,6 +111,7 @@ demoWeb = do
           , toRun = Nothing
           , cheatMode = False
           , userWebPort = Nothing
+          , repoGitInfo = Nothing
           }
   case res of
     Left errMsg -> T.putStrLn errMsg

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -162,6 +162,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time (getZonedTime)
 import Data.Vector qualified as V
+import GitHash (GitInfo)
 import Linear (zero)
 import Network.Wai.Handler.Warp (Port)
 import Swarm.Game.Entity as E
@@ -922,6 +923,8 @@ data AppOpts = AppOpts
     cheatMode :: Bool
   , -- | Explicit port on which to run the web API
     userWebPort :: Maybe Port
+  , -- | Information about the Git repository (not present in release).
+    repoGitInfo :: Maybe GitInfo
   }
 
 -- | Initialize the 'AppState'.


### PR DESCRIPTION
It is probably safer to have Template Haskell GitInfo in Main and not depend on it in Swarm modules.

Depending on how the build system and TH interact we were either recompiling too often or not often enough.
- if the git info was evaluated once and not again after making a commit, then it was not up to date
- if the git info was reevaluated on every commit then we would needlessly recompile dependent modules

I believe it was only the former, but this helps even in that case (any code change recompiles Main).