### PR TITLE
Merge new requirements context with existing when running from REPL

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -836,7 +836,7 @@ handleREPLEventTyping = \case
             -- `reprogram` at runtime.  See the discussion at
             -- https://github.com/swarm-game/swarm/pull/827 for more
             -- details.
-            . (gameState . baseRobot . robotContext . defReqs .~ reqCtx)
+            . (gameState . baseRobot . robotContext . defReqs <>~ reqCtx)
             -- Set up the robot's CESK machine to evaluate/execute the
             -- given term, being sure to initialize the CESK machine
             -- environment and store from the top-level context.


### PR DESCRIPTION
Fixes #964.  Unfortunately I don't know of any way to make a test for this.  Part of the reason we went so long without noticing is that it only specifically affected the code path for running terms from the REPL, and tests can never run that code.