### PR TITLE
Move `Swarm.Game.Value` -> `Swarm.Language.Value`

### DIFF
--- a/src/Swarm/Game/CESK.hs
+++ b/src/Swarm/Game/CESK.hs
@@ -94,7 +94,6 @@ import GHC.Generics (Generic)
 import Prettyprinter (Doc, Pretty (..), hsep, (<+>))
 import Swarm.Game.Entity (Count, Entity)
 import Swarm.Game.Exception
-import Swarm.Game.Value as V
 import Swarm.Game.World (WorldUpdate (..))
 import Swarm.Language.Context
 import Swarm.Language.Module
@@ -103,6 +102,7 @@ import Swarm.Language.Pretty
 import Swarm.Language.Requirement (ReqCtx)
 import Swarm.Language.Syntax
 import Swarm.Language.Types
+import Swarm.Language.Value as V
 
 ------------------------------------------------------------
 -- Frames and continuations

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -95,13 +95,13 @@ import Swarm.Game.CESK
 import Swarm.Game.Display (Display, curOrientation, defaultRobotDisplay, invisible)
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Log
-import Swarm.Game.Value as V
 import Swarm.Language.Capability (Capability)
 import Swarm.Language.Context qualified as Ctx
 import Swarm.Language.Requirement (ReqCtx)
 import Swarm.Language.Syntax (toDirection)
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Types (TCtx)
+import Swarm.Language.Value as V
 import Swarm.Util.Location
 import Swarm.Util.Yaml
 import System.Clock (TimeSpec)

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -147,7 +147,6 @@ import Swarm.Game.Recipe (
 import Swarm.Game.Robot
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.Terrain (TerrainType (..))
-import Swarm.Game.Value (Value)
 import Swarm.Game.World (Coords (..), WorldFun (..), locToCoords, worldFunFromArray)
 import Swarm.Game.World qualified as W
 import Swarm.Game.WorldGen (Seed, findGoodOrigin, testWorld2FromArray)
@@ -158,6 +157,7 @@ import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Syntax (Const, Term' (TText), allConst)
 import Swarm.Language.Typed (Typed (Typed))
 import Swarm.Language.Types
+import Swarm.Language.Value (Value)
 import Swarm.TUI.Model.Achievement.Attainment
 import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.Util (getDataFileNameSafe, getElemsInArea, isRightOr, manhattan, uniq, (<+=), (<<.=), (?))

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -60,7 +60,6 @@ import Swarm.Game.Recipe
 import Swarm.Game.Robot
 import Swarm.Game.Scenario (objectiveCondition)
 import Swarm.Game.State
-import Swarm.Game.Value
 import Swarm.Game.World qualified as W
 import Swarm.Language.Capability
 import Swarm.Language.Context hiding (delete)
@@ -70,6 +69,7 @@ import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Requirement qualified as R
 import Swarm.Language.Syntax
 import Swarm.Language.Typed (Typed (..))
+import Swarm.Language.Value
 import Swarm.TUI.Model.Achievement.Attainment
 import Swarm.TUI.Model.Achievement.Definitions
 import Swarm.Util

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -516,7 +516,7 @@ data Length = Short | Long
 
 -- | The arity of a constant, /i.e./ how many arguments it expects.
 --   The runtime system will collect arguments to a constant (see
---   'Swarm.Game.Value.VCApp') until it has enough, then dispatch
+--   'Swarm.Language.Value.VCApp') until it has enough, then dispatch
 --   the constant's behavior.
 arity :: Const -> Int
 arity c = case constMeta $ constInfo c of

--- a/src/Swarm/Language/Value.hs
+++ b/src/Swarm/Language/Value.hs
@@ -3,14 +3,14 @@
 {-# LANGUAGE GADTs #-}
 
 -- |
--- Module      :  Swarm.Game.Value
+-- Module      :  Swarm.Language.Value
 -- Copyright   :  Brent Yorgey
 -- Maintainer  :  byorgey@gmail.com
 --
 -- SPDX-License-Identifier: BSD-3-Clause
 --
 -- Values and environments used for interpreting the Swarm language.
-module Swarm.Game.Value (
+module Swarm.Language.Value (
   -- * Values
   Value (..),
   stripVResult,

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -72,7 +72,6 @@ import Swarm.Game.Robot
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.State
 import Swarm.Game.Step (gameTick)
-import Swarm.Game.Value (Value (VUnit), prettyValue, stripVResult)
 import Swarm.Game.World qualified as W
 import Swarm.Language.Capability (Capability (CMake))
 import Swarm.Language.Context
@@ -85,6 +84,7 @@ import Swarm.Language.Requirement qualified as R
 import Swarm.Language.Syntax
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Types
+import Swarm.Language.Value (Value (VUnit), prettyValue, stripVResult)
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Inventory.Sorting (cycleSortDirection, cycleSortOrder)
 import Swarm.TUI.List

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -99,7 +99,6 @@ library
                       Swarm.Game.State
                       Swarm.Game.Step
                       Swarm.Game.Terrain
-                      Swarm.Game.Value
                       Swarm.Game.World
                       Swarm.Game.WorldGen
                       Swarm.Language.Context
@@ -119,6 +118,7 @@ library
                       Swarm.Language.Typecheck
                       Swarm.Language.Typed
                       Swarm.Language.Types
+                      Swarm.Language.Value
                       Swarm.TUI.Attr
                       Swarm.TUI.Border
                       Swarm.TUI.Controller

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -9,7 +9,7 @@ import Data.Char (ord)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Game.State
-import Swarm.Game.Value
+import Swarm.Language.Value
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck

--- a/test/unit/TestUtil.hs
+++ b/test/unit/TestUtil.hs
@@ -14,9 +14,9 @@ import Swarm.Game.Exception
 import Swarm.Game.Robot
 import Swarm.Game.State
 import Swarm.Game.Step (gameTick, hypotheticalRobot, stepCESK)
-import Swarm.Game.Value
 import Swarm.Language.Context
 import Swarm.Language.Pipeline (ProcessedTerm (..), processTerm)
+import Swarm.Language.Value
 
 eval :: GameState -> Text -> IO (GameState, Robot, Either Text (Value, Int))
 eval g = either (return . (g,hypotheticalRobot undefined 0,) . Left) (evalPT g) . processTerm1


### PR DESCRIPTION
It's always bothered me that `Value` lived under the `Game` namespace; I don't know why I did it that way initially.  It really belongs with `Language`, since the type of values that result from evaluating/executing a program are part of the definition of a language.