### PR TITLE
use two rows for keyboard commands list

### DIFF
--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -752,17 +752,21 @@ drawModalMenu s = vLimit 1 . hBox $ map (padLeftRight 1 . drawKeyCmd) globalKeyC
 -- This excludes the F-key modals that are shown elsewhere.
 drawKeyMenu :: AppState -> Widget Name
 drawKeyMenu s =
-  vLimit 1
-    . hBox
-    . (++ [gameModeWidget])
-    . map (padLeftRight 1 . drawKeyCmd)
-    . (globalKeyCmds ++)
-    . map highlightKeyCmds
-    . keyCmdsFor
-    . focusGetCurrent
-    . view (uiState . uiFocusRing)
-    $ s
+  vLimit 2 $
+    hBox
+      [ vBox
+          [ mkCmdRow globalKeyCmds
+          , padLeft (Pad 2) $ mkCmdRow focusedPanelCmds
+          ]
+      , gameModeWidget
+      ]
  where
+  mkCmdRow = hBox . map drawPaddedCmd
+  drawPaddedCmd = padLeftRight 1 . drawKeyCmd
+  focusedPanelCmds =
+    map highlightKeyCmds $
+      keyCmdsFor $ focusGetCurrent $ view (uiState . uiFocusRing) s
+
   isReplWorking = s ^. gameState . replWorking
   isPaused = s ^. gameState . paused
   viewingBase = (s ^. gameState . viewCenterRule) == VCRobot 0


### PR DESCRIPTION
There are too many keyboard commands to list on one line, so they get cut off even with a very wide terminal.  This PR splits panel-specific commands into a separate row from global commands.

| Version | Screenshot |
| --- | --- |
| Before: | ![Screenshot from 2022-11-04 01-30-49](https://user-images.githubusercontent.com/261693/199928352-5e1c2c15-4ae3-41e1-b8ac-9943dd9d548d.png) |
| After: | ![Screenshot from 2022-11-04 01-30-08](https://user-images.githubusercontent.com/261693/199928331-b797d760-4272-493f-b26c-da9cddc5f8e2.png) |

