### PR TITLE
Add a `foldText` constant as a generic eliminator for the `text` type

### DIFF
--- a/src/Swarm/Game/CESK.hs
+++ b/src/Swarm/Game/CESK.hs
@@ -130,6 +130,10 @@ data Frame
     -- application) in environment @e@.  We will also push an 'FApp'
     -- frame on the stack.
     FArg Term Env
+  | -- | @FVArg v@ is like @FArg@ except that the argument is already
+    -- a value; when we are done evaluating the left-hand side of
+    -- the application we just directly apply it.
+    FVArg Value
   | -- | @FApp v@ says that we were evaluating the right-hand side of
     -- an application; once we are done, we should pass the resulting
     -- value as an argument to @v@.
@@ -341,6 +345,7 @@ prettyFrame :: Frame -> String
 prettyFrame (FSnd t _) = "(_, " ++ prettyString t ++ ")"
 prettyFrame (FFst v) = "(" ++ from (prettyValue v) ++ ", _)"
 prettyFrame (FArg t _) = "_ " ++ prettyString t
+prettyFrame (FVArg v) = "_ " ++ from (prettyValue v)
 prettyFrame (FApp v) = prettyString (valueToTerm v) ++ " _"
 prettyFrame (FLet x t _) = "let " ++ from x ++ " = _ in " ++ prettyString t
 prettyFrame (FTry t) = "try _ (" ++ prettyString (valueToTerm t) ++ ")"

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -450,6 +450,8 @@ stepCESK cesk = case cesk of
   In (TApp t1 t2) e s k -> return $ In t1 e s (FArg t2 e : k)
   -- Once that's done, switch to evaluating the argument.
   Out v1 s (FArg t2 e : k) -> return $ In t2 e s (FApp v1 : k)
+  -- If the argument is already a value, return it directly and push an FApp.
+  Out v1 s (FVArg v2 : k) -> return $ Out v2 s (FApp v1 : k)
   -- We can evaluate an application of a closure in the usual way.
   Out v2 s (FApp (VClo x t e) : k) -> return $ In t (addBinding x v2 e) s k
   -- We can also evaluate an application of a constant by collecting

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -205,6 +205,7 @@ constCaps = \case
   Concat -> Just CText
   Split -> Just CText
   Chars -> Just CText
+  FoldText -> Just CText
   -- ----------------------------------------------------------------
   -- Some God-like abilities.
   As -> Just CGod

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -352,6 +352,8 @@ data Const
     Chars
   | -- | Split string into two parts.
     Split
+  | -- | Generic text eliminator, i.e. fold.
+    FoldText
   | -- Function composition with nice operators
 
     -- | Application operator - helps to avoid parentheses:
@@ -644,6 +646,8 @@ constInfo c = case c of
       , "`(s1,s2) == split (chars s1) (s1 ++ s2)`"
       , "So split can be used to undo concatenation if you know the length of the original string."
       ]
+  FoldText ->
+    function 3 "Process a text value with a left fold."
   AppF ->
     binaryOp "$" 0 R . doc "Apply the function on the left to the value on the right." $
       [ "This operator is useful to avoid nesting parentheses."

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -527,6 +527,7 @@ inferConst c = case c of
   Concat -> [tyQ| text -> text -> text |]
   Chars -> [tyQ| text -> int |]
   Split -> [tyQ| int -> text -> (text * text) |]
+  FoldText -> [tyQ| (a -> int -> a) -> a -> text -> a |]
   AppF -> [tyQ| (a -> b) -> a -> b |]
   Swap -> [tyQ| text -> cmd text |]
   Atomic -> [tyQ| cmd a -> cmd a |]

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -527,7 +527,7 @@ inferConst c = case c of
   Concat -> [tyQ| text -> text -> text |]
   Chars -> [tyQ| text -> int |]
   Split -> [tyQ| int -> text -> (text * text) |]
-  FoldText -> [tyQ| (a -> int -> a) -> a -> text -> a |]
+  FoldText -> [tyQ| (int -> a -> a) -> a -> text -> a |]
   AppF -> [tyQ| (a -> b) -> a -> b |]
   Swap -> [tyQ| text -> cmd text |]
   Atomic -> [tyQ| cmd a -> cmd a |]


### PR DESCRIPTION
`foldText` lets you do a left fold over the ASCII values of the characters in a `text`.  For example,
```
foldText (\c. \n. n+1) 0 "hello" == 5
```
To make this really useful we probably also need a way to convert back from ASCII values to `text`.

I wanted this because... actually, I forget why now.  I had a specific reason.  I'll add it when I think of it again.  In any case a fold in theory lets you do anything at all with a `text` value.

This is a draft PR.  Still need to add some tests, maybe also add an `int -> text` conversion as well.  Would also love feedback on anything at all.  Should we keep the `chars` function, now that you can just implement it with `foldText`?