### PR TITLE
warn of unused variables

### DIFF
--- a/data/test/language-snippets/warnings/unused-vars/multiple-lambda-first-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/multiple-lambda-first-unused.sw
@@ -1,0 +1,3 @@
+def put = \x. \y.
+    place y;
+    end;

--- a/data/test/language-snippets/warnings/unused-vars/multiple-lambda-second-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/multiple-lambda-second-unused.sw
@@ -1,0 +1,3 @@
+def put = \x. \y.
+    place x;
+    end;

--- a/data/test/language-snippets/warnings/unused-vars/multiple-let-all-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/multiple-let-all-unused.sw
@@ -1,0 +1,3 @@
+let x = "foo" in
+let y = "bar" in
+place "quux";

--- a/data/test/language-snippets/warnings/unused-vars/multiple-let-first-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/multiple-let-first-unused.sw
@@ -1,0 +1,3 @@
+let x = "foo" in
+let y = "bar" in
+place y;

--- a/data/test/language-snippets/warnings/unused-vars/multiple-let-second-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/multiple-let-second-unused.sw
@@ -1,0 +1,3 @@
+let x = "foo" in
+let y = "bar" in
+place x;

--- a/data/test/language-snippets/warnings/unused-vars/recursive-let.sw
+++ b/data/test/language-snippets/warnings/unused-vars/recursive-let.sw
@@ -1,0 +1,1 @@
+let one = 1 in let fac = \n. if (n == 0) {one} {n * fac (n-1)} in 17

--- a/data/test/language-snippets/warnings/unused-vars/shadowed-variable-lambda-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/shadowed-variable-lambda-unused.sw
@@ -1,0 +1,1 @@
+def y = \x. \x. x + 1 end

--- a/data/test/language-snippets/warnings/unused-vars/shadowed-variable-let-intermediate-use.sw
+++ b/data/test/language-snippets/warnings/unused-vars/shadowed-variable-let-intermediate-use.sw
@@ -1,0 +1,4 @@
+let x = "flower" in
+place x;
+x <- grab;
+give parent x;

--- a/data/test/language-snippets/warnings/unused-vars/shadowed-variable-let-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/shadowed-variable-let-unused.sw
@@ -1,0 +1,3 @@
+let x = "flower" in
+x <- grab;
+give parent x;

--- a/data/test/language-snippets/warnings/unused-vars/single-bind-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/single-bind-unused.sw
@@ -1,0 +1,2 @@
+x <- grab;
+place "foo";

--- a/data/test/language-snippets/warnings/unused-vars/single-bind-used.sw
+++ b/data/test/language-snippets/warnings/unused-vars/single-bind-used.sw
@@ -1,0 +1,2 @@
+x <- grab;
+place x;

--- a/src/Swarm/Language/LSP.hs
+++ b/src/Swarm/Language/LSP.hs
@@ -14,8 +14,7 @@ module Swarm.Language.LSP where
 import Control.Lens (to, (^.))
 import Control.Monad (void)
 import Control.Monad.IO.Class
-import Data.Foldable (forM_)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text.IO qualified as Text
 import Language.LSP.Diagnostics
@@ -25,6 +24,7 @@ import Language.LSP.Types qualified as J
 import Language.LSP.Types.Lens qualified as J
 import Language.LSP.VFS
 import Swarm.Language.LSP.Hover qualified as H
+import Swarm.Language.LSP.VarUsage qualified as VU
 import Swarm.Language.Parse
 import Swarm.Language.Pipeline
 import System.IO (stderr)
@@ -42,7 +42,7 @@ lspMain =
         , interpretHandler = \env -> Iso (runLspT env) liftIO
         , options =
             defaultOptions
