### PR TITLE
prepare maps for yaml normalization

### DIFF
--- a/data/scenarios/Challenges/hanoi.yaml
+++ b/data/scenarios/Challenges/hanoi.yaml
@@ -157,7 +157,7 @@ known:
 world:
   default: [grass, null]
   palette:
-    ' ': [grass]
+    ',': [grass]
     '_': [stone]
     'v': [stone, null, base]
     '┌': [stone, upper left corner]
@@ -182,5 +182,5 @@ world:
     │2│.│.│
     │3│.│.│
     └─┴─┴─┘
-     ^ ^ ^ 
-       X   
+    ,^,^,^,
+    ,,,X,,,

--- a/data/scenarios/Challenges/teleport.yaml
+++ b/data/scenarios/Challenges/teleport.yaml
@@ -58,6 +58,7 @@ known: [water, wavy water, flower, tree]
 world:
   default: [ice, water]
   palette:
+    ',': [ice, water]
     ' ': [ice, water]
     '~': [ice, wavy water]
     '*': [grass, flower]
@@ -74,9 +75,9 @@ world:
   upperleft: [-1, 3]
   map: |
     ~~   ~         ~    ~
-    ~┌─────┐~  ┌─────┐~  
+    ~┌─────┐~  ┌─────┐~ ,
     ┌┘.....└───┘T...*└┐ ~
-    │_....._   _..λ.._│  
+    │_....._   _..λ.._│ ,
     └┐.....┌───┐*...T┌┘ ~
-    ~└─────┘ ~~└─────┘~  
+    ~└─────┘ ~~└─────┘~ ,
     ~~~   ~        ~    ~


### PR DESCRIPTION
Towards #845

`yq` requires that string literals do not have trailing spaces.
This PR replaces space characters with commas so that the right edge of the map rectangle is straight.