### PR TITLE
Scenario launch options selection

### DIFF
--- a/src/Swarm/Game/Scenario/Status.hs
+++ b/src/Swarm/Game/Scenario/Status.hs
@@ -32,8 +32,8 @@ import Swarm.Util.Lens (makeLensesNoSigs)
 --
 -- Type parameters are utilized to support all of these use cases.
 data ParameterizableLaunchParams code f = LaunchParams
-  { seedVal :: a (Maybe Seed)
-  , initialCode :: a (Maybe b)
+  { seedVal :: f (Maybe Seed)
+  , initialCode :: f (Maybe code)
   }
 
 type SerializableLaunchParams = ParameterizableLaunchParams FilePath Identity
@@ -116,7 +116,7 @@ updateScenarioInfoOnFinish
   si@(ScenarioInfo p prevPlayState) = case prevPlayState of
     Played launchParams (Metric _ (ProgressStats start _currentPlayMetrics)) prevBestRecords ->
       ScenarioInfo p $
-        Played initialScript newPlayMetric $
+        Played launchParams newPlayMetric $
           updateBest newPlayMetric prevBestRecords
      where
       el = (diffUTCTime `on` zonedTimeToUTC) z start

--- a/src/Swarm/Game/Scenario/Status.hs
+++ b/src/Swarm/Game/Scenario/Status.hs
@@ -51,8 +51,8 @@ deriving instance ToJSON SerializableLaunchParams
 data ScenarioStatus
   = NotStarted
   | Played
+      -- | initial seed and script to run
       SerializableLaunchParams
-      -- ^ initial seed and script to run
       ProgressMetric
       BestRecords
   deriving (Eq, Ord, Show, Read, Generic)

--- a/src/Swarm/Game/Scenario/Status.hs
+++ b/src/Swarm/Game/Scenario/Status.hs
@@ -51,7 +51,6 @@ deriving instance ToJSON SerializableLaunchParams
 data ScenarioStatus
   = NotStarted
   | Played
-      -- | initial seed and script to run
       SerializableLaunchParams
       ProgressMetric
       BestRecords

--- a/src/Swarm/Game/Scenario/Status.hs
+++ b/src/Swarm/Game/Scenario/Status.hs
@@ -114,7 +114,7 @@ updateScenarioInfoOnFinish
   ticks
   completed
   si@(ScenarioInfo p prevPlayState) = case prevPlayState of
-    Played initialScript (Metric _ (ProgressStats start _currentPlayMetrics)) prevBestRecords ->
+    Played launchParams (Metric _ (ProgressStats start _currentPlayMetrics)) prevBestRecords ->
       ScenarioInfo p $
         Played initialScript newPlayMetric $
           updateBest newPlayMetric prevBestRecords

--- a/src/Swarm/Game/Scenario/Status.hs
+++ b/src/Swarm/Game/Scenario/Status.hs
@@ -31,7 +31,7 @@ import Swarm.Util.Lens (makeLensesNoSigs)
 -- * Carrying fully-validated launch parameters.
 --
 -- Type parameters are utilized to support all of these use cases.
-data ParameterizableLaunchParams b a = LaunchParms
+data ParameterizableLaunchParams code f = LaunchParms
   { seedVal :: a (Maybe Seed)
   , initialCode :: a (Maybe b)
   }

--- a/src/Swarm/Game/Scenario/Status.hs
+++ b/src/Swarm/Game/Scenario/Status.hs
@@ -31,19 +31,19 @@ import Swarm.Util.Lens (makeLensesNoSigs)
 -- * Carrying fully-validated launch parameters.
 --
 -- Type parameters are utilized to support all of these use cases.
-data ParameterizableLaunchParams code f = LaunchParms
+data ParameterizableLaunchParams code f = LaunchParams
   { seedVal :: a (Maybe Seed)
   , initialCode :: a (Maybe b)
   }
 
-type SerializableLaunchParms = ParameterizableLaunchParams FilePath Identity
-deriving instance Eq SerializableLaunchParms
-deriving instance Ord SerializableLaunchParms
-deriving instance Show SerializableLaunchParms
-deriving instance Read SerializableLaunchParms
-deriving instance Generic SerializableLaunchParms
-deriving instance FromJSON SerializableLaunchParms
-deriving instance ToJSON SerializableLaunchParms
+type SerializableLaunchParams = ParameterizableLaunchParams FilePath Identity
+deriving instance Eq SerializableLaunchParams
+deriving instance Ord SerializableLaunchParams
+deriving instance Show SerializableLaunchParams
+deriving instance Read SerializableLaunchParams
+deriving instance Generic SerializableLaunchParams
+deriving instance FromJSON SerializableLaunchParams
+deriving instance ToJSON SerializableLaunchParams
 
 -- | A "ScenarioStatus" stores the status of a scenario along with
 --   appropriate metadata: "NotStarted", or "Played".
@@ -51,7 +51,7 @@ deriving instance ToJSON SerializableLaunchParms
 data ScenarioStatus
   = NotStarted
   | Played
-      SerializableLaunchParms
+      SerializableLaunchParams
       -- ^ initial seed and script to run
       ProgressMetric
       BestRecords
@@ -64,9 +64,9 @@ instance ToJSON ScenarioStatus where
   toEncoding = genericToEncoding scenarioOptions
   toJSON = genericToJSON scenarioOptions
 
-getLaunchParams :: ScenarioStatus -> SerializableLaunchParms
+getLaunchParams :: ScenarioStatus -> SerializableLaunchParams
 getLaunchParams = \case
-  NotStarted -> LaunchParms (pure Nothing) (pure Nothing)
+  NotStarted -> LaunchParams (pure Nothing) (pure Nothing)
   Played x _ _ -> x
 
 -- | A "ScenarioInfo" record stores metadata about a scenario: its

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -790,7 +790,7 @@ focusedRange g = computedRange <$ focusedRobot g
   (minRadius, maxRadius) = over both (gain baseInv . gain focInv) (16, 64)
 
 -- | Clear the 'robotLogUpdated' flag of the focused robot.
-clearFocusedRobotLogUpdated :: Has (State GameState) sig m => m ()
+clearFocusedRobotLogUpdated :: (Has (State GameState) sig m) => m ()
 clearFocusedRobotLogUpdated = do
   n <- use focusedRobotID
   robotMap . ix n . robotLogUpdated .= False
@@ -799,7 +799,7 @@ clearFocusedRobotLogUpdated = do
 --   first, generate a unique ID number for it.  Then, add it to the
 --   main robot map, the active robot set, and to to the index of
 --   robots by location. Return the updated robot.
-addTRobot :: Has (State GameState) sig m => TRobot -> m Robot
+addTRobot :: (Has (State GameState) sig m) => TRobot -> m Robot
 addTRobot r = do
   rid <- gensym <+= 1
   let r' = instantiateRobot rid r
@@ -809,7 +809,7 @@ addTRobot r = do
 -- | Add a robot to the game state, adding it to the main robot map,
 --   the active robot set, and to to the index of robots by
 --   location.
-addRobot :: Has (State GameState) sig m => Robot -> m ()
+addRobot :: (Has (State GameState) sig m) => Robot -> m ()
 addRobot r = do
   let rid = r ^. robotID
 
@@ -822,7 +822,7 @@ maxMessageQueueSize :: Int
 maxMessageQueueSize = 1000
 
 -- | Add a message to the message queue.
-emitMessage :: Has (State GameState) sig m => LogEntry -> m ()
+emitMessage :: (Has (State GameState) sig m) => LogEntry -> m ()
 emitMessage msg = messageQueue %= (|> msg) . dropLastIfLong
  where
   tooLong s = Seq.length s >= maxMessageQueueSize
@@ -831,23 +831,23 @@ emitMessage msg = messageQueue %= (|> msg) . dropLastIfLong
 
 -- | Takes a robot out of the activeRobots set and puts it in the waitingRobots
 --   queue.
-sleepUntil :: Has (State GameState) sig m => RID -> TickNumber -> m ()
+sleepUntil :: (Has (State GameState) sig m) => RID -> TickNumber -> m ()
 sleepUntil rid time = do
   internalActiveRobots %= IS.delete rid
   internalWaitingRobots . at time . non [] %= (rid :)
 
 -- | Takes a robot out of the activeRobots set.
-sleepForever :: Has (State GameState) sig m => RID -> m ()
+sleepForever :: (Has (State GameState) sig m) => RID -> m ()
 sleepForever rid = internalActiveRobots %= IS.delete rid
 
 -- | Adds a robot to the activeRobots set.
-activateRobot :: Has (State GameState) sig m => RID -> m ()
+activateRobot :: (Has (State GameState) sig m) => RID -> m ()
 activateRobot rid = internalActiveRobots %= IS.insert rid
 
 -- | Removes robots whose wake up time matches the current game ticks count
 --   from the waitingRobots queue and put them back in the activeRobots set
 --   if they still exist in the keys of robotMap.
-wakeUpRobotsDoneSleeping :: Has (State GameState) sig m => m ()
+wakeUpRobotsDoneSleeping :: (Has (State GameState) sig m) => m ()
 wakeUpRobotsDoneSleeping = do
   time <- use ticks
   mrids <- internalWaitingRobots . at time <<.= Nothing
@@ -865,7 +865,7 @@ wakeUpRobotsDoneSleeping = do
 -- | Clear the "watch" state of all of the
 -- awakened robots
 clearWatchingRobots ::
-  Has (State GameState) sig m =>
+  (Has (State GameState) sig m) =>
   [RID] ->
   m ()
 clearWatchingRobots rids = do
@@ -876,7 +876,7 @@ clearWatchingRobots rids = do
 --
 -- NOTE: Clearing "TickNumber" map entries from "internalWaitingRobots"
 -- upon wakeup is handled by "wakeUpRobotsDoneSleeping" in State.hs
-wakeWatchingRobots :: Has (State GameState) sig m => Location -> m ()
+wakeWatchingRobots :: (Has (State GameState) sig m) => Location -> m ()
 wakeWatchingRobots loc = do
   currentTick <- use ticks
   waitingMap <- use waitingRobots
@@ -929,7 +929,7 @@ wakeWatchingRobots loc = do
       Waiting _ c -> Waiting newWakeTime c
       x -> x
 
-deleteRobot :: Has (State GameState) sig m => RID -> m ()
+deleteRobot :: (Has (State GameState) sig m) => RID -> m ()
 deleteRobot rn = do
   internalActiveRobots %= IS.delete rn
   mrobot <- robotMap . at rn <<.= Nothing

--- a/src/Swarm/TUI/Attr.hs
+++ b/src/Swarm/TUI/Attr.hs
@@ -44,11 +44,13 @@ module Swarm.TUI.Attr (
   greenAttr,
   redAttr,
   defAttr,
+  customEditFocusedAttr,
 ) where
 
 import Brick
 import Brick.Forms
 import Brick.Widgets.Dialog
+import Brick.Widgets.Edit qualified as E
 import Brick.Widgets.List
 import Data.Bifunctor (bimap)
 import Data.Text (unpack)
@@ -77,6 +79,7 @@ swarmAttrMap =
            (highlightAttr, fg V.cyan)
          , (invalidFormInputAttr, fg V.red)
          , (focusedFormInputAttr, V.defAttr)
+         , (customEditFocusedAttr, V.black `on` V.yellow)
          , (listSelectedFocusedAttr, bg V.blue)
          , (infoAttr, fg (V.rgbColor @Int 50 50 50))
          , (buttonSelectedAttr, bg V.blue)
@@ -167,6 +170,9 @@ infoAttr = attrName "info"
 boldAttr = attrName "bold"
 dimAttr = attrName "dim"
 defAttr = attrName "def"
+
+customEditFocusedAttr :: AttrName
+customEditFocusedAttr = attrName "custom" <> E.editFocusedAttr
 
 -- | Some basic colors used in TUI.
 redAttr, greenAttr, blueAttr, yellowAttr, cyanAttr, lightCyanAttr, magentaAttr :: AttrName

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -93,6 +93,9 @@ import Swarm.Language.Types
 import Swarm.Language.Value (Value (VKey, VUnit), prettyValue, stripVResult)
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Inventory.Sorting (cycleSortDirection, cycleSortOrder)
+import Swarm.TUI.Launch.Controller
+import Swarm.TUI.Launch.Model
+import Swarm.TUI.Launch.Prep (prepareLaunchDialog)
 import Swarm.TUI.List
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Goal
@@ -133,7 +136,12 @@ handleEvent = \case
           -- quitGame function would have already halted the app).
           NoMenu -> const halt
           MainMenu l -> handleMainMenuEvent l
