### PR TITLE
Make goal text NonEmpty

### DIFF
--- a/data/scenarios/Testing/201-require/201-require-device-creative1.yaml
+++ b/data/scenarios/Testing/201-require/201-require-device-creative1.yaml
@@ -4,7 +4,9 @@ description: |
   Require a device the base has using the 'require' command in creative mode.
   https://github.com/swarm-game/swarm/issues/201
 objectives:
-  - condition: |
+  - goal:
+      - Boat is properly removed from builder's inventory and equipped on buildee
+    condition: |
       try {
         r <- robotNumbered 1;
         p <- as r {whereami};

--- a/data/scenarios/Testing/201-require/533-reprogram-simple.yaml
+++ b/data/scenarios/Testing/201-require/533-reprogram-simple.yaml
@@ -5,7 +5,9 @@ description: |
   the target robot doesn't have.
   https://github.com/swarm-game/swarm/pulls/533
 objectives:
-  - condition: |
+  - goal:
+      - Reprogram
+    condition: |
       try {
         base_boats <- as base {count "boat"};
         base_solar <- as base {count "solar panel"};

--- a/src/Swarm/Game/Scenario/Objective.hs
+++ b/src/Swarm/Game/Scenario/Objective.hs
@@ -7,6 +7,8 @@ module Swarm.Game.Scenario.Objective where
 import Control.Applicative ((<|>))
 import Control.Lens hiding (from, (<.>))
 import Data.Aeson
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -60,7 +62,7 @@ instance FromJSON PrerequisiteConfig where
 -- | An objective is a condition to be achieved by a player in a
 --   scenario.
 data Objective = Objective
-  { _objectiveGoal :: [Text]
+  { _objectiveGoal :: NonEmpty Text
   , _objectiveTeaser :: Maybe Text
   , _objectiveCondition :: ProcessedTerm
   , _objectiveId :: Maybe ObjectiveLabel
@@ -75,7 +77,7 @@ makeLensesWith (lensRules & generateSignatures .~ False) ''Objective
 
 -- | An explanation of the goal of the objective, shown to the player
 --   during play.  It is represented as a list of paragraphs.
-objectiveGoal :: Lens' Objective [Text]
+objectiveGoal :: Lens' Objective (NonEmpty Text)
 
 -- | A very short (3-5 words) description of the goal for
 -- displaying on the left side of the Objectives modal.
@@ -113,7 +115,7 @@ objectiveAchievement :: Lens' Objective (Maybe AchievementInfo)
 instance FromJSON Objective where
   parseJSON = withObject "objective" $ \v ->
     Objective
-      <$> (fmap . map) reflow (v .:? "goal" .!= [])
+      <$> (fmap . NE.map) reflow (v .: "goal")
       <*> (v .:? "teaser")
       <*> (v .: "condition")
       <*> (v .:? "id")

--- a/src/Swarm/Game/Scenario/Objective/Presentation/Render.hs
+++ b/src/Swarm/Game/Scenario/Objective/Presentation/Render.hs
@@ -10,7 +10,7 @@ import Control.Applicative ((<|>))
 import Control.Lens hiding (Const, from)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as M
-import Data.Maybe (listToMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Vector qualified as V
 import Swarm.Game.Scenario.Objective
 import Swarm.Game.Scenario.Objective.Presentation.Model
@@ -71,10 +71,10 @@ drawGoalListItem = \case
   Header gs -> withAttr boldAttr $ str $ show gs
   Goal gs obj -> getCompletionIcon obj gs <+> titleWidget
    where
-    textSource = obj ^. objectiveTeaser <|> obj ^. objectiveId <|> listToMaybe (obj ^. objectiveGoal)
-    titleWidget = maybe (txt "?") withEllipsis textSource
+    textSource = obj ^. objectiveTeaser <|> obj ^. objectiveId
+    titleWidget = withEllipsis $ fromMaybe (NE.head $ obj ^. objectiveGoal) textSource
 
 singleGoalDetails :: GoalEntry -> Widget Name
 singleGoalDetails = \case
-  Header _gs -> displayParagraphs [" "]
-  Goal _gs obj -> displayParagraphs $ obj ^. objectiveGoal
+  Header _gs -> str " "
+  Goal _gs obj -> displayParagraphs $ NE.toList $ obj ^. objectiveGoal


### PR DESCRIPTION
Here's how the 20 scenarios with missing goals were identified:

    find data/scenarios -name "*.yaml" -printf "%p\t" -exec yq '.objectives | map(has("goal")) | all' {} \; | grep false | cut -f1