### PR TITLE
Todo enforcement line number

### DIFF
--- a/.github/workflows/check_todos.yml
+++ b/.github/workflows/check_todos.yml
@@ -16,9 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          if grep --include \*.hs -riP '(TODO|FIXME|XXX):?\s' src 2>&1 | grep -vP '#\d+'; then
-              echo "Please add a link to Issue, for example: TODO: #123"
-              exit 1
-          else
-              echo "No TODOs without links found, all good!"
-          fi
+          scripts/enforce-todo-issues.sh

--- a/.github/workflows/check_todos.yml
+++ b/.github/workflows/check_todos.yml
@@ -1,4 +1,4 @@
-name: Look for TODOs
+name: Enforce issue references for TODOs
 on:
   push:
     paths:
@@ -11,7 +11,7 @@ on:
     branches:
       - main
 jobs:
-  build:
+  enforce:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/scripts/enforce-todo-issues.sh
+++ b/scripts/enforce-todo-issues.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+
+
+if grep --line-number --include \*.hs -riP '(TODO|FIXME|XXX):?\s' src 2>&1 | grep -vP '#\d+'; then
+  echo "Please add a link to Issue, for example: TODO: #123"
+  exit 1
+else
+  echo "No TODOs without links found, all good!"
+fi


### PR DESCRIPTION
As an extension to #514, include the line number in the grep output, and move the grep logic to a script, so that it can be used within VS Code and clicking on the file:line will open the editor at the right place.

![vscode-demo](https://user-images.githubusercontent.com/261693/214456476-c27b2360-1018-4281-8930-45faaa17d66b.png)

The GitHub action still works.  See this CI run: https://github.com/swarm-game/swarm/actions/runs/4001861308/jobs/6868527786