-          NewGameMenu l -> handleNewGameMenuEvent l
+          NewGameMenu l ->
+            if s ^. uiState . uiLaunchConfig . controls . fileBrowser . fbIsDisplayed
+              then handleFBEvent
+              else case s ^. uiState . uiLaunchConfig . controls . isDisplayedFor of
+                Nothing -> handleNewGameMenuEvent l
+                Just siPair -> handleLaunchOptionsEvent siPair
           MessagesMenu -> handleMainMessagesEvent
           AchievementsMenu l -> handleMainAchievementsEvent l
           AboutMenu -> pressAnyKey (MainMenu (mainMenu About))
@@ -222,7 +230,10 @@ handleMainMessagesEvent = \case
  where
   returnToMainMenu = uiState . uiMenu .= MainMenu (mainMenu Messages)
 
-handleNewGameMenuEvent :: NonEmpty (BL.List Name ScenarioItem) -> BrickEvent Name AppEvent -> EventM Name AppState ()
+handleNewGameMenuEvent ::
+  NonEmpty (BL.List Name ScenarioItem) ->
+  BrickEvent Name AppEvent ->
+  EventM Name AppState ()
 handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
   Key V.KEnter ->
     case snd <$> BL.listSelectedElement curMenu of
@@ -231,6 +242,8 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
       Just (SICollection _ c) -> do
         cheat <- use $ uiState . uiCheatMode
         uiState . uiMenu .= NewGameMenu (NE.cons (mkScenarioList cheat c) scenarioStack)
+  CharKey 'o' -> showLaunchDialog
+  CharKey 'O' -> showLaunchDialog
   Key V.KEsc -> exitNewGameMenu scenarioStack
   CharKey 'q' -> exitNewGameMenu scenarioStack
   ControlChar 'q' -> halt
