### PR TITLE
Introduce autoplay flag

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -43,7 +43,7 @@ cliParser =
         , command "version" (info (pure Version) (progDesc "Get current and upstream version."))
         ]
     )
-    <|> Run <$> (AppOpts <$> seed <*> scenario <*> run <*> cheat <*> webPort <*> pure gitInfo)
+    <|> Run <$> (AppOpts <$> seed <*> scenario <*> run <*> autoplay <*> cheat <*> webPort <*> pure gitInfo)
  where
   format :: Parser CLI
   format =
@@ -78,6 +78,8 @@ cliParser =
   scenario = optional $ strOption (long "scenario" <> short 'c' <> metavar "FILE" <> help "Name of a scenario to load")
   run :: Parser (Maybe String)
   run = optional $ strOption (long "run" <> short 'r' <> metavar "FILE" <> help "Run the commands in a file at startup")
+  autoplay :: Parser Bool
+  autoplay = switch (long "autoplay" <> short 'a' <> help "Automatically run the solution defined in the scenario, if there is one. Mutually exclusive with --run.")
   cheat :: Parser Bool
   cheat = switch (long "cheat" <> short 'x' <> help "Enable cheat mode")
 

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -108,7 +108,8 @@ demoWeb = do
         AppOpts
           { userSeed = Nothing
           , userScenario = demoScenario
-          , toRun = Nothing
+          , scriptToRun = Nothing
+          , autoPlay = False
           , cheatMode = False
           , userWebPort = Nothing
           , repoGitInfo = Nothing

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -146,7 +146,7 @@ import Brick.Focus
 import Brick.Forms
 import Brick.Widgets.Dialog (Dialog)
 import Brick.Widgets.List qualified as BL
-import Control.Applicative (Applicative (liftA2))
+import Control.Applicative (Applicative (liftA2), (<|>))
 import Control.Lens hiding (from, (<.>))
 import Control.Monad.Except
 import Control.Monad.State
@@ -181,6 +181,7 @@ import Swarm.Game.ScenarioInfo (
   scenarioCollectionToList,
   scenarioItemByPath,
   scenarioPath,
+  scenarioSolution,
   scenarioStatus,
   _SISingle,
  )
@@ -927,7 +928,9 @@ data AppOpts = AppOpts
   , -- | Scenario the user wants to play.
     userScenario :: Maybe FilePath
   , -- | Code to be run on base.
-    toRun :: Maybe FilePath
+    scriptToRun :: Maybe FilePath
+  , -- | Automatically run the solution defined in the scenario file
+    autoPlay :: Bool
   , -- | Should cheat mode be enabled?
     cheatMode :: Bool
   , -- | Explicit port on which to run the web API
@@ -939,7 +942,8 @@ data AppOpts = AppOpts
 -- | Initialize the 'AppState'.
 initAppState :: AppOpts -> ExceptT Text IO AppState
 initAppState AppOpts {..} = do
-  let skipMenu = isJust userScenario || isJust toRun || isJust userSeed
+  let isRunningInitialProgram = isJust scriptToRun || autoPlay
+      skipMenu = isJust userScenario || isRunningInitialProgram || isJust userSeed
   gs <- initGameState
   ui <- initUIState (not skipMenu) cheatMode
   let rs = initRuntimeState
@@ -947,12 +951,19 @@ initAppState AppOpts {..} = do
     False -> return $ AppState gs ui rs
     True -> do
       (scenario, path) <- loadScenario (fromMaybe "classic" userScenario) (gs ^. entityMap)
+
+      let maybeAutoplay = do
+            guard autoPlay
+            soln <- scenario ^. scenarioSolution
+            return $ SuggestedSolution soln
+      let realToRun = maybeAutoplay <|> (ScriptPath <$> scriptToRun)
+
       execStateT
-        (startGameWithSeed userSeed (scenario, ScenarioInfo path NotStarted NotStarted NotStarted) toRun)
+        (startGameWithSeed userSeed (scenario, ScenarioInfo path NotStarted NotStarted NotStarted) realToRun)
         (AppState gs ui rs)
 
 -- | Load a 'Scenario' and start playing the game.
-startGame :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair -> Maybe FilePath -> m ()
+startGame :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair -> Maybe CodeToRun -> m ()
 startGame = startGameWithSeed Nothing
 
 -- | Re-initialize the game from the stored reference to the current scenario.
@@ -969,7 +980,7 @@ restartGame currentSeed siPair = startGameWithSeed (Just currentSeed) siPair Not
 
 -- | Load a 'Scenario' and start playing the game, with the
 --   possibility for the user to override the seed.
-startGameWithSeed :: (MonadIO m, MonadState AppState m) => Maybe Seed -> ScenarioInfoPair -> Maybe FilePath -> m ()
+startGameWithSeed :: (MonadIO m, MonadState AppState m) => Maybe Seed -> ScenarioInfoPair -> Maybe CodeToRun -> m ()
 startGameWithSeed userSeed siPair@(_scene, si) toRun = do
   t <- liftIO getZonedTime
   ss <- use $ gameState . scenarios
@@ -995,7 +1006,7 @@ nextScenario = \case
 -- XXX do we need to keep an old entity map around???
 
 -- | Modify the 'AppState' appropriately when starting a new scenario.
-scenarioToAppState :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair -> Maybe Seed -> Maybe String -> m ()
+scenarioToAppState :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair -> Maybe Seed -> Maybe CodeToRun -> m ()
 scenarioToAppState siPair@(scene, _) userSeed toRun = do
   withLensIO gameState $ scenarioToGameState scene userSeed toRun
   withLensIO uiState $ scenarioToUIState siPair


### PR DESCRIPTION
This PR introduces an `--autoplay` flag that causes the solution stored in the `solutions` field of a scenario file (which was selected on the command line via the `--scenario` option) to be automatically run when the game starts, identically to the `--run` option.

The purpose is to:
1. more easily showcase scenarios to the community
2. facilitate a quick a sanity check that the solution text in the yaml file is correct

# Test procedure

    stack run -- --scenario data/scenarios/Tutorials/conditionals.yaml --autoplay

This has the same effect as manually copying the solution stored in `conditionals.yaml` to `myfile.sw`, and then running:

    stack run -- --scenario data/scenarios/Tutorials/conditionals.yaml --run myfile.sw

<a href="https://asciinema.org/a/mGB5VDKhsLLPdrItZWi3qsHUV" target="_blank"><img src="https://asciinema.org/a/mGB5VDKhsLLPdrItZWi3qsHUV.svg" width="640" /></a>