### PR TITLE
use nested sum type to simplify panel enumeration

### DIFF
--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -16,6 +16,7 @@ module Swarm.TUI.Model (
   -- * Custom UI label types
   -- $uilabel
   AppEvent (..),
+  FocusablePanel (..),
   Name (..),
 
   -- * Menus and dialogs
@@ -224,9 +225,7 @@ data AppEvent
   | UpstreamVersion (Either NewReleaseFailure String)
   deriving (Show)
 
--- | 'Name' represents names to uniquely identify various components
---   of the UI, such as forms, panels, caches, extents, and lists.
-data Name
+data FocusablePanel
   = -- | The panel containing the REPL.
     REPLPanel
   | -- | The panel containing the world view.
@@ -235,6 +234,12 @@ data Name
     RobotPanel
   | -- | The info panel on the bottom left.
     InfoPanel
+  deriving (Eq, Ord, Show, Read, Bounded, Enum)
+
+-- | 'Name' represents names to uniquely identify various components
+--   of the UI, such as forms, panels, caches, extents, and lists.
+data Name
+  = FocusablePanel FocusablePanel
   | -- | The REPL input form.
     REPLInput
   | -- | The render cache for the world view.
@@ -820,7 +825,7 @@ focusedEntity =
 
 -- | The initial state of the focus ring.
 initFocusRing :: FocusRing Name
-initFocusRing = focusRing [REPLPanel, InfoPanel, RobotPanel, WorldPanel]
+initFocusRing = focusRing $ map FocusablePanel listEnums
 
 -- | The initial tick speed.
 initLgTicksPerSecond :: Int

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -271,11 +271,11 @@ drawGameUI s =
       hBox
         [ hLimitPercent 25 $
             vBox
-              [ vLimitPercent 50 $ panel highlightAttr fr RobotPanel plainBorder $ drawRobotPanel s
+              [ vLimitPercent 50 $ panel highlightAttr fr (FocusablePanel RobotPanel) plainBorder $ drawRobotPanel s
               , panel
                   highlightAttr
                   fr
-                  InfoPanel
+                  (FocusablePanel InfoPanel)
                   ( plainBorder
                       & topLabels . centerLabel
                       .~ (if moreTop then Just (txt " · · · ") else Nothing)
@@ -288,7 +288,7 @@ drawGameUI s =
             [ panel
                 highlightAttr
                 fr
-                WorldPanel
+                (FocusablePanel WorldPanel)
                 ( plainBorder
                     & bottomLabels . rightLabel ?~ padLeftRight 1 (drawTPS s)
                     & topLabels . leftLabel ?~ drawModalMenu s
@@ -297,11 +297,11 @@ drawGameUI s =
                 )
                 (drawWorld (s ^. uiState . uiShowRobots) (s ^. gameState))
             , drawKeyMenu s
-            , clickable REPLPanel $
+            , clickable (FocusablePanel REPLPanel) $
                 panel
                   highlightAttr
                   fr
-                  REPLPanel
+                  (FocusablePanel REPLPanel)
                   ( plainBorder
                       & topLabels . rightLabel .~ (drawType <$> (s ^. uiState . uiREPL . replType))
                   )
@@ -828,24 +828,24 @@ drawKeyMenu s =
     "pop out" | (s ^. uiState . uiMoreInfoBot) || (s ^. uiState . uiMoreInfoTop) -> Alert
     _ -> PanelSpecific
 
-  keyCmdsFor (Just REPLPanel) =
+  keyCmdsFor (Just (FocusablePanel REPLPanel)) =
     [ ("↓↑", "history")
     ]
       ++ [("Enter", "execute") | not isReplWorking]
       ++ [("^c", "cancel") | isReplWorking]
       ++ [("M-p", renderControlModeSwitch ctrlMode) | creative]
-  keyCmdsFor (Just WorldPanel) =
+  keyCmdsFor (Just (FocusablePanel WorldPanel)) =
     [ ("←↓↑→ / hjkl", "scroll") | creative
     ]
       ++ [("c", "recenter") | not viewingBase]
       ++ [("f", "FPS")]
-  keyCmdsFor (Just RobotPanel) =
+  keyCmdsFor (Just (FocusablePanel RobotPanel)) =
     [ ("Enter", "pop out")
     , ("m", "make")
     , ("0", (if showZero then "hide" else "show") <> " 0")
     , (":/;", T.unwords ["Sort:", renderSortMethod inventorySort])
     ]
-  keyCmdsFor (Just InfoPanel) = []
+  keyCmdsFor (Just (FocusablePanel InfoPanel)) = []
   keyCmdsFor _ = []
 
 data KeyHighlight = NoHighlight | Alert | PanelSpecific
@@ -874,7 +874,7 @@ drawWorld showRobots g =
     . cached WorldCache
     . reportExtent WorldExtent
     -- Set the clickable request after the extent to play nice with the cache
-    . clickable WorldPanel
+    . clickable (FocusablePanel WorldPanel)
     . Widget Fixed Fixed
     $ do
       ctx <- getContext
@@ -1217,7 +1217,7 @@ renderREPLPrompt focus repl = ps1 <+> replE
   replE =
     renderEditor
       (color . vBox . map txt)
-      (focusGetCurrent focus `elem` [Nothing, Just REPLPanel, Just REPLInput])
+      (focusGetCurrent focus `elem` [Nothing, Just (FocusablePanel REPLPanel), Just REPLInput])
       replEditor
 
 -- | Draw the REPL.


### PR DESCRIPTION
This trick facilitates use of `listEnums` and more concise pattern matching.

Towards #873.