@@ -238,6 +251,10 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
     menu' <- nestEventM' curMenu (handleListEvent ev)
     uiState . uiMenu .= NewGameMenu (menu' :| rest)
   _ -> continueWithoutRedraw
+ where
+  showLaunchDialog = case snd <$> BL.listSelectedElement curMenu of
+    Just (SISingle siPair) -> Brick.zoom (uiState . uiLaunchConfig) $ prepareLaunchDialog siPair
+    _ -> continueWithoutRedraw
 
 exitNewGameMenu :: NonEmpty (BL.List Name ScenarioItem) -> EventM Name AppState ()
 exitNewGameMenu stk = do
@@ -460,7 +477,7 @@ getNormalizedCurrentScenarioPath =
 
 saveScenarioInfoOnFinish :: (MonadIO m, MonadState AppState m) => FilePath -> m (Maybe ScenarioInfo)
 saveScenarioInfoOnFinish p = do
-  initialCode <- use $ gameState . initiallyRunCode
+  initialRunCode <- use $ gameState . initiallyRunCode
   t <- liftIO getZonedTime
   wc <- use $ gameState . winCondition
   let won = case wc of
@@ -475,7 +492,7 @@ saveScenarioInfoOnFinish p = do
       currentScenarioInfo = runtimeState . scenarios . scenarioItemByPath p . _SISingle . _2
 
   replHist <- use $ uiState . uiREPL . replHistory
-  let determinator = CodeSizeDeterminators initialCode $ replHist ^. replHasExecutedManualInput
+  let determinator = CodeSizeDeterminators initialRunCode $ replHist ^. replHasExecutedManualInput
   currentScenarioInfo
     %= updateScenarioInfoOnFinish determinator t ts won
   status <- preuse currentScenarioInfo

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -1050,14 +1050,14 @@ handleREPLEventPiloting x = case x of
       & replPromptText .~ nt
       & replPromptType .~ CmdPrompt []
 
-runBaseWebCode :: MonadState AppState m => T.Text -> m ()
+runBaseWebCode :: (MonadState AppState m) => T.Text -> m ()
 runBaseWebCode uinput = do
   s <- get
   let topCtx = topContext s
   unless (s ^. gameState . replWorking) $
     runBaseCode topCtx uinput
 
-runBaseCode :: MonadState AppState m => RobotContext -> T.Text -> m ()
+runBaseCode :: (MonadState AppState m) => RobotContext -> T.Text -> m ()
 runBaseCode topCtx uinput =
   case processTerm' (topCtx ^. defTypes) (topCtx ^. defReqs) uinput of
     Right mt -> do
@@ -1068,7 +1068,7 @@ runBaseCode topCtx uinput =
     Left err -> do
       uiState . uiError ?= err
 
-runBaseTerm :: MonadState AppState m => RobotContext -> Maybe ProcessedTerm -> m ()
+runBaseTerm :: (MonadState AppState m) => RobotContext -> Maybe ProcessedTerm -> m ()
 runBaseTerm topCtx =
   modify . maybe id startBaseProgram
  where
@@ -1270,7 +1270,7 @@ adjReplHistIndex d s =
 worldScrollDist :: Int32
 worldScrollDist = 8
 
-onlyCreative :: MonadState AppState m => m () -> m ()
+onlyCreative :: (MonadState AppState m) => m () -> m ()
 onlyCreative a = do
   c <- use $ gameState . creativeMode
   when c a

--- a/src/Swarm/TUI/Launch/Controller.hs
+++ b/src/Swarm/TUI/Launch/Controller.hs
@@ -16,7 +16,7 @@ import Graphics.Vty qualified as V
 import Swarm.Game.ScenarioInfo
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Launch.Model
-import Swarm.TUI.Launch.Prep (initFileBrowserWidget, makeFocusRingWith, parseWidgetParms, toValidatedParms)
+import Swarm.TUI.Launch.Prep (initFileBrowserWidget, makeFocusRingWith, parseWidgetParams, toValidatedParams)
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.StateUpdate
@@ -26,12 +26,12 @@ import Swarm.Util (listEnums)
 cacheValidatedInputs :: EventM Name AppState ()
 cacheValidatedInputs = do
   launchControls <- use $ uiState . uiLaunchConfig . controls
-  parsedParams <- liftIO $ parseWidgetParms launchControls
+  parsedParams <- liftIO $ parseWidgetParams launchControls
   uiState . uiLaunchConfig . editingParams .= parsedParams
 
   currentRing <- use $ uiState . uiLaunchConfig . controls . scenarioConfigFocusRing
 
-  let eitherLaunchParams = toValidatedParms parsedParams
+  let eitherLaunchParams = toValidatedParams parsedParams
       modifyRingMembers = case eitherLaunchParams of
         Left _ -> filter (/= StartGameButton)
         Right _ -> id
@@ -147,7 +147,7 @@ handleLaunchOptionsEvent siPair = \case
       uiState . uiLaunchConfig . controls . fileBrowser . fbIsDisplayed .= True
     StartGameButton -> do
       params <- use $ uiState . uiLaunchConfig . editingParams
-      let eitherLaunchParams = toValidatedParms params
+      let eitherLaunchParams = toValidatedParams params
       forM_ eitherLaunchParams $ \launchParams -> do
         closeModal
         startGameWithSeed siPair launchParams

--- a/src/Swarm/TUI/Launch/Controller.hs
+++ b/src/Swarm/TUI/Launch/Controller.hs
@@ -1,0 +1,155 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Event handling for the scenario launch configuration dialog.
+module Swarm.TUI.Launch.Controller where
+
+import Brick hiding (Direction, Location)
+import Brick.Focus
+import Brick.Widgets.Edit (handleEditorEvent)
+import Brick.Widgets.FileBrowser
+import Brick.Widgets.FileBrowser qualified as FB
+import Control.Lens
+import Control.Monad.Except (forM_, liftIO, when)
+import Data.Maybe (listToMaybe)
+import Graphics.Vty qualified as V
+import Swarm.Game.ScenarioInfo
+import Swarm.TUI.Controller.Util
+import Swarm.TUI.Launch.Model
+import Swarm.TUI.Launch.Prep (initFileBrowserWidget, makeFocusRingWith, parseWidgetParms, toValidatedParms)
+import Swarm.TUI.Model
+import Swarm.TUI.Model.Name
+import Swarm.TUI.Model.StateUpdate
+import Swarm.TUI.Model.UI
+import Swarm.Util (listEnums)
+
+cacheValidatedInputs :: EventM Name AppState ()
+cacheValidatedInputs = do
+  launchControls <- use $ uiState . uiLaunchConfig . controls
+  parsedParams <- liftIO $ parseWidgetParms launchControls
+  uiState . uiLaunchConfig . editingParams .= parsedParams
+
+  currentRing <- use $ uiState . uiLaunchConfig . controls . scenarioConfigFocusRing
+
+  let eitherLaunchParams = toValidatedParms parsedParams
+      modifyRingMembers = case eitherLaunchParams of
+        Left _ -> filter (/= StartGameButton)
+        Right _ -> id
+      maybeCurrentFocus = focusGetCurrent currentRing
+      refocusRing = maybe id focusSetCurrent maybeCurrentFocus
+
+  uiState . uiLaunchConfig . controls . scenarioConfigFocusRing .= refocusRing (makeFocusRingWith $ modifyRingMembers listEnums)
+
+-- | If the FileBrowser is in "search mode", then we allow
+-- more of the key events to pass through. Otherwise,
+-- we intercept things like "q" (for quit) and Space (so that
+-- we can restrict file selection to at most one).
+handleFBEvent ::
+  BrickEvent Name AppEvent ->
+  EventM Name AppState ()
+handleFBEvent ev = do
+  fb <- use $ uiState . uiLaunchConfig . controls . fileBrowser . fbWidget
+  let isSearching = fileBrowserIsSearching fb
+  case (isSearching, ev) of
+    (False, Key V.KEsc) -> closeModal
+    (False, CharKey 'q') -> closeModal
+    (False, ControlChar 'q') -> closeModal
+    -- Intercept the "space" key so that it cannot be used to select files
+    -- (see note below).
+    (False, CharKey ' ') -> return ()
+    (_, VtyEvent e) -> do
+      (shouldClose, maybeSingleFile) <- Brick.zoom (uiState . uiLaunchConfig . controls . fileBrowser . fbWidget) $ do
+        handleFileBrowserEvent e
+        -- If the browser has a selected file after handling the
+        -- event (because the user pressed Enter), close the dialog.
+        case e of
+          V.EvKey V.KEnter [] -> do
+            b' <- get
+            case FB.fileBrowserSelection b' of
+              [] -> return (False, Nothing)
+              -- We only allow one file to be selected
+              -- by closing immediately.
+              -- This is a hack illustrated in the Brick FileBrowser demo:
+              -- https://github.com/jtdaugherty/brick/blob/4b40476d5d58c40720170d21503c11596bc9ee39/programs/FileBrowserDemo.hs#L68-L69
+              -- It is not foolproof on its own, so we also intercept
+              -- the "Space" key above.
+              xs -> return (True, FB.fileInfoFilePath <$> listToMaybe xs)
+          -- NOTE: The "Space" key also selects a file.
+          -- Apparently, even when directories are specified as
+          -- non-selectable via "FB.selectNonDirectories", the internal state
+          -- of the FileBrowser dialog
+          -- briefly adds a directory to its "fileBrowserSelection" list
+          -- when the "space" key is pressed.
+          -- So it is not enough to simply check whether the selection list
+          -- is nonempty after *any* keypress; we specifically have to listen for "Enter".
+          --
+          -- WARNING: There is still a bug when one presses the "space" key to mark
+          -- a directory, then presses "Enter" right afterward.
+          -- The directory will get selected, and then swarm will crash.
+          -- This is why we prevent the Space key from being handled by the FileBrowser
+          -- unless we are in file searching mode.
+          _ -> return (False, Nothing)
+
+      when shouldClose $ do
+        uiState . uiLaunchConfig . controls . fileBrowser . maybeSelectedFile .= maybeSingleFile
+        closeModal
+    _ -> return ()
+ where
+  closeModal = do
+    uiState . uiLaunchConfig . controls . fileBrowser . fbIsDisplayed .= False
+    cacheValidatedInputs
+
+handleLaunchOptionsEvent ::
+  ScenarioInfoPair ->
+  BrickEvent Name AppEvent ->
+  EventM Name AppState ()
+handleLaunchOptionsEvent siPair = \case
+  Key V.KBackTab ->
+    uiState . uiLaunchConfig . controls . scenarioConfigFocusRing %= focusPrev
+  Key V.KUp ->
+    uiState . uiLaunchConfig . controls . scenarioConfigFocusRing %= focusPrev
+  CharKey '\t' ->
+    uiState . uiLaunchConfig . controls . scenarioConfigFocusRing %= focusNext
+  Key V.KDown ->
+    uiState . uiLaunchConfig . controls . scenarioConfigFocusRing %= focusNext
+  MouseDown n _ _ _ ->
+    case n of
+      ScenarioConfigControl (ScenarioConfigPanelControl x) -> do
+        uiState . uiLaunchConfig . controls . scenarioConfigFocusRing %= focusSetCurrent n
+        activateFocusedControl x
+      _ -> return ()
+  CharKey ' ' -> activateControl
+  Key V.KEnter -> activateControl
+  Key V.KEsc -> closeModal
+  CharKey 'q' -> closeModal
+  ControlChar 'q' -> closeModal
+  ev -> do
+    fr <- use $ uiState . uiLaunchConfig . controls . scenarioConfigFocusRing
+    case focusGetCurrent fr of
+      Just (ScenarioConfigControl (ScenarioConfigPanelControl SeedSelector)) -> do
+        Brick.zoom (uiState . uiLaunchConfig . controls . seedValueEditor) (handleEditorEvent ev)
+        cacheValidatedInputs
+      _ -> return ()
+ where
+  activateControl = do
+    fr <- use $ uiState . uiLaunchConfig . controls . scenarioConfigFocusRing
+    case focusGetCurrent fr of
+      Just (ScenarioConfigControl (ScenarioConfigPanelControl item)) ->
+        activateFocusedControl item
+      _ -> return ()
+
+  activateFocusedControl item = case item of
+    SeedSelector -> return ()
+    ScriptSelector -> do
+      maybeSingleFile <- use $ uiState . uiLaunchConfig . controls . fileBrowser . maybeSelectedFile
+      configuredFB <- initFileBrowserWidget maybeSingleFile
+      uiState . uiLaunchConfig . controls . fileBrowser . fbWidget .= configuredFB
+      uiState . uiLaunchConfig . controls . fileBrowser . fbIsDisplayed .= True
+    StartGameButton -> do
+      params <- use $ uiState . uiLaunchConfig . editingParams
+      let eitherLaunchParams = toValidatedParms params
+      forM_ eitherLaunchParams $ \launchParams -> do
+        closeModal
+        startGameWithSeed siPair launchParams
+
+  closeModal = uiState . uiLaunchConfig . controls . isDisplayedFor .= Nothing

--- a/src/Swarm/TUI/Launch/Model.hs
+++ b/src/Swarm/TUI/Launch/Model.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Types for representing state of the launch dialog,
+-- along with conversion functions for validated launch parameters.
+module Swarm.TUI.Launch.Model where
+
+import Brick.Focus qualified as Focus
+import Brick.Widgets.Edit
+import Brick.Widgets.FileBrowser qualified as FB
+import Control.Lens (makeLenses)
+import Data.Functor.Identity (Identity (Identity))
+import Data.Text (Text)
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (LaunchParms), ScenarioInfoPair, SerializableLaunchParms)
+import Swarm.Game.State (CodeToRun, getRunCodePath, parseCodeFile)
+import Swarm.TUI.Model.Name
+
+type LaunchParms a = ParameterizableLaunchParams CodeToRun a
+
+-- | Use this to store error messages
+-- on individual fields
+type EditingLaunchParms = LaunchParms (Either Text)
+
+-- | In this stage in the UI pipeline, both fields
+-- have already been validated, and "Nothing" means
+-- that the field is simply absent.
+type ValidatedLaunchParms = LaunchParms Identity
+
+toSerializableParams :: ValidatedLaunchParms -> SerializableLaunchParms
+toSerializableParams (LaunchParms seedValue (Identity codeToRun)) =
+  LaunchParms seedValue $ pure $ getRunCodePath =<< codeToRun
+
+parseCode :: Maybe FilePath -> IO (Either Text (Maybe CodeToRun))
+parseCode maybeSelectedFile = case maybeSelectedFile of
+  Just codeFile -> do
+    eitherParsedCode <- parseCodeFile codeFile
+    return $ Just <$> eitherParsedCode
+  Nothing -> return $ Right Nothing
+
+fromSerializableParams :: SerializableLaunchParms -> IO EditingLaunchParms
+fromSerializableParams (LaunchParms (Identity maybeSeedValue) (Identity maybeCodePath)) = do
+  eitherCode <- parseCode maybeCodePath
+  return $ LaunchParms (Right maybeSeedValue) eitherCode
+
+data FileBrowserControl = FileBrowserControl
+  { _fbWidget :: FB.FileBrowser Name
+  , _maybeSelectedFile :: Maybe FilePath
+  , _fbIsDisplayed :: Bool
+  }
+
+makeLenses ''FileBrowserControl
+
+-- | UI elements to configure scenario launch options
+data LaunchControls = LaunchControls
+  { _fileBrowser :: FileBrowserControl
+  , _seedValueEditor :: Editor Text Name
+  , _scenarioConfigFocusRing :: Focus.FocusRing Name
+  , _isDisplayedFor :: Maybe ScenarioInfoPair
+  }
+
+makeLenses ''LaunchControls
+
+-- | UI elements to configure scenario launch options
+data LaunchOptions = LaunchOptions
+  { _controls :: LaunchControls
+  , _editingParams :: EditingLaunchParms
+  }
+
+makeLenses ''LaunchOptions

