### PR TITLE
lower max bounds on yaml package

### DIFF
--- a/swarm.cabal
+++ b/swarm.cabal
@@ -210,7 +210,7 @@ library
                       warp                          >= 3.2 && < 3.4,
                       witch                         >= 1.1.1.0 && < 1.2,
                       word-wrap                     >= 0.5 && < 0.6,
-                      yaml                          >= 0.11 && < 0.12,
+                      yaml                          >= 0.11 && < 0.11.9.0,
     hs-source-dirs:   src
     default-language: Haskell2010
     default-extensions:


### PR DESCRIPTION
Observed a CI breakage seemingly due to new `yaml` package release:
https://github.com/swarm-game/swarm/actions/runs/4107732825/jobs/7087565682

Also tested in #1091.

`yaml` release PR for reference:
https://github.com/snoyberg/yaml/pull/206