### PR TITLE
Make sure newly built robots consistently face north

### DIFF
--- a/data/scenarios/Tutorials/build.yaml
+++ b/data/scenarios/Tutorials/build.yaml
@@ -20,7 +20,8 @@ objectives:
         TIP: You can use the name of the flower directly ("pickerelweed"),
         or you can use bind notation: `f <- harvest; ... ; place f;`.
       - |
-        TIP: Newly built robots always start out facing north.
+        TIP: Newly built robots start out facing the same
+        direction as their parent, which in this case will always be north.
     condition: |
       try {
         teleport self (0,-1);

--- a/data/scenarios/Tutorials/scan.yaml
+++ b/data/scenarios/Tutorials/scan.yaml
@@ -30,7 +30,7 @@ solution: |
   }
 robots:
   - name: base
-    dir: [1,0]
+    dir: [0,1]
     heavy: true
     display:
       char: Ω

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1345,7 +1345,7 @@ execConst c vs s k = do
               ["A robot built by the robot named " <> r ^. robotName <> "."]
               (Just (r ^. robotLocation))
               ( ((r ^. robotOrientation) >>= \dir -> guard (dir /= zero) >> return dir)
-                  ? east
+                  ? north
               )
               defaultRobotDisplay
               (In cmd e s [FExec])


### PR DESCRIPTION
Closes #757 .  As discussed there:

- Default direction for robots whose parents have no direction is now `north`
- Fix the `scan` tutorial `base` to be facing north
- Clarify the text in the `build` tutorial to state that newly built robots face the same direction as their parent, which in the tutorial will always be north.