--- a/src/Swarm/TUI/Launch/Model.hs
+++ b/src/Swarm/TUI/Launch/Model.hs
@@ -14,24 +14,24 @@ import Brick.Widgets.FileBrowser qualified as FB
 import Control.Lens (makeLenses)
 import Data.Functor.Identity (Identity (Identity))
 import Data.Text (Text)
-import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (LaunchParms), ScenarioInfoPair, SerializableLaunchParms)
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (LaunchParams), ScenarioInfoPair, SerializableLaunchParams)
 import Swarm.Game.State (CodeToRun, getRunCodePath, parseCodeFile)
 import Swarm.TUI.Model.Name
 
-type LaunchParms a = ParameterizableLaunchParams CodeToRun a
+type LaunchParams a = ParameterizableLaunchParams CodeToRun a
 
 -- | Use this to store error messages
 -- on individual fields
-type EditingLaunchParms = LaunchParms (Either Text)
+type EditingLaunchParams = LaunchParams (Either Text)
 
 -- | In this stage in the UI pipeline, both fields
 -- have already been validated, and "Nothing" means
 -- that the field is simply absent.
-type ValidatedLaunchParms = LaunchParms Identity
+type ValidatedLaunchParams = LaunchParams Identity
 
-toSerializableParams :: ValidatedLaunchParms -> SerializableLaunchParms
-toSerializableParams (LaunchParms seedValue (Identity codeToRun)) =
-  LaunchParms seedValue $ pure $ getRunCodePath =<< codeToRun
+toSerializableParams :: ValidatedLaunchParams -> SerializableLaunchParams
+toSerializableParams (LaunchParams seedValue (Identity codeToRun)) =
+  LaunchParams seedValue $ pure $ getRunCodePath =<< codeToRun
 
 parseCode :: Maybe FilePath -> IO (Either Text (Maybe CodeToRun))
 parseCode maybeSelectedFile = case maybeSelectedFile of
@@ -40,10 +40,10 @@ parseCode maybeSelectedFile = case maybeSelectedFile of
     return $ Just <$> eitherParsedCode
   Nothing -> return $ Right Nothing
 
-fromSerializableParams :: SerializableLaunchParms -> IO EditingLaunchParms
-fromSerializableParams (LaunchParms (Identity maybeSeedValue) (Identity maybeCodePath)) = do
+fromSerializableParams :: SerializableLaunchParams -> IO EditingLaunchParams
+fromSerializableParams (LaunchParams (Identity maybeSeedValue) (Identity maybeCodePath)) = do
   eitherCode <- parseCode maybeCodePath
