### PR TITLE
Allow retoggling robot visibility before 2 seconds

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -264,13 +264,15 @@ handleMainEvent ev = do
     MetaChar 'h' -> do
       t <- liftIO $ getTime Monotonic
       h <- use $ uiState . uiHideRobotsUntil
-      if h >= t
-        then -- ignore repeated keypresses
-          continueWithoutRedraw
-        else -- hide for two seconds
-        do
-          uiState . uiHideRobotsUntil .= t + TimeSpec 2 0
-          invalidateCacheEntry WorldCache
+      let reappearanceTime =
+            if h > t
+              then -- a second keypress before the two seconds elapse will toggle the display back
+                t
+              else -- hide for two seconds
+                t + TimeSpec 2 0
+      do
+        uiState . uiHideRobotsUntil .= reappearanceTime
+        invalidateCacheEntry WorldCache
     -- pausing and stepping
     ControlChar 'p' | isRunning -> safeTogglePause
     ControlChar 'o' | isRunning -> do


### PR DESCRIPTION
As an enhancement to #761, a second `Meta+h` keypress before the 2 seconds expire should immediately unhide the robots.

This is handy for the impatient/nearsighted among us, where toggling in quick succession makes the robot easier to find.