### PR TITLE
Improve user experience around quitting & moving between tutorial challenges

### DIFF
--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -23,7 +23,10 @@ objectives:
         idea.
       - To prepare you, this simulator will walk you through a series of hands-on
         exercises that introduce you to the way robots work and the programming
-        language you will use to control them.
+        language you will use to control them.  Note that your progress through
+        the tutorials will be saved automatically.  You can return to
+        the menu at any time to jump around between tutorials or pick
+        up again where you left off.
       - |
         When you're ready for your first challenge, close this dialog with Esc or Ctrl-G,
         and type at the prompt:

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -370,6 +370,7 @@ handleModalEvent = \case
     toggleModal QuitModal
     case dialogSelection <$> mdialog of
       Just (Just QuitButton) -> quitGame
+      Just (Just KeepPlayingButton) -> toggleModal KeepPlayingModal
       Just (Just (NextButton scene)) -> saveScenarioInfoOnQuit >> uncurry startGame scene Nothing
       _ -> return ()
   ev -> do

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -436,11 +436,12 @@ data ModalType
   | RobotsModal
   | WinModal
   | QuitModal
+  | KeepPlayingModal
   | DescriptionModal Entity
   | GoalModal [Text]
   deriving (Eq, Show)
 
-data ButtonSelection = CancelButton | QuitButton | NextButton (Scenario, ScenarioInfo)
+data ButtonSelection = CancelButton | KeepPlayingButton | QuitButton | NextButton (Scenario, ScenarioInfo)
 
 data Modal = Modal
   { _modalType :: ModalType

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -487,7 +487,7 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
             )
       DescriptionModal e -> (descriptionTitle e, Nothing, descriptionWidth)
       QuitModal ->
-        let stopMsg = fromMaybe ("Quit to" ++ maybe "" (" "++) (into @String <$> curMenuName s) ++ " menu") haltingMessage
+        let stopMsg = fromMaybe ("Quit to" ++ maybe "" (" " ++) (into @String <$> curMenuName s) ++ " menu") haltingMessage
          in ( ""
             , Just (0, [("Keep playing", CancelButton), (stopMsg, QuitButton)])
             , T.length (quitMsg (s ^. uiState . uiMenu)) + 4
@@ -498,8 +498,8 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
 -- | Get the name of the current New Game menu.
 curMenuName :: AppState -> Maybe Text
 curMenuName s = case s ^. uiState . uiMenu of
-  NewGameMenu (_ :| (parentMenu : _))
-    -> Just (parentMenu ^. BL.listSelectedElementL . to scenarioItemName)
+  NewGameMenu (_ :| (parentMenu : _)) ->
+    Just (parentMenu ^. BL.listSelectedElementL . to scenarioItemName)
   NewGameMenu _ -> Just "Scenarios"
   _ -> Nothing
 

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -480,7 +480,6 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
                   | Just scene <- [nextScenario (s ^. uiState . uiMenu)]
                   ]
                     ++ [ (stopMsg, QuitButton)
-
                        , (continueMsg, KeepPlayingButton)
                        ]
                 )

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -447,11 +447,11 @@ drawModal s = \case
   KeepPlayingModal -> padLeftRight 1 (displayParagraphs ["Have fun!  Hit Ctrl-Q whenever you're ready to proceed to the next challenge or return to the menu."])
 
 quitMsg :: Menu -> Text
-quitMsg m = "Are you sure you want to " <> quitAction <> "? All progress will be lost!"
+quitMsg m = "Are you sure you want to " <> quitAction <> "? All progress on this scenario will be lost!"
  where
   quitAction = case m of
     NoMenu -> "quit"
-    _ -> "quit and return to the menu"
+    _ -> "return to the menu"
 
 -- | Generate a fresh modal window of the requested type.
 generateModal :: AppState -> ModalType -> Modal

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -487,13 +487,21 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
             )
       DescriptionModal e -> (descriptionTitle e, Nothing, descriptionWidth)
       QuitModal ->
-        let stopMsg = fromMaybe "Quit to menu" haltingMessage
+        let stopMsg = fromMaybe ("Quit to" ++ maybe "" (" "++) (into @String <$> curMenuName s) ++ " menu") haltingMessage
          in ( ""
             , Just (0, [("Keep playing", CancelButton), (stopMsg, QuitButton)])
             , T.length (quitMsg (s ^. uiState . uiMenu)) + 4
             )
       GoalModal _ -> (" Goal ", Nothing, 80)
       KeepPlayingModal -> ("", Just (0, [("OK", CancelButton)]), 80)
+
+-- | Get the name of the current New Game menu.
+curMenuName :: AppState -> Maybe Text
+curMenuName s = case s ^. uiState . uiMenu of
+  NewGameMenu (_ :| (parentMenu : _))
+    -> Just (parentMenu ^. BL.listSelectedElementL . to scenarioItemName)
+  NewGameMenu _ -> Just "Scenarios"
+  _ -> Nothing
 
 robotsListWidget :: AppState -> Widget Name
 robotsListWidget s = hCenter table

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -613,7 +613,7 @@ helpWidget theSeed mport =
     , ("Ctrl-o", "single step")
     , ("Ctrl-z", "decrease speed")
     , ("Ctrl-w", "increase speed")
-    , ("Ctrl-q", "quit the game")
+    , ("Ctrl-q", "quit the current scenario")
     , ("Meta-w", "focus on the world map")
     , ("Meta-e", "focus on the robot inventory")
     , ("Meta-r", "focus on the REPL")

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -444,6 +444,7 @@ drawModal s = \case
   DescriptionModal e -> descriptionWidget s e
   QuitModal -> padBottom (Pad 1) $ hCenter $ txt (quitMsg (s ^. uiState . uiMenu))
   GoalModal g -> padLeftRight 1 (displayParagraphs g)
+  KeepPlayingModal -> padLeftRight 1 (displayParagraphs ["Have fun!  Hit Ctrl-Q whenever you're ready to proceed to the next challenge or return to the menu."])
 
 quitMsg :: Menu -> Text
 quitMsg m = "Are you sure you want to " <> quitAction <> "? All progress will be lost!"
@@ -479,7 +480,8 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
                   | Just scene <- [nextScenario (s ^. uiState . uiMenu)]
                   ]
                     ++ [ (stopMsg, QuitButton)
-                       , (continueMsg, CancelButton)
+
+                       , (continueMsg, KeepPlayingButton)
                        ]
                 )
             , sum (map length [nextMsg, stopMsg, continueMsg]) + 32
@@ -492,6 +494,7 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
             , T.length (quitMsg (s ^. uiState . uiMenu)) + 4
             )
       GoalModal _ -> (" Goal ", Nothing, 80)
+      KeepPlayingModal -> ("", Just (0, [("OK", CancelButton)]), 80)
 
 robotsListWidget :: AppState -> Widget Name
 robotsListWidget s = hCenter table


### PR DESCRIPTION
- Help modal now says "quit the current scenario" instead of "quit game" for Ctrl-q
- If you select "Keep playing" after completing a challenge scenario, it will now pop up a modal advising you to hit Ctrl-q whenever you're ready to move on.
- Added a note at the beginning of the tutorial reassuring that your progress will be saved and you can pick up where you left off from the menu.
- Improved quit dialog in a couple ways:
    - Now warns that "your progress *on the current scenario* will be lost" (to emphasize that e.g. your progress on the entire tutorial won't be lost).
    - Now says "quit to XXX menu" where XXX is the specific menu you will return to.

Closes #595. Closes #759.