-  return $ LaunchParms (Right maybeSeedValue) eitherCode
+  return $ LaunchParams (Right maybeSeedValue) eitherCode
 
 data FileBrowserControl = FileBrowserControl
   { _fbWidget :: FB.FileBrowser Name
@@ -66,7 +66,7 @@ makeLenses ''LaunchControls
 -- | UI elements to configure scenario launch options
 data LaunchOptions = LaunchOptions
   { _controls :: LaunchControls
-  , _editingParams :: EditingLaunchParms
+  , _editingParams :: EditingLaunchParams
   }
 
 makeLenses ''LaunchOptions

--- a/src/Swarm/TUI/Launch/Prep.hs
+++ b/src/Swarm/TUI/Launch/Prep.hs
@@ -80,7 +80,7 @@ initConfigPanel = do
   ring = makeFocusRingWith listEnums
 
 initFileBrowserWidget ::
-  MonadIO m =>
+  (MonadIO m) =>
   Maybe FilePath ->
   m (FB.FileBrowser Name)
 initFileBrowserWidget maybePlayedScript = do

--- a/src/Swarm/TUI/Launch/Prep.hs
+++ b/src/Swarm/TUI/Launch/Prep.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- HLINT ignore "Use <$>" -}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Prepares and validates scenario launch parameters
+module Swarm.TUI.Launch.Prep where
+
+import Brick (EventM)
+import Brick.Focus qualified as Focus
+import Brick.Widgets.Edit
+import Brick.Widgets.FileBrowser qualified as FB
+import Control.Arrow (left)
+import Control.Lens ((.=), (^.))
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Functor.Identity (runIdentity)
+import Data.Text qualified as T
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (..), ScenarioInfoPair, getLaunchParams, scenarioStatus)
+import Swarm.Game.State (getRunCodePath)
+import Swarm.TUI.Launch.Model
+import Swarm.TUI.Model.Name
+import Swarm.Util (listEnums)
+import System.FilePath (takeDirectory)
+import Text.Read (readEither)
+
+swarmLangFileExtension :: String
+swarmLangFileExtension = "sw"
+
+toValidatedParms :: EditingLaunchParms -> Either T.Text ValidatedLaunchParms
+toValidatedParms (LaunchParms eitherSeedVal eitherInitialCode) = do
+  maybeSeed <- eitherSeedVal
+  maybeParsedCode <- eitherInitialCode
+  return $ LaunchParms (pure maybeSeed) (pure maybeParsedCode)
+
+parseWidgetParms :: LaunchControls -> IO EditingLaunchParms
+parseWidgetParms (LaunchControls (FileBrowserControl _fb maybeSelectedScript _) seedEditor _ _) = do
+  eitherParsedCode <- parseCode maybeSelectedScript
+  return $ LaunchParms eitherMaybeSeed eitherParsedCode
+ where
+  eitherMaybeSeed =
+    if T.null seedFieldText
+      then Right Nothing
+      else
+        fmap Just
+          . left T.pack
+          . readEither
+          . T.unpack
+          $ seedFieldText
+
+  seedFieldText = mconcat $ getEditContents seedEditor
+
+makeFocusRingWith :: [ScenarioConfigPanelFocusable] -> Focus.FocusRing Name
+makeFocusRingWith = Focus.focusRing . map (ScenarioConfigControl . ScenarioConfigPanelControl)
+
+initEditorWidget :: T.Text -> Editor T.Text Name
+initEditorWidget =
+  editorText
+    (ScenarioConfigControl $ ScenarioConfigPanelControl SeedSelector)
+    (Just 1) -- only allow a single line
+
+-- | Called before any particular scenario is selected, so we
+-- supply some "Nothing"s as defaults to the "ValidatedLaunchParms".
+initConfigPanel :: IO LaunchOptions
+initConfigPanel = do
+  -- NOTE: This is kind of pointless, because we must re-instantiate the FileBrowser
+  -- when it is first displayed, anyway.
+  fb <-
+    FB.newFileBrowser
+      FB.selectNonDirectories
+      (ScenarioConfigControl $ ScenarioConfigPanelControl ScriptSelector)
+      Nothing -- Initial working directory to display
+  return $
+    LaunchOptions
+      (LaunchControls (FileBrowserControl fb Nothing False) myForm ring Nothing)
+      (LaunchParms (Right Nothing) (Right Nothing))
+ where
+  myForm = initEditorWidget ""
+  ring = makeFocusRingWith listEnums
+
+initFileBrowserWidget ::
+  MonadIO m =>
+  Maybe FilePath ->
+  m (FB.FileBrowser Name)
+initFileBrowserWidget maybePlayedScript = do
+  fb <-
+    liftIO $
+      FB.newFileBrowser
+        FB.selectNonDirectories
+        (ScenarioConfigControl $ ScenarioConfigPanelControl ScriptSelector)
+        (takeDirectory <$> maybePlayedScript) -- Initial working directory to display
+  return $ FB.setFileBrowserEntryFilter (Just $ FB.fileExtensionMatch swarmLangFileExtension) fb
+
+-- | If the selected scenario has been launched with an initial script before,
+-- set the file browser to initially open that script's directory.
+-- Then set the launch dialog to be displayed.
+--
+-- Note that the FileBrowser widget normally allows multiple selections ("marked" files).
+-- However, there do not exist any public "setters" set the marked files, so we have
+-- some workarounds:
+-- * When the user marks the first file, we immediately close the FileBrowser widget.
+-- * We re-instantiate the FileBrowser from scratch every time it is opened, so that
+--   it is not possible to mark more than one file.
+-- * The "marked file" is persisted outside of the FileBrowser state, and the
+--   "initial directory" is set upon instantiation from that external state.
+prepareLaunchDialog ::
+  ScenarioInfoPair ->
+  EventM Name LaunchOptions ()
+prepareLaunchDialog siPair@(_, si) = do
+  let serializableLaunchParams = getLaunchParams $ si ^. scenarioStatus
+  launchEditingParams <- liftIO $ fromSerializableParams serializableLaunchParams
+  editingParams .= launchEditingParams
+
+  let maybePlayedScript = case initialCode launchEditingParams of
+        Right codeToRun -> getRunCodePath =<< codeToRun
+        Left _ -> Nothing
+
+  controls . fileBrowser . maybeSelectedFile .= maybePlayedScript
+  controls . seedValueEditor .= initEditorWidget (maybe "" (T.pack . show) $ runIdentity $ seedVal serializableLaunchParams)
+  controls . isDisplayedFor .= Just siPair

--- a/src/Swarm/TUI/Launch/Prep.hs
+++ b/src/Swarm/TUI/Launch/Prep.hs
@@ -28,16 +28,16 @@ import Text.Read (readEither)
 swarmLangFileExtension :: String
 swarmLangFileExtension = "sw"
 
-toValidatedParms :: EditingLaunchParms -> Either T.Text ValidatedLaunchParms
-toValidatedParms (LaunchParms eitherSeedVal eitherInitialCode) = do
+toValidatedParams :: EditingLaunchParams -> Either T.Text ValidatedLaunchParams
+toValidatedParams (LaunchParams eitherSeedVal eitherInitialCode) = do
   maybeSeed <- eitherSeedVal
   maybeParsedCode <- eitherInitialCode
-  return $ LaunchParms (pure maybeSeed) (pure maybeParsedCode)
+  return $ LaunchParams (pure maybeSeed) (pure maybeParsedCode)
 
-parseWidgetParms :: LaunchControls -> IO EditingLaunchParms
-parseWidgetParms (LaunchControls (FileBrowserControl _fb maybeSelectedScript _) seedEditor _ _) = do
+parseWidgetParams :: LaunchControls -> IO EditingLaunchParams
+parseWidgetParams (LaunchControls (FileBrowserControl _fb maybeSelectedScript _) seedEditor _ _) = do
   eitherParsedCode <- parseCode maybeSelectedScript
-  return $ LaunchParms eitherMaybeSeed eitherParsedCode
+  return $ LaunchParams eitherMaybeSeed eitherParsedCode
  where
   eitherMaybeSeed =
     if T.null seedFieldText
@@ -61,7 +61,7 @@ initEditorWidget =
     (Just 1) -- only allow a single line
 
 -- | Called before any particular scenario is selected, so we
--- supply some "Nothing"s as defaults to the "ValidatedLaunchParms".
+-- supply some "Nothing"s as defaults to the "ValidatedLaunchParams".
 initConfigPanel :: IO LaunchOptions
 initConfigPanel = do
   -- NOTE: This is kind of pointless, because we must re-instantiate the FileBrowser
@@ -74,7 +74,7 @@ initConfigPanel = do
   return $
     LaunchOptions
       (LaunchControls (FileBrowserControl fb Nothing False) myForm ring Nothing)
-      (LaunchParms (Right Nothing) (Right Nothing))
+      (LaunchParams (Right Nothing) (Right Nothing))
  where
   myForm = initEditorWidget ""
   ring = makeFocusRingWith listEnums

