### PR TITLE
Fix: add first heard message to log

### DIFF
--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1084,7 +1084,7 @@ execConst c vs s k = do
         m <- traceLog Said msg -- current robot will inserted to robot set, so it needs the log
         emitMessage m
         let addLatestClosest rl = \case
-              Seq.Empty -> Seq.Empty
+              Seq.Empty -> Seq.singleton m
               es Seq.:|> e
                 | e ^. leTime < m ^. leTime -> es |> e |> m
                 | manhattan rl (e ^. leLocation) > manhattan rl (m ^. leLocation) -> es |> m


### PR DESCRIPTION
When the logger is empty, newly heard messages would have been ignored.