### PR TITLE
User-controllable sort criteria

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -80,6 +80,7 @@ import Swarm.Language.Requirement qualified as R
 import Swarm.Language.Syntax
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Types
+import Swarm.TUI.Inventory.Sorting (cycleSortDirection, cycleSortOrder)
 import Swarm.TUI.List
 import Swarm.TUI.Model
 import Swarm.TUI.View (generateModal)
@@ -919,6 +920,12 @@ handleRobotPanelEvent = \case
   (CharKey '0') -> do
     uiState . uiInventoryShouldUpdate .= True
     uiState . uiShowZero %= not
+  (CharKey ';') -> do
+    uiState . uiInventoryShouldUpdate .= True
+    uiState . uiInventorySort %= cycleSortOrder
+  (CharKey ':') -> do
+    uiState . uiInventoryShouldUpdate .= True
+    uiState . uiInventorySort %= cycleSortDirection
   (VtyEvent ev) -> do
     -- This does not work we want to skip redrawing in the no-list case
     -- Brick.zoom (uiState . uiInventory . _Just . _2) (handleListEventWithSeparators ev (is _Separator))

--- a/src/Swarm/TUI/Inventory/Sorting.hs
+++ b/src/Swarm/TUI/Inventory/Sorting.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Swarm.TUI.Inventory.Sorting (
+  InventorySortOptions (..),
+  InventorySortDirection (..),
+  InventorySortOrder (..),
+  cycleSortOrder,
+  cycleSortDirection,
+  defaultSortOptions,
+  sortInventory,
+  renderSortMethod,
+) where
+
+import Algorithms.NaturalSort (sortKey)
+import Control.Lens (view)
+import Data.List (sortBy)
+import Data.Ord (Down (Down), comparing)
+import Data.Text qualified as T
+import Swarm.Game.Entity as E
+import Swarm.Util (cycleEnum)
+
+data InventorySortDirection
+  = Ascending
+  | Descending
+  deriving (Enum, Bounded, Eq)
+
+data InventorySortOrder
+  = ByNaturalAlphabetic
+  | ByQuantity
+  | ByType
+  deriving (Enum, Bounded, Eq)
+
+data InventorySortOptions = InventorySortOptions InventorySortDirection InventorySortOrder
+
+defaultSortOptions :: InventorySortOptions
+defaultSortOptions = InventorySortOptions Ascending ByNaturalAlphabetic
+
+renderSortMethod :: InventorySortOptions -> T.Text
+renderSortMethod (InventorySortOptions direction order) =
+  T.unwords [prefix, label]
+ where
+  prefix = case direction of
+    Ascending -> "↑"
+    Descending -> "↓"
+  label = case order of
+    ByNaturalAlphabetic -> "name"
+    ByQuantity -> "count"
+    ByType -> "type"
+
+cycleSortOrder :: InventorySortOptions -> InventorySortOptions
+cycleSortOrder (InventorySortOptions direction order) =
+  InventorySortOptions direction (cycleEnum order)
+
+cycleSortDirection :: InventorySortOptions -> InventorySortOptions
+cycleSortDirection (InventorySortOptions direction order) =
+  InventorySortOptions (cycleEnum direction) order
+
+-- | All non-alphabetic sort criteria perform alphabetic tie-breaking.
+-- "Reverse ordering" only applies to the *primary* sort criteria; the secondary
+-- alphabetic sort is always in ascending order.
+getSortCompartor :: Ord a => InventorySortOptions -> (a, Entity) -> (a, Entity) -> Ordering
+getSortCompartor (InventorySortOptions direction order) = case order of
+  ByNaturalAlphabetic -> compReversible (alphabetic . snd)
+  ByQuantity -> compReversible fst <> secondary
+  ByType -> compReversible (view entityProperties . snd) <> secondary
+ where
+  alphabetic = sortKey . T.toLower . view entityName
+  secondary = comparing (alphabetic . snd)
+
+  compReversible :: Ord a => (b -> a) -> b -> b -> Ordering
+  compReversible = case direction of
+    Ascending -> comparing
+    Descending -> \f -> comparing (Down . f)
+
+sortInventory :: Ord a => InventorySortOptions -> [(a, Entity)] -> [(a, Entity)]
+sortInventory opts =
+  sortBy $ getSortCompartor opts

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -79,6 +79,7 @@ module Swarm.TUI.Model (
   uiReplHistory,
   uiReplLast,
   uiInventory,
+  uiInventorySort,
   uiMoreInfoTop,
   uiMoreInfoBot,
   uiScrollToEnd,
@@ -152,7 +153,7 @@ import Control.Monad.Except
 import Control.Monad.State
 import Data.Bits (FiniteBits (finiteBitSize))
 import Data.Foldable (toList)
-import Data.List (findIndex, sortOn)
+import Data.List (findIndex)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
@@ -187,6 +188,7 @@ import Swarm.Game.ScenarioInfo (
 import Swarm.Game.State
 import Swarm.Game.World qualified as W
 import Swarm.Language.Types
+import Swarm.TUI.Inventory.Sorting
 import Swarm.Util
 import Swarm.Version (NewReleaseFailure (NoMainUpstreamRelease))
 import System.Clock
@@ -529,6 +531,7 @@ data UIState = UIState
   , _uiReplLast :: Text
   , _uiReplHistory :: REPLHistory
   , _uiInventory :: Maybe (Int, BL.List Name InventoryListEntry)
+  , _uiInventorySort :: InventorySortOptions
   , _uiMoreInfoTop :: Bool
   , _uiMoreInfoBot :: Bool
   , _uiScrollToEnd :: Bool
@@ -595,6 +598,7 @@ uiReplLast :: Lens' UIState Text
 -- | History of things the user has typed at the REPL, interleaved
 --   with outputs the system has generated.
 uiReplHistory :: Lens' UIState REPLHistory
+uiInventorySort :: Lens' UIState InventorySortOptions
 
 -- | The hash value of the focused robot entity (so we can tell if its
 --   inventory changed) along with a list of the items in the
@@ -836,6 +840,7 @@ initUIState showMainMenu cheatMode = liftIO $ do
       , _uiReplHistory = newREPLHistory history
       , _uiReplLast = ""
       , _uiInventory = Nothing
+      , _uiInventorySort = defaultSortOptions
       , _uiMoreInfoTop = False
       , _uiMoreInfoBot = False
       , _uiScrollToEnd = False
@@ -869,12 +874,13 @@ populateInventoryList Nothing = uiInventory .= Nothing
 populateInventoryList (Just r) = do
   mList <- preuse (uiInventory . _Just . _2)
   showZero <- use uiShowZero
+  sortOptions <- use uiInventorySort
   let mkInvEntry (n, e) = InventoryEntry n e
       mkInstEntry (_, e) = InstalledEntry e
       itemList mk label =
         (\case [] -> []; xs -> Separator label : xs)
           . map mk
-          . sortOn (T.toLower . view entityName . snd)
+          . sortInventory sortOptions
           . filter shouldDisplay
           . elems
 
@@ -1015,6 +1021,7 @@ scenarioToUIState siPair u =
       & uiGoal .~ Nothing
       & uiFocusRing .~ initFocusRing
       & uiInventory .~ Nothing
+      & uiInventorySort .~ defaultSortOptions
       & uiShowFPS .~ False
       & uiShowZero .~ True
       & lgTicksPerSecond .~ initLgTicksPerSecond

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -93,6 +93,7 @@ import Swarm.Language.Typecheck (inferConst)
 import Swarm.Language.Types (Polytype)
 import Swarm.TUI.Attr
 import Swarm.TUI.Border
+import Swarm.TUI.Inventory.Sorting (renderSortMethod)
 import Swarm.TUI.Model
 import Swarm.TUI.Panel
 import Swarm.Util
@@ -767,6 +768,7 @@ drawKeyMenu s =
     Just g | g /= [] -> True
     _ -> False
   showZero = s ^. uiState . uiShowZero
+  inventorySort = s ^. uiState . uiInventorySort
 
   gameModeWidget =
     padLeft Max . padLeftRight 1
@@ -803,6 +805,7 @@ drawKeyMenu s =
     [ ("Enter", "pop out")
     , ("m", "make")
     , ("0", (if showZero then "hide" else "show") <> " 0")
+    , (":/;", T.unwords ["Sort:", renderSortMethod inventorySort])
     ]
   keyCmdsFor (Just InfoPanel) = []
   keyCmdsFor _ = []

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -116,6 +116,7 @@ library
                       Swarm.TUI.Model
                       Swarm.TUI.View
                       Swarm.TUI.Controller
+                      Swarm.TUI.Inventory.Sorting
                       Swarm.App
                       Swarm.Version
                       Swarm.Web
@@ -152,6 +153,7 @@ library
                       minimorph                     >= 0.3 && < 0.4,
                       mtl                           >= 2.2.2 && < 2.3,
                       murmur3                       >= 1.0.4 && < 1.1,
+                      natural-sort                  >= 0.1.2 && < 0.2,
                       parser-combinators            >= 1.2 && < 1.4,
                       prettyprinter                 >= 1.7.0 && < 1.8,
                       random                        >= 1.2.0 && < 1.3,


### PR DESCRIPTION
When the inventory pane is selected (Alt+e), one can use the `;` and `:` keys to cycle sort criteria and sort direction, respectively.
![Screenshot from 2022-10-26 21-52-11](https://user-images.githubusercontent.com/261693/198195262-e0ba6f22-cdda-4a29-bc99-398f721a1ed5.png)

This functionality is implemented in a new module to avoid exacerbating #707.

Note that `entityProperties` may be an unreliable criteria to sort, because it is a list that itself may contain duplicates or items in unpredictable order.  Perhaps this field should be made a `Set` (#794).