### PR TITLE
recursion bug demo

### DIFF
--- a/data/scenarios/Testing/1032-recursion/1032-recursion-truncated-output.yaml
+++ b/data/scenarios/Testing/1032-recursion/1032-recursion-truncated-output.yaml
@@ -1,0 +1,42 @@
+version: 1
+name: Demo recursion bug
+author: Karl Ostmo
+description: |
+  Demo recursion bug
+creative: false
+seed: 1
+robots:
+  - name: base
+    dir: [1, 0]
+    devices:
+      - branch predictor
+      - bitcoin
+      - comparator
+      - dictionary
+      - lambda
+      - logger
+      - string
+      - calculator
+      - treads
+    program: |
+      def go = \n.
+          if (n > 0) {
+              idx <- random 4;
+              log $ "In: " ++ format idx;
+
+              go $ n - 1;
+
+              log $ "Out: " ++ format idx;
+          } {};
+          end;
+
+      go 4;
+world:
+  default: [blank]
+  upperleft: [0, 0]
+  offset: false
+  palette:
+    'B': [grass, null, base]
+    '.': [grass]
+  map: |
+    B...

--- a/data/scenarios/Testing/1032-recursion/1032-recursion-zeroed-output.yaml
+++ b/data/scenarios/Testing/1032-recursion/1032-recursion-zeroed-output.yaml
@@ -1,0 +1,43 @@
+version: 1
+name: Demo recursion bug
+author: Karl Ostmo
+description: |
+  Demo recursion bug
+creative: false
+seed: 1
+robots:
+  - name: base
+    dir: [1, 0]
+    devices:
+      - branch predictor
+      - bitcoin
+      - comparator
+      - dictionary
+      - lambda
+      - logger
+      - string
+      - calculator
+      - treads
+    program: |
+      def go = \n.
+          if (n > 0) {
+              idx <- random 4;
+              log $ "In: " ++ format idx;
+
+              go $ n - 1;
+
+              log $ "Out: " ++ format idx;
+              move;
+          } {};
+          end;
+
+      go 4;
+world:
+  default: [blank]
+  upperleft: [0, 0]
+  offset: false
+  palette:
+    'B': [grass, null, base]
+    '.': [grass]
+  map: |
+    B...


### PR DESCRIPTION
Two demonstrations for #1032 are added in this PR.

## Value overwriting demo

```
./scripts/play.sh --scenario scenarios/Testing/1032-recursion/1032-recursion-zeroed-output.yaml
```
Log output:
```
In: 1
In: 3
In: 0
In: 2
Out: 0
Out: 0
Out: 0
Out: 0
```

## Truncation demo
This program is **identical** to the one above, except that the final `move` command is omitted.  Omitting this seems to cause the program to stop producing output prematurely.
```
./scripts/play.sh --scenario scenarios/Testing/1032-recursion/1032-recursion-truncated-output.yaml
```
Log output:
```
In: 1
In: 3
In: 0
In: 2
Out: 0
Out: 0
```