### PR TITLE
nonposession unit test

### DIFF
--- a/data/scenarios/Testing/858-inventory/00-ORDER.txt
+++ b/data/scenarios/Testing/858-inventory/00-ORDER.txt
@@ -1,2 +1,3 @@
 858-possession-objective.yaml
+858-nonpossession-objective.yaml
 858-counting-objective.yaml

--- a/data/scenarios/Testing/858-inventory/858-nonpossession-objective.yaml
+++ b/data/scenarios/Testing/858-inventory/858-nonpossession-objective.yaml
@@ -1,0 +1,35 @@
+version: 1
+name: Evaluate possession of an item
+description: |
+  Opposite test case of 858-possession-objective
+creative: false
+objectives:
+  - goal:
+      - |
+        Get rid of 1 tree.
+    condition: |-
+      as base {
+        x <- has "tree";
+        return $ not x;
+      };
+robots:
+  - name: base
+    dir: [0, 1]
+    devices:
+      - treads
+      - scanner
+      - grabber
+    inventory:
+      - [1, tree]
+solution: |
+  place "tree";
+known: [tree]
+world:
+  default: [blank]
+  palette:
+    'B': [grass, null, base]
+    'w': [grass]
+  upperleft: [0, 0]
+  map: |-
+    w
+    B

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -191,8 +191,10 @@ testScenarioSolution _ci _em =
         , testGroup
             "Possession criteria (#858)"
             [ testSolution Default "Testing/858-inventory/858-possession-objective"
-            , expectFailBecause "Known bug #858" $
+            , expectFailBecause "Known bug #858 - count" $
                 testSolution Default "Testing/858-inventory/858-counting-objective"
+            , expectFailBecause "Known bug #858 - has" $
+                testSolution Default "Testing/858-inventory/858-nonpossession-objective"
             ]
         , testGroup
             "Require (#201)"


### PR DESCRIPTION
The `858-possession-objective.yaml` unit test scenario demonstrates that `has "tree"` works as a goal criteria.
However, `x <- has "tree"; not x` does not work!

Could be related to #858?