-              { -- set sync options to get DidSave event
+              { -- set sync options to get DidSave event, as well as Open and Close events.
                 textDocumentSync =
                   Just
                     ( J.TextDocumentSyncOptions
@@ -60,38 +60,74 @@ lspMain =
   -- handler is called for each key-stroke.
   syncKind = J.TdSyncFull
 
+diagnosticSourcePrefix :: Text
+diagnosticSourcePrefix = "swarm-lsp"
+
 debug :: MonadIO m => Text -> m ()
 debug msg = liftIO $ Text.hPutStrLn stderr $ "[swarm-lsp] " <> msg
 
 validateSwarmCode :: J.NormalizedUri -> J.TextDocumentVersion -> Text -> LspM () ()
 validateSwarmCode doc version content = do
   -- debug $ "Validating: " <> from (show doc) <> " ( " <> content <> ")"
-  flushDiagnosticsBySource 0 (Just "swarm-lsp")
-  let err = case readTerm' content of
-        Right Nothing -> Nothing
-        Right (Just term) -> case processParsedTerm' mempty mempty term of
-          Right _ -> Nothing
-          Left e -> Just $ showTypeErrorPos content e
-        Left e -> Just $ showErrorPos e
+
+  -- FIXME With this call to flushDiagnosticsBySource in place, the warnings
+  -- in other buffers (editor tabs) end up getting cleared when switching between
+  -- (focusing on) other buffers in VS Code.
+  -- However, getting rid of this seems to break error highlighting.
+  flushDiagnosticsBySource 0 (Just diagnosticSourcePrefix)
+
+  let (parsingErrs, unusedVarWarnings) = case readTerm' content of
+        Right Nothing -> ([], [])
+        Right (Just term) -> (parsingErrors, unusedWarnings)
+         where
+          VU.Usage _ problems = VU.getUsage mempty term
+          unusedWarnings = mapMaybe (VU.toErrPos content) problems
+
+          parsingErrors = case processParsedTerm' mempty mempty term of
+            Right _ -> []
+            Left e -> pure $ showTypeErrorPos content e
+        Left e -> (pure $ showErrorPos e, [])
   -- debug $ "-> " <> from (show err)
-  forM_ err sendDiagnostic
+
+  publishDiags $
+    map makeUnusedVarDiagnostic unusedVarWarnings
+
+  -- NOTE: "publishDiags" keeps only one diagnostic at a
+  -- time (the most recent) so we make sure the errors are
+  -- issued last (after any warnings).
+  -- Note that it does not achieve the desired effect to simply
+  -- concatenate the two diagnostic lists into a single
+  -- publishDiagnostics function call (regardless of the order
+  -- of the lists).
+  publishDiags $
+    map makeParseErrorDiagnostic parsingErrs
  where
-  sendDiagnostic :: ((Int, Int), (Int, Int), Text) -> LspM () ()
-  sendDiagnostic ((startLine, startCol), (endLine, endCol), msg) = do
-    let diags =
-          [ J.Diagnostic
-              ( J.Range
-                  (J.Position (fromIntegral startLine) (fromIntegral startCol))
-                  (J.Position (fromIntegral endLine) (fromIntegral endCol))
-              )
-              (Just J.DsWarning) -- severity
-              Nothing -- code
-              (Just "swarm-lsp") -- source
-              msg
-              Nothing -- tags
-              (Just (J.List []))
-          ]
-    publishDiagnostics 1 doc version (partitionBySource diags)
+  publishDiags :: [J.Diagnostic] -> LspM () ()
+  publishDiags = publishDiagnostics 1 doc version . partitionBySource
+
+  makeUnusedVarDiagnostic :: (J.Range, Text) -> J.Diagnostic
+  makeUnusedVarDiagnostic (range, msg) =
+    J.Diagnostic
+      range
+      (Just J.DsWarning) -- severity
+      Nothing -- code
+      (Just diagnosticSourcePrefix) -- source
+      msg
+      (Just (J.List [J.DtUnnecessary])) -- tags
+      Nothing -- related source code info
+  makeParseErrorDiagnostic :: ((Int, Int), (Int, Int), Text) -> J.Diagnostic
+  makeParseErrorDiagnostic ((startLine, startCol), (endLine, endCol), msg) =
+    J.Diagnostic
+      ( J.Range
+          (J.Position (fromIntegral startLine) (fromIntegral startCol))
+          (J.Position (fromIntegral endLine) (fromIntegral endCol))
+      )
+      (Just J.DsError) -- severity
+      Nothing -- code
+      (Just diagnosticSourcePrefix) -- source
+      msg
+      Nothing -- tags
+      (Just (J.List []))
 
 handlers :: Handlers (LspM ())
 handlers =

--- a/src/Swarm/Language/LSP/VarUsage.hs
+++ b/src/Swarm/Language/LSP/VarUsage.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Swarm.Language.LSP.VarUsage where
+
+import Control.Monad (guard)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map (Map)
+import Data.Map qualified as M
+import Data.Set (Set)
+import Data.Set qualified as S
+import Data.Text (Text)
+import Data.Text qualified as T
+import Language.LSP.Types qualified as J
+import Swarm.Language.Parse qualified as P
+import Swarm.Language.Syntax
+import Swarm.Util qualified as U
+
+data BindingType
+  = Lambda
+  | Let
+  | Bind
+  deriving (Eq, Show)
+
+data VarUsage = VarUsage LocVar BindingType
+
+type BindingSites = Map Var (NonEmpty SrcLoc)
+
+data Usage = Usage
+  { usages :: Set LocVar
+  -- ^ Variable references
+  , problems :: [VarUsage]
+  -- ^ Variable declarations without any references
+  }
+
+instance Semigroup Usage where
+  Usage y1 z1 <> Usage y2 z2 =
+    Usage
+      (y1 <> y2)
+      (z1 <> z2)
+
+instance Monoid Usage where
+  mempty = Usage mempty mempty
+
+toErrPos :: Text -> VarUsage -> Maybe (J.Range, Text)
+toErrPos code (VarUsage (LV loc v) scope) = do
+  -- A leading underscore will suppress the unused variable warning
+  guard $ not $ "_" `T.isPrefixOf` v
+  rangePair <- case loc of
+    SrcLoc s e -> Just (s, e)
+    _ -> Nothing
+  let (start, end) = P.getLocRange code rangePair
+      ((startLine, startCol), (endLine, endCol)) = (minusOne start, minusOne end)
+      range =
+        J.Range
+          (J.Position (fromIntegral startLine) (fromIntegral startCol))
+          (J.Position (fromIntegral endLine) (fromIntegral endCol))
+  return (range, txt)
+ where
+  txt =
+    T.unwords
+      [ "Unused variable"
+      , U.quote v
+      , "in"
+      , T.pack $ show scope
+      , "expression"
+      ]
+  minusOne (x, y) = (x - 1, y - 1)
+
+-- | Descends the syntax tree rooted at a variable declaration,
+-- accumulating variable references.
+-- Generates a "problem" if an associated variable reference
+-- is not encountered in the subtree for this declaration.
+checkOccurrences ::
+  BindingSites ->
+  LocVar ->
+  BindingType ->
+  [Syntax] ->
+  Usage
+checkOccurrences bindings lv@(LV loc v) declType childSyntaxes =
+  Usage childUsages $ missing <> deeperMissing
+ where
+  deeperBindings = M.insertWith (<>) v (pure loc) bindings
+  Usage childUsages deeperMissing = mconcat $ map (getUsage deeperBindings) childSyntaxes
+  missing = [VarUsage lv declType | lv `S.notMember` childUsages]
+
+-- | Build up the bindings map as a function argument as
+-- we descend into the syntax tree.
+-- Aggregates unused bindings as we return from each layer.
+getUsage ::
+  BindingSites ->
+  Syntax ->
+  Usage
+getUsage bindings (Syntax _pos t) = case t of
+  TVar v -> Usage myUsages mempty
+   where
+    myUsages = case M.lookup v bindings of
+      Nothing -> mempty
+      Just (loc :| _) -> S.singleton $ LV loc v
+  SLam v _ s -> checkOccurrences bindings v Lambda [s]
+  SApp s1 s2 -> getUsage bindings s1 <> getUsage bindings s2
+  SLet _ v _ s1 s2 -> getUsage bindings s1 <> checkOccurrences bindings v Let [s2]
+  SPair s1 s2 -> getUsage bindings s1 <> getUsage bindings s2
+  SDef _ _v _ s -> getUsage bindings s
+  SBind maybeVar s1 s2 -> case maybeVar of
+    Just v -> checkOccurrences bindings v Bind [s1, s2]
+    Nothing -> getUsage bindings s1 <> getUsage bindings s2
+  SDelay _ s -> getUsage bindings s
+  _ -> mempty

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -782,7 +782,7 @@ data SrcLoc
   = NoLoc
   | -- | Half-open interval from start (inclusive) to end (exclusive)
     SrcLoc Int Int
-  deriving (Eq, Show, Data, Generic, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, Data, Generic, FromJSON, ToJSON)
 
 instance Semigroup SrcLoc where
   NoLoc <> l = l
@@ -871,7 +871,7 @@ data DelayType
 --   binding sites. (Variable occurrences are a bare TVar which gets
 --   wrapped in a Syntax node, so we don't need LocVar for those.)
 data LocVar = LV {lvSrcLoc :: SrcLoc, lvVar :: Var}
-  deriving (Eq, Show, Data, Generic, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, Data, Generic, FromJSON, ToJSON)
 
 -- | Terms of the Swarm language.
 data Term

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -24,7 +24,7 @@ extra-source-files: CHANGELOG.md
                     editors/emacs/*.el
                     editors/vscode/syntaxes/*.json
 data-dir:           data/
-data-files:         *.yaml, scenarios/**/*.yaml, scenarios/**/*.txt, scenarios/**/*.sw, *.txt
+data-files:         *.yaml, scenarios/**/*.yaml, scenarios/**/*.txt, scenarios/**/*.sw, *.txt, test/language-snippets/**/*.sw
 
 source-repository head
     type:     git
@@ -107,6 +107,7 @@ library
                       Swarm.Language.Elaborate
                       Swarm.Language.LSP
                       Swarm.Language.LSP.Hover
+                      Swarm.Language.LSP.VarUsage
                       Swarm.Language.Parse
                       Swarm.Language.Parse.QQ
                       Swarm.Language.Pipeline
@@ -230,6 +231,7 @@ test-suite swarm-unit
                       TestNotification
                       TestLanguagePipeline
                       TestPretty
+                      TestLSP
                       TestUtil
 
     build-depends:    tasty                         >= 0.10 && < 1.5,

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -22,6 +22,7 @@ import Test.Tasty.QuickCheck (
  )
 import TestEval (testEval)
 import TestInventory (testInventory)
+import TestLSP (testLSP)
 import TestLanguagePipeline (testLanguagePipeline)
 import TestModel (testModel)
 import TestNotification (testNotification)
@@ -46,6 +47,7 @@ tests g =
     , testInventory
     , testNotification g
     , testMisc
+    , testLSP
     ]
 
 testMisc :: TestTree

--- a/test/unit/TestLSP.hs
+++ b/test/unit/TestLSP.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | LSP unit tests
+module TestLSP (testLSP) where
+
+import Data.Text (Text)
+import Data.Text.IO qualified as TIO
+import Swarm.Language.LSP.VarUsage qualified as VU
+import Swarm.Language.Parse (readTerm')
+import Swarm.Language.Syntax qualified as S
+import System.FilePath ((</>))
+import Test.Tasty
+import Test.Tasty.HUnit
+
+baseTestPath :: FilePath
+baseTestPath = "data/test/language-snippets/warnings/unused-vars"
+
+data UnusedVar = UnusedVar S.Var VU.BindingType
+  deriving (Eq, Show)
+
+simplifyWarning :: VU.VarUsage -> UnusedVar
+simplifyWarning (VU.VarUsage (S.LV _ v) scope) = UnusedVar v scope
+
+testLSP :: TestTree
+testLSP =
+  testGroup
+    "Unused variable warnings"
+    [ testCase "outer lambda" $
+        checkFile "multiple-lambda-first-unused.sw" $
+          pure $
+            UnusedVar "x" VU.Lambda
+    , testCase "inner lambda" $
+        checkFile "multiple-lambda-second-unused.sw" $
+          pure $
+            UnusedVar "y" VU.Lambda
+    , testCase "shadowed variable name" $
+        checkFile "shadowed-variable-lambda-unused.sw" $
+          pure $
+            UnusedVar "x" VU.Lambda
+    , testCase "outer let" $
+        checkFile "multiple-let-first-unused.sw" $
+          pure $
+            UnusedVar "x" VU.Let
+    , testCase "outer let" $
+        checkFile "multiple-let-second-unused.sw" $
+          pure $
+            UnusedVar "y" VU.Let
+    , testCase "multiple unused let" $
+        checkFile
+          "multiple-let-all-unused.sw"
+          [UnusedVar "x" VU.Let, UnusedVar "y" VU.Let]
+    , testCase "shadowed let without usage" $
+        checkFile
+          "shadowed-variable-let-unused.sw"
+          [UnusedVar "x" VU.Let]
+    , testCase "shadowed let with intermediate usage" $
+        checkFile
+          "shadowed-variable-let-intermediate-use.sw"
+          []
+    , testCase "recursive let" $
+        checkFile
+          "recursive-let.sw"
+          [UnusedVar "fac" VU.Let]
+    , testCase "single unused bind" $
+        checkFile
+          "single-bind-unused.sw"
+          [UnusedVar "x" VU.Bind]
+    , testCase "single used bind" $
+        checkFile
+          "single-bind-used.sw"
+          []
+    ]
+ where
+  checkFile :: FilePath -> [UnusedVar] -> IO ()
+  checkFile filename expectedWarnings = do
+    content <- TIO.readFile fullPath
+    let actualWarnings = getWarnings content
+    assertEqual "failed" expectedWarnings actualWarnings
+   where
+    fullPath = baseTestPath </> filename
+
+  getWarnings :: Text -> [UnusedVar]
+  getWarnings content =
+    case readTerm' content of
+      Right (Just term) -> map simplifyWarning problems
+       where
+        VU.Usage _ problems = VU.getUsage mempty term
+      _ -> []

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -249,7 +249,7 @@ testLanguagePipeline =
  where
   valid = flip process ""
 
-  roundTrip txt = assertEqual "rountrip" term (decodeThrow $ encode term)
+  roundTrip txt = assertEqual "roundtrip" term (decodeThrow $ encode term)
    where
     decodeThrow v = case eitherDecode v of
       Left e -> error $ "Decoding of " <> from (T.decodeUtf8 (from v)) <> " failed with: " <> from e


### PR DESCRIPTION
Closes #863.

Implements unused variable checking for `Let`, `Lambda`, and `Bind`.

Also:
* Now distinguishes between parsing errors and warnings via red vs. yellow squigglies in VS Code.
* Added unit tests

![Screenshot from 2023-01-09 13-08-28](https://user-images.githubusercontent.com/261693/211409652-4385ae52-3cec-4dfe-b78f-a2cc4b2d7cd3.png)