### PR TITLE
Add the full expected location for the data directory

### DIFF
--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -277,7 +277,7 @@ dataNotFound f = do
   return $
     T.unlines
       [ "Could not find the data: " <> squotes f
-      , "Try downloading the Swarm 'data' directory to: " <> squotes d
+      , "Try downloading the Swarm 'data' directory to: " <> squotes (d </> "data")
       ]
 
 -- | Get path to swarm data, optionally creating necessary


### PR DESCRIPTION
Copying the data directory directly into ~/.local/share/swarm does not work, this commit prevents that mistake.