### PR TITLE
Reformat all files with new Fourmolu version 0.9.0.0 standard

### DIFF
--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -80,10 +80,11 @@ appMain opts = do
       let logP p = logEvent Said ("Web API", -2) ("started on :" <> T.pack (show p))
       let logE e = logEvent ErrorTrace ("Web API", -2) (T.pack e)
       let s' =
-            s & runtimeState
-              %~ case eport of
-                Right p -> (webPort ?~ p) . (eventLog %~ logP p)
-                Left e -> eventLog %~ logE e
+            s
+              & runtimeState
+                %~ case eport of
+                  Right p -> (webPort ?~ p) . (eventLog %~ logP p)
+                  Left e -> eventLog %~ logE e
 
       -- Update the reference for every event
       let eventHandler e = do

--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -198,33 +198,33 @@ defaultGrowthTime = GrowthTime (100, 200)
 --   entities stored in the world that are the same will literally
 --   just be stored as pointers to the same shared record.
 data Entity = Entity
-  { -- | A hash value computed from the other fields
-    _entityHash :: Int
-  , -- | The way this entity should be displayed on the world map.
-    _entityDisplay :: Display
-  , -- | The name of the entity, used /e.g./ in an inventory display.
-    _entityName :: Text
-  , -- | The plural of the entity name, in case it is irregular.  If
-    --   this field is @Nothing@, default pluralization heuristics
-    --   will be used (see 'plural').
-    _entityPlural :: Maybe Text
-  , -- | A longer-form description. Each 'Text' value is one
-    --   paragraph.
-    _entityDescription :: [Text]
-  , -- | The entity's orientation (if it has one).  For example, when
-    --   a robot moves, it moves in the direction of its orientation.
-    _entityOrientation :: Maybe (V2 Int64)
-  , -- | If this entity grows, how long does it take?
-    _entityGrowth :: Maybe GrowthTime
-  , -- | The name of a different entity obtained when this entity is
-    -- grabbed.
-    _entityYields :: Maybe Text
-  , -- | Properties of the entity.
-    _entityProperties :: Set EntityProperty
-  , -- | Capabilities provided by this entity.
-    _entityCapabilities :: Set Capability
-  , -- | Inventory of other entities held by this entity.
-    _entityInventory :: Inventory
+  { _entityHash :: Int
+  -- ^ A hash value computed from the other fields
+  , _entityDisplay :: Display
+  -- ^ The way this entity should be displayed on the world map.
+  , _entityName :: Text
+  -- ^ The name of the entity, used /e.g./ in an inventory display.
+  , _entityPlural :: Maybe Text
+  -- ^ The plural of the entity name, in case it is irregular.  If
+  --   this field is @Nothing@, default pluralization heuristics
+  --   will be used (see 'plural').
+  , _entityDescription :: [Text]
+  -- ^ A longer-form description. Each 'Text' value is one
+  --   paragraph.
+  , _entityOrientation :: Maybe (V2 Int64)
+  -- ^ The entity's orientation (if it has one).  For example, when
+  --   a robot moves, it moves in the direction of its orientation.
+  , _entityGrowth :: Maybe GrowthTime
+  -- ^ If this entity grows, how long does it take?
+  , _entityYields :: Maybe Text
+  -- ^ The name of a different entity obtained when this entity is
+  -- grabbed.
+  , _entityProperties :: Set EntityProperty
+  -- ^ Properties of the entity.
+  , _entityCapabilities :: Set Capability
+  -- ^ Capabilities provided by this entity.
+  , _entityInventory :: Inventory
+  -- ^ Inventory of other entities held by this entity.
   }
   -- Note that an entity does not have a location, because the
   -- location of an entity is implicit in the way it is stored (by
@@ -236,7 +236,8 @@ data Entity = Entity
 --   value and simply combines the other fields.
 instance Hashable Entity where
   hashWithSalt s (Entity _ disp nm pl descr orient grow yld props caps inv) =
-    s `hashWithSalt` disp
+    s
+      `hashWithSalt` disp
       `hashWithSalt` nm
       `hashWithSalt` pl
       `hashWithSalt` descr

--- a/src/Swarm/Game/Exception.hs
+++ b/src/Swarm/Game/Exception.hs
@@ -135,32 +135,32 @@ formatIncapableFix = \case
 formatIncapable :: EntityMap -> IncapableFix -> Requirements -> Term -> Text
 formatIncapable em f (Requirements caps _ inv) tm
   | CGod `S.member` caps =
-    unlinesExText
-      [ "Thou shalt not utter such blasphemy:"
-      , squote $ prettyText tm
-      , "If God in troth thou wantest to play, try thou a Creative game."
-      ]
+      unlinesExText
+        [ "Thou shalt not utter such blasphemy:"
+        , squote $ prettyText tm
+        , "If God in troth thou wantest to play, try thou a Creative game."
+        ]
   | not (null capsNone) =
-    unlinesExText
-      [ "Missing the " <> capMsg <> " for:"
-      , squote $ prettyText tm
-      , "but no device yet provides it. See"
-      , "https://github.com/swarm-game/swarm/issues/26"
-      ]
+      unlinesExText
+        [ "Missing the " <> capMsg <> " for:"
+        , squote $ prettyText tm
+        , "but no device yet provides it. See"
+        , "https://github.com/swarm-game/swarm/issues/26"
+        ]
   | not (S.null caps) =
-    unlinesExText
-      ( "You do not have the devices required for:" :
-        squote (prettyText tm) :
-        "Please " <> formatIncapableFix f <> ":" :
-        (("- " <>) . formatDevices <$> filter (not . null) deviceSets)
-      )
+      unlinesExText
+        ( "You do not have the devices required for:"
+            : squote (prettyText tm)
+            : "Please " <> formatIncapableFix f <> ":"
+            : (("- " <>) . formatDevices <$> filter (not . null) deviceSets)
+        )
   | otherwise =
-    unlinesExText
-      ( "You are missing required inventory for:" :
-        squote (prettyText tm) :
-        "Please obtain:" :
-        (("- " <>) . formatEntity <$> M.assocs inv)
-      )
+      unlinesExText
+        ( "You are missing required inventory for:"
+            : squote (prettyText tm)
+            : "Please obtain:"
+            : (("- " <>) . formatEntity <$> M.assocs inv)
+        )
  where
   capList = S.toList caps
   deviceSets = map (`deviceForCap` em) capList

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -113,18 +113,18 @@ import System.Clock (TimeSpec)
 -- | A record that stores the information
 --   for all definitions stored in a 'Robot'
 data RobotContext = RobotContext
-  { -- | Map definition names to their types.
-    _defTypes :: TCtx
-  , -- | Map definition names to the capabilities
-    --   required to evaluate/execute them.
-    _defReqs :: ReqCtx
-  , -- | Map definition names to their values. Note that since
-    --   definitions are delayed, the values will just consist of
-    --   'VRef's pointing into the store.
-    _defVals :: Env
-  , -- | A store containing memory cells allocated to hold
-    --   definitions.
-    _defStore :: Store
+  { _defTypes :: TCtx
+  -- ^ Map definition names to their types.
+  , _defReqs :: ReqCtx
+  -- ^ Map definition names to the capabilities
+  --   required to evaluate/execute them.
+  , _defVals :: Env
+  -- ^ Map definition names to their values. Note that since
+  --   definitions are delayed, the values will just consist of
+  --   'VRef's pointing into the store.
+  , _defStore :: Store
+  -- ^ A store containing memory cells allocated to hold
+  --   definitions.
   }
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
@@ -147,11 +147,13 @@ instance At RobotContext where
         req <- Ctx.lookup name (ctx ^. defReqs)
         return $ Typed val typ req
     setter ctx Nothing =
-      ctx & defTypes %~ Ctx.delete name
+      ctx
+        & defTypes %~ Ctx.delete name
         & defVals %~ Ctx.delete name
         & defReqs %~ Ctx.delete name
     setter ctx (Just (Typed val typ req)) =
-      ctx & defTypes %~ Ctx.addBinding name typ
+      ctx
+        & defTypes %~ Ctx.addBinding name typ
         & defVals %~ Ctx.addBinding name val
         & defReqs %~ Ctx.addBinding name req
 
@@ -160,19 +162,19 @@ data LogSource = Said | Logged | ErrorTrace
 
 -- | An entry in a robot's log.
 data LogEntry = LogEntry
-  { -- | The time at which the entry was created.
-    --   Note that this is the first field we sort on.
-    _leTime :: Integer
-  , -- | Whether this log records a said message.
-    _leSaid :: LogSource
-  , -- | The name of the robot that generated the entry.
-    _leRobotName :: Text
-  , -- | The ID of the robot that generated the entry.
-    _leRobotID :: Int
-  , -- | Location of the robot at log entry creation.
-    _leLocation :: V2 Int64
-  , -- | The text of the log entry.
-    _leText :: Text
+  { _leTime :: Integer
+  -- ^ The time at which the entry was created.
+  --   Note that this is the first field we sort on.
+  , _leSaid :: LogSource
+  -- ^ Whether this log records a said message.
+  , _leRobotName :: Text
+  -- ^ The name of the robot that generated the entry.
+  , _leRobotID :: Int
+  -- ^ The ID of the robot that generated the entry.
+  , _leLocation :: V2 Int64
+  -- ^ Location of the robot at log entry creation.
+  , _leText :: Text
+  -- ^ The text of the log entry.
   }
   deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
@@ -207,9 +209,9 @@ type family RobotID (phase :: RobotPhase) :: * where
 data RobotR (phase :: RobotPhase) = RobotR
   { _robotEntity :: Entity
   , _installedDevices :: Inventory
-  , -- | A cached view of the capabilities this robot has.
-    --   Automatically generated from '_installedDevices'.
-    _robotCapabilities :: Set Capability
+  , _robotCapabilities :: Set Capability
+  -- ^ A cached view of the capabilities this robot has.
+  --   Automatically generated from '_installedDevices'.
   , _robotLog :: Seq LogEntry
   , _robotLogUpdated :: Bool
   , _robotLocation :: RobotLocation phase

--- a/src/Swarm/Game/ScenarioInfo.hs
+++ b/src/Swarm/Game/ScenarioInfo.hs
@@ -90,20 +90,20 @@ instance Ord ZonedTime where
 data ScenarioStatus
   = NotStarted
   | InProgress
-      { -- | Time when the scenario was started including time zone.
-        _scenarioStarted :: ZonedTime
-      , -- | Time elapsed until quitting the scenario.
-        _scenarioElapsed :: NominalDiffTime
-      , -- | Ticks elapsed until quitting the scenario.
-        _scenarioElapsedTicks :: Integer
+      { _scenarioStarted :: ZonedTime
+      -- ^ Time when the scenario was started including time zone.
+      , _scenarioElapsed :: NominalDiffTime
+      -- ^ Time elapsed until quitting the scenario.
+      , _scenarioElapsedTicks :: Integer
+      -- ^ Ticks elapsed until quitting the scenario.
       }
   | Complete
-      { -- | Time when the scenario was started including time zone.
-        _scenarioStarted :: ZonedTime
-      , -- | Time elapsed until quitting the scenario.
-        _scenarioElapsed :: NominalDiffTime
-      , -- | Ticks elapsed until quitting the scenario.
-        _scenarioElapsedTicks :: Integer
+      { _scenarioStarted :: ZonedTime
+      -- ^ Time when the scenario was started including time zone.
+      , _scenarioElapsed :: NominalDiffTime
+      -- ^ Time elapsed until quitting the scenario.
+      , _scenarioElapsedTicks :: Integer
+      -- ^ Ticks elapsed until quitting the scenario.
       }
   deriving (Eq, Ord, Show, Read, Generic)
 
@@ -256,7 +256,10 @@ loadScenarioDir em dir = do
     False -> do
       when (dirName /= "Testing") $
         sendIO . putStrLn $
-          "Warning: no " <> orderFileName <> " file found in " <> dirName
+          "Warning: no "
+            <> orderFileName
+            <> " file found in "
+            <> dirName
             <> ", using alphabetical order"
       return Nothing
     True -> Just . filter (not . null) . lines <$> sendIO (readFile orderFile)
@@ -269,18 +272,21 @@ loadScenarioDir em dir = do
 
       unless (null missing) $
         sendIO . putStr . unlines $
-          ( "Warning: while processing " <> (dirName </> orderFileName) <> ": files not listed in "
+          ( "Warning: while processing "
+              <> (dirName </> orderFileName)
+              <> ": files not listed in "
               <> orderFileName
               <> " will be ignored"
-          ) :
-          map ("  - " <>) missing
+          )
+            : map ("  - " <>) missing
 
       unless (null dangling) $
         sendIO . putStr . unlines $
-          ( "Warning: while processing " <> (dirName </> orderFileName)
+          ( "Warning: while processing "
+              <> (dirName </> orderFileName)
               <> ": nonexistent files will be ignored"
-          ) :
-          map ("  - " <>) dangling
+          )
+            : map ("  - " <>) dangling
     Nothing -> pure ()
 
   -- Only keep the files from 00-ORDER.txt that actually exist.

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -370,7 +370,7 @@ tickRobot r = do
 tickRobotRec :: (Has (State GameState) sig m, Has (Lift IO) sig m) => Robot -> m Robot
 tickRobotRec r
   | isActive r && (r ^. runningAtomic || r ^. tickSteps > 0) =
-    stepRobot r >>= tickRobotRec
+      stepRobot r >>= tickRobotRec
   | otherwise = return r
 
 -- | Single-step a robot by decrementing its 'tickSteps' counter and
@@ -459,7 +459,7 @@ stepCESK cesk = case cesk of
   Out v2 s (FApp (VCApp c args) : k)
     | not (isCmd c)
         && arity c == length args + 1 ->
-      evalConst c (reverse (v2 : args)) s k
+        evalConst c (reverse (v2 : args)) s k
     | otherwise -> return $ Out (VCApp c (v2 : args)) s k
   Out _ s (FApp _ : _) -> badMachineState s "FApp of non-function"
   -- To evaluate non-recursive let expressions, we start by focusing on the
@@ -1616,10 +1616,10 @@ execConst c vs s k = do
       else do
         -- check if robot has all devices to execute new command
         all null missingDeviceSets
-          `holdsOrFail` ( singularSubjectVerb subject "do" :
-                          "not have required devices, please" :
-                          formatIncapableFix fixI <> ":" :
-                          (("\n  - " <>) . formatDevices <$> filter (not . null) missingDeviceSets)
+          `holdsOrFail` ( singularSubjectVerb subject "do"
+                            : "not have required devices, please"
+                            : formatIncapableFix fixI <> ":"
+                            : (("\n  - " <>) . formatDevices <$> filter (not . null) missingDeviceSets)
                         )
         -- check that there are in fact devices to provide every required capability
         not (any null deviceSets) `holdsOr` Incapable fixI (R.Requirements missingCaps S.empty M.empty) cmd
@@ -1683,20 +1683,20 @@ execConst c vs s k = do
       Just e
         | systemRob -> return ()
         | otherwise -> do
-          -- robots can not walk through walls
-          when (e `hasProperty` Unwalkable) $
-            case failIfBlocked of
-              Destroy -> destroyIfNotBase
-              ThrowExn -> throwError $ cmdExn c ["There is a", e ^. entityName, "in the way!"]
-              IgnoreFail -> return ()
+            -- robots can not walk through walls
+            when (e `hasProperty` Unwalkable) $
+              case failIfBlocked of
+                Destroy -> destroyIfNotBase
+                ThrowExn -> throwError $ cmdExn c ["There is a", e ^. entityName, "in the way!"]
+                IgnoreFail -> return ()
 
-          -- robots drown if they walk over liquid without boat
-          caps <- use robotCapabilities
-          when (e `hasProperty` Liquid && CFloat `S.notMember` caps) $
-            case failIfDrown of
-              Destroy -> destroyIfNotBase
-              ThrowExn -> throwError $ cmdExn c ["There is a dangerous liquid", e ^. entityName, "in the way!"]
-              IgnoreFail -> return ()
+            -- robots drown if they walk over liquid without boat
+            caps <- use robotCapabilities
+            when (e `hasProperty` Liquid && CFloat `S.notMember` caps) $
+              case failIfDrown of
+                Destroy -> destroyIfNotBase
+                ThrowExn -> throwError $ cmdExn c ["There is a dangerous liquid", e ^. entityName, "in the way!"]
+                IgnoreFail -> return ()
 
   getRobotWithinTouch :: HasRobotStepState sig m => RID -> m Robot
   getRobotWithinTouch rid = do
@@ -1855,11 +1855,11 @@ updateRobotLocation ::
 updateRobotLocation oldLoc newLoc
   | oldLoc == newLoc = return ()
   | otherwise = do
-    rid <- use robotID
-    robotsByLocation . at oldLoc %= deleteOne rid
-    robotsByLocation . at newLoc . non Empty %= IS.insert rid
-    modify (unsafeSetRobotLocation newLoc)
-    flagRedraw
+      rid <- use robotID
+      robotsByLocation . at oldLoc %= deleteOne rid
+      robotsByLocation . at newLoc . non Empty %= IS.insert rid
+      modify (unsafeSetRobotLocation newLoc)
+      flagRedraw
  where
   -- Make sure empty sets don't hang around in the
   -- robotsByLocation map.  We don't want a key with an

--- a/src/Swarm/Game/WorldGen.hs
+++ b/src/Swarm/Game/WorldGen.hs
@@ -102,9 +102,9 @@ testWorld2 em baseSeed = second (readEntity em) (WF tw2)
       | sample ix cl0 > 0.5 = (StoneT, Just "mountain")
       | h `mod` 30 == 0 = (StoneT, Just "boulder")
       | sample ix cl0 > 0 =
-        case h `mod` 30 of
-          1 -> (DirtT, Just "LaTeX")
-          _ -> (DirtT, Just "tree")
+          case h `mod` 30 of
+            1 -> (DirtT, Just "LaTeX")
+            _ -> (DirtT, Just "tree")
       | otherwise = (GrassT, Nothing)
     genBiome Small Hard Natural
       | h `mod` 100 == 0 = (StoneT, Just "lodestone")

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -134,7 +134,7 @@ identifier = (lexeme . try) (p >>= check) <?> "variable name"
   p = (:) <$> (letterChar <|> char '_') <*> many (alphaNumChar <|> char '_' <|> char '\'')
   check s
     | toLower t `elem` reservedWords =
-      fail $ "reserved word '" ++ s ++ "' cannot be used as variable name"
+        fail $ "reserved word '" ++ s ++ "' cannot be used as variable name"
     | otherwise = return t
    where
     t = into @Text s
@@ -185,11 +185,11 @@ parsePolytype =
     -- Otherwise, require all variables to be explicitly quantified
     | S.null free = return $ Forall xs ty
     | otherwise =
-      fail $
-        unlines
-          [ "  Type contains free variable(s): " ++ unwords (map from (S.toList free))
-          , "  Try adding them to the 'forall'."
-          ]
+        fail $
+          unlines
+            [ "  Type contains free variable(s): " ++ unwords (map from (S.toList free))
+            , "  Try adding them to the 'forall'."
+            ]
    where
     free = tyVars ty `S.difference` S.fromList xs
 
@@ -255,18 +255,22 @@ parseTermAtom =
           *> ( ( TRequireDevice
                   <$> (textLiteral <?> "device name in double quotes")
                )
-                <|> ( TRequire <$> (fromIntegral <$> integer)
+                <|> ( TRequire
+                        <$> (fromIntegral <$> integer)
                         <*> (textLiteral <?> "entity name in double quotes")
                     )
              )
-        <|> SLam <$> (symbol "\\" *> identifier)
+        <|> SLam
+          <$> (symbol "\\" *> identifier)
           <*> optional (symbol ":" *> parseType)
           <*> (symbol "." *> parseTerm)
-        <|> sLet <$> (reserved "let" *> identifier)
+        <|> sLet
+          <$> (reserved "let" *> identifier)
           <*> optional (symbol ":" *> parsePolytype)
           <*> (symbol "=" *> parseTerm)
           <*> (reserved "in" *> parseTerm)
-        <|> sDef <$> (reserved "def" *> identifier)
+        <|> sDef
+          <$> (reserved "def" *> identifier)
           <*> optional (symbol ":" *> parsePolytype)
           <*> (symbol "=" *> parseTerm <* reserved "end")
         <|> parens (mkTuple <$> (parseTerm `sepBy` symbol ","))

--- a/src/Swarm/Language/Requirement.hs
+++ b/src/Swarm/Language/Requirement.hs
@@ -230,7 +230,8 @@ requirements' = go
     -- lambda.
     TLet r x _ t1 t2 ->
       (if r then insert (ReqCap CRecursion) else id) $
-        insert (ReqCap CEnv) $ go (Ctx.delete x ctx) t1 <> go (Ctx.delete x ctx) t2
+        insert (ReqCap CEnv) $
+          go (Ctx.delete x ctx) t1 <> go (Ctx.delete x ctx) t2
     -- We also delete the name in a TBind, if any, while recursing on
     -- the RHS.
     TBind mx t1 t2 -> go ctx t1 <> go (maybe id Ctx.delete mx ctx) t2

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -433,7 +433,8 @@ infer s@(Syntax l t) = (`catchError` addLocToTypeErr s) $ case t of
             upty'
         ftyvs = tyvs `S.difference` S.fromList xs
     unless (S.null ftyvs) $
-      throwError $ EscapedSkolem l (head (S.toList ftyvs))
+      throwError $
+        EscapedSkolem l (head (S.toList ftyvs))
 
 addLocToTypeErr :: Syntax -> TypeErr -> Infer a
 addLocToTypeErr s te = case te of
@@ -619,32 +620,32 @@ analyzeAtomic locals (Syntax l t) = case t of
   TVar x
     | x `S.member` locals -> return 0
     | otherwise -> do
-      mxTy <- asks $ Ctx.lookup x
-      case mxTy of
-        -- If the variable is undefined, return 0 to indicate the
-        -- atomic block is valid, because we'd rather have the error
-        -- caught by the real name+type checking.
-        Nothing -> return 0
-        Just xTy -> do
-          -- Use applyBindings to make sure that we apply as much
-          -- information as unification has learned at this point.  In
-          -- theory, continuing to typecheck other terms elsewhere in
-          -- the program could give us further information about xTy,
-          -- so we might have incomplete information at this point.
-          -- However, since variables referenced in an atomic block
-          -- must necessarily have simple types, it's unlikely this
-          -- will really make a difference.  The alternative, more
-          -- "correct" way to do this would be to simply emit some
-          -- constraints at this point saying that xTy must be a
-          -- simple type, and check later that the constraint holds,
-          -- after performing complete type inference.  However, since
-          -- the current approach is much simpler, we'll stick with
-          -- this until such time as we have concrete examples showing
-          -- that the more correct, complex way is necessary.
-          xTy' <- applyBindings xTy
-          if isSimpleUPolytype xTy'
-            then return 0
-            else throwError (InvalidAtomic l (NonSimpleVarType x xTy') t)
+        mxTy <- asks $ Ctx.lookup x
+        case mxTy of
+          -- If the variable is undefined, return 0 to indicate the
+          -- atomic block is valid, because we'd rather have the error
+          -- caught by the real name+type checking.
+          Nothing -> return 0
+          Just xTy -> do
+            -- Use applyBindings to make sure that we apply as much
+            -- information as unification has learned at this point.  In
+            -- theory, continuing to typecheck other terms elsewhere in
+            -- the program could give us further information about xTy,
+            -- so we might have incomplete information at this point.
+            -- However, since variables referenced in an atomic block
+            -- must necessarily have simple types, it's unlikely this
+            -- will really make a difference.  The alternative, more
+            -- "correct" way to do this would be to simply emit some
+            -- constraints at this point saying that xTy must be a
+            -- simple type, and check later that the constraint holds,
+            -- after performing complete type inference.  However, since
+            -- the current approach is much simpler, we'll stick with
+            -- this until such time as we have concrete examples showing
+            -- that the more correct, complex way is necessary.
+            xTy' <- applyBindings xTy
+            if isSimpleUPolytype xTy'
+              then return 0
+              else throwError (InvalidAtomic l (NonSimpleVarType x xTy') t)
   -- No lambda, `let` or `def` allowed!
   SLam {} -> throwError (InvalidAtomic l AtomicDupingThing t)
   SLet {} -> throwError (InvalidAtomic l AtomicDupingThing t)

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -243,11 +243,11 @@ handleMainEvent ev = do
     Key V.KEsc
       | isJust (s ^. uiState . uiError) -> uiState . uiError .= Nothing
       | Just m <- s ^. uiState . uiModal -> do
-        safeAutoUnpause
-        uiState . uiModal .= Nothing
-        -- message modal is not autopaused, so update notifications when leaving it
-        when (m ^. modalType == MessagesModal) $ do
-          gameState . lastSeenMessageTime .= s ^. gameState . ticks
+          safeAutoUnpause
+          uiState . uiModal .= Nothing
+          -- message modal is not autopaused, so update notifications when leaving it
+          when (m ^. modalType == MessagesModal) $ do
+            gameState . lastSeenMessageTime .= s ^. gameState . ticks
     FKey 1 -> toggleModal HelpModal
     FKey 2 -> toggleModal RobotsModal
     FKey 3 | not (null (s ^. gameState . availableRecipes . notificationsContent)) -> do
@@ -833,8 +833,8 @@ handleREPLEventTyping = \case
             Just found
               | T.null uinput -> uiState %= resetREPL "" (CmdPrompt [])
               | otherwise -> do
-                uiState %= resetREPL found (CmdPrompt [])
-                modify validateREPLForm
+                  uiState %= resetREPL found (CmdPrompt [])
+                  modify validateREPLForm
       else continueWithoutRedraw
   Key V.KUp -> modify $ adjReplHistIndex Older
   Key V.KDown -> modify $ adjReplHistIndex Newer
@@ -900,12 +900,12 @@ tabComplete names em repl = case repl ^. replPromptType of
     -- the CmdPrompt, so when Tab is pressed again, this case then gets executed and
     -- repopulates them.
     | otherwise -> case candidateMatches of
-      [] -> setCmd t []
-      [m] -> setCmd (completeWith m) []
-      -- Perform completion with the first candidate, then populate the list
-      -- of all candidates with the current completion moved to the back
-      -- of the queue.
-      (m : ms) -> setCmd (completeWith m) (ms ++ [m])
+        [] -> setCmd t []
+        [m] -> setCmd (completeWith m) []
+        -- Perform completion with the first candidate, then populate the list
+        -- of all candidates with the current completion moved to the back
+        -- of the queue.
+        (m : ms) -> setCmd (completeWith m) (ms ++ [m])
  where
   -- checks the "parity" of the number of quotes. If odd, then there is an open quote.
   hasOpenQuotes = (== 1) . (`mod` 2) . T.count "\""
@@ -941,17 +941,17 @@ validateREPLForm s =
   case replPrompt of
     CmdPrompt _
       | T.null uinput ->
-        let theType = s ^. gameState . replStatus . replActiveType
-         in s & uiState . uiREPL . replType .~ theType
+          let theType = s ^. gameState . replStatus . replActiveType
+           in s & uiState . uiREPL . replType .~ theType
     CmdPrompt _
       | otherwise ->
-        let result = processTerm' (topCtx ^. defTypes) (topCtx ^. defReqs) uinput
-            theType = case result of
-              Right (Just (ProcessedTerm _ (Module ty _) _ _)) -> Just ty
-              _ -> Nothing
-         in s
-              & uiState . uiREPL . replValid .~ isRight result
-              & uiState . uiREPL . replType .~ theType
+          let result = processTerm' (topCtx ^. defTypes) (topCtx ^. defReqs) uinput
+              theType = case result of
+                Right (Just (ProcessedTerm _ (Module ty _) _ _)) -> Just ty
+                _ -> Nothing
+           in s
+                & uiState . uiREPL . replValid .~ isRight result
+                & uiState . uiREPL . replType .~ theType
     SearchPrompt _ -> s
  where
   uinput = s ^. uiState . uiREPL . replPromptText

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -933,22 +933,22 @@ populateInventoryList (Just r) = do
 
 -- | Command-line options for configuring the app.
 data AppOpts = AppOpts
-  { -- | Explicit seed chosen by the user.
-    userSeed :: Maybe Seed
-  , -- | Scenario the user wants to play.
-    userScenario :: Maybe FilePath
-  , -- | Code to be run on base.
-    scriptToRun :: Maybe FilePath
-  , -- | Automatically run the solution defined in the scenario file
-    autoPlay :: Bool
-  , -- | Should cheat mode be enabled?
-    cheatMode :: Bool
-  , -- | What colour mode should be used?
-    colorMode :: Maybe ColorMode
-  , -- | Explicit port on which to run the web API
-    userWebPort :: Maybe Port
-  , -- | Information about the Git repository (not present in release).
-    repoGitInfo :: Maybe GitInfo
+  { userSeed :: Maybe Seed
+  -- ^ Explicit seed chosen by the user.
+  , userScenario :: Maybe FilePath
+  -- ^ Scenario the user wants to play.
+  , scriptToRun :: Maybe FilePath
+  -- ^ Code to be run on base.
+  , autoPlay :: Bool
+  -- ^ Automatically run the solution defined in the scenario file
+  , cheatMode :: Bool
+  -- ^ Should cheat mode be enabled?
+  , colorMode :: Maybe ColorMode
+  -- ^ What colour mode should be used?
+  , userWebPort :: Maybe Port
+  -- ^ Explicit port on which to run the web API
+  , repoGitInfo :: Maybe GitInfo
+  -- ^ Information about the Git repository (not present in release).
   }
 
 -- | Initialize the 'AppState'.

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -110,13 +110,13 @@ drawUI :: AppState -> [Widget Name]
 drawUI s
   | s ^. uiState . uiPlaying = drawGameUI s
   | otherwise = case s ^. uiState . uiMenu of
-    -- We should never reach the NoMenu case if uiPlaying is false; we would have
-    -- quit the app instead.  But just in case, we display the main menu anyway.
-    NoMenu -> [drawMainMenuUI s (mainMenu NewGame)]
-    MainMenu l -> [drawMainMenuUI s l]
-    NewGameMenu stk -> [drawNewGameMenuUI stk]
-    MessagesMenu -> [drawMainMessages s]
-    AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
+      -- We should never reach the NoMenu case if uiPlaying is false; we would have
+      -- quit the app instead.  But just in case, we display the main menu anyway.
+      NoMenu -> [drawMainMenuUI s (mainMenu NewGame)]
+      MainMenu l -> [drawMainMenuUI s l]
+      NewGameMenu stk -> [drawNewGameMenuUI stk]
+      MessagesMenu -> [drawMainMessages s]
+      AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
 
 drawMainMessages :: AppState -> Widget Name
 drawMainMessages s = renderDialog dial . padBottom Max . scrollList $ drawLogs ls
@@ -169,7 +169,8 @@ drawNewGameMenuUI (l :| ls) =
       [ vBox
           [ withAttr boldAttr . txt $ breadcrumbs ls
           , txt " "
-          , vLimit 20 . hLimit 35
+          , vLimit 20
+              . hLimit 35
               . BL.renderList (const $ padRight Max . drawScenarioItem) True
               $ l
           ]
@@ -278,9 +279,9 @@ drawGameUI s =
                   (FocusablePanel InfoPanel)
                   ( plainBorder
                       & topLabels . centerLabel
-                      .~ (if moreTop then Just (txt " · · · ") else Nothing)
+                        .~ (if moreTop then Just (txt " · · · ") else Nothing)
                       & bottomLabels . centerLabel
-                      .~ (if moreBot then Just (txt " · · · ") else Nothing)
+                        .~ (if moreBot then Just (txt " · · · ") else Nothing)
                   )
                   $ drawInfoPanel s
               ]
@@ -403,12 +404,12 @@ drawTPS s = hBox (tpsInfo : rateInfo)
 
   rateInfo
     | s ^. uiState . uiShowFPS =
-      [ txt " ("
-      , str (printf "%0.1f" (s ^. uiState . uiTPF))
-      , txt " tpf, "
-      , str (printf "%0.1f" (s ^. uiState . uiFPS))
-      , txt " fps)"
-      ]
+        [ txt " ("
+        , str (printf "%0.1f" (s ^. uiState . uiTPF))
+        , txt " tpf, "
+        , str (printf "%0.1f" (s ^. uiState . uiFPS))
+        , txt " fps)"
+        ]
     | otherwise = []
 
   l = s ^. uiState . lgTicksPerSecond
@@ -692,8 +693,8 @@ mkAvailableList gs notifLens notifRender = map padRender news <> notifSep <> map
   (news, knowns) = splitAt count (gs ^. notifLens . notificationsContent)
   notifSep
     | count > 0 && not (null knowns) =
-      [ padBottom (Pad 1) (withAttr redAttr $ hBorderWithLabel (padLeftRight 1 (txt "new↑")))
-      ]
+        [ padBottom (Pad 1) (withAttr redAttr $ hBorderWithLabel (padLeftRight 1 (txt "new↑")))
+        ]
     | otherwise = []
 
 constHeader :: Widget Name
@@ -753,10 +754,10 @@ drawModalMenu s = vLimit 1 . hBox $ map (padLeftRight 1 . drawKeyCmd) globalKeyC
   notificationKey notifLens key name
     | null (s ^. gameState . notifLens . notificationsContent) = Nothing
     | otherwise =
-      let highlight
-            | s ^. gameState . notifLens . notificationsCount > 0 = Alert
-            | otherwise = NoHighlight
-       in Just (highlight, key, name)
+        let highlight
+              | s ^. gameState . notifLens . notificationsCount > 0 = Alert
+              | otherwise = NoHighlight
+         in Just (highlight, key, name)
 
   globalKeyCmds =
     catMaybes
@@ -787,7 +788,9 @@ drawKeyMenu s =
   drawPaddedCmd = padLeftRight 1 . drawKeyCmd
   focusedPanelCmds =
     map highlightKeyCmds $
-      keyCmdsFor $ focusGetCurrent $ view (uiState . uiFocusRing) s
+      keyCmdsFor $
+        focusGetCurrent $
+          view (uiState . uiFocusRing) s
 
   isReplWorking = s ^. gameState . replWorking
   isPaused = s ^. gameState . paused
@@ -807,7 +810,8 @@ drawKeyMenu s =
     Typing -> "pilot"
 
   gameModeWidget =
-    padLeft Max . padLeftRight 1
+    padLeft Max
+      . padLeftRight 1
       . txt
       . (<> " mode")
       $ case creative of
@@ -898,8 +902,10 @@ displayEntityCell g coords = maybeToList (displayForEntity <$> W.lookupEntity co
   displayForEntity e = (if known e then id else hidden) (e ^. entityDisplay)
 
   known e =
-    e `hasProperty` Known
-      || (e ^. entityName) `elem` (g ^. knownEntities)
+    e
+      `hasProperty` Known
+      || (e ^. entityName)
+      `elem` (g ^. knownEntities)
       || case hidingMode g of
         HideAllEntities -> False
         HideNoEntity -> True
@@ -1038,13 +1044,13 @@ explainRecipes :: AppState -> Entity -> Widget Name
 explainRecipes s e
   | null recipes = emptyWidget
   | otherwise =
-    vBox
-      [ padBottom (Pad 1) (hBorderWithLabel (txt "Recipes"))
-      , padLeftRight 2 $
-          hCenter $
-            vBox $
-              map (hLimit widthLimit . padBottom (Pad 1) . drawRecipe (Just e) inv) recipes
-      ]
+      vBox
+        [ padBottom (Pad 1) (hBorderWithLabel (txt "Recipes"))
+        , padLeftRight 2 $
+            hCenter $
+              vBox $
+                map (hLimit widthLimit . padBottom (Pad 1) . drawRecipe (Just e) inv) recipes
+        ]
  where
   recipes = recipesWith s e
 
@@ -1099,11 +1105,11 @@ drawRecipe me inv (Recipe ins outs reqs time _weight) =
   connector
     | null reqs = hLimit 5 hBorder
     | otherwise =
-      hBox
-        [ hLimit 2 hBorder
-        , joinableBorder (Edges True False True True)
-        , hLimit 2 hBorder
-        ]
+        hBox
+          [ hLimit 2 hBorder
+          , joinableBorder (Edges True False True True)
+          , hLimit 2 hBorder
+          ]
   inLen = length ins + length times
   outLen = length outs
   times = [(fromIntegral time, timeE) | time /= 1]

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -350,9 +350,9 @@ indefiniteQ w = MM.indefiniteDet w <+> squote w
 singularSubjectVerb :: Text -> Text -> Text
 singularSubjectVerb sub verb
   | verb == "be" = case toUpper sub of
-    "I" -> "I am"
-    "YOU" -> sub <+> "are"
-    _ -> sub <+> "is"
+      "I" -> "I am"
+      "YOU" -> sub <+> "are"
+      _ -> sub <+> "is"
   | otherwise = sub <+> (if is3rdPerson then verb3rd else verb)
  where
   is3rdPerson = toUpper sub `notElem` ["I", "YOU"]

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -251,7 +251,7 @@ testEval g =
       Left err ->
         p err
           @? "Expected predicate did not hold on error message "
-          ++ from @Text @String err
+            ++ from @Text @String err
 
   evaluatesTo :: Text -> Value -> Assertion
   evaluatesTo tm val = do

--- a/test/unit/TestPretty.hs
+++ b/test/unit/TestPretty.hs
@@ -36,17 +36,22 @@ testPrettyConst =
     , testCase
         "operators #8 - double unary negation"
         ( equalPretty "-(-1)" $
-            TApp (TConst Neg) $ TApp (TConst Neg) (TInt 1)
+            TApp (TConst Neg) $
+              TApp (TConst Neg) (TInt 1)
         )
     , testCase
         "operators #8 - unary negation with strongly fixing binary operator"
         ( equalPretty "-1 ^ (-2)" $
-            TApp (TConst Neg) $ mkOp' Exp (TInt 1) $ TApp (TConst Neg) (TInt 2)
+            TApp (TConst Neg) $
+              mkOp' Exp (TInt 1) $
+                TApp (TConst Neg) (TInt 2)
         )
     , testCase
         "operators #8 - unary negation with weakly fixing binary operator"
         ( equalPretty "-(1 + -2)" $
-            TApp (TConst Neg) $ mkOp' Add (TInt 1) $ TApp (TConst Neg) (TInt 2)
+            TApp (TConst Neg) $
+              mkOp' Add (TInt 1) $
+                TApp (TConst Neg) (TInt 2)
         )
     , testCase
         "operators #8 - simple infix operator"


### PR DESCRIPTION
This is a follow-up to #888.

Making sure the `main` branch has the latest formatting standard will ensure PR diffs are not noisy.

Currently open Pull Requests will simply need to re-run their formatter to align with `main`, and then rebase.

## Summary of apparent changes

* Indentation
* Record field comments are moved from prepositive style to postpositive.
* `:` moved from line-trailing to line-leading
* Chains of `$` and `<>` are broken into separate lines