### PR TITLE
Improve OnHover for Def/Let, App and Const

### DIFF
--- a/src/Swarm/Language/LSP/Hover.hs
+++ b/src/Swarm/Language/LSP/Hover.hs
@@ -195,8 +195,10 @@ explain len trm = case trm ^. sTerm of
   TRef {} -> pure $ pureDoc "A memory reference.  These likewise never show up in surface syntax but are here to facilitate pretty-printing."
   TRequireDevice {} -> pure $ pureDoc "Require a specific device to be equipped."
   TRequire {} -> pure $ pureDoc "Require a certain number of an entity."
-  TVar v -> pure $ pureDoc $ "`" <> v <> ": " <> prettyType ty <> "`"
-  SLam (LV _s v) _mType _syn -> pure . pureDoc $ "A lambda expression binding the variable " <> U.bquote v <> "."
+  TVar v -> pure $ pureDoc $ typeSignature len v ty ""
+  SLam (LV _s v) _mType _syn -> pure . pureDoc $
+    typeSignature len v ty $
+    "A lambda expression binding the variable " <> U.bquote v <> "."
   SApp _ _ -> explainFunction len trm
   SLet isRecursive var mTypeAnn rhs _b -> pure $ explainDefinition len False isRecursive var (rhs ^. sType) mTypeAnn
   SDef isRecursive var mTypeAnn rhs -> pure $ explainDefinition len True isRecursive var (rhs ^. sType) mTypeAnn

--- a/src/Swarm/Language/LSP/Hover.hs
+++ b/src/Swarm/Language/LSP/Hover.hs
@@ -201,8 +201,13 @@ explain trm = case trm ^. sTerm of
   SDelay {} ->
     pure . T.unlines $
       [ "Delay evaluation of a term, written `{...}`."
+      , ""
       , "Swarm is an eager language, but in some cases (e.g. for `if` statements and recursive bindings) we need to delay evaluation."
-      , "The counterpart to `{...}` is `force`, where `force {t} = t`."
+      , ""
+      , "The counterpart to `{...}` is `force`:"
+      , "```"
+      , "force {t} = t"
+      , "```"
       ]
   -- internal syntax that should not actually show in hover
   TRef {} -> internal "A memory reference."

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -33,6 +33,7 @@ module Swarm.Language.Parse (
   showShortError,
   showErrorPos,
   getLocRange,
+  unTuple,
 ) where
 
 import Control.Lens (view, (^.))
@@ -296,6 +297,11 @@ mkTuple [x] = x
 mkTuple (x : xs) = let r = mkTuple xs in loc x r $ SPair x r
  where
   loc a b = Syntax $ (a ^. sLoc) <> (b ^. sLoc)
