### PR TITLE
Better advertise pop-out for entity descriptions

### DIFF
--- a/data/scenarios/Tutorials/grab.yaml
+++ b/data/scenarios/Tutorials/grab.yaml
@@ -7,7 +7,10 @@ objectives:
       - Previously you learned how to make new things (like a branch predictor) from ingredients.
         Now you will learn how to obtain the ingredients you need.
       - There are some trees ahead of your robot; `move` to each one and `grab` it.
-      - You can learn more by reading about the grabber device in your inventory.
+      - You can learn more by reading about the grabber device in your
+        inventory.  Remember, if the description does not fit in the
+        lower left info box, you can either hit `Enter` to pop out the
+        description, or focus the info box in order to scroll.
       - |
         TIP: You can use the arrow key Up ('↑') to reuse your previous commands.
     condition: |

--- a/data/scenarios/Tutorials/move.yaml
+++ b/data/scenarios/Tutorials/move.yaml
@@ -32,9 +32,14 @@ objectives:
   - goal:
       - Well done! In addition to `move`, you can use the `turn` command
         to turn your robot, for example, `turn right` or `turn east`.
-      - Switch to the inventory view (by clicking on it, or typing `Alt+E`)
-        and select the treads device to read about the details.
-        You can come back to the REPL prompt by clicking on it or typing `Alt+R`.
+      - Switch to the inventory view in the upper left (by clicking on it or typing `Alt+E`)
+        and select the `treads` device to read about the details.
+        If the bottom-left info panel is not big enough to read the
+        whole thing, you can hit `Enter` on the `treads` device to pop
+        out the description, or you can focus the info panel (with
+        `Alt+T` or by clicking) and scroll it with arrow keys or PgUp/PgDown.
+        When you're done reading, you can come back to the REPL prompt
+        by clicking on it or typing `Alt+R`.
       - Afterwards, move your robot to the coordinates (8,4) in the northeast corner
         marked with two flowers.
       - |

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -791,7 +791,7 @@ drawKeyMenu s =
   keyCmdsFor (Just REPLPanel) =
     [ ("↓↑", "history")
     ]
-      ++ [("Ret", "execute") | not isReplWorking]
+      ++ [("Enter", "execute") | not isReplWorking]
       ++ [("^c", "cancel") | isReplWorking]
   keyCmdsFor (Just WorldPanel) =
     [ ("←↓↑→ / hjkl", "scroll") | creative
@@ -799,7 +799,7 @@ drawKeyMenu s =
       ++ [("c", "recenter") | not viewingBase]
       ++ [("f", "FPS")]
   keyCmdsFor (Just RobotPanel) =
-    [ ("Ret", "pop out")
+    [ ("Enter", "pop out")
     , ("m", "make")
     , ("0", (if showZero then "hide" else "show") <> " 0")
     ]

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -810,15 +810,16 @@ data KeyHighlight = NoHighlight | Alert | PanelSpecific
 
 -- | Draw a single key command in the menu.
 drawKeyCmd :: (KeyHighlight, Text, Text) -> Widget Name
-drawKeyCmd (h, key, cmd) = hBox
-  [ withAttr attr (txt $ T.concat ["[", key, "] "])
-  , txt cmd
-  ]
-  where
-    attr = case h of
-      NoHighlight -> defAttr
-      Alert -> notifAttr
-      PanelSpecific -> highlightAttr
+drawKeyCmd (h, key, cmd) =
+  hBox
+    [ withAttr attr (txt $ T.concat ["[", key, "] "])
+    , txt cmd
+    ]
+ where
+  attr = case h of
+    NoHighlight -> defAttr
+    Alert -> notifAttr
+    PanelSpecific -> highlightAttr
 
 ------------------------------------------------------------
 -- World panel

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -726,7 +726,7 @@ drawModalMenu s = vLimit 1 . hBox $ map (padLeftRight 1 . drawKeyCmd) globalKeyC
     | null (s ^. gameState . notifLens . notificationsContent) = Nothing
     | otherwise =
       let highlight
-            | s ^. gameState . notifLens . notificationsCount > 0 = Highlighted
+            | s ^. gameState . notifLens . notificationsCount > 0 = Alert
             | otherwise = NoHighlight
        in Just (highlight, key, name)
 
@@ -751,7 +751,7 @@ drawKeyMenu s =
     . (++ [gameModeWidget])
     . map (padLeftRight 1 . drawKeyCmd)
     . (globalKeyCmds ++)
-    . map (\(k, n) -> (NoHighlight, k, n))
+    . map highlightKeyCmds
     . keyCmdsFor
     . focusGetCurrent
     . view (uiState . uiFocusRing)
@@ -784,6 +784,10 @@ drawKeyMenu s =
       ]
   may b = if b then Just else const Nothing
 
+  highlightKeyCmds (k, n) = (,k,n) $ case n of
+    "pop out" | (s ^. uiState . uiMoreInfoBot) || (s ^. uiState . uiMoreInfoTop) -> Alert
+    _ -> PanelSpecific
+
   keyCmdsFor (Just REPLPanel) =
     [ ("↓↑", "history")
     ]
@@ -793,6 +797,7 @@ drawKeyMenu s =
     [ ("←↓↑→ / hjkl", "scroll") | creative
     ]
       ++ [("c", "recenter") | not viewingBase]
+      ++ [("f", "FPS")]
   keyCmdsFor (Just RobotPanel) =
     [ ("Ret", "pop out")
     , ("m", "make")
@@ -801,12 +806,19 @@ drawKeyMenu s =
   keyCmdsFor (Just InfoPanel) = []
   keyCmdsFor _ = []
 
-data KeyHighlight = NoHighlight | Highlighted
+data KeyHighlight = NoHighlight | Alert | PanelSpecific
 
 -- | Draw a single key command in the menu.
 drawKeyCmd :: (KeyHighlight, Text, Text) -> Widget Name
-drawKeyCmd (Highlighted, key, cmd) = hBox [withAttr notifAttr (txt $ T.concat ["[", key, "] "]), txt cmd]
-drawKeyCmd (NoHighlight, key, cmd) = txt $ T.concat ["[", key, "] ", cmd]
+drawKeyCmd (h, key, cmd) = hBox
+  [ withAttr attr (txt $ T.concat ["[", key, "] "])
+  , txt cmd
+  ]
+  where
+    attr = case h of
+      NoHighlight -> defAttr
+      Alert -> notifAttr
+      PanelSpecific -> highlightAttr
 
 ------------------------------------------------------------
 -- World panel

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -794,7 +794,7 @@ drawKeyMenu s =
     ]
       ++ [("c", "recenter") | not viewingBase]
   keyCmdsFor (Just RobotPanel) =
-    [ ("Ret", "focus")
+    [ ("Ret", "pop out")
     , ("m", "make")
     , ("0", (if showZero then "hide" else "show") <> " 0")
     ]


### PR DESCRIPTION
Closes #764.

- Hint now says `[Ret] pop out` instead of `[Ret] focus`.
- `pop out` is now highlighted whenever the info panel can scroll.
- Add hints to the tutorial about popping out or scrolling entity descriptions.
- All panel-specific keys are now highlighted the same color as the focused panel.
- Added a panel-specific key hint for `f` on the World panel toggling FPS info.