### PR TITLE
Fix broken link to emacs mode

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -14,7 +14,7 @@ The current LSP implementation features the following extensions:
 
 Using [lsp-mode](https://github.com/emacs-lsp/lsp-mode):
 
-Load the [swarm-mode.el](../contribs/swarm-mode.el) and start
+Load the [swarm-mode.el](emacs/swarm-mode.el) and start
 the `M-x lsp` service in a *swarm-mode* buffer.
 
 ## VS Code and VS Codium


### PR DESCRIPTION
The link to the emacs mode in `editors/README.md` was broken.