### PR TITLE
improve github action name

### DIFF
--- a/.github/workflows/check_todos.yml
+++ b/.github/workflows/check_todos.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
 jobs:
-  enforce:
+  Enforce issue references:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Makes the TODO checker job displayed on Pull Requests more specific than `enforce`, changed to `Enforce issue references`.
# Before
![Screenshot from 2023-02-09 16-17-36](https://user-images.githubusercontent.com/261693/217968698-11561ef6-0afd-4541-8489-28bfe57d55c9.png)
