### PR TITLE
allow `text-zipper-0.13` and `witch-1.2`

### DIFF
--- a/swarm.cabal
+++ b/swarm.cabal
@@ -201,7 +201,7 @@ library
                       template-haskell              >= 2.16 && < 2.20,
                       text                          >= 1.2.4 && < 2.1,
                       text-rope                     >= 0.2 && < 0.3,
-                      text-zipper                   >= 0.10 && < 0.13,
+                      text-zipper                   >= 0.10 && < 0.14,
                       time                          >= 1.9 && < 1.14,
                       unification-fd                >= 0.11  && < 0.12,
                       unordered-containers          >= 0.2.14 && < 0.3,
@@ -209,7 +209,7 @@ library
                       vty                           >= 5.33 && < 5.39,
                       wai                           >= 3.2 && < 3.3,
                       warp                          >= 3.2 && < 3.4,
-                      witch                         >= 1.1.1.0 && < 1.2,
+                      witch                         >= 1.1.1.0 && < 1.3,
                       word-wrap                     >= 0.5 && < 0.6,
                       yaml                          >= 0.11 && < 0.11.9.0,
     hs-source-dirs:   src


### PR DESCRIPTION
Built successfully with `cabal build --constraint='text-zipper >= 0.13' --constraint='witch >= 1.2'`, and the changelogs for those releases seem to indicates the changes won't affect us.