### PR TITLE
let-in syntax highlighting

### DIFF
--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -30,7 +30,7 @@
 				{
 				"name": "keyword.control.dictionary.let",
 				"begin": "\\s*let\\s+(\\w+)\\s*(:((\\s*(cmd|dir|text|int|void|unit|actor|\\(|\\)|\\{|\\}|(\\*|\\+|->)|[a-z]\\w*|forall ([a-z]\\w*\\s*)+.)\\s*)+))?=",
-				"end": "\\s*in",
+				"end": "\\s*in\\b",
 				"beginCaptures": {
 					"1": {"name": "entity.name.function"},
 					"3": {"name": "entity.name.type"}


### PR DESCRIPTION
Currently, the syntax highlighter matches any word prefixed with `in`, e.g. `inL` or `inner` is matched.  This PR adds a word boundary to the regex.