--- a/src/Swarm/TUI/Launch/View.hs
+++ b/src/Swarm/TUI/Launch/View.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Rendering of the scenario launch configuration dialog.
+module Swarm.TUI.Launch.View where
+
+import Brick
+import Brick.Focus
+import Brick.Forms qualified as BF
+import Brick.Widgets.Border
+import Brick.Widgets.Center (centerLayer, hCenter)
+import Brick.Widgets.Edit
+import Brick.Widgets.Edit qualified as E
+import Brick.Widgets.FileBrowser qualified as FB
+import Control.Exception qualified as E
+import Control.Lens
+import Data.Either (isRight)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Swarm.Game.Scenario (scenarioSeed)
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (..))
+import Swarm.Game.State (getRunCodePath)
+import Swarm.TUI.Attr
+import Swarm.TUI.Launch.Model
+import Swarm.TUI.Launch.Prep
+import Swarm.TUI.Model.Name
+import Swarm.TUI.View.Util (EllipsisSide (Beginning), withEllipsis)
+import Swarm.Util (brackets, parens)
+
+drawFileBrowser :: FB.FileBrowser Name -> Widget Name
+drawFileBrowser b =
+  centerLayer $ hLimit 50 $ ui <=> help
+ where
+  ui =
+    vLimit 15 $
+      borderWithLabel (txt "Choose a file") $
+        FB.renderFileBrowser True b
+
+  footerRows =
+    map
+      (withDefAttr dimAttr . hCenter . txt)
+      [ "Up/Down: navigate"
+      , "/: search, Ctrl-C or Esc: cancel search"
+      , "Enter: change directory or select file"
+      , "Esc: quit"
+      ]
+
+  help =
+    padTop (Pad 1) $
+      vBox $
+        [ case FB.fileBrowserException b of
+            Nothing -> emptyWidget
+            Just e ->
+              hCenter
+                . withDefAttr BF.invalidFormInputAttr
+                . txt
+                . T.pack
+                $ E.displayException e
+        ]
+          <> footerRows
+
+optionDescription :: ScenarioConfigPanelFocusable -> Maybe Text
+optionDescription = \case
+  SeedSelector -> Just "Leaving this field blank will use the default seed for the scenario."
+  ScriptSelector -> Just "Selecting a script to be run upon start permits eligibility for code size scoring."
+  StartGameButton -> Nothing
+
+drawLaunchConfigPanel :: LaunchOptions -> [Widget Name]
+drawLaunchConfigPanel (LaunchOptions lc launchParams) =
+  addFileBrowser [panelWidget]
+ where
+  validatedOptions = toValidatedParms launchParams
+  LaunchControls (FileBrowserControl fb _ isFbDisplayed) seedEditor ring displayedFor = lc
+  addFileBrowser =
+    if isFbDisplayed
+      then (drawFileBrowser fb :)
+      else id
+
+  getFocusedConfigPanel :: Maybe ScenarioConfigPanelFocusable
+  getFocusedConfigPanel = case focusGetCurrent ring of
+    Just (ScenarioConfigControl (ScenarioConfigPanelControl x)) -> Just x
+    _ -> Nothing
+
+  isFocused = (== getFocusedConfigPanel) . Just
+
+  highlightIfFocused x =
+    if isFocused x
+      then withDefAttr highlightAttr
+      else id
+
+  mkButton name label =
+    clickable (ScenarioConfigControl $ ScenarioConfigPanelControl name)
+      . highlightIfFocused name
+      . withAttr boldAttr
+      $ txt label
+
+  mkSeedEditorWidget =
+    hLimit 10 $
+      overrideAttr E.editFocusedAttr customEditFocusedAttr $
+        renderEditor (txt . mconcat) (isFocused SeedSelector) seedEditor
+  seedEntryWidget = case seedVal launchParams of
+    Left _ -> mkSeedEditorWidget
+    Right x -> mkSeedEntryWidget x
+
+  scenarioSeedText = maybe "random" show $ view scenarioSeed . fst =<< displayedFor
+  mkSeedEntryWidget seedEntryContent =
+    if isFocused SeedSelector
+      then mkSeedEditorWidget
+      else case seedEntryContent of
+        Just x -> str $ show x
+        Nothing ->
+          withDefAttr dimAttr $
+            txt $
+              T.unwords
+                [ "scenario default"
+                , parens $ T.pack scenarioSeedText
+                ]
+
+  unspecifiedFileMessage =
+    if isFocused ScriptSelector
+      then str "<[Enter] to select>"
+      else withDefAttr dimAttr $ str "<none>"
+
+  fileEntryWidget = case initialCode launchParams of
+    Left _ -> str "<invalid>"
+    Right maybeFilepath ->
+      maybe
+        unspecifiedFileMessage
+        (withEllipsis Beginning . T.pack)
+        (getRunCodePath =<< maybeFilepath)
+
+  panelWidget =
+    centerLayer
+      . borderWithLabel (str " Configure scenario launch ")
+      . hLimit 60
+      . padAll 1
+      $ vBox widgetMembers
+   where
+    startButton =
+      hCenter . mkButton StartGameButton $
+        T.unwords
+          [ ">>"
+          , "Launch with these settings"
+          , "<<"
+          ]
+
+    widgetMembers =
+      [ controlsBox
+      , infoBox
+      , if isRight validatedOptions then startButton else emptyWidget
+      ]
+
+    formatInfo header content =
+      hBox
+        [ padLeft (Pad 6) . withAttr boldAttr . txt $ brackets header
+        , padLeft (Pad 1) $ txtWrap content
+        ]
+
+    infoContent = case validatedOptions of
+      Left errmsg -> withDefAttr BF.invalidFormInputAttr $ formatInfo "Error" errmsg
+      Right _ -> case optionDescription =<< getFocusedConfigPanel of
+        Just desc -> withDefAttr dimAttr $ formatInfo "Info" desc
+        Nothing -> str " "
+
+    infoBox =
+      vLimit 4
+        . padBottom Max
+        . padRight (Pad 2)
+        $ infoContent
+
+    padControl widgetName label widgetObj =
+      padBottom (Pad 1) $
+        padLeft (Pad 2) $
+          hBox
+            [ mkButton widgetName (label <> ": ")
+            , widgetObj
+            ]
+
+    controlsBox =
+      vBox
+        [ padControl ScriptSelector "Script" fileEntryWidget
+        , padControl SeedSelector "Seed" seedEntryWidget
+        ]

--- a/src/Swarm/TUI/Launch/View.hs
+++ b/src/Swarm/TUI/Launch/View.hs
@@ -71,7 +71,7 @@ drawLaunchConfigPanel :: LaunchOptions -> [Widget Name]
 drawLaunchConfigPanel (LaunchOptions lc launchParams) =
   addFileBrowser [panelWidget]
  where
-  validatedOptions = toValidatedParms launchParams
+  validatedOptions = toValidatedParams launchParams
   LaunchControls (FileBrowserControl fb _ isFbDisplayed) seedEditor ring displayedFor = lc
   addFileBrowser =
     if isFbDisplayed

--- a/src/Swarm/TUI/Model/Menu.hs
+++ b/src/Swarm/TUI/Model/Menu.hs
@@ -76,9 +76,10 @@ data MainMenuEntry
   deriving (Eq, Ord, Show, Read, Bounded, Enum)
 
 data Menu
-  = NoMenu -- We started playing directly from command line, no menu to show
+  = -- | We started playing directly from command line, no menu to show
+    NoMenu
   | MainMenu (BL.List Name MainMenuEntry)
-  | -- Stack of scenario item lists. INVARIANT: the currently selected
+  | -- | Stack of scenario item lists. INVARIANT: the currently selected
     -- menu item is ALWAYS the same as the scenario currently being played.
     -- See https://github.com/swarm-game/swarm/issues/1064 and
     -- https://github.com/swarm-game/swarm/pull/1065.
@@ -104,7 +105,11 @@ mkScenarioList cheat = flip (BL.list ScenarioList) 1 . V.fromList . filterTest .
 mkNewGameMenu :: Bool -> ScenarioCollection -> FilePath -> Maybe Menu
 mkNewGameMenu cheat sc path = NewGameMenu . NE.fromList <$> go (Just sc) (splitPath path) []
  where
-  go :: Maybe ScenarioCollection -> [FilePath] -> [BL.List Name ScenarioItem] -> Maybe [BL.List Name ScenarioItem]
+  go ::
+    Maybe ScenarioCollection ->
+    [FilePath] ->
+    [BL.List Name ScenarioItem] ->
+    Maybe [BL.List Name ScenarioItem]
   go _ [] stk = Just stk
   go Nothing _ _ = Nothing
   go (Just curSC) (thing : rest) stk = go nextSC rest (lst : stk)

--- a/src/Swarm/TUI/Model/Name.hs
+++ b/src/Swarm/TUI/Model/Name.hs
@@ -13,6 +13,18 @@ data FocusablePanel
     InfoPanel
   deriving (Eq, Ord, Show, Read, Bounded, Enum)
 
+data ScenarioConfigPanel
+  = ScenarioConfigFileSelector
+  | ScenarioConfigPanelControl ScenarioConfigPanelFocusable
+  deriving (Eq, Ord, Show, Read)
+
+data ScenarioConfigPanelFocusable
+  = -- | The file selector for launching a scenario with a script
+    ScriptSelector
+  | SeedSelector
+  | StartGameButton
+  deriving (Eq, Ord, Show, Read, Bounded, Enum)
+
 data GoalWidget
   = ObjectivesList
   | GoalSummary
@@ -46,6 +58,8 @@ data Name
     MenuList
   | -- | The list of achievements.
     AchievementList
