### PR TITLE
Nested sum type for directions

### DIFF
--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -96,14 +96,14 @@
                "robotnamed"
                "robotnumbered"
                "knows"
-               "left"
-               "right"
-               "back"
-               "forward"
                "north"
                "south"
                "east"
                "west"
+               "left"
+               "right"
+               "back"
+               "forward"
                "down"
              ))
              (x-types '("int" "text" "dir" "bool" "cmd" "void" "unit" "actor"))

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -89,7 +89,7 @@
 			"patterns": [
 				{
 				"name": "variable.language.dir",
-				"match": "\\b(?i)(left|right|back|forward|north|south|east|west|down)\\b"
+				"match": "\\b(?i)(north|south|east|west|left|right|back|forward|down)\\b"
 				},
 				{
 				"name": "variable.parameter",

--- a/src/Swarm/Game/Display.hs
+++ b/src/Swarm/Game/Display.hs
@@ -129,10 +129,8 @@ instance ToJSON Display where
 -- | Look up the character that should be used for a display.
 displayChar :: Display -> Char
 displayChar disp = fromMaybe (disp ^. defaultChar) $ do
-  dir <- disp ^. curOrientation
-  case dir of
-    DAbsolute d -> M.lookup d (disp ^. orientationMap)
-    _ -> Nothing
+  DAbsolute d <- disp ^. curOrientation
+  M.lookup d (disp ^. orientationMap)
 
 -- | Render a display as a UI widget.
 renderDisplay :: Display -> Widget n

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1011,9 +1011,9 @@ execConst c vs s k = do
         drill <- preferredDrill `isJustOr` Fatal "Drill is required but not installed?!"
 
         let directionText = case d of
-              DDown -> "under"
-              DForward -> "ahead of"
-              DBack -> "behind"
+              DRelative DDown -> "under"
+              DRelative DForward -> "ahead of"
+              DRelative DBack -> "behind"
               _ -> dirSyntax (dirInfo d) <> " of"
 
         (nextLoc, nextME) <- lookInDirection d


### PR DESCRIPTION
Code simplification, improved type safety (see [this comment](https://github.com/swarm-game/swarm/pull/876#discussion_r1029843033)).

This technique may also simplify the implementation of `CReverse` (see #950) if we choose to do so.