### PR TITLE
achievements board

### DIFF
--- a/src/Swarm/Game/Exception.hs
+++ b/src/Swarm/Game/Exception.hs
@@ -32,6 +32,7 @@ import Swarm.Language.Capability (Capability (CGod), capabilityName)
 import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Requirement (Requirements (..))
 import Swarm.Language.Syntax (Const, Term)
+import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.Util
 import Witch (from)
 
@@ -74,7 +75,7 @@ data Exn
   | -- | A command failed in some "normal" way (/e.g./ a 'Move'
     --   command could not move, or a 'Grab' command found nothing to
     --   grab, /etc./).
-    CmdFailed Const Text
+    CmdFailed Const Text (Maybe GameplayAchievement)
   | -- | The user program explicitly called 'Undefined' or 'Fail'.
     User Text
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
@@ -89,7 +90,7 @@ formatExn em = \case
       , "<https://github.com/swarm-game/swarm/issues/new>."
       ]
   InfiniteLoop -> "Infinite loop detected!"
-  (CmdFailed c t) -> T.concat [prettyText c, ": ", t]
+  (CmdFailed c t _) -> T.concat [prettyText c, ": ", t]
   (User t) -> "Player exception: " <> t
   (Incapable f caps tm) -> formatIncapable em f caps tm
 

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -32,6 +32,7 @@ module Swarm.Game.State (
   creativeMode,
   winCondition,
   winSolution,
+  gameAchievements,
   runStatus,
   paused,
   robotMap,
@@ -157,6 +158,8 @@ import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Syntax (Const, Term (TText), allConst)
 import Swarm.Language.Typed (Typed (Typed))
 import Swarm.Language.Types
+import Swarm.TUI.Model.Achievement.Attainment
+import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.Util (getDataFileNameSafe, getElemsInArea, isRightOr, manhattan, uniq, (<+=), (<<.=), (?))
 import Swarm.Util.Location
 import System.Clock qualified as Clock
@@ -256,6 +259,7 @@ data GameState = GameState
   { _creativeMode :: Bool
   , _winCondition :: WinCondition
   , _winSolution :: Maybe ProcessedTerm
+  , _gameAchievements :: Map GameplayAchievement Attainment
   , _runStatus :: RunStatus
   , _robotMap :: IntMap Robot
   , -- A set of robots to consider for the next game tick. It is guaranteed to
@@ -331,6 +335,9 @@ winCondition :: Lens' GameState WinCondition
 -- | How to win (if possible). This is useful for automated testing
 --   and to show help to cheaters (or testers).
 winSolution :: Lens' GameState (Maybe ProcessedTerm)
+
+-- | Map of in-game achievements that were attained
+gameAchievements :: Lens' GameState (Map GameplayAchievement Attainment)
 
 -- | The current 'RunStatus'.
 runStatus :: Lens' GameState RunStatus
@@ -706,6 +713,9 @@ initGameState = do
       { _creativeMode = False
       , _winCondition = NoWinCondition
       , _winSolution = Nothing
+      , -- This does not need to be initialized with anything,
+        -- since the master list of achievements is stored in UIState
+        _gameAchievements = mempty
       , _runStatus = Running
       , _robotMap = IM.empty
       , _robotsByLocation = M.empty

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -48,6 +48,7 @@ import Data.Set (Set)
 import Data.Set qualified as S
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Time (getZonedTime)
 import Data.Tuple (swap)
 import Linear (V2 (..), zero)
 import Swarm.Game.CESK
@@ -68,6 +69,8 @@ import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Requirement qualified as R
 import Swarm.Language.Syntax
 import Swarm.Language.Typed (Typed (..))
+import Swarm.TUI.Model.Achievement.Attainment
+import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.Util
 import Swarm.Util.Location
 import System.Clock (TimeSpec)
@@ -336,7 +339,11 @@ hasCapabilityFor cap term = do
 
 -- | Create an exception about a command failing.
 cmdExn :: Const -> [Text] -> Exn
-cmdExn c parts = CmdFailed c (T.unwords parts)
+cmdExn c parts = CmdFailed c (T.unwords parts) Nothing
+
+-- | Create an exception about a command failing, with an achievement
+cmdExnWithAchievement :: Const -> [Text] -> GameplayAchievement -> Exn
+cmdExnWithAchievement c parts a = CmdFailed c (T.unwords parts) $ Just a
 
 -- | Raise an exception about a command failing with a formatted error message.
 raise :: (Has (Throw Exn) sig m) => Const -> [Text] -> m a
@@ -596,15 +603,27 @@ stepCESK cesk = case cesk of
   -- First, if we were running a try block but evaluation completed normally,
   -- just ignore the try block and continue.
   Out v s (FTry {} : k) -> return $ Out v s k
-  -- If an exception rises all the way to the top level without being
-  -- handled, turn it into an error message.
-
-  -- HOWEVER, we have to make sure to check that the robot has the
-  -- 'log' capability which is required to collect and view logs.
-  --
-  -- Notice how we call resetBlackholes on the store, so that any
-  -- cells which were in the middle of being evaluated will be reset.
   Up exn s [] -> do
+    -- Here, an exception has risen all the way to the top level without being
+    -- handled.
+    case exn of
+      CmdFailed _ _ (Just a) -> do
+        currentTime <- sendIO getZonedTime
+        gameAchievements
+          %= M.insertWith
+            (<>)
+            a
+            (Attainment (GameplayAchievement a) Nothing currentTime)
+      _ -> return ()
+
+    -- If an exception rises all the way to the top level without being
+    -- handled, turn it into an error message.
+
+    -- HOWEVER, we have to make sure to check that the robot has the
+    -- 'log' capability which is required to collect and view logs.
+    --
+    -- Notice how we call resetBlackholes on the store, so that any
+    -- cells which were in the middle of being evaluated will be reset.
     let s' = resetBlackholes s
     h <- hasCapability CLog
     em <- use entityMap
@@ -736,7 +755,7 @@ execConst c vs s k = do
         return $ Waiting (time + d) (Out VUnit s k)
       _ -> badConst
     Selfdestruct -> do
-      destroyIfNotBase
+      destroyIfNotBase $ Just AttemptSelfDestructBase
       flagRedraw
       return $ Out VUnit s k
     Move -> do
@@ -1718,10 +1737,13 @@ execConst c vs s k = do
               [de] -> Right $ Just $ snd de
               _ -> Left $ Fatal "Bad recipe:\n more than one unmovable entity produced."
 
-  destroyIfNotBase :: HasRobotStepState sig m => m ()
-  destroyIfNotBase = do
+  destroyIfNotBase :: HasRobotStepState sig m => Maybe GameplayAchievement -> m ()
+  destroyIfNotBase mAch = do
     rid <- use robotID
-    (rid /= 0) `holdsOrFail` ["You consider destroying your base, but decide not to do it after all."]
+    holdsOrFailWithAchievement
+      (rid /= 0)
+      ["You consider destroying your base, but decide not to do it after all."]
+      mAch
     selfDestruct .= True
 
   -- Make sure nothing is in the way. Note that system robots implicitly ignore and base throws on failure.
@@ -1737,7 +1759,7 @@ execConst c vs s k = do
             -- robots can not walk through walls
             when (e `hasProperty` Unwalkable) $
               case failIfBlocked of
-                Destroy -> destroyIfNotBase
+                Destroy -> destroyIfNotBase Nothing
                 ThrowExn -> throwError $ cmdExn c ["There is a", e ^. entityName, "in the way!"]
                 IgnoreFail -> return ()
 
@@ -1745,7 +1767,7 @@ execConst c vs s k = do
             caps <- use robotCapabilities
             when (e `hasProperty` Liquid && CFloat `S.notMember` caps) $
               case failIfDrown of
-                Destroy -> destroyIfNotBase
+                Destroy -> destroyIfNotBase Nothing
                 ThrowExn -> throwError $ cmdExn c ["There is a dangerous liquid", e ^. entityName, "in the way!"]
                 IgnoreFail -> return ()
 
@@ -1769,6 +1791,11 @@ execConst c vs s k = do
 
   holdsOrFail :: (Has (Throw Exn) sig m) => Bool -> [Text] -> m ()
   holdsOrFail a ts = a `holdsOr` cmdExn c ts
+
+  holdsOrFailWithAchievement :: (Has (Throw Exn) sig m) => Bool -> [Text] -> Maybe GameplayAchievement -> m ()
+  holdsOrFailWithAchievement a ts mAch = case mAch of
+    Nothing -> holdsOrFail a ts
+    Just ach -> a `holdsOr` cmdExnWithAchievement c ts ach
 
   isJustOrFail :: (Has (Throw Exn) sig m) => Maybe a -> [Text] -> m a
   isJustOrFail a ts = a `isJustOr` cmdExn c ts
@@ -2003,8 +2030,9 @@ incompatCmp v1 v2 =
 incomparable :: Has (Throw Exn) sig m => Value -> Value -> m a
 incomparable v1 v2 =
   throwError $
-    CmdFailed Lt $
-      T.unwords ["Comparison is undefined for ", prettyValue v1, "and", prettyValue v2]
+    cmdExn
+      Lt
+      ["Comparison is undefined for ", prettyValue v1, "and", prettyValue v2]
 
 ------------------------------------------------------------
 -- Arithmetic
@@ -2027,13 +2055,13 @@ evalArith = \case
 -- | Perform an integer division, but return @Nothing@ for division by
 --   zero.
 safeDiv :: Has (Throw Exn) sig m => Integer -> Integer -> m Integer
-safeDiv _ 0 = throwError $ CmdFailed Div "Division by zero"
+safeDiv _ 0 = throwError $ cmdExn Div $ pure "Division by zero"
 safeDiv a b = return $ a `div` b
 
 -- | Perform exponentiation, but return @Nothing@ if the power is negative.
 safeExp :: Has (Throw Exn) sig m => Integer -> Integer -> m Integer
 safeExp a b
-  | b < 0 = throwError $ CmdFailed Exp "Negative exponent"
+  | b < 0 = throwError $ cmdExn Exp $ pure "Negative exponent"
   | otherwise = return $ a ^ b
 
 ------------------------------------------------------------

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -62,6 +62,7 @@ import Data.String (fromString)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Time (getZonedTime)
+import Data.Vector qualified as V
 import Graphics.Vty qualified as V
 import Linear
 import Swarm.Game.CESK (cancel, emptyStore, initMachine)
@@ -85,6 +86,7 @@ import Swarm.TUI.Controller.Util
 import Swarm.TUI.Inventory.Sorting (cycleSortDirection, cycleSortOrder)
 import Swarm.TUI.List
 import Swarm.TUI.Model
+import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.StateUpdate
 import Swarm.TUI.View (generateModal)
@@ -118,6 +120,7 @@ handleEvent = \case
           MainMenu l -> handleMainMenuEvent l
           NewGameMenu l -> handleNewGameMenuEvent l
           MessagesMenu -> handleMainMessagesEvent
+          AchievementsMenu l -> handleMainAchievementsEvent l
           AboutMenu -> pressAnyKey (MainMenu (mainMenu About))
 
 -- | The event handler for the main menu.
@@ -152,10 +155,13 @@ handleMainMenuEvent menu = \case
                   _ -> error "No first tutorial found!"
                 _ -> error "No first tutorial found!"
           startGame firstTutorial Nothing
+        Achievements -> uiState . uiMenu .= AchievementsMenu (BL.list AchievementList (V.fromList listAchievements) 1)
         Messages -> do
           runtimeState . eventLog . notificationsCount .= 0
           uiState . uiMenu .= MessagesMenu
-        About -> uiState . uiMenu .= AboutMenu
+        About -> do
+          uiState . uiMenu .= AboutMenu
+          attainAchievement $ GlobalAchievement LookedAtAboutScreen
         Quit -> halt
   CharKey 'q' -> halt
   ControlChar 'q' -> halt
@@ -172,6 +178,21 @@ getTutorials sc = case M.lookup "Tutorials" (scMap sc) of
 -- | If we are in a New Game menu, advance the menu to the next item in order.
 advanceMenu :: Menu -> Menu
 advanceMenu = _NewGameMenu . ix 0 %~ BL.listMoveDown
+
+handleMainAchievementsEvent ::
+  BL.List Name CategorizedAchievement ->
+  BrickEvent Name AppEvent ->
+  EventM Name AppState ()
+handleMainAchievementsEvent l e = case e of
+  Key V.KEsc -> returnToMainMenu
+  CharKey 'q' -> returnToMainMenu
+  ControlChar 'q' -> returnToMainMenu
+  VtyEvent ev -> do
+    l' <- nestEventM' l (handleListEvent ev)
+    uiState . uiMenu .= AchievementsMenu l'
+  _ -> continueWithoutRedraw
+ where
+  returnToMainMenu = uiState . uiMenu .= MainMenu (mainMenu Messages)
 
 handleMainMessagesEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleMainMessagesEvent = \case

--- a/src/Swarm/TUI/Model/Achievement/Attainment.hs
+++ b/src/Swarm/TUI/Model/Achievement/Attainment.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Swarm.TUI.Model.Achievement.Attainment where
+
+import Control.Lens hiding (from, (<.>))
+import Data.Aeson (
+  Options (..),
+  defaultOptions,
+  genericParseJSON,
+  genericToJSON,
+ )
+import Data.Function (on)
+import Data.Text (Text)
+import Data.Time (ZonedTime, zonedTimeToUTC)
+import Data.Yaml as Y
+import GHC.Generics (Generic)
+import Swarm.TUI.Model.Achievement.Definitions
+
+data Attainment = Attainment
+  { _achievement :: CategorizedAchievement
+  , _maybeScenarioPath :: Maybe Text
+  -- ^ from which scenario was it obtained?
+  , _obtainedAt :: ZonedTime
+  }
+  deriving (Generic)
+
+makeLenses ''Attainment
+
+instance Eq Attainment where
+  (==) = (==) `on` _achievement
+
+instance Ord Attainment where
+  compare = compare `on` (zonedTimeToUTC . _obtainedAt)
+
+instance Semigroup Attainment where
+  (<>) = min
+
+instance FromJSON Attainment where
+  parseJSON = genericParseJSON achievementJsonOptions
+
+instance ToJSON Attainment where
+  toJSON = genericToJSON achievementJsonOptions
+
+achievementJsonOptions :: Options
+achievementJsonOptions =
+  defaultOptions
+    { fieldLabelModifier = tail -- drops leading underscore
+    }

--- a/src/Swarm/TUI/Model/Achievement/Definitions.hs
+++ b/src/Swarm/TUI/Model/Achievement/Definitions.hs
@@ -1,0 +1,88 @@
+module Swarm.TUI.Model.Achievement.Definitions where
+
+import Data.Aeson
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Swarm.Util
+
+data ExpectedEffort
+  = Trivial
+  | Easy
+  | Moderate
+  | Gruelling
+  deriving (Eq, Ord, Show, Bounded, Enum)
+
+data Quotation = Quotation
+  { attribution :: Text
+  , content :: Text
+  }
+  deriving (Show)
+
+data FlavorText
+  = Freeform Text
+  | FTQuotation Quotation
+  deriving (Show)
+
+data AchievementInfo = AchievementInfo
+  { title :: Text
+  -- ^ Guidelines:
+  -- * prefer puns, pop culture references, etc.
+  -- * should be a phrase in Title Case.
+  -- * For achievements that are "obfuscated", this can be
+  --   a vague "clue" as to what the attainment entails.
+  , humorousElaboration :: Maybe FlavorText
+  -- ^ Explain the reference, e.g. in the form of a full quote
+  -- from a movie, or something you might find
+  -- in a fortune cookie
+  , attainmentProcess :: Text
+  -- ^ Precisely what must be done to obtain this achievement.
+  , effort :: ExpectedEffort
+  , isObfuscated :: Bool
+  -- ^ Hides the attainment process until after the achievement is attained.
+  -- Best when the title + elaboration constitute a good clue.
+  }
+  deriving (Show)
+
+data CategorizedAchievement
+  = GlobalAchievement GlobalAchievement
+  | GameplayAchievement GameplayAchievement
+  deriving (Eq, Ord, Show, Generic)
+
+categorizedAchievementJsonOptions :: Options
+categorizedAchievementJsonOptions =
+  defaultOptions
+    { sumEncoding = UntaggedValue
+    }
+
+instance ToJSON CategorizedAchievement where
+  toJSON = genericToJSON categorizedAchievementJsonOptions
+
+instance FromJSON CategorizedAchievement where
+  parseJSON = genericParseJSON categorizedAchievementJsonOptions
+
+-- | Achievements that entail some aggregate of actions
+-- across scenarios
+data GlobalAchievement
+  = CompletedSingleTutorial
+  | CompletedAllTutorials
+  | LookedAtAboutScreen
+  deriving (Eq, Ord, Show, Bounded, Enum, Generic)
+
+instance FromJSON GlobalAchievement
+instance ToJSON GlobalAchievement
+
+-- | Achievements obtained while playing a single scenario
+data GameplayAchievement
+  = CraftedBitcoin
+  | RobotIntoWater
+  | AttemptSelfDestructBase
+  | DestroyedBase
+  deriving (Eq, Ord, Show, Bounded, Enum, Generic)
+
+instance FromJSON GameplayAchievement
+instance ToJSON GameplayAchievement
+
+listAchievements :: [CategorizedAchievement]
+listAchievements =
+  map GlobalAchievement listEnums
+    <> map GameplayAchievement listEnums

--- a/src/Swarm/TUI/Model/Achievement/Description.hs
+++ b/src/Swarm/TUI/Model/Achievement/Description.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Swarm.TUI.Model.Achievement.Description where
+
+import Swarm.TUI.Model.Achievement.Definitions
+
+describe :: CategorizedAchievement -> AchievementInfo
+describe (GlobalAchievement CompletedSingleTutorial) =
+  AchievementInfo
+    "Welcome Freshmen"
+    (Just $ Freeform "School is in session!")
+    "Complete one of the tutorials."
+    Easy
+    False
+describe (GlobalAchievement CompletedAllTutorials) =
+  AchievementInfo
+    "Autodidact"
+    ( Just $
+        FTQuotation $
+          Quotation
+            "Terry Pratchet"
+            "I didn't go to university... But I have sympathy for those who did."
+    )
+    "Complete all of the tutorials."
+    Moderate
+    False
+describe (GlobalAchievement LookedAtAboutScreen) =
+  AchievementInfo
+    "About time!"
+    Nothing
+    "View the About screen."
+    Trivial
+    True
+describe (GameplayAchievement CraftedBitcoin) =
+  -- Bitcoin is the deepest level of the recipes
+  -- hierarchy.
+  AchievementInfo
+    "Master of Your Craft"
+    Nothing
+    "Make a Bitcoin"
+    Moderate
+    True
+describe (GameplayAchievement RobotIntoWater) =
+  AchievementInfo
+    "Watery Grave"
+    (Just $ Freeform "This little robot thinks he's a submarine.")
+    "Destroy a robot by sending it into the water."
+    Easy
+    True
+describe (GameplayAchievement AttemptSelfDestructBase) =
+  AchievementInfo
+    "Call of the Void"
+    (Just $ Freeform "What does that big red button do?")
+    "Attempt to self-destruct your base."
+    Easy
+    True
+describe (GameplayAchievement DestroyedBase) =
+  AchievementInfo
+    "That Could Have Gone Better"
+    (Just $ Freeform "Boom.")
+    "Actually destroy your base."
+    Moderate
+    True

--- a/src/Swarm/TUI/Model/Achievement/Persistence.hs
+++ b/src/Swarm/TUI/Model/Achievement/Persistence.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Swarm.TUI.Model.Achievement.Persistence where
+
+import Control.Arrow (left)
+import Control.Carrier.Lift (sendIO)
+import Data.Text (Text, pack)
+import Data.Yaml qualified as Y
+import Data.Yaml.Aeson (prettyPrintParseException)
+import Swarm.TUI.Model.Achievement.Attainment
+import Swarm.Util
+import System.Directory (
+  doesFileExist,
+ )
+import System.FilePath
+
+-- | Get path to swarm achievements, optionally creating necessary
+--   directories.
+getSwarmAchievementsPath :: Bool -> IO FilePath
+getSwarmAchievementsPath createDirs =
+  (</> "achievements") <$> getSwarmDataPath createDirs
+
+-- | Load saved info about achievements from XDG data directory.
+loadAchievementsInfo ::
+  IO (Either Text [Attainment])
+loadAchievementsInfo = do
+  savedAchievementsPath <- getSwarmAchievementsPath True
+  hasSavedAchievements <- sendIO $ doesFileExist savedAchievementsPath
+  if not hasSavedAchievements
+    then return $ pure []
+    else
+      left (pack . prettyPrintParseException)
+        <$> sendIO (Y.decodeFileEither savedAchievementsPath)
+
+-- | Save info about achievements to XDG data directory.
+saveAchievementsInfo ::
+  [Attainment] ->
+  IO ()
+saveAchievementsInfo si = do
+  savedAchievementsPath <- getSwarmAchievementsPath True
+  Y.encodeFile savedAchievementsPath si

--- a/src/Swarm/TUI/Model/Menu.hs
+++ b/src/Swarm/TUI/Model/Menu.hs
@@ -24,6 +24,7 @@ import Swarm.Game.ScenarioInfo (
   scenarioCollectionToList,
  )
 import Swarm.Game.State
+import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.TUI.Model.Name
 import Swarm.Util
 import System.FilePath (dropTrailingPathSeparator, splitPath, takeFileName)
@@ -60,13 +61,20 @@ data Modal = Modal
 
 makeLenses ''Modal
 
-data MainMenuEntry = NewGame | Tutorial | Messages | About | Quit
+data MainMenuEntry
+  = NewGame
+  | Tutorial
+  | Achievements
+  | Messages
+  | About
+  | Quit
   deriving (Eq, Ord, Show, Read, Bounded, Enum)
 
 data Menu
   = NoMenu -- We started playing directly from command line, no menu to show
   | MainMenu (BL.List Name MainMenuEntry)
   | NewGameMenu (NonEmpty (BL.List Name ScenarioItem)) -- stack of scenario item lists
+  | AchievementsMenu (BL.List Name CategorizedAchievement)
   | MessagesMenu
   | AboutMenu
 

--- a/src/Swarm/TUI/Model/Name.hs
+++ b/src/Swarm/TUI/Model/Name.hs
@@ -28,6 +28,8 @@ data Name
     InventoryListItem Int
   | -- | The list of main menu choices.
     MenuList
+  | -- | The list of achievements.
+    AchievementList
   | -- | The list of scenario choices.
     ScenarioList
   | -- | The scrollable viewport for the info panel.

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -5,13 +5,16 @@ module Swarm.TUI.Model.StateUpdate (
   initAppState,
   startGame,
   restartGame,
+  attainAchievement,
   scenarioToAppState,
 ) where
 
+import Brick
 import Control.Applicative ((<|>))
 import Control.Lens hiding (from, (<.>))
 import Control.Monad.Except
 import Control.Monad.State
+import Data.Map qualified as M
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import Data.Time (getZonedTime)
@@ -30,6 +33,9 @@ import Swarm.Game.ScenarioInfo (
 import Swarm.Game.State
 import Swarm.TUI.Inventory.Sorting
 import Swarm.TUI.Model
+import Swarm.TUI.Model.Achievement.Attainment
+import Swarm.TUI.Model.Achievement.Definitions
+import Swarm.TUI.Model.Achievement.Persistence
 import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.UI
 import System.Clock
@@ -97,6 +103,17 @@ scenarioToAppState siPair@(scene, _) userSeed toRun = do
     x <- use l
     x' <- liftIO $ a x
     l .= x'
+
+attainAchievement :: CategorizedAchievement -> EventM Name AppState ()
+attainAchievement a = do
+  currentTime <- liftIO getZonedTime
+  (uiState . uiAchievements)
+    %= M.insertWith
+      (<>)
+      a
+      (Attainment a Nothing currentTime)
+  newAchievements <- use $ uiState . uiAchievements
+  liftIO $ saveAchievementsInfo $ M.elems newAchievements
 
 -- | Modify the UI state appropriately when starting a new scenario.
 scenarioToUIState :: ScenarioInfoPair -> UIState -> IO UIState

--- a/src/Swarm/TUI/Model/UI.hs
+++ b/src/Swarm/TUI/Model/UI.hs
@@ -20,6 +20,7 @@ module Swarm.TUI.Model.UI (
   uiError,
   uiModal,
   uiGoal,
+  uiAchievements,
   lgTicksPerSecond,
   lastFrameTime,
   accumulatedTime,
@@ -45,10 +46,12 @@ module Swarm.TUI.Model.UI (
 
 import Brick.Focus
 import Brick.Widgets.List qualified as BL
+import Control.Arrow ((&&&))
 import Control.Lens hiding (from, (<.>))
 import Control.Monad.Except
 import Data.Bits (FiniteBits (finiteBitSize))
 import Data.Map (Map)
+import Data.Map qualified as M
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Game.ScenarioInfo (
@@ -56,6 +59,9 @@ import Swarm.Game.ScenarioInfo (
  )
 import Swarm.Game.World qualified as W
 import Swarm.TUI.Inventory.Sorting
+import Swarm.TUI.Model.Achievement.Attainment
+import Swarm.TUI.Model.Achievement.Definitions
+import Swarm.TUI.Model.Achievement.Persistence
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.Repl
@@ -83,6 +89,7 @@ data UIState = UIState
   , _uiError :: Maybe Text
   , _uiModal :: Maybe Modal
   , _uiGoal :: Maybe [Text]
+  , _uiAchievements :: Map CategorizedAchievement Attainment
   , _uiShowFPS :: Bool
   , _uiShowZero :: Bool
   , _uiHideRobotsUntil :: TimeSpec
@@ -162,6 +169,9 @@ uiModal :: Lens' UIState (Maybe Modal)
 -- | Status of the scenario goal: whether there is one, and whether it
 --   has been displayed to the user initially.
 uiGoal :: Lens' UIState (Maybe [Text])
+
+-- | Map of achievements that were attained
+uiAchievements :: Lens' UIState (Map CategorizedAchievement Attainment)
 
 -- | A toggle to show the FPS by pressing `f`
 uiShowFPS :: Lens' UIState Bool
@@ -249,11 +259,12 @@ initLgTicksPerSecond = 4 -- 2^4 = 16 ticks / second
 --   parameter indicates whether we should start off by showing the
 --   main menu.
 initUIState :: Bool -> Bool -> ExceptT Text IO UIState
-initUIState showMainMenu cheatMode = liftIO $ do
-  historyT <- readFileMayT =<< getSwarmHistoryPath False
-  appDataMap <- readAppData
+initUIState showMainMenu cheatMode = do
+  historyT <- liftIO $ readFileMayT =<< getSwarmHistoryPath False
+  appDataMap <- liftIO readAppData
   let history = maybe [] (map REPLEntry . T.lines) historyT
-  startTime <- getTime Monotonic
+  startTime <- liftIO $ getTime Monotonic
+  achievements <- ExceptT loadAchievementsInfo
   return $
     UIState
       { _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
@@ -270,6 +281,7 @@ initUIState showMainMenu cheatMode = liftIO $ do
       , _uiError = Nothing
       , _uiModal = Nothing
       , _uiGoal = Nothing
+      , _uiAchievements = M.fromList $ map (view achievement &&& id) achievements
       , _uiShowFPS = False
       , _uiShowZero = True
       , _uiHideRobotsUntil = startTime - 1

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -99,6 +99,7 @@ import Swarm.TUI.Inventory.Sorting (renderSortMethod)
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Repl
 import Swarm.TUI.Panel
+import Swarm.TUI.View.Achievement
 import Swarm.TUI.View.Util
 import Swarm.Util
 import Swarm.Util.Location
@@ -119,6 +120,7 @@ drawUI s
       NoMenu -> [drawMainMenuUI s (mainMenu NewGame)]
       MainMenu l -> [drawMainMenuUI s l]
       NewGameMenu stk -> [drawNewGameMenuUI stk]
+      AchievementsMenu l -> [drawAchievementsMenuUI s l]
       MessagesMenu -> [drawMainMessages s]
       AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
 
@@ -135,7 +137,7 @@ drawMainMenuUI s l =
   vBox . catMaybes $
     [ drawLogo <$> logo
     , hCenter . padTopBottom 2 <$> newVersionWidget version
-    , Just . centerLayer . vLimit 5 . hLimit 20 $
+    , Just . centerLayer . vLimit 6 . hLimit 20 $
         BL.renderList (const (hCenter . drawMainMenuEntry s)) True l
     ]
  where
@@ -249,6 +251,7 @@ drawMainMenuEntry :: AppState -> MainMenuEntry -> Widget Name
 drawMainMenuEntry s = \case
   NewGame -> txt "New game"
   Tutorial -> txt "Tutorial"
+  Achievements -> txt "Achievements"
   About -> txt "About"
   Messages -> highlightMessages $ txt "Messages"
   Quit -> txt "Quit"

--- a/src/Swarm/TUI/View/Achievement.hs
+++ b/src/Swarm/TUI/View/Achievement.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Swarm.TUI.View.Achievement where
+
+import Brick
+import Brick.Widgets.Border (borderWithLabel)
+import Brick.Widgets.Center (hCenter)
+import Brick.Widgets.List qualified as BL
+import Control.Lens ((^.))
+import Data.Map (Map)
+import Data.Map qualified as M
+import Data.Time.Format (defaultTimeLocale, formatTime)
+import Swarm.TUI.Attr
+import Swarm.TUI.Model
+import Swarm.TUI.Model.Achievement.Attainment
+import Swarm.TUI.Model.Achievement.Definitions
+import Swarm.TUI.Model.Achievement.Description
+import Swarm.TUI.Model.UI
+import Text.Wrap
+
+padAllEvenly :: Int -> Widget Name -> Widget Name
+padAllEvenly x w = padTopBottom x $ padLeftRight (2 * x) w
+
+getCompletionIcon :: Bool -> Widget Name
+getCompletionIcon = \case
+  False -> txt " ○  "
+  True -> withAttr greenAttr $ txt " ●  "
+
+drawAchievementsMenuUI :: AppState -> BL.List Name CategorizedAchievement -> Widget Name
+drawAchievementsMenuUI s l =
+  vBox
+    [ hCenter $ padTopBottom 1 $ str "🏆  Achievements 🏆 "
+    , hCenter $
+        hBox
+          [ hLimitPercent 30 $
+              padAll 2 $
+                BL.renderList (const $ drawAchievementListItem attainedMap) True l
+          , hLimitPercent 50 $
+              maybe emptyWidget (singleAchievementDetails attainedMap . snd) $
+                BL.listSelectedElement l
+          ]
+    ]
+ where
+  attainedMap = s ^. uiState . uiAchievements
+
+drawAchievementListItem ::
+  Map CategorizedAchievement Attainment ->
+  CategorizedAchievement ->
+  Widget Name
+drawAchievementListItem attainedMap x =
+  getCompletionIcon wasAttained <+> titleWidget
+ where
+  wasAttained = M.member x attainedMap
+  titleWidget = txtWrap $ title details
+  details = describe x
+
+singleAchievementDetails ::
+  Map CategorizedAchievement Attainment ->
+  CategorizedAchievement ->
+  Widget Name
+singleAchievementDetails attainedMap x =
+  padRight (Pad 1) $ borderWithLabel titleWidget $ padAllEvenly 1 innerContent
+ where
+  wasAttained = M.member x attainedMap
+
+  renderFlavorTextWidget :: FlavorText -> Widget Name
+  renderFlavorTextWidget (Freeform t) = txtWrap t
+  renderFlavorTextWidget (FTQuotation (Quotation author quoteContent)) =
+    vBox
+      [ txtWrap quoteContent
+      , padLeft Max $
+          padRight (Pad 2) $
+            txtWrapWith (defaultWrapSettings {fillStrategy = FillIndent 2}) $
+              "--" <> author
+      ]
+
+  innerContent =
+    vBox
+      [ maybe emptyWidget (padAllEvenly 2 . renderFlavorTextWidget) $ humorousElaboration details
+      , txtWrap $
+          if wasAttained || not (isObfuscated details)
+            then attainmentProcess details
+            else "???"
+      , case M.lookup x attainedMap of
+          Nothing -> emptyWidget
+          Just attainment ->
+            padTop (Pad 1) $
+              hBox
+                [ txt "Obtained: "
+                , withAttr cyanAttr $
+                    str $
+                      formatTime defaultTimeLocale "%l:%M%P on %b %e, %Y" $
+                        attainment ^. obtainedAt
+                ]
+      , padTop (Pad 1) $
+          hBox
+            [ txt "Effort: "
+            , withAttr boldAttr $ str $ show $ effort details
+            ]
+      ]
+
+  titleWidget = padLeftRight 1 $ txt $ title details
+  details = describe x

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -268,7 +268,8 @@ dataNotFound f = do
       ]
 
 -- | Get path to swarm data, optionally creating necessary
---   directories.
+--   directories. This could fail if user has bad permissions
+--   on his own $HOME or $XDG_DATA_HOME which is unlikely.
 getSwarmDataPath :: Bool -> IO FilePath
 getSwarmDataPath createDirs = do
   swarmData <- getXdgDirectory XdgData "swarm"
@@ -279,13 +280,10 @@ getSwarmDataPath createDirs = do
 --   directories.
 getSwarmSavePath :: Bool -> IO FilePath
 getSwarmSavePath createDirs = do
-  swarmSave <- getXdgDirectory XdgData ("swarm" </> "saves")
-  when createDirs (createDirectoryIfMissing True swarmSave)
-  pure swarmSave
+  (</> "saves") <$> getSwarmDataPath createDirs
 
 -- | Get path to swarm history, optionally creating necessary
---   directories. This could fail if user has bad permissions
---   on his own $HOME or $XDG_DATA_HOME which is unlikely.
+--   directories.
 getSwarmHistoryPath :: Bool -> IO FilePath
 getSwarmHistoryPath createDirs =
   (</> "history") <$> getSwarmDataPath createDirs

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -117,12 +117,17 @@ library
                       Swarm.TUI.List
                       Swarm.TUI.Panel
                       Swarm.TUI.Model
+                      Swarm.TUI.Model.Achievement.Attainment
+                      Swarm.TUI.Model.Achievement.Definitions
+                      Swarm.TUI.Model.Achievement.Description
+                      Swarm.TUI.Model.Achievement.Persistence
                       Swarm.TUI.Model.Menu
                       Swarm.TUI.Model.Name
                       Swarm.TUI.Model.Repl
                       Swarm.TUI.Model.StateUpdate
                       Swarm.TUI.Model.UI
                       Swarm.TUI.View
+                      Swarm.TUI.View.Achievement
                       Swarm.TUI.View.Util
                       Swarm.TUI.Controller
                       Swarm.TUI.Controller.Util


### PR DESCRIPTION
Towards #797.

This PR implements defines the achievements schema, defines a few example achievements, and implements saving and loading.

Main menu entry:
![Screenshot from 2022-10-26 23-33-47](https://user-images.githubusercontent.com/261693/198208799-f20fa52a-42ff-4d78-91c8-f15a5c90486e.png)

Achievements screen:
![image](https://user-images.githubusercontent.com/261693/207794293-eee4c7f6-4c03-438d-993c-3ffd92ea0b1e.png)
