### PR TITLE
allow `vty-5.38`

### DIFF
--- a/swarm.cabal
+++ b/swarm.cabal
@@ -205,7 +205,7 @@ library
                       unification-fd                >= 0.11  && < 0.12,
                       unordered-containers          >= 0.2.14 && < 0.3,
                       vector                        >= 0.12 && < 0.14,
-                      vty                           >= 5.33 && < 5.38,
+                      vty                           >= 5.33 && < 5.39,
                       wai                           >= 3.2 && < 3.3,
                       warp                          >= 3.2 && < 3.4,
                       witch                         >= 1.1.1.0 && < 1.2,


### PR DESCRIPTION
Tried with `cabal test --constraint='vty >= 5.38'` and all seemed to work fine.