### PR TITLE
also run `handleInfoPanelEvent` for dialogs other than `GoalModal`

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -419,7 +419,7 @@ handleModalEvent = \case
                 uiState . uiGoal . listWidget .= newList
               GoalSummary -> handleInfoPanelEvent modalScroll (VtyEvent ev)
             _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
-      _ -> return ()
+      _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
    where
     refreshList lw = nestEventM' lw $ handleListEventWithSeparators ev isHeader
 


### PR DESCRIPTION
Fixes #1068.