+  | -- | An individual control within the scenario launch config panel
+    ScenarioConfigControl ScenarioConfigPanel
   | -- | The list of goals/objectives.
     GoalWidgets GoalWidget
   | -- | The list of scenario choices.

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -8,6 +8,7 @@ module Swarm.TUI.Model.StateUpdate (
   initAppStateForScenario,
   classicGame0,
   startGame,
+  startGameWithSeed,
   restartGame,
   attainAchievement,
   attainAchievement',
@@ -44,6 +45,7 @@ import Swarm.Game.ScenarioInfo (
 import Swarm.Game.State
 import Swarm.TUI.Attr (swarmAttrMap)
 import Swarm.TUI.Inventory.Sorting
+import Swarm.TUI.Launch.Model (ValidatedLaunchParms, toSerializableParams)
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Goal (emptyGoalDisplay)
 import Swarm.TUI.Model.Repl
@@ -79,12 +81,12 @@ initAppState AppOpts {..} = do
             Right x -> (x, rs)
             Left e -> (ScenarioInfo path NotStarted, addWarnings rs e)
       execStateT
-        (startGameWithSeed userSeed (scenario, si) codeToRun)
+        (startGameWithSeed (scenario, si) $ LaunchParms (pure userSeed) (pure codeToRun))
         (AppState gs ui newRs)
 
 -- | Load a 'Scenario' and start playing the game.
 startGame :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair -> Maybe CodeToRun -> m ()
-startGame = startGameWithSeed Nothing
+startGame siPair = startGameWithSeed siPair . LaunchParms (pure Nothing) . pure
 
 -- | Re-initialize the game from the stored reference to the current scenario.
 --
@@ -96,17 +98,16 @@ startGame = startGameWithSeed Nothing
 -- Since scenarios are stored as a Maybe in the UI state, we handle the Nothing
 -- case upstream so that the Scenario passed to this function definitely exists.
 restartGame :: (MonadIO m, MonadState AppState m) => Seed -> ScenarioInfoPair -> m ()
-restartGame currentSeed siPair = startGameWithSeed (Just currentSeed) siPair Nothing
+restartGame currentSeed siPair = startGameWithSeed siPair $ LaunchParms (pure (Just currentSeed)) (pure Nothing)
 
 -- | Load a 'Scenario' and start playing the game, with the
 --   possibility for the user to override the seed.
 startGameWithSeed ::
   (MonadIO m, MonadState AppState m) =>
-  Maybe Seed ->
   ScenarioInfoPair ->
-  Maybe CodeToRun ->
+  ValidatedLaunchParms ->
   m ()
-startGameWithSeed userSeed siPair@(_scene, si) toRun = do
+startGameWithSeed siPair@(_scene, si) lp@(LaunchParms (Identity userSeed) (Identity toRun)) = do
   t <- liftIO getZonedTime
   ss <- use $ runtimeState . scenarios
   p <- liftIO $ normalizeScenarioPath ss (si ^. scenarioPath)
@@ -116,7 +117,10 @@ startGameWithSeed userSeed siPair@(_scene, si) toRun = do
     . _SISingle
     . _2
     . scenarioStatus
-    .= Played (Metric Attempted $ ProgressStats t emptyAttemptMetric) (prevBest t)
+    .= Played
+      (toSerializableParams lp)
+      (Metric Attempted $ ProgressStats t emptyAttemptMetric)
+      (prevBest t)
   scenarioToAppState siPair userSeed toRun
   -- Beware: currentScenarioPath must be set so that progress/achievements can be saved.
   -- It has just been cleared in scenarioToAppState.
@@ -124,7 +128,7 @@ startGameWithSeed userSeed siPair@(_scene, si) toRun = do
  where
   prevBest t = case si ^. scenarioStatus of
     NotStarted -> emptyBest t
-    Played _ b -> b
+    Played _ _ b -> b
 
 -- | Modify the 'AppState' appropriately when starting a new scenario.
 scenarioToAppState ::

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -45,7 +45,7 @@ import Swarm.Game.ScenarioInfo (
 import Swarm.Game.State
 import Swarm.TUI.Attr (swarmAttrMap)
 import Swarm.TUI.Inventory.Sorting
-import Swarm.TUI.Launch.Model (ValidatedLaunchParms, toSerializableParams)
+import Swarm.TUI.Launch.Model (ValidatedLaunchParams, toSerializableParams)
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Goal (emptyGoalDisplay)
 import Swarm.TUI.Model.Repl
@@ -81,12 +81,12 @@ initAppState AppOpts {..} = do
             Right x -> (x, rs)
             Left e -> (ScenarioInfo path NotStarted, addWarnings rs e)
       execStateT
-        (startGameWithSeed (scenario, si) $ LaunchParms (pure userSeed) (pure codeToRun))
+        (startGameWithSeed (scenario, si) $ LaunchParams (pure userSeed) (pure codeToRun))
         (AppState gs ui newRs)
 
 -- | Load a 'Scenario' and start playing the game.
 startGame :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair -> Maybe CodeToRun -> m ()
-startGame siPair = startGameWithSeed siPair . LaunchParms (pure Nothing) . pure
+startGame siPair = startGameWithSeed siPair . LaunchParams (pure Nothing) . pure
 
 -- | Re-initialize the game from the stored reference to the current scenario.
 --
@@ -98,16 +98,16 @@ startGame siPair = startGameWithSeed siPair . LaunchParms (pure Nothing) . pure
 -- Since scenarios are stored as a Maybe in the UI state, we handle the Nothing
 -- case upstream so that the Scenario passed to this function definitely exists.
 restartGame :: (MonadIO m, MonadState AppState m) => Seed -> ScenarioInfoPair -> m ()
-restartGame currentSeed siPair = startGameWithSeed siPair $ LaunchParms (pure (Just currentSeed)) (pure Nothing)
+restartGame currentSeed siPair = startGameWithSeed siPair $ LaunchParams (pure (Just currentSeed)) (pure Nothing)
 
 -- | Load a 'Scenario' and start playing the game, with the
 --   possibility for the user to override the seed.
 startGameWithSeed ::
   (MonadIO m, MonadState AppState m) =>
   ScenarioInfoPair ->
-  ValidatedLaunchParms ->
+  ValidatedLaunchParams ->
   m ()
-startGameWithSeed siPair@(_scene, si) lp@(LaunchParms (Identity userSeed) (Identity toRun)) = do
+startGameWithSeed siPair@(_scene, si) lp@(LaunchParams (Identity userSeed) (Identity toRun)) = do
   t <- liftIO getZonedTime
   ss <- use $ runtimeState . scenarios
   p <- liftIO $ normalizeScenarioPath ss (si ^. scenarioPath)

--- a/src/Swarm/TUI/Model/UI.hs
+++ b/src/Swarm/TUI/Model/UI.hs
@@ -13,6 +13,7 @@ module Swarm.TUI.Model.UI (
   uiPlaying,
   uiCheatMode,
   uiFocusRing,
+  uiLaunchConfig,
   uiWorldCursor,
   uiREPL,
   uiInventory,
@@ -74,6 +75,8 @@ import Swarm.Game.ScenarioInfo (
 import Swarm.Game.World qualified as W
 import Swarm.TUI.Attr (swarmAttrMap)
 import Swarm.TUI.Inventory.Sorting
+import Swarm.TUI.Launch.Model
+import Swarm.TUI.Launch.Prep
 import Swarm.TUI.Model.Goal
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
@@ -93,6 +96,7 @@ data UIState = UIState
   , _uiPlaying :: Bool
   , _uiCheatMode :: Bool
   , _uiFocusRing :: FocusRing Name
+  , _uiLaunchConfig :: LaunchOptions
   , _uiWorldCursor :: Maybe W.Coords
   , _uiREPL :: REPLState
   , _uiInventory :: Maybe (Int, BL.List Name InventoryListEntry)
@@ -140,6 +144,9 @@ uiPlaying :: Lens' UIState Bool
 
 -- | Cheat mode, i.e. are we allowed to turn creative mode on and off?
 uiCheatMode :: Lens' UIState Bool
+
+-- | Configuration modal when launching a scenario
+uiLaunchConfig :: Lens' UIState LaunchOptions
 
 -- | The focus ring is the set of UI panels we can cycle among using
 --   the Tab key.
@@ -290,11 +297,13 @@ initUIState speedFactor showMainMenu cheatMode = do
   let history = maybe [] (map REPLEntry . T.lines) historyT
   startTime <- liftIO $ getTime Monotonic
   (warnings, achievements) <- liftIO loadAchievementsInfo
+  launchConfigPanel <- liftIO initConfigPanel
   let out =
         UIState
           { _uiMenu = if showMainMenu then MainMenu (mainMenu NewGame) else NoMenu
           , _uiPlaying = not showMainMenu
           , _uiCheatMode = cheatMode
+          , _uiLaunchConfig = launchConfigPanel
           , _uiFocusRing = initFocusRing
           , _uiWorldCursor = Nothing
           , _uiREPL = initREPLState $ newREPLHistory history

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -37,7 +37,12 @@ module Swarm.TUI.View (
 import Brick hiding (Direction, Location)
 import Brick.Focus
 import Brick.Forms
-import Brick.Widgets.Border (hBorder, hBorderWithLabel, joinableBorder, vBorder)
+import Brick.Widgets.Border (
+  hBorder,
+  hBorderWithLabel,
+  joinableBorder,
+  vBorder,
+ )
 import Brick.Widgets.Center (center, centerLayer, hCenter)
 import Brick.Widgets.Dialog
 import Brick.Widgets.Edit (getEditContents, renderEditor)
@@ -91,6 +96,8 @@ import Swarm.Language.Typecheck (inferConst)
 import Swarm.TUI.Attr
 import Swarm.TUI.Border
 import Swarm.TUI.Inventory.Sorting (renderSortMethod)
+import Swarm.TUI.Launch.Model
+import Swarm.TUI.Launch.View
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Goal (goalsContent, hasAnythingToShow)
 import Swarm.TUI.Model.Repl (lastEntry)
@@ -117,7 +124,7 @@ drawUI s
       -- quit the app instead.  But just in case, we display the main menu anyway.
       NoMenu -> [drawMainMenuUI s (mainMenu NewGame)]
       MainMenu l -> [drawMainMenuUI s l]
-      NewGameMenu stk -> [drawNewGameMenuUI stk]
+      NewGameMenu stk -> drawNewGameMenuUI stk $ s ^. uiState . uiLaunchConfig
       AchievementsMenu l -> [drawAchievementsMenuUI s l]
       MessagesMenu -> [drawMainMessages s]
       AboutMenu -> [drawAboutMenuUI (s ^. uiState . appData . at "about")]
@@ -165,35 +172,52 @@ drawLogo = centerLayer . vBox . map (hBox . T.foldr (\c ws -> drawThing c : ws) 
   attrFor '▒' = dirtAttr
   attrFor _ = defAttr
 
-drawNewGameMenuUI :: NonEmpty (BL.List Name ScenarioItem) -> Widget Name
-drawNewGameMenuUI (l :| ls) =
-  padLeftRight 20
-    . centerLayer
-    $ hBox
-      [ vBox
-          [ withAttr boldAttr . txt $ breadcrumbs ls
-          , txt " "
-          , vLimit 20
-              . hLimit 35
-              . BL.renderList (const $ padRight Max . drawScenarioItem) True
-              $ l
-          ]
-      , padLeft (Pad 5) (maybe (txt "") (drawDescription . snd) (BL.listSelectedElement l))
-      ]
+-- | When launching a game, a modal prompt may appear on another layer
+-- to input seed and/or a script to run.
+drawNewGameMenuUI ::
+  NonEmpty (BL.List Name ScenarioItem) ->
+  LaunchOptions ->
+  [Widget Name]
+drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
+  Nothing -> pure mainWidget
+  Just _ -> drawLaunchConfigPanel launchOptions <> pure mainWidget
  where
+  displayedFor = launchOptions ^. controls . isDisplayedFor
+  mainWidget =
+    vBox
+      [ padLeftRight 20
+          . centerLayer
+          $ hBox
+            [ vBox
+                [ withAttr boldAttr . txt $ breadcrumbs ls
+                , txt " "
+                , vLimit 20
+                    . hLimit 35
+                    . BL.renderList (const $ padRight Max . drawScenarioItem) True
+                    $ l
+                ]
+            , padLeft (Pad 5) (maybe (txt "") (drawDescription . snd) (BL.listSelectedElement l))
+            ]
+      , launchOptionsMessage
+      ]
+
+  launchOptionsMessage = case (displayedFor, snd <$> BL.listSelectedElement l) of
+    (Nothing, Just (SISingle _)) -> hCenter $ txt "Press 'o' for launch options"
+    _ -> emptyWidget
+
   drawScenarioItem (SISingle (s, si)) = padRight (Pad 1) (drawStatusInfo s si) <+> txt (s ^. scenarioName)
   drawScenarioItem (SICollection nm _) = padRight (Pad 1) (withAttr boldAttr $ txt " > ") <+> txt nm
   drawStatusInfo s si = case si ^. scenarioStatus of
     NotStarted -> txt " ○ "
-    Played (Metric Attempted _) _ -> case s ^. scenarioObjectives of
+    Played _initialScript (Metric Attempted _) _ -> case s ^. scenarioObjectives of
       [] -> withAttr cyanAttr $ txt " ◉ "
       _ -> withAttr yellowAttr $ txt " ◎ "
-    Played (Metric Completed _) _ -> withAttr greenAttr $ txt " ● "
+    Played _initialScript (Metric Completed _) _ -> withAttr greenAttr $ txt " ● "
 
   describeStatus :: ScenarioStatus -> Widget n
   describeStatus = \case
     NotStarted -> withAttr cyanAttr $ txt "not started"
-    Played pm _best -> describeProgress pm
+    Played _initialScript pm _best -> describeProgress pm
 
   breadcrumbs :: [BL.List Name ScenarioItem] -> Text
   breadcrumbs =
@@ -291,7 +315,7 @@ makeBestScoreRows scenarioStat =
  where
   getBests = case scenarioStat of
     NotStarted -> Nothing
-    Played _ best -> Just best
+    Played _initialScript _ best -> Just best
 
   makeBestRows b = map (makeBestRow hasMultiple) groups
    where

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -202,7 +202,7 @@ drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
       ]
 
   launchOptionsMessage = case (displayedFor, snd <$> BL.listSelectedElement l) of
-    (Nothing, Just (SISingle _)) -> hCenter $ txt "Press 'o' for launch options"
+    (Nothing, Just (SISingle _)) -> hCenter $ txt "Press 'o' for launch options, or 'Enter' to launch with defaults"
     _ -> emptyWidget
 
   drawScenarioItem (SISingle (s, si)) = padRight (Pad 1) (drawStatusInfo s si) <+> txt (s ^. scenarioName)

--- a/src/Swarm/TUI/View/Objective.hs
+++ b/src/Swarm/TUI/View/Objective.hs
@@ -88,7 +88,7 @@ drawGoalListItem _isSelected e = case e of
   Goal gs obj -> getCompletionIcon obj gs <+> titleWidget
    where
     textSource = obj ^. objectiveTeaser <|> obj ^. objectiveId <|> listToMaybe (obj ^. objectiveGoal)
-    titleWidget = maybe (txt "?") withEllipsis textSource
+    titleWidget = maybe (txt "?") (withEllipsis End) textSource
 
 singleGoalDetails :: GoalEntry -> Widget Name
 singleGoalDetails = \case

--- a/src/Swarm/TUI/View/Util.hs
+++ b/src/Swarm/TUI/View/Util.hs
@@ -131,8 +131,10 @@ quitMsg m = "Are you sure you want to " <> quitAction <> "? All progress on this
 displayParagraphs :: [Text] -> Widget Name
 displayParagraphs = vBox . map (padBottom (Pad 1) . txtWrap)
 
-withEllipsis :: Text -> Widget Name
-withEllipsis t =
+data EllipsisSide = Beginning | End
+
+withEllipsis :: EllipsisSide -> Text -> Widget Name
+withEllipsis side t =
   Widget Greedy Fixed $ do
     ctx <- getContext
     let w = ctx ^. availWidthL
@@ -140,7 +142,9 @@ withEllipsis t =
         tLength = T.length t
         newText =
           if tLength > w
-            then T.take (w - T.length ellipsis) t <> ellipsis
+            then case side of
+              Beginning -> ellipsis <> T.drop (w - T.length ellipsis) t
+              End -> T.take (w - T.length ellipsis) t <> ellipsis
             else t
     render $ txt newText
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -103,6 +103,10 @@ library
                       Swarm.Game.Robot
                       Swarm.Game.Scenario
                       Swarm.Game.Scenario.Cell
+                      Swarm.TUI.Launch.Controller
+                      Swarm.TUI.Launch.Model
+                      Swarm.TUI.Launch.Prep
+                      Swarm.TUI.Launch.View
                       Swarm.Game.Scenario.Objective
                       Swarm.Game.Scenario.Objective.Graph
                       Swarm.Game.Scenario.Objective.Logic


### PR DESCRIPTION
Closes #358 and closes #866.

Allows specification of a seed value and/or the path of a script to run.  Specifying a script to run in advance allows eligibility for code size scoring.

Some effort was invested into integrating the Brick `FileBrowser` widget and discovering its idiosyncrasies.  This paves the way for more applications of `FileBrowser` within Swarm.

## Usage

From the scenario selection menu, press the `o` key to pop up a dialog for launch options.

![Screenshot from 2023-06-06 01-38-25](https://github.com/swarm-game/swarm/assets/261693/e306f2ce-db30-4906-9b02-db8e44bc5e99)

Any manually-selected initial-script or seed are persisted to disk and will pre-populate the launch configuration dialog upon the next play.  If a certain scenario is subsequently launched the normal way (i.e. by pressing `Enter` instead of `o`), then this clears the saved script path/seed, and the next pop-up of the launch configuration dialog will not see its fields pre-populated.

## Warning: Save format changed

This PR changes the `ScenarioStatus` datatype, and therefore game status/progress saved previously to this PR will not be recognized.  See https://github.com/swarm-game/swarm/pull/974#discussion_r1111335102 for discussion about this situation.