### PR TITLE
Preserve seed upon restart

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -371,7 +371,7 @@ handleModalEvent = \case
     case dialogSelection <$> mdialog of
       Just (Just QuitButton) -> quitGame
       Just (Just KeepPlayingButton) -> toggleModal KeepPlayingModal
-      Just (Just (StartOverButton siPair)) -> restartGame siPair
+      Just (Just (StartOverButton currentSeed siPair)) -> restartGame currentSeed siPair
       Just (Just (NextButton siPair)) -> saveScenarioInfoOnQuit >> startGame siPair Nothing
       _ -> return ()
   ev -> do

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -444,7 +444,7 @@ data ModalType
   | GoalModal [Text]
   deriving (Eq, Show)
 
-data ButtonSelection = CancelButton | KeepPlayingButton | StartOverButton ScenarioInfoPair | QuitButton | NextButton ScenarioInfoPair
+data ButtonSelection = CancelButton | KeepPlayingButton | StartOverButton Seed ScenarioInfoPair | QuitButton | NextButton ScenarioInfoPair
 
 data Modal = Modal
   { _modalType :: ModalType
@@ -964,8 +964,8 @@ startGame = startGameWithSeed Nothing
 --
 -- Since scenarios are stored as a Maybe in the UI state, we handle the Nothing
 -- case upstream so that the Scenario passed to this function definitely exists.
-restartGame :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair -> m ()
-restartGame siPair = startGame siPair Nothing
+restartGame :: (MonadIO m, MonadState AppState m) => Seed -> ScenarioInfoPair -> m ()
+restartGame currentSeed siPair = startGameWithSeed (Just currentSeed) siPair Nothing
 
 -- | Load a 'Scenario' and start playing the game, with the
 --   possibility for the user to override the seed.

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -457,7 +457,8 @@ quitMsg m = "Are you sure you want to " <> quitAction <> "? All progress on this
 generateModal :: AppState -> ModalType -> Modal
 generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth `min` requiredWidth))
  where
-  currentScenario = s ^. (uiState . scenarioRef)
+  currentScenario = s ^. uiState . scenarioRef
+  currentSeed = s ^. gameState . seed
   haltingMessage = case s ^. uiState . uiMenu of
     NoMenu -> Just "Quit"
     _ -> Nothing
@@ -489,7 +490,7 @@ generateModal s mt = Modal mt (dialog (Just title) buttons (maxModalWindowWidth 
       DescriptionModal e -> (descriptionTitle e, Nothing, descriptionWidth)
       QuitModal ->
         let stopMsg = fromMaybe ("Quit to" ++ maybe "" (" " ++) (into @String <$> curMenuName s) ++ " menu") haltingMessage
-            maybeStartOver = sequenceA ("Start over", StartOverButton <$> currentScenario)
+            maybeStartOver = sequenceA ("Start over", StartOverButton currentSeed <$> currentScenario)
          in ( ""
             , Just
                 ( 0


### PR DESCRIPTION
Part of #549

Before this change, if the Classic scenario was started:

```
stack run -- --scenario data/scenarios/classic.yaml
```
and then "Start over" is selected from the Quit dialog, a new seed was generated.

Now, the previous seed is re-used.