### PR TITLE
Add a button to the Quit dialog to restart a scenario.

### DIFF
--- a/src/Swarm/Game/ScenarioInfo.hs
+++ b/src/Swarm/Game/ScenarioInfo.hs
@@ -25,6 +25,7 @@ module Swarm.Game.ScenarioInfo (
   scenarioBestTime,
   scenarioBestTicks,
   updateScenarioInfoOnQuit,
+  ScenarioInfoPair,
 
   -- * Scenario collection
   ScenarioCollection (..),
@@ -130,6 +131,8 @@ instance ToJSON ScenarioInfo where
   toEncoding = genericToEncoding scenarioOptions
   toJSON = genericToJSON scenarioOptions
 
+type ScenarioInfoPair = (Scenario, ScenarioInfo)
+
 scenarioOptions :: Options
 scenarioOptions =
   defaultOptions
@@ -173,12 +176,12 @@ updateScenarioInfoOnQuit z ticks completed (ScenarioInfo p s bTime bTicks) = cas
 
 -- | A scenario item is either a specific scenario, or a collection of
 --   scenarios (*e.g.* the scenarios contained in a subdirectory).
-data ScenarioItem = SISingle Scenario ScenarioInfo | SICollection Text ScenarioCollection
+data ScenarioItem = SISingle ScenarioInfoPair | SICollection Text ScenarioCollection
   deriving (Eq, Show)
 
 -- | Retrieve the name of a scenario item.
 scenarioItemName :: ScenarioItem -> Text
-scenarioItemName (SISingle s _ss) = s ^. scenarioName
+scenarioItemName (SISingle (s, _ss)) = s ^. scenarioName
 scenarioItemName (SICollection name _) = name
 
 -- | A scenario collection is a tree of scenarios, keyed by name,
@@ -330,7 +333,7 @@ loadScenarioItem em path = do
     False -> do
       s <- loadScenarioFile em path
       si <- loadScenarioInfo path
-      return $ SISingle s si
+      return $ SISingle (s, si)
 
 ------------------------------------------------------------
 -- Some lenses + prisms

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -157,10 +157,10 @@ handleMainMenuEvent menu = \case
           -- Extract the first tutorial challenge and run it
           let firstTutorial = case scOrder tutorialCollection of
                 Just (t : _) -> case M.lookup t (scMap tutorialCollection) of
-                  Just (SISingle scene si) -> (scene, si)
+                  Just (SISingle siPair) -> siPair
                   _ -> error "No first tutorial found!"
                 _ -> error "No first tutorial found!"
-          uncurry startGame firstTutorial Nothing
+          startGame firstTutorial Nothing
         Messages -> do
           runtimeState . eventLog . notificationsCount .= 0
           uiState . uiMenu .= MessagesMenu
@@ -196,7 +196,7 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
   Key V.KEnter ->
     case snd <$> BL.listSelectedElement curMenu of
       Nothing -> continueWithoutRedraw
-      Just (SISingle scene si) -> startGame scene si Nothing
+      Just (SISingle siPair) -> startGame siPair Nothing
       Just (SICollection _ c) -> do
         cheat <- use $ uiState . uiCheatMode
         uiState . uiMenu .= NewGameMenu (NE.cons (mkScenarioList cheat c) scenarioStack)
@@ -371,7 +371,8 @@ handleModalEvent = \case
     case dialogSelection <$> mdialog of
       Just (Just QuitButton) -> quitGame
       Just (Just KeepPlayingButton) -> toggleModal KeepPlayingModal
-      Just (Just (NextButton scene)) -> saveScenarioInfoOnQuit >> uncurry startGame scene Nothing
+      Just (Just (StartOverButton siPair)) -> restartGame siPair
+      Just (Just (NextButton siPair)) -> saveScenarioInfoOnQuit >> startGame siPair Nothing
       _ -> return ()
   ev -> do
     Brick.zoom (uiState . uiModal . _Just . modalDialog) (handleDialogEvent ev)


### PR DESCRIPTION
* Introduces a type alias `ScenarioInfoPair`.
* Introduces a new member `_scenarioRef` to the `UIState` record.
* Add a "Start over" button to the Quit dialog, which carries a reference to the current scenario.

Closes #549