### PR TITLE
One file per achievement record

### DIFF
--- a/src/Swarm/TUI/Model/Achievement/Persistence.hs
+++ b/src/Swarm/TUI/Model/Achievement/Persistence.hs
@@ -8,15 +8,15 @@ import Control.Monad (forM, forM_)
 import Data.Either (partitionEithers)
 import Data.Yaml qualified as Y
 import Swarm.TUI.Model.Achievement.Attainment
-import Swarm.Util
 import Swarm.TUI.Model.Achievement.Definitions
+import Swarm.TUI.Model.Failure
+import Swarm.Util
 import System.Directory (
   doesDirectoryExist,
   doesFileExist,
   listDirectory,
  )
-import System.FilePath ( (</>) )
-import Swarm.TUI.Model.Failure
+import System.FilePath ((</>))
 
 -- | Get path to swarm achievements, optionally creating necessary
 --   directories.
@@ -40,8 +40,7 @@ loadAchievementsInfo = do
           then do
             eitherDecodedFile <- sendIO (Y.decodeFileEither fullPath)
             return $ left (AssetNotLoaded Achievement p . CanNotParse) eitherDecodedFile
-          else
-            return . Left $ AssetNotLoaded Achievement p (EntryNot File)
+          else return . Left $ AssetNotLoaded Achievement p (EntryNot File)
       return $ partitionEithers eithersList
     else return ([AssetNotLoaded Achievement "." (DoesNotExist Directory)], [])
 

--- a/src/Swarm/TUI/Model/Achievement/Persistence.hs
+++ b/src/Swarm/TUI/Model/Achievement/Persistence.hs
@@ -4,36 +4,68 @@ module Swarm.TUI.Model.Achievement.Persistence where
 
 import Control.Arrow (left)
 import Control.Carrier.Lift (sendIO)
+import Control.Monad (forM, forM_)
+import Data.Either (partitionEithers)
 import Data.Text (Text, pack)
+import Data.Text qualified as T
 import Data.Yaml qualified as Y
 import Data.Yaml.Aeson (prettyPrintParseException)
 import Swarm.TUI.Model.Achievement.Attainment
 import Swarm.Util
 import System.Directory (
+  doesDirectoryExist,
   doesFileExist,
+  listDirectory,
  )
+import System.FilePath
+import System.IO (hPutStrLn, stderr)
 
 -- | Get path to swarm achievements, optionally creating necessary
 --   directories.
 getSwarmAchievementsPath :: Bool -> IO FilePath
-getSwarmAchievementsPath createDirs = getSwarmXdgDataFile createDirs "achievements"
+getSwarmAchievementsPath createDirs = getSwarmXdgDataSubdir createDirs "achievement"
 
 -- | Load saved info about achievements from XDG data directory.
 loadAchievementsInfo ::
   IO (Either Text [Attainment])
 loadAchievementsInfo = do
-  savedAchievementsPath <- getSwarmAchievementsPath True
-  hasSavedAchievements <- sendIO $ doesFileExist savedAchievementsPath
-  if not hasSavedAchievements
-    then return $ pure []
-    else
-      left (pack . prettyPrintParseException)
-        <$> sendIO (Y.decodeFileEither savedAchievementsPath)
+  savedAchievementsPath <- getSwarmAchievementsPath False
+  doesParentExist <- doesDirectoryExist savedAchievementsPath
+  if doesParentExist
+    then do
+      contents <- listDirectory savedAchievementsPath
+      eithersList <- forM contents $ \p -> do
+        let fullPath = savedAchievementsPath </> p
+        isFile <- doesFileExist fullPath
+        if isFile
+          then do
+            eitherDecodedFile <- sendIO (Y.decodeFileEither fullPath)
+            return $ left (pack . prettyPrintParseException) eitherDecodedFile
+          else
+            return $
+              Left $
+                T.unwords
+                  [ "Entry"
+                  , quote $ T.pack fullPath
+                  , "is not a file!"
+                  ]
+      let (bads, goods) = partitionEithers eithersList
+      forM_ bads $ \b ->
+        hPutStrLn stderr $ T.unpack b
+      return $ pure goods
+    else return $ pure []
 
 -- | Save info about achievements to XDG data directory.
 saveAchievementsInfo ::
   [Attainment] ->
   IO ()
-saveAchievementsInfo si = do
+saveAchievementsInfo attainmentList = do
   savedAchievementsPath <- getSwarmAchievementsPath True
-  Y.encodeFile savedAchievementsPath si
+  forM_ attainmentList $ \x -> do
+    let achievementName =
+          T.unpack $
+            T.takeWhileEnd (/= ' ') $
+              T.pack $
+                show (_achievement x)
+        fullPath = savedAchievementsPath </> achievementName
+    Y.encodeFile fullPath x

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -14,10 +14,12 @@ import Control.Applicative ((<|>))
 import Control.Lens hiding (from, (<.>))
 import Control.Monad.Except
 import Control.Monad.State
