### PR TITLE
Tutorial improvements

### DIFF
--- a/data/scenarios/Tutorials/bind2.yaml
+++ b/data/scenarios/Tutorials/bind2.yaml
@@ -77,10 +77,12 @@ robots:
       attr: robot
     devices:
       - 3D printer
+      - logger
     inventory:
       - [1, solar panel]
       - [1, treads]
       - [1, grabber]
+      - [1, compass]
   - name: floorspot
     system: true
   - name: pedestal

--- a/data/scenarios/Tutorials/require.yaml
+++ b/data/scenarios/Tutorials/require.yaml
@@ -56,6 +56,7 @@ robots:
       - [10, boat]
       - [10, grabber]
       - [10, scanner]
+      - [10, compass]
 known: [water]
 world:
   default: [blank]


### PR DESCRIPTION
A few miscellaneous tutorial improvements.
- In the `bind` tutorial, give the base a `compass` (in inventory) and `logger` (installed).

  There's no reason not to allow a `compass` in this challenge, if people had become comfortable typing things like `turn north`.

  Also, the base absolutely ought to have a `logger` equipped.  As it is, if the user tries to `build` a robot that does something the base does not have the devices for (such as `turn east`, before), it simply fails silently.

- Give the base some `compass` devices in `require` tutorial. Again, no reason we need to wean players off the `compass` quite yet.

The "first steps" tutorial is the first place where the player won't have a `compass`.  I don't know if it's worth calling that out explicitly in the goal text, or if we just let the player figure it out.