### PR TITLE
Drills by capability

### DIFF
--- a/src/Swarm/DocGen.hs
+++ b/src/Swarm/DocGen.hs
@@ -321,7 +321,7 @@ entityToList e =
     escapeTable
     [ codeQuote . T.singleton $ e ^. entityDisplay . to displayChar
     , addLink ("#" <> linkID) $ view entityName e
-    , T.intercalate ", " $ Capability.capabilityName <$> view E.entityCapabilities e
+    , T.intercalate ", " $ Capability.capabilityName <$> Set.toList (view E.entityCapabilities e)
     , T.intercalate ", " . map tshow . filter (/= E.Portable) $ toList props
     , if E.Portable `elem` props
         then ":heavy_check_mark:"
@@ -351,7 +351,7 @@ entityToSection e =
       <> [T.intercalate "\n\n" $ view E.entityDescription e]
  where
   props = view E.entityProperties e
-  caps = view E.entityCapabilities e
+  caps = Set.toList $ view E.entityCapabilities e
 
 entitiesPage :: PageAddress -> [Entity] -> Text
 entitiesPage _a es =

--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -69,6 +69,7 @@ module Swarm.Game.Entity (
   isSubsetOf,
   isEmpty,
   inventoryCapabilities,
+  extantElemsWithCapability,
 
   -- ** Modification
   insert,
@@ -97,7 +98,7 @@ import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe, isJust, listToMaybe)
 import Data.Set (Set)
-import Data.Set qualified as Set (fromList, toList, unions)
+import Data.Set qualified as Set (fromList, member, toList, unions)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Yaml
@@ -568,8 +569,15 @@ isEmpty = all ((== 0) . fst) . elems
 inventoryCapabilities :: Inventory -> Set Capability
 inventoryCapabilities = Set.unions . map (^. entityCapabilities) . nonzeroEntities
 
+-- | List elements that have at least one copy in the inventory.
 nonzeroEntities :: Inventory -> [Entity]
 nonzeroEntities = map snd . filter ((> 0) . fst) . elems
+
+-- | List elements that possess a given Capability and
+-- exist with nonzero count in the inventory.
+extantElemsWithCapability :: Capability -> Inventory -> [Entity]
+extantElemsWithCapability cap =
+  filter (Set.member cap . (^. entityCapabilities)) . nonzeroEntities
 
 -- | Delete a single copy of a certain entity from an inventory.
 delete :: Entity -> Inventory -> Inventory

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -2014,7 +2014,7 @@ updateAvailableRecipes invs e = do
 
 updateAvailableCommands :: Has (State GameState) sig m => Entity -> m ()
 updateAvailableCommands e = do
-  let newCaps = S.fromList (e ^. entityCapabilities)
+  let newCaps = e ^. entityCapabilities
       keepConsts = \case
         Just cap -> cap `S.member` newCaps
         Nothing -> False


### PR DESCRIPTION
This PR consists of two commits:
1. Refactor list of capabilities to sets (continuation of #794)
2. Instead of hard-coding drill names, select equipped entities by their `drill` capability

This allows scenario authors to define their own drills.