### PR TITLE
Use internal attribute type in Display

### DIFF
--- a/src/Swarm/Game/Terrain.hs
+++ b/src/Swarm/Game/Terrain.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- |
 -- Module      :  Swarm.Game.Terrain
 -- Copyright   :  Brent Yorgey
@@ -17,7 +19,6 @@ import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Swarm.Game.Display
-import Swarm.TUI.Attr
 import Text.Read (readMaybe)
 import Witch (into)
 
@@ -41,9 +42,9 @@ instance FromJSON TerrainType where
 terrainMap :: Map TerrainType Display
 terrainMap =
   M.fromList
-    [ (StoneT, defaultTerrainDisplay '▒' rockAttr)
-    , (DirtT, defaultTerrainDisplay '▒' dirtAttr)
-    , (GrassT, defaultTerrainDisplay '▒' grassAttr)
-    , (IceT, defaultTerrainDisplay ' ' iceAttr)
-    , (BlankT, defaultTerrainDisplay ' ' defAttr)
+    [ (StoneT, defaultTerrainDisplay '▒' (ATerrain "stone"))
+    , (DirtT, defaultTerrainDisplay '▒' (ATerrain "dirt"))
+    , (GrassT, defaultTerrainDisplay '▒' (ATerrain "grass"))
+    , (IceT, defaultTerrainDisplay ' ' (ATerrain "ice"))
+    , (BlankT, defaultTerrainDisplay ' ' ADefault)
     ]

--- a/src/Swarm/TUI/Attr.hs
+++ b/src/Swarm/TUI/Attr.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
 -- Module      :  Swarm.TUI.Attr
@@ -20,6 +19,7 @@ module Swarm.TUI.Attr (
   swarmAttrMap,
   worldAttributes,
   worldPrefix,
+  toAttrName,
 
   -- ** Terrain attributes
   dirtAttr,
@@ -55,9 +55,17 @@ import Brick.Forms
 import Brick.Widgets.Dialog
 import Brick.Widgets.List
 import Data.Bifunctor (bimap)
-import Data.Yaml
+import Data.Text (unpack)
 import Graphics.Vty qualified as V
-import Witch (from)
+import Swarm.Game.Display (Attribute (..))
+
+toAttrName :: Attribute -> AttrName
+toAttrName = \case
+  ARobot -> robotAttr
+  AEntity -> entityAttr
+  AWorld n -> worldPrefix <> attrName (unpack n)
+  ATerrain n -> terrainPrefix <> attrName (unpack n)
+  ADefault -> defAttr
 
 -- | A mapping from the defined attribute names to TUI attributes.
 swarmAttrMap :: AttrMap
@@ -173,9 +181,3 @@ yellowAttr = attrName "yellow"
 cyanAttr = attrName "cyan"
 lightCyanAttr = attrName "lightCyan"
 magentaAttr = attrName "magenta"
-
-instance ToJSON AttrName where
-  toJSON = toJSON . head . attrNameComponents
-
-instance FromJSON AttrName where
-  parseJSON = withText "AttrName" (pure . attrName . from)

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -10,9 +10,14 @@ import Swarm.Game.Display
 import Swarm.Game.Entity as E
 import Swarm.Game.Robot
 import Swarm.Game.State
-import Swarm.Game.Terrain (terrainMap)
+import Swarm.Game.Terrain
 import Swarm.Game.World qualified as W
+import Swarm.TUI.Attr
 import Swarm.TUI.Model.Name
+
+-- | Render a display as a UI widget.
+renderDisplay :: Display -> Widget n
+renderDisplay disp = withAttr (disp ^. displayAttr . to toAttrName) $ str [displayChar disp]
 
 -- | Render the 'Display' for a specific location.
 drawLoc :: Bool -> GameState -> W.Coords -> Widget Name


### PR DESCRIPTION
This avoids using `Brick.AttrName` and we can remove the `-fno-warn-orphans` from `Attr.hs`.

As a bonus, we can now specify a terrain attribute (`terrain_stone`) in a scenario along with the `default` attribute.

- split off from #1069
- part of #1043