### PR TITLE
Add achievement for losing

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -445,7 +445,7 @@ saveScenarioInfoOnQuit = do
             case segments of
               firstDir : _ -> do
                 when (won && firstDir == tutorialsDirname) $
-                  attainAchievement' t (Just $ T.pack p) (GlobalAchievement CompletedSingleTutorial)
+                  attainAchievement' t (Just p) (GlobalAchievement CompletedSingleTutorial)
               _ -> return ()
             liftIO $ saveScenarioInfo p si
 

--- a/src/Swarm/TUI/Model/Achievement/Attainment.hs
+++ b/src/Swarm/TUI/Model/Achievement/Attainment.hs
@@ -10,7 +10,6 @@ import Data.Aeson (
   genericToJSON,
  )
 import Data.Function (on)
-import Data.Text (Text)
 import Data.Time (ZonedTime, zonedTimeToUTC)
 import Data.Yaml as Y
 import GHC.Generics (Generic)
@@ -18,7 +17,7 @@ import Swarm.TUI.Model.Achievement.Definitions
 
 data Attainment = Attainment
   { _achievement :: CategorizedAchievement
-  , _maybeScenarioPath :: Maybe Text
+  , _maybeScenarioPath :: Maybe FilePath
   -- ^ from which scenario was it obtained?
   , _obtainedAt :: ZonedTime
   }

--- a/src/Swarm/TUI/Model/Achievement/Definitions.hs
+++ b/src/Swarm/TUI/Model/Achievement/Definitions.hs
@@ -77,6 +77,7 @@ data GameplayAchievement
   | RobotIntoWater
   | AttemptSelfDestructBase
   | DestroyedBase
+  | LoseScenario
   deriving (Eq, Ord, Show, Bounded, Enum, Generic)
 
 instance FromJSON GameplayAchievement

--- a/src/Swarm/TUI/Model/Achievement/Description.hs
+++ b/src/Swarm/TUI/Model/Achievement/Description.hs
@@ -61,3 +61,10 @@ describe (GameplayAchievement DestroyedBase) =
     "Actually destroy your base."
     Moderate
     True
+describe (GameplayAchievement LoseScenario) =
+  AchievementInfo
+    "Silver Lining"
+    (Just $ Freeform "Here's your consolation prize.")
+    "Lose at a scenario."
+    Easy
+    True

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -114,7 +114,12 @@ attainAchievement a = do
   currentTime <- liftIO getZonedTime
   attainAchievement' currentTime Nothing a
 
-attainAchievement' :: (MonadIO m, MonadState AppState m) => ZonedTime -> Maybe Text -> CategorizedAchievement -> m ()
+attainAchievement' ::
+  (MonadIO m, MonadState AppState m) =>
+  ZonedTime ->
+  Maybe FilePath ->
+  CategorizedAchievement ->
+  m ()
 attainAchievement' t p a = do
   (uiState . uiAchievements)
     %= M.insertWith


### PR DESCRIPTION
## Test procedure

1. Start game

       ./scripts/play.sh
3. Observe empty achievements
4. Select "New Game" -> "Challenges" -> "Lake crossing"
5. `turn east; move`

![image](https://user-images.githubusercontent.com/261693/214680712-425dd684-cf72-42c2-85d1-e0c50147ff67.png)

![image](https://user-images.githubusercontent.com/261693/214680901-81cc6b8a-30da-4266-b30a-d8ec3c73db5f.png)


