### PR TITLE
Copy requirements map to robot context when loading a new `ProcessedTerm`

### DIFF
--- a/data/scenarios/Challenges/Mazes/easy_cave_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/easy_cave_maze.yaml
@@ -15,7 +15,6 @@ solution: |
   def until = \p. \c. b <- p; if b {} {c; until p c} end;
   def fwd = until blocked move end;
   build {
-    require "branch predictor"; // #540
     turn east;
     until (ishere "goal") (fwd; turn right; fwd; turn left);
     grab

--- a/data/scenarios/Challenges/Mazes/easy_spiral_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/easy_spiral_maze.yaml
@@ -16,7 +16,6 @@ solution: |
   def until = \p. \c. b <- p; if b {} {c; until p c} end;
   def fwd = until blocked move end;
   build {
-    require "branch predictor"; // #540
     turn west;
     until (ishere "goal") (fwd; turn right);
     grab

--- a/data/scenarios/Challenges/Mazes/invisible_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/invisible_maze.yaml
@@ -25,9 +25,6 @@ solution: |
   def rightBlocked = tR; b <- blocked; tL; return b end;
   def mazeStep = ifC rightBlocked {ifC blocked {tL} {move}} {tR; move} end;
   build {
-    require "treads"; require "branch predictor"; require "lambda";
-    require "strange loop"; require "scanner"; require "grabber";   // #540
-
     forever (mazeStep; ifC (ishere "goal") {grab; return ()} {})
   }
 robots:

--- a/data/scenarios/Challenges/Mazes/loopy_maze_sol.sw
+++ b/data/scenarios/Challenges/Mazes/loopy_maze_sol.sw
@@ -14,9 +14,5 @@ def DFS =
   tB; move; tB
 end;
 build {
-  require "treads"; require "scanner"; require "lambda";
-  require "strange loop"; require "branch predictor";
-  require "grabber";  // #540
-
   require 500 "rock"; DFS
 }

--- a/data/scenarios/Testing/394-build-drill.yaml
+++ b/data/scenarios/Testing/394-build-drill.yaml
@@ -9,7 +9,7 @@ objectives:
       try {
         as base {l <- has "detonator"; return (not l)}
       } { return false }
-# When testing, add `s <- build {...}; n <- as s {whoami}; log n` 
+# When testing, add `s <- build {...}; n <- as s {whoami}; log n`
 solution: |
   def forever = \c. c ; forever c end;
   def unblock = try {drill forward} {} end;
@@ -21,7 +21,6 @@ solution: |
     forever (
       build {
         log "Hi, I am pusher";
-        require "drill";          // #540
         forever push
       };
       log "- robot built"

--- a/data/scenarios/Testing/562-lodestone.sw
+++ b/data/scenarios/Testing/562-lodestone.sw
@@ -32,10 +32,8 @@ build {log "Hey!"; turn north; m2; l <- grab; turn back; m2; place l};
 until (ishere "lodestone") {grab};
 
 // get two bit (0)
-// TODO: require should not be necessary
 build {
   log "Hi!";
-  require "branch predictor";
   repeat (
     log "I am going for a bit";
     turn east; m2; x <- until (ishere "bit (0)") {harvest}; turn back; m2; place x;

--- a/data/scenarios/Testing/562-lodestone.yaml
+++ b/data/scenarios/Testing/562-lodestone.yaml
@@ -27,6 +27,7 @@ robots:
       - branch predictor
     inventory:
       - [10, drill]
+      - [10, lambda]
       - [10, logger]
       - [10, compass]
       - [10, treads]

--- a/data/scenarios/Tutorials/conditionals.yaml
+++ b/data/scenarios/Tutorials/conditionals.yaml
@@ -62,9 +62,6 @@ solution: |
   def pick = move; ifC (ishere VSR) {grab; return ()} {} end;
   def pickrow = x4 pick; turn back; x4 move end;
   build {
-    require "treads"; require "branch predictor"; require "grabber";
-    require "lambda"; require "scanner";  // #540
-
     turn south; x4 (move; tL; pickrow; tL); tB; x4 move; x4 (give base VSR)
   }
 robots:

--- a/data/scenarios/Tutorials/def.yaml
+++ b/data/scenarios/Tutorials/def.yaml
@@ -46,7 +46,6 @@ solution: |
   def tB = turn back end;
   def S = m16; tL; m2; tL; m16; tR; m2; tR; m16 end;
   build {
-    require "treads";  // #540
     turn right; S; f <- harvest; tB; S; give base f
   }
 robots:

--- a/data/scenarios/Tutorials/farming.sw
+++ b/data/scenarios/Tutorials/farming.sw
@@ -39,14 +39,9 @@ def harvest_lambdas =
   )
 end;
 build {
-  require "treads"; require "harvester"; require "logger";
-  require "lambda"; require "branch predictor";             // #540
   require 1 "lambda";
   tB; move; tR; plant_field "lambda";
 };
 build {
-  require "treads"; require "harvester"; require "logger"; require "scanner";
-  require "grabber";
-  require "lambda"; require "branch predictor"; require "strange loop";  // #540
   harvest_lambdas
 }

--- a/data/scenarios/Tutorials/lambda.yaml
+++ b/data/scenarios/Tutorials/lambda.yaml
@@ -34,7 +34,6 @@ solution: |
   def tL = turn left end;
   def s = m4; tL; m2; tL; m4; tR; m2; tR end;
   build {
-    require "treads"; require "lambda";  // #540
     turn right;
     x4 (x4 s; m4; m2; tR; x4 (x4 move); tL; m2);
     grab

--- a/data/scenarios/Tutorials/require.yaml
+++ b/data/scenarios/Tutorials/require.yaml
@@ -34,8 +34,6 @@ entities:
 solution: |
   def m5 = move; move; move; move; move end;
   build {
-    require "treads";  // #540
-
     require "boat"; turn right;
     m5; f <- grab; turn back; m5; give base f
   }

--- a/data/scenarios/Tutorials/requireinv.yaml
+++ b/data/scenarios/Tutorials/requireinv.yaml
@@ -38,7 +38,6 @@ solution: |
   def mp = move; place "rock" end;
   def rr = turn right; move; turn right; x4 mp; turn back; x4 move end;
   build {
-    require "treads"; require "grabber"; require "lambda"; // #540
     require 16 "rock";
     x4 rr
   };

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1434,12 +1434,11 @@ execConst c vs s k = do
           processTerm (into @Text f) `isRightOr` \err ->
             cmdExn Run ["Error in", fileName, "\n", err]
 
-        return $ case mt of
-          Nothing -> Out VUnit s k
-          -- XXX need to get reqCtx from mt and make it available
-          -- somehow when running this sub-machine...  This will also
-          -- be a hack that should become better once we get #495...
-          Just t -> initMachine' t empty s k
+        case mt of
+          Nothing -> return $ Out VUnit s k
+          Just t@(ProcessedTerm _ _ _ reqCtx) -> do
+            robotContext . defReqs <>= reqCtx
+            return $ initMachine' t empty s k
       _ -> badConst
     Not -> case vs of
       [VBool b] -> return $ Out (VBool (not b)) s k

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1436,6 +1436,9 @@ execConst c vs s k = do
 
         return $ case mt of
           Nothing -> Out VUnit s k
+          -- XXX need to get reqCtx from mt and make it available
+          -- somehow when running this sub-machine...  This will also
+          -- be a hack that should become better once we get #495...
           Just t -> initMachine' t empty s k
       _ -> badConst
     Not -> case vs of

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1437,6 +1437,10 @@ execConst c vs s k = do
         case mt of
           Nothing -> return $ Out VUnit s k
           Just t@(ProcessedTerm _ _ _ reqCtx) -> do
+            -- Add the reqCtx from the ProcessedTerm to the current robot's defReqs.
+            -- See #827 for an explanation of (1) why this is needed, (2) why
+            -- it's slightly technically incorrect, and (3) why it is still way
+            -- better than what we had before.
             robotContext . defReqs <>= reqCtx
             return $ initMachine' t empty s k
       _ -> badConst

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -729,8 +729,9 @@ handleREPLEvent = \case
         repl = s ^. uiState . uiREPL
         uinput = repl ^. replPromptText
 
-        startBaseProgram t@(ProcessedTerm _ (Module ty _) reqs _) =
+        startBaseProgram t@(ProcessedTerm _ (Module ty _) reqs reqCtx) =
           (gameState . replStatus .~ REPLWorking (Typed Nothing ty reqs))
+            . (gameState . baseRobot . robotContext . defReqs .~ reqCtx)
             . (gameState . baseRobot . machine .~ initMachine t (topCtx ^. defVals) (topCtx ^. defStore))
             . (gameState %~ execState (activateRobot 0))
 

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -729,10 +729,28 @@ handleREPLEvent = \case
         repl = s ^. uiState . uiREPL
         uinput = repl ^. replPromptText
 
+        -- The player typed something at the REPL and hit Enter; this
+        -- function takes the resulting ProcessedTerm (if the REPL
+        -- input is valid) and sets up the base robot to run it.
         startBaseProgram t@(ProcessedTerm _ (Module ty _) reqs reqCtx) =
+          -- Set the REPL status to Working
           (gameState . replStatus .~ REPLWorking (Typed Nothing ty reqs))
+            -- The `reqCtx` maps names of variables defined in the
+            -- term (by `def` statements) to their requirements.
+            -- E.g. if we had `def m = move end`, the reqCtx would
+            -- record the fact that `m` needs the `move` capability.
+            -- We simply dump the entire `reqCtx` into the robot's
+            -- context, so we can look up requirements if we later
+            -- need to requirements-check an argument to `build` or
+            -- `reprogram` at runtime.  See the discussion at
+            -- https://github.com/swarm-game/swarm/pull/827 for more
+            -- details.
             . (gameState . baseRobot . robotContext . defReqs .~ reqCtx)
+            -- Set up the robot's CESK machine to evaluate/execute the
+            -- given term, being sure to initialize the CESK machine
+            -- environment and store from the top-level context.
             . (gameState . baseRobot . machine .~ initMachine t (topCtx ^. defVals) (topCtx ^. defStore))
+            -- Finally, be sure to activate the base robot.
             . (gameState %~ execState (activateRobot 0))
 
     if not $ s ^. gameState . replWorking

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -47,7 +47,6 @@ import System.Environment (getEnvironment)
 import System.FilePath.Posix (takeExtension, (</>))
 import System.Timeout (timeout)
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.ExpectedFailure (expectFailBecause)
 import Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCase)
 import Witch (into)
 

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -220,6 +220,9 @@ testScenarioSolution _ci _em =
       Just sol@(ProcessedTerm _ _ _ reqCtx) -> do
         let gs' =
               gs
+                -- See #827 for an explanation of why it's important to set
+                -- the robotContext defReqs here (and also why this will,
+                -- hopefully, eventually, go away).
                 & baseRobot . robotContext . defReqs .~ reqCtx
                 & baseRobot . machine .~ initMachine sol Ctx.empty emptyStore
         m <- timeout (time s) (snd <$> runStateT playUntilWin gs')

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -190,8 +190,7 @@ testScenarioSolution _ci _em =
             , testSolution Default "Testing/201-require/201-require-device-creative"
             , testSolution Default "Testing/201-require/201-require-device-creative1"
             , testSolution Default "Testing/201-require/201-require-entities"
-            , expectFailBecause "Awaiting fix (#540)" $
-                testSolution Default "Testing/201-require/201-require-entities-def"
+            , testSolution Default "Testing/201-require/201-require-entities-def"
             , testSolution Default "Testing/201-require/533-reprogram-simple"
             , testSolution Default "Testing/201-require/533-reprogram"
             ]


### PR DESCRIPTION
Closes #540.

When we typecheck and capability check a new term, resulting in a `ProcessedTerm`, we already know the `Requirement`s for all the `def`s it contains.  This PR simply takes all those definition requirements and adds them to `robotContext . defReqs` just before installing the new `ProcessedTerm` in the CESK machine, so that if we ever encounter the name of any of the definitions inside an argument to `build` or `reprogram`---which we capability check at runtime---we will be able to properly match up names with their requirements.

This is a hack for several reasons:
- We really shouldn't be capability-checking arguments to `build` and `reprogram` at runtime in the first place---ideally we should be able to check everything statically.  But fixing that will require implementing #231 .
- We have to do this in three places in the code: when loading a new term into the base when the player hits Enter at the REPL; when executing `run`; and when running the solution from a scenario in the integration tests.  Ideally, there would be only one place, but I don't have a good idea at the moment how to refactor things properly.
- Technically, the names being defined shouldn't be in scope until after their corresponding `def` runs, so it's incorrect to dump them all into the `defReqs` prior to executing any of the `def`s.
    - However, doing it properly, with each name coming into scope with its requirements right after the `def` runs, is very tricky/annoying to implement for more reasons than I care to write about here (believe me, I tried, and it made my brain hurt).  For starters, we don't really have access to the robot state when stepping the CESK machine.
    - The only scenario where this would be a problem is if (1) there is already a name `x` defined, and then we (2) `run` a `.sw` file containing, first, a `build` command whose argument references `x`, and second, a redefinition of `x`.  In that case the `build` would incorrectly decide that the `x` in the argument to `build` has the requirements of the *second* `x` (the one that will be redefined later) even though the first `x` is the one that should still be in scope.  However, this seems like a very unlikely scenario (who would write a `.sw` file that depends on some specific name already being defined before it is run, but then redefines that same name later?) and I'd *much* rather have that obscure problem than the current very relevant and annoying one.

However, it's a simple hack that solves the issue and will be easy to get rid of later if and when we do something better.  I'm a big believer in doing things the right way, but in this instance I definitely think we should just do the simple thing that mostly works and then continue to make it better in the future.