### PR TITLE
Add `isempty : cmd bool` to check whether current cell has an entity

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -914,9 +914,13 @@
     about their surroundings.  Simply give `scan` a direction in which to scan,
     and information about the scanned item (if any) will be added to the robot's
     inventory."
-  - "A scanner also enables the `blocked` command, which returns a
+  - "A scanner also enables `blocked : cmd bool`, which returns a
      boolean value indicating whether the robot's path is blocked
-     (i.e. whether executing a `move` command would fail)."
+     (i.e. whether executing a `move` command would fail);
+     `ishere : text -> cmd bool` for checking whether the current
+     cell contains a particular entity; and `isempty : cmd bool` for
+     checking whether the current cell is empty of entities. Note that
+     `ishere` and `isempty` do not detect robots, only entities."
   - "Finally, robots can use the `upload` command to copy their accumulated
     knowledge to another nearby robot; for example, `upload base`."
   properties: [portable]

--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -20,3 +20,4 @@
 397-wrong-missing.yaml
 961-custom-capabilities.yaml
 956-GPS.yaml
+958-isempty.yaml

--- a/data/scenarios/Testing/958-isempty.yaml
+++ b/data/scenarios/Testing/958-isempty.yaml
@@ -10,12 +10,12 @@ objectives:
         The goal is to pick up the thing right after the empty
         spot in the row.
 solution: |
-  def find_flower =
+  def find_thing =
     e <- isempty;
     move;
-    if e {} {find_flower}
+    if e {} {find_thing}
   end;
-  find_flower;
+  find_thing;
   grab
 robots:
   - name: base

--- a/data/scenarios/Testing/958-isempty.yaml
+++ b/data/scenarios/Testing/958-isempty.yaml
@@ -1,0 +1,57 @@
+version: 1
+name: Test isempty
+description: |
+  Test the `isempty` command.
+objectives:
+  - condition: |
+      as base {has "thneed"}
+    goal:
+      - |
+        The goal is to pick up the thing right after the empty
+        spot in the row.
+solution: |
+  def find_flower =
+    e <- isempty;
+    move;
+    if e {} {find_flower}
+  end;
+  find_flower;
+  grab
+robots:
+  - name: base
+    dir: [1,0]
+    devices:
+      - scanner
+      - branch predictor
+      - grabber
+      - strange loop
+      - lambda
+      - dictionary
+      - logger
+      - treads
+      - solar panel
+entities:
+  - name: thneed
+    display:
+      attr: gold
+      char: 'Y'
+    description:
+    - A thing that everyone needs!
+    properties: [portable]
+world:
+  default: [blank]
+  palette:
+    '.': [grass]
+    '>': [grass, tree, base]
+    'o': [grass, rock]
+    '$': [grass, LaTeX]
+    'i': [grass, cotton]
+    '0': [grass, bit (0)]
+    '1': [grass, bit (1)]
+    'R': [grass, pixel (R)]
+    'G': [grass, pixel (G)]
+    'B': [grass, pixel (B)]
+    'Y': [grass, thneed]
+  upperleft: [-5, 5]
+  map: |
+    >o$i01R.YGB

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -82,6 +82,7 @@
                "scan"
                "upload"
                "ishere"
+               "isempty"
                "meet"
                "meetall"
                "whoami"

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -58,7 +58,7 @@
 				},
 				{
 				"name": "keyword.other",
-				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|install|equip|unequip|make|has|installed|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|time|whereami|heading|blocked|scan|upload|ishere|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|teleport|as|robotnamed|robotnumbered|knows)\\b"
+				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|install|equip|unequip|make|has|installed|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|time|whereami|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|teleport|as|robotnamed|robotnumbered|knows)\\b"
 				}
 			]
 			},

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1267,6 +1267,10 @@ execConst c vs s k = do
           Nothing -> return $ Out (VBool False) s k
           Just e -> return $ Out (VBool (T.toLower (e ^. entityName) == T.toLower name)) s k
       _ -> badConst
