### PR TITLE
improved handling of REPL mouse clicks

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -281,10 +281,8 @@ handleMainEvent ev = do
         WorldPanel -> do
           mouseCoordsM <- Brick.zoom gameState (mouseLocToWorldCoords mouseLoc)
           uiState . uiWorldCursor .= mouseCoordsM
-        REPLPanel ->
-          -- Do not clear the world cursor when going back to the REPL
-          continueWithoutRedraw
-        _ -> uiState . uiWorldCursor .= Nothing >> continueWithoutRedraw
+        REPLInput -> handleREPLEvent ev
+        _ -> continueWithoutRedraw
     MouseUp n _ _mouseLoc -> do
       case n of
         InventoryListItem pos -> uiState . uiInventory . traverse . _2 %= BL.listMoveTo pos


### PR DESCRIPTION
- Never clear the `uiWorldCursor`.
    - In practice it seemed annoying and glitchy to understand when it would or wouldn't clear.  After clicking somewhere on the map to see the coordinates I was always afraid I was going to do the wrong thing and cause the cursor display to clear before I could make use of it.
- Pass on mouse clicks to the REPL input form 
    - This means you can click in the middle of the input to move the cursor 
    - Closes #470.