### PR TITLE
remove --cabal-default-extensions arg from fourmolu invocation

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -2,5 +2,4 @@ restylers_version: dev
 restylers:
   - fourmolu:
       arguments:
-        [ '--cabal-default-extensions'
-        ]
+        []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,16 +214,16 @@ them!
 
 #### Formatting style
 
-We use [`fourmolu-0.4.0.0`](https://hackage.haskell.org/package/fourmolu)
+We use [`fourmolu-0.9.0.0`](https://hackage.haskell.org/package/fourmolu)
 with a [custom
 configuration](https://github.com/swarm-game/swarm/blob/main/fourmolu.yaml)
 for formatting Haskell code.
 
 You can run the formatter from the shell:
 ```bash
-cabal install fourmolu-0.4.0.0
+cabal install fourmolu-0.9.0.0
 cd path/to/the/root/of/swarm/repo
-find src/ app/ test/ -name "*.hs" | xargs fourmolu --mode=inplace --cabal-default-extensions
+find src/ app/ test/ -name "*.hs" | xargs fourmolu --mode=inplace
 ```
 
 For convenience, one may alternatively execute this script:

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -3,6 +3,7 @@ comma-style: leading
 record-brace-space: true
 indent-wheres: false # 'false' means save space by only half-indenting the 'where' keyword
 diff-friendly-import-export: true
+let-style: inline
 respectful: true
 haddock-style: single-line
 newlines-between-decls: 1

--- a/scripts/reformat-code.sh
+++ b/scripts/reformat-code.sh
@@ -3,4 +3,4 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 
-find src/ app/ test/ -name "*.hs" | xargs fourmolu --mode=inplace --cabal-default-extensions
+find src/ app/ test/ -name "*.hs" | xargs fourmolu --mode=inplace


### PR DESCRIPTION
Restyled.io uses fourmolu version `0.10.1.0`.  It is not clear how it could be pegged to `0.4.0.0`.  The latest I was able to install on my machine with `cabal install` was `0.9.0.0`.

fixes #888