+    Isempty -> do
+      loc <- use robotLocation
+      me <- entityAt loc
+      return $ Out (VBool (isNothing me)) s k
     Self -> do
       rid <- use robotID
       return $ Out (VRobot rid) s k

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -71,7 +71,7 @@ data Capability
     CSenseloc
   | -- | Execute the 'Blocked' command
     CSensefront
-  | -- | Execute the 'Ishere' command
+  | -- | Execute the 'Ishere' and 'Isempty' commands
     CSensehere
   | -- | Execute the 'Scan' command
     CScan
@@ -192,6 +192,7 @@ constCaps = \case
   Blocked -> Just CSensefront
   Scan -> Just CScan
   Ishere -> Just CSensehere
+  Isempty -> Just CSensehere
   Upload -> Just CScan
   Build -> Just CBuild
   Salvage -> Just CSalvage

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -294,8 +294,10 @@ data Const
     Scan
   | -- | Upload knowledge to another robot
     Upload
-  | -- | See if a specific entity is here. (This may be removed.)
+  | -- | See if a specific entity is here.
     Ishere
+  | -- | Check whether the current cell is empty
+    Isempty
   | -- | Get a reference to oneself
     Self
   | -- | Get the robot's parent
@@ -633,12 +635,17 @@ constInfo c = case c of
   Heading -> command 0 Intangible "Get the current heading."
   Blocked -> command 0 Intangible "See if the robot can move forward."
   Scan ->
-    command 0 Intangible . doc "Scan a nearby location for entities." $
+    command 1 Intangible . doc "Scan a nearby location for entities." $
       [ "Adds the entity (not actor) to your inventory with count 0 if there is any."
       , "If you can use sum types, you can also inspect the result directly."
       ]
   Upload -> command 1 short "Upload a robot's known entities and log to another robot."
   Ishere -> command 1 Intangible "See if a specific entity is in the current location."
+  Isempty ->
+    command 0 Intangible . doc "Check if the current location is empty." $
+      [ "Detects whether or not the current location contains an entity."
+      , "Does not detect robots or other actors."
+      ]
   Self -> function 0 "Get a reference to the current robot."
   Parent -> function 0 "Get a reference to the robot's parent."
   Base -> function 0 "Get a reference to the base."

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -494,6 +494,7 @@ inferConst c = case c of
   Scan -> [tyQ| dir -> cmd (unit + text) |]
   Upload -> [tyQ| actor -> cmd unit |]
   Ishere -> [tyQ| text -> cmd bool |]
+  Isempty -> [tyQ| cmd bool |]
   Self -> [tyQ| actor |]
   Parent -> [tyQ| actor |]
   Base -> [tyQ| actor |]

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -231,6 +231,7 @@ testScenarioSolution _ci _em =
               any ("GPS receiver" `T.isInfixOf`) msgs
         , testSolution Default "Testing/961-custom-capabilities"
         , testSolution Default "Testing/956-GPS"
+        , testSolution Default "Testing/958-isempty"
         ]
     ]
  where


### PR DESCRIPTION
As I've been playing around in classic mode I've found it a bit annoying/unbalanced that although you can use `ishere : text -> cmd bool` to check for the presence of a *specific* entity, the only way to check whether a cell is empty is to write something like
```
def is_empty : cmd bool =
  s <- scan down;
  return (s == inl ())
end
```
However, this requires having a `comparator` and an `ADT calculator` --- the latter in particular is quite difficult to construct.  So, I propose adding a primitive `isempty : cmd bool`.  Note this doesn't make `scan` useless --- it's more powerful still since it lets you find out the name of anything (even stuff not in the current cell).  

An alternative might be to get rid of `ishere` as well (since it can also be programmed in terms of `scan`), but tons of obvious early-game automation (*e.g.* harvesting a tree plantation) depends on being able to have conditionals based on the presence or absence of certain entities, and it would be unreasonable to have that depend on making an `ADT calculator`.

The `scanner` now provides quite a few commands; I think that's OK but chime in if you think we ought to split it into multiple devices.  I think it makes sense to have `scan`, `ishere`, and `isempty` all provided by `scanner` since it's just providing several interfaces to the same "service", one general and several simpler but easier-to-use versions.  If we split anything out it could make sense to split out `blocked` (`laser range finder`, perhaps?) and/or `upload`.