### PR TITLE
set focus to REPL panel when clicking on REPL input

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -292,7 +292,9 @@ handleMainEvent ev = do
         WorldPanel -> do
           mouseCoordsM <- Brick.zoom gameState (mouseLocToWorldCoords mouseLoc)
           uiState . uiWorldCursor .= mouseCoordsM
-        REPLInput -> handleREPLEvent ev
+        REPLInput -> do
+          setFocus REPLPanel
+          handleREPLEvent ev
         _ -> continueWithoutRedraw
     MouseUp n _ _mouseLoc -> do
       case n of


### PR DESCRIPTION
Ensure that focus changes to the REPL panel also when clicking on the REPL input itself.

Cleaning up a small leftover issue from #801.