### PR TITLE
Fix `EntityMap` merging

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -18,3 +18,4 @@
 920-meet.yaml
 955-heading.yaml
 397-wrong-missing.yaml
+961-custom-capabilities.yaml

--- a/data/scenarios/Testing/961-custom-capabilities.yaml
+++ b/data/scenarios/Testing/961-custom-capabilities.yaml
@@ -1,0 +1,42 @@
+version: 1
+name: Test issue 961 (custom entities providing capabilities)
+description: |
+  Test that custom entities providing a capability are considered
+  for installation.
+  https://github.com/swarm-game/swarm/issues/961
+objectives:
+  - condition: |
+      mover <- robotNumbered 1;
+      as mover { loc <- whereami; return $ loc == (0,1) }
+    goal:
+    - |
+      Get a robot to (0,1)!
+solution: |
+  build {move}
+entities:
+  - name: wheels
+    display:
+      attr: device
+      char: 'o'
+    description:
+    - A non-traditional means of locomotion.
+    properties: [known, portable]
+    capabilities: [move]
+robots:
+  - name: base
+    dir: [0,1]
+    devices:
+      - 3D printer
+      - logger
+    inventory:
+      - [1, wheels]
+      - [1, solar panel]
+world:
+  default: [blank]
+  palette:
+    'Ω': [grass, null, base]
+    '.': [grass]
+  upperleft: [0,1]
+  map: |
+    .
+    Ω

--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -293,7 +293,7 @@ data EntityMap = EntityMap
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
 instance Semigroup EntityMap where
-  EntityMap n1 c1 <> EntityMap n2 c2 = EntityMap (n1 <> n2) (c1 <> c2)
+  EntityMap n1 c1 <> EntityMap n2 c2 = EntityMap (n1 <> n2) (M.unionWith (<>) c1 c2)
 
 instance Monoid EntityMap where
   mempty = EntityMap M.empty M.empty

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -229,6 +229,7 @@ testScenarioSolution _ci _em =
               not (any ("treads" `T.isInfixOf`) msgs)
             assertBool "Error message should mention no device provides senseloc" $
               any ("senseloc" `T.isInfixOf`) msgs
+        , testSolution Default "Testing/961-custom-capabilities"
         ]
     ]
  where


### PR DESCRIPTION
Fixes #961.  Merging the `entitiesByCap` maps simply with `(<>)` (which is the same as `M.union`) was not correct: map union is left-biased, so if both maps had entities keyed to the same capability, the entities from the right-hand map would simply be thrown away.  Instead, we must merge them with `M.unionWith (<>)` which will append the two `Entity` lists for a given capability.