### PR TITLE
Fix hypothetical result of condition

### DIFF
--- a/data/scenarios/Testing/858-inventory/858-nonpossession-objective.yaml
+++ b/data/scenarios/Testing/858-inventory/858-nonpossession-objective.yaml
@@ -1,5 +1,5 @@
 version: 1
-name: Evaluate possession of an item
+name: Evaluate nonpossession of an item
 description: |
   Opposite test case of 858-possession-objective
 creative: false

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -137,19 +137,28 @@ gameTick = do
       -- Execute the win condition check *hypothetically*: i.e. in a
       -- fresh CESK machine, using a copy of the current game state.
       v <- runThrow @Exn . evalState @GameState g $ evalPT (obj ^. objectiveCondition)
+      let markWin = winCondition .= maybe (Won False) WinConditions (NE.nonEmpty objs)
       case v of
         -- Log exceptions in the message queue so we can check for them in tests
         Left exn -> do
-          em <- use entityMap
-          time <- use ticks
           let h = hypotheticalRobot (Out VUnit emptyStore []) 0
-              hid = view robotID h
-              hn = view robotName h
-              farAway = Location maxBound maxBound
-          let m = LogEntry time ErrorTrace hn hid farAway $ formatExn em exn
+          em <- use entityMap
+          m <- evalState @Robot h $ createLogEntry ErrorTrace (formatExn em exn)
           emitMessage m
-        Right (VBool True) -> winCondition .= maybe (Won False) WinConditions (NE.nonEmpty objs)
-        _ -> return ()
+        Right (VBool res) -> when res markWin
+        Right (VResult (VBool res) _env) -> when res markWin
+        Right val -> do
+          let h = hypotheticalRobot (Out VUnit emptyStore []) 0
+          m <-
+            evalState @Robot h $
+              createLogEntry ErrorTrace $
+                T.unwords
+                  [ "Non boolean value:"
+                  , prettyValue val
+                  , "real:"
+                  , T.pack (show val)
+                  ]
+          emitMessage m
     _ -> return ()
 
   -- Advance the game time by one.

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -47,7 +47,6 @@ import System.Environment (getEnvironment)
 import System.FilePath.Posix (takeExtension, (</>))
 import System.Timeout (timeout)
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.ExpectedFailure (expectFailBecause)
 import Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCase)
 import Witch (into)
 
@@ -192,10 +191,8 @@ testScenarioSolution _ci _em =
         , testGroup
             "Possession criteria (#858)"
             [ testSolution Default "Testing/858-inventory/858-possession-objective"
-            , expectFailBecause "Known bug #858 - count" $
-                testSolution Default "Testing/858-inventory/858-counting-objective"
-            , expectFailBecause "Known bug #858 - has" $
-                testSolution Default "Testing/858-inventory/858-nonpossession-objective"
+            , testSolution Default "Testing/858-inventory/858-counting-objective"
+            , testSolution Default "Testing/858-inventory/858-nonpossession-objective"
             ]
         , testGroup
             "Require (#201)"


### PR DESCRIPTION
- handle `VResult` in hypothetical
- log unexpected result values
- closes #858 

When a bind occurred in hypothetical evaluation, then the `Value` was a `VResult` that we silently discarded.
Now it is handled and all other values are logged.