### PR TITLE
Ctrl+C should clear the REPL text

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -723,6 +723,7 @@ handleREPLEvent = \case
   ControlKey 'c' -> do
     gameState . baseRobot . machine %= cancel
     uiState . uiREPL . replPromptType .= CmdPrompt []
+    uiState . uiREPL . replPromptText .= ""
   Key V.KEnter -> do
     s <- get
     let topCtx = topContext s


### PR DESCRIPTION
Currently there's no (obvious?) shortcut to clear the currently typed text in the REPL.

Mapping CTRL+c to this action would be familiar to terminal users.