### PR TITLE
Ignore scenario subdirs starting with underscore

### DIFF
--- a/src/Swarm/Game/ScenarioInfo.hs
+++ b/src/Swarm/Game/ScenarioInfo.hs
@@ -57,7 +57,7 @@ import Data.Aeson (
   genericToEncoding,
   genericToJSON,
  )
-import Data.Char (isLower, isSpace, toLower)
+import Data.Char (isSpace, toLower)
 import Data.Function (on)
 import Data.List (intercalate, stripPrefix, (\\))
 import Data.Map (Map)
@@ -260,7 +260,7 @@ loadScenarioDir em dir = do
             <> ", using alphabetical order"
       return Nothing
     True -> Just . filter (not . null) . lines <$> sendIO (readFile orderFile)
-  fs <- sendIO $ keepYamlOrNonLowerDirectory <$> listDirectory dir
+  fs <- sendIO $ keepYamlOrPublicDirectory <$> listDirectory dir
 
   case morder of
     Just order -> do
@@ -288,10 +288,10 @@ loadScenarioDir em dir = do
   SC morder' . M.fromList <$> mapM (\item -> (item,) <$> loadScenarioItem em (dir </> item)) fs
  where
   -- Keep only files which are .yaml files or directories that start
-  -- with something other than a lowercase letter.
-  keepYamlOrNonLowerDirectory =
+  -- with something other than an underscore.
+  keepYamlOrPublicDirectory =
     filter
-      (\f -> takeExtensions f == ".yaml" || (takeExtensions f == "" && not (isLower (head f))))
+      (\f -> takeExtensions f == ".yaml" || (takeExtensions f == "" && head f /= '_'))
 
 -- | How to transform scenario path to save path.
 scenarioPathToSavePath :: FilePath -> FilePath -> FilePath


### PR DESCRIPTION
Such subdirectories can be used to e.g. organize `.sw` files, and will be ignored when recursively loading scenarios.

This resolves an issue we noticed while reviewing #835, which uses a subdirectory to hold multiple `.sw` files for a scenario and was generating a lot of spurious warnings.