+import Data.List qualified as List
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import Data.Time (ZonedTime, getZonedTime)
+import Swarm.Game.Log (ErrorLevel (..), LogSource (ErrorTrace))
 import Swarm.Game.Scenario (loadScenario)
 import Swarm.Game.ScenarioInfo (
   ScenarioInfo (..),
@@ -36,12 +38,10 @@ import Swarm.TUI.Model
 import Swarm.TUI.Model.Achievement.Attainment
 import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.TUI.Model.Achievement.Persistence
+import Swarm.TUI.Model.Failure (prettyFailure)
 import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.UI
 import System.Clock
-import Swarm.Game.Log ( LogSource(ErrorTrace), ErrorLevel(..) ) 
-import Data.List qualified as List
-import Swarm.TUI.Model.Failure (prettyFailure)
 
 -- | Initialize the 'AppState'.
 initAppState :: AppOpts -> ExceptT Text IO AppState
@@ -51,7 +51,7 @@ initAppState AppOpts {..} = do
   gs <- initGameState
   (warnings, ui) <- initUIState (not skipMenu) cheatMode
   let logWarning rs w = rs & eventLog %~ logEvent (ErrorTrace Error) ("UI Loading", -8) (prettyFailure w)
-  let rs = List.foldl' logWarning initRuntimeState warnings 
+  let rs = List.foldl' logWarning initRuntimeState warnings
   case skipMenu of
     False -> return $ AppState gs ui rs
     True -> do

--- a/src/Swarm/TUI/Model/UI.hs
+++ b/src/Swarm/TUI/Model/UI.hs
@@ -62,12 +62,12 @@ import Swarm.TUI.Inventory.Sorting
 import Swarm.TUI.Model.Achievement.Attainment
 import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.TUI.Model.Achievement.Persistence
+import Swarm.TUI.Model.Failure (SystemFailure)
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.Repl
 import Swarm.Util
 import System.Clock
-import Swarm.TUI.Model.Failure (SystemFailure)
 
 ------------------------------------------------------------
 -- UI state
@@ -266,36 +266,37 @@ initUIState showMainMenu cheatMode = do
   let history = maybe [] (map REPLEntry . T.lines) historyT
   startTime <- liftIO $ getTime Monotonic
   (warnings, achievements) <- liftIO loadAchievementsInfo
-  let out = UIState
-        { _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
-        , _uiPlaying = not showMainMenu
-        , _uiCheatMode = cheatMode
-        , _uiFocusRing = initFocusRing
-        , _uiWorldCursor = Nothing
-        , _uiREPL = initREPLState $ newREPLHistory history
-        , _uiInventory = Nothing
-        , _uiInventorySort = defaultSortOptions
-        , _uiMoreInfoTop = False
-        , _uiMoreInfoBot = False
-        , _uiScrollToEnd = False
-        , _uiError = Nothing
-        , _uiModal = Nothing
-        , _uiGoal = Nothing
-        , _uiAchievements = M.fromList $ map (view achievement &&& id) achievements
-        , _uiShowFPS = False
-        , _uiShowZero = True
-        , _uiHideRobotsUntil = startTime - 1
-        , _uiInventoryShouldUpdate = False
-        , _uiTPF = 0
-        , _uiFPS = 0
-        , _lgTicksPerSecond = initLgTicksPerSecond
-        , _lastFrameTime = startTime
-        , _accumulatedTime = 0
-        , _lastInfoTime = 0
-        , _tickCount = 0
-        , _frameCount = 0
-        , _frameTickCount = 0
-        , _appData = appDataMap
-        , _scenarioRef = Nothing
-        }
+  let out =
+        UIState
+          { _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
+          , _uiPlaying = not showMainMenu
+          , _uiCheatMode = cheatMode
+          , _uiFocusRing = initFocusRing
+          , _uiWorldCursor = Nothing
+          , _uiREPL = initREPLState $ newREPLHistory history
+          , _uiInventory = Nothing
+          , _uiInventorySort = defaultSortOptions
+          , _uiMoreInfoTop = False
+          , _uiMoreInfoBot = False
+          , _uiScrollToEnd = False
+          , _uiError = Nothing
+          , _uiModal = Nothing
+          , _uiGoal = Nothing
+          , _uiAchievements = M.fromList $ map (view achievement &&& id) achievements
+          , _uiShowFPS = False
+          , _uiShowZero = True
+          , _uiHideRobotsUntil = startTime - 1
+          , _uiInventoryShouldUpdate = False
+          , _uiTPF = 0
+          , _uiFPS = 0
+          , _lgTicksPerSecond = initLgTicksPerSecond
+          , _lastFrameTime = startTime
+          , _accumulatedTime = 0
+          , _lastInfoTime = 0
+          , _tickCount = 0
+          , _frameCount = 0
+          , _frameTickCount = 0
+          , _appData = appDataMap
+          , _scenarioRef = Nothing
+          }
   return (warnings, out)


### PR DESCRIPTION
Closes #953

## Testing

First, earn a couple of achievements by playing the game.  Then, stuff some garbage into the `achievement` directory and rerun the game:

```
kostmo@dell-ubuntu:~/github/swarm$ touch ~/.local/share/swarm/achievement/foo
kostmo@dell-ubuntu:~/github/swarm$ mkdir ~/.local/share/swarm/achievement/bar
kostmo@dell-ubuntu:~/github/swarm$ stack run
Aeson exception:
Error in $: parsing Swarm.TUI.Model.Achievement.Attainment.Attainment(Attainment) failed, expected Object, but encountered Null
Entry "/home/kostmo/.local/share/swarm/achievement/bar" is not a file!
```

Observe that the game starts fine and is able to display our original 2 achievements.