### PR TITLE
Parameterize scenario datatypes

### DIFF
--- a/src/Swarm/Game/Scenario.hs
+++ b/src/Swarm/Game/Scenario.hs
@@ -23,8 +23,10 @@ module Swarm.Game.Scenario (
   objectiveCondition,
 
   -- * WorldDescription
-  Cell (..),
-  WorldDescription (..),
+  PCell (..),
+  Cell,
+  PWorldDescription (..),
+  WorldDescription,
   IndexedTRobot,
 
   -- * Scenario

--- a/src/Swarm/Game/Scenario/Cell.hs
+++ b/src/Swarm/Game/Scenario/Cell.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Swarm.Game.Scenario.Cell (
-  Cell (..),
+  PCell (..),
+  Cell,
 ) where
 
 import Control.Lens hiding (from, (<.>))
@@ -22,12 +23,18 @@ import Swarm.Util.Yaml
 
 -- | A single cell in a world map, which contains a terrain value,
 --   and optionally an entity and robot.
-data Cell = Cell
+--   It is parameterized on the Entity type to facilitate less
+--   stateful versions of the Entity type in rendering scenario data.
+data PCell e = Cell
   { cellTerrain :: TerrainType
-  , cellEntity :: Maybe Entity
+  , cellEntity :: Maybe e
   , cellRobots :: [IndexedTRobot]
   }
   deriving (Eq, Show)
+
+-- | A single cell in a world map, which contains a terrain value,
+--   and optionally an entity and robot.
+type Cell = PCell Entity
 
 -- | Parse a tuple such as @[grass, rock, base]@ into a 'Cell'.  The
 --   entity and robot, if present, are immediately looked up and


### PR DESCRIPTION
Towards #873

## Motivation

The `Entity` datatype has a fair amount of state and extra fields that are not relevant to serializing a scenario (in particular, a world map) to a file.

In this PR, the `Cell` record is renamed to `PCell` (representing "Parameterized Cell"), replacing `Entity` with a type parameter.  This permits the introduction of a trimmed-down `Entity` type for the purpose of serialization.  This lightweight type can also be a reliable `Map` key.

A type alias `Cell` is created with the original `Entity` type as a parameter.

The `WorldDescription` and `WorldPalette` are likewise parameterized on the `Cell` type.