+
+unTuple :: Syntax' ty -> [Syntax' ty]
+unTuple = \case
+  Syntax' _ (SPair s1 s2) _ -> s1 : unTuple s2
+  s -> [s]
 
 -- | Construct an 'SLet', automatically filling in the Boolean field
 --   indicating whether it is recursive.

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -76,6 +76,7 @@ module Swarm.Language.Syntax (
   Term,
   mkOp,
   mkOp',
+  unfoldApps,
 
   -- * Erasure
   erase,
@@ -96,6 +97,8 @@ import Data.Data (Data)
 import Data.Data.Lens (uniplate)
 import Data.Hashable (Hashable)
 import Data.List qualified as L (tail)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as M
 import Data.Set qualified as S
 import Data.String (IsString (fromString))
@@ -785,6 +788,14 @@ constInfo c = case c of
 
   lowShow :: Show a => a -> Text
   lowShow a = toLower (from (show a))
+
+-- | Turn function application chain into a list.
+-- >>> unfoldApps (mkOp' Mul (TInt 1) (TInt 2)) -- 1 * 2
+-- TConst Mul :| [TInt 1,TInt 2]
+unfoldApps :: Term -> NonEmpty Term
+unfoldApps trm = NonEmpty.reverse . flip NonEmpty.unfoldr trm $ \case
+  SApp (Syntax _ t1) (Syntax _ t2) -> (t2, Just t1)
+  t -> (t, Nothing)
 
 ------------------------------------------------------------
 -- Basic terms

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -790,15 +790,6 @@ constInfo c = case c of
   lowShow :: Show a => a -> Text
   lowShow a = toLower (from (show a))
 
--- | Turn function application chain into a list.
--- >>> sWrap f = fmap (^. sTerm) . f . Syntax NoLoc
--- >>> sWrap unfoldApps (mkOp' Mul (TInt 1) (TInt 2)) -- 1 * 2
--- TConst Mul :| [TInt 1,TInt 2]
-unfoldApps :: Syntax' ty -> NonEmpty (Syntax' ty)
-unfoldApps trm = NonEmpty.reverse . flip NonEmpty.unfoldr trm $ \case
-  Syntax' _ (SApp s1 s2) _ -> (s2, Just s1)
-  s -> (s, Nothing)
-
 ------------------------------------------------------------
 -- Basic terms
 ------------------------------------------------------------
@@ -1013,6 +1004,19 @@ mkOp c s1@(Syntax l1 _) s2@(Syntax l2 _) = Syntax newLoc newTerm
 -- | Make infix operation, discarding any syntax related location
 mkOp' :: Const -> Term -> Term -> Term
 mkOp' c t1 = TApp (TApp (TConst c) t1)
+
+-- $setup
+-- >>> import Control.Lens ((^.))
+
+-- | Turn function application chain into a list.
+--
+-- >>> syntaxWrap f = fmap (^. sTerm) . f . Syntax NoLoc
+-- >>> syntaxWrap unfoldApps (mkOp' Mul (TInt 1) (TInt 2)) -- 1 * 2
+-- TConst Mul :| [TInt 1,TInt 2]
+unfoldApps :: Syntax' ty -> NonEmpty (Syntax' ty)
+unfoldApps trm = NonEmpty.reverse . flip NonEmpty.unfoldr trm $ \case
+  Syntax' _ (SApp s1 s2) _ -> (s2, Just s1)
+  s -> (s, Nothing)
 
 --------------------------------------------------
 -- Erasure

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -87,6 +87,7 @@ module Swarm.Language.Syntax (
   freeVarsT,
   freeVarsV,
   mapFreeS,
+  locVarToSyntax',
 ) where
 
 import Control.Arrow (Arrow ((&&&)))
@@ -790,12 +791,13 @@ constInfo c = case c of
   lowShow a = toLower (from (show a))
 
 -- | Turn function application chain into a list.
--- >>> unfoldApps (mkOp' Mul (TInt 1) (TInt 2)) -- 1 * 2
+-- >>> sWrap f = fmap (^. sTerm) . f . Syntax NoLoc
+-- >>> sWrap unfoldApps (mkOp' Mul (TInt 1) (TInt 2)) -- 1 * 2
 -- TConst Mul :| [TInt 1,TInt 2]
-unfoldApps :: Term -> NonEmpty Term
+unfoldApps :: Syntax' ty -> NonEmpty (Syntax' ty)
 unfoldApps trm = NonEmpty.reverse . flip NonEmpty.unfoldr trm $ \case
-  SApp (Syntax _ t1) (Syntax _ t2) -> (t2, Just t1)
-  t -> (t, Nothing)
+  Syntax' _ (SApp s1 s2) _ -> (s2, Just s1)
+  s -> (s, Nothing)
 
 ------------------------------------------------------------
 -- Basic terms
@@ -823,6 +825,9 @@ data DelayType
 --   wrapped in a Syntax node, so we don't need LocVar for those.)
 data LocVar = LV {lvSrcLoc :: SrcLoc, lvVar :: Var}
   deriving (Eq, Ord, Show, Data, Generic, FromJSON, ToJSON)
+
+locVarToSyntax' :: LocVar -> ty -> Syntax' ty
+locVarToSyntax' (LV s v) = Syntax' s (TVar v)
 
 -- | Terms of the Swarm language.
 data Term' ty

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- | Swarm unit tests
 module TestLanguagePipeline where


### PR DESCRIPTION
* unfold function application and tuples
* add type signatures to syntax using #990 
* show hovered variable definition name using #993
* fix indenting for multiline text

- closes #985 