### PR TITLE
Fix typos

### DIFF
--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -28,7 +28,7 @@ idleProgram :: ProcessedTerm
 idleProgram = [tmQ| {} |]
 
 -- | The program of a robot which waits a random number of ticks, changes its
---   appearence, then waits another random number of ticks, places a tree, and
+--   appearance, then waits another random number of ticks, places a tree, and
 --   then self-destructs.
 treeProgram :: ProcessedTerm
 treeProgram =

--- a/data/scenarios/Challenges/hanoi.yaml
+++ b/data/scenarios/Challenges/hanoi.yaml
@@ -57,7 +57,7 @@ robots:
       // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       // if
       //  0. I stand on unlocked X
-      //  1. place noth of me is NOT empty
+      //  1. place north of me is NOT empty
       // then
       //  - lock X
       run "scenarios/Challenges/hanoi-invariant.sw"

--- a/editors/vscode/DEVELOPING.md
+++ b/editors/vscode/DEVELOPING.md
@@ -1,7 +1,7 @@
 ## Developing
 
 > The extension was created using [`yo code`](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#developing-a-new-grammar-extension)
-> and further extended to suport LSP by including modified
+> and further extended to support LSP by including modified
 > [Microsoft lsp-sample](https://github.com/microsoft/vscode-extension-samples/tree/main/lsp-sample).
 >
 > As a note, this is deliberately a separate file from `README.md` which shows in the VSCode extension view.

--- a/example/list.sw
+++ b/example/list.sw
@@ -148,7 +148,7 @@ end
 // nil : listI
 def nil = 0 end
 
-// Add non-negative number to beggining of list (cons adds the sign)
+// Add non-negative number to beginning of list (cons adds the sign)
 // consP : nat -> listI -> int
 def consP = \x.\xs.
   if (x == 0)
@@ -159,7 +159,7 @@ def consP = \x.\xs.
     }
 end
 
-// Add integer to the beggining of the list
+// Add integer to the beginning of the list
 // consP : int -> listI -> listI
 def cons = \x.\xs.
   if (x >= 0)

--- a/src/Swarm/DocGen.hs
+++ b/src/Swarm/DocGen.hs
@@ -415,7 +415,7 @@ recipesToDot classic emap recipes = do
   world <- diamond "World"
   base <- diamond "Base"
   -- --------------------------------------------------------------------------
-  -- add nodes with for all the known entites
+  -- add nodes with for all the known entities
   let enames' = toList . Map.keysSet . entitiesByName $ emap
       enames = filter (`Set.notMember` ignoredEntites) enames'
   ebmap <- Map.fromList . zip enames <$> mapM (box . unpack) enames
@@ -425,7 +425,7 @@ recipesToDot classic emap recipes = do
       getE = safeGetEntity ebmap
       nid = getE . view entityName
   -- --------------------------------------------------------------------------
-  -- Get the starting inventories, entites present in the world and compute
+  -- Get the starting inventories, entities present in the world and compute
   -- how hard each entity is to get - see 'recipeLevels'.
   let devs = startingDevices classic
       inv = startingInventory classic
@@ -439,13 +439,13 @@ recipesToDot classic emap recipes = do
     mapM_ ((base ---<>) . nid) devs
     mapM_ ((base .->.) . nid . fst) $ Map.toList inv
   -- --------------------------------------------------------------------------
-  -- World entites
+  -- World entities
   (_wc, ()) <- Dot.cluster $ do
     Dot.attribute ("style", "filled")
     Dot.attribute ("color", "forestgreen")
     mapM_ ((uncurry (Dot..->.) . (world,)) . getE) (toList testWorld2Entites)
   -- --------------------------------------------------------------------------
-  let -- put a hidden node above and below entites and connect them by hidden edges
+  let -- put a hidden node above and below entities and connect them by hidden edges
       wrapBelowAbove :: Set Entity -> Dot (NodeId, NodeId)
       wrapBelowAbove ns = do
         b <- hiddenNode
@@ -454,7 +454,7 @@ recipesToDot classic emap recipes = do
         mapM_ (b .~>.) ns'
         mapM_ (.~>. t) ns'
         return (b, t)
-      -- put set of entites in nice
+      -- put set of entities in nice
       subLevel :: Int -> Set Entity -> Dot (NodeId, NodeId)
       subLevel i ns = fmap snd . Dot.cluster $ do
         Dot.attribute ("style", "filled")
@@ -471,7 +471,7 @@ recipesToDot classic emap recipes = do
             ]
         return bt
   -- --------------------------------------------------------------------------
-  -- order entites into clusters based on how "far" they are from
+  -- order entities into clusters based on how "far" they are from
   -- what is available at the start - see 'recipeLevels'.
   bottom <- wrapBelowAbove worldEntites
   ls <- zipWithM subLevel [1 ..] (tail levels)
@@ -495,14 +495,14 @@ recipesToDot classic emap recipes = do
 -- RECIPE LEVELS
 -- ----------------------------------------------------------------------------
 
--- | Order entites in sets depending on how soon it is possible to obtain them.
+-- | Order entities in sets depending on how soon it is possible to obtain them.
 --
 -- So:
---  * Level 0 - starting entites (for example those obtainable in the world)
+--  * Level 0 - starting entities (for example those obtainable in the world)
 --  * Level N+1 - everything possible to make (or drill) from Level N
 --
--- This is almost a BFS, but the requirement is that the set of entites
--- required for recipe is subset of the entites known in Level N.
+-- This is almost a BFS, but the requirement is that the set of entities
+-- required for recipe is subset of the entities known in Level N.
 --
 -- If we ever depend on some graph library, this could be rewritten
 -- as some BFS-like algorithm with added recipe nodes, but you would
@@ -524,7 +524,7 @@ recipeLevels recipes start = levels
             then ls
             else go (n : ls) (Set.union n known)
 
--- | Get classic scenario to figure out starting entites.
+-- | Get classic scenario to figure out starting entities.
 classicScenario :: ExceptT Text IO Scenario
 classicScenario = do
   entities <- loadEntities >>= guardRight "load entities"
@@ -536,7 +536,7 @@ startingDevices = Set.fromList . map snd . E.elems . view installedDevices . ins
 startingInventory :: Scenario -> Map Entity Int
 startingInventory = Map.fromList . map swap . E.elems . view robotInventory . instantiateRobot 0 . head . view scenarioRobots
 
--- | Ignore utility entites that are just used for tutorials and challenges.
+-- | Ignore utility entities that are just used for tutorials and challenges.
 ignoredEntites :: Set Text
 ignoredEntites =
   Set.fromList

--- a/src/Swarm/Game/Display.hs
+++ b/src/Swarm/Game/Display.hs
@@ -167,7 +167,7 @@ defaultEntityDisplay c =
 --   priority 10.
 --
 --   Note that the 'defaultChar' is used for direction 'DDown'
---   and is overriden for the special base robot.
+--   and is overridden for the special base robot.
 defaultRobotDisplay :: Display
 defaultRobotDisplay =
   Display

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -111,14 +111,14 @@ import Swarm.Util.Yaml
 import System.Clock (TimeSpec)
 
 -- | A record that stores the information
---   for all defintions stored in a 'Robot'
+--   for all definitions stored in a 'Robot'
 data RobotContext = RobotContext
   { -- | Map definition names to their types.
     _defTypes :: TCtx
-  , -- | Map defintion names to the capabilities
+  , -- | Map definition names to the capabilities
     --   required to evaluate/execute them.
     _defReqs :: ReqCtx
-  , -- | Map defintion names to their values. Note that since
+  , -- | Map definition names to their values. Note that since
     --   definitions are delayed, the values will just consist of
     --   'VRef's pointing into the store.
     _defVals :: Env

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -230,7 +230,7 @@ data TypeErr
 
 -- | Various reasons the body of an @atomic@ might be invalid.
 data InvalidAtomicReason
-  = -- | The arugment has too many tangible commands.
+  = -- | The argument has too many tangible commands.
     TooManyTicks Int
   | -- | The argument uses some way to duplicate code: @def@, @let@, or lambda.
     AtomicDupingThing

--- a/src/Swarm/TUI/Attr.hs
+++ b/src/Swarm/TUI/Attr.hs
@@ -15,7 +15,7 @@
 -- and not those used in the world map, to avoid abusing attributes.
 -- For example using the robot attribute to highlight some text.
 --
--- The few attributes that we use for drawing the logo are an exeption.
+-- The few attributes that we use for drawing the logo are an exception.
 module Swarm.TUI.Attr (
   swarmAttrMap,
   worldAttributes,

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -583,7 +583,7 @@ robotsListWidget s = hCenter table
 
   basePos :: V2 Double
   basePos = realToFrac <$> fromMaybe (V2 0 0) (g ^? baseRobot . robotLocation)
-  -- Keep the base and non sytem robot (e.g. no seed)
+  -- Keep the base and non system robot (e.g. no seed)
   isRelevant robot = robot ^. robotID == 0 || not (robot ^. systemRobot)
   -- Keep the robot that are less than 32 unit away from the base
   isNear robot = creative || distance (realToFrac <$> robot ^. robotLocation) basePos < 32


### PR DESCRIPTION
All changes should be non-semantic (e.g., only in code comments).

I am brand new to Swarm, apologies if I misinterpreted something (thinking particularly of "entites") as a typo that is not; happy to revert those if so.

Code itself is not changed, so `ignoredEntites` remains, though I expect it should be `ignoredEntities` (with an "i" added).