### PR TITLE
simplify color parsing

### DIFF
--- a/src/Swarm/Game/Scenario/Style.hs
+++ b/src/Swarm/Game/Scenario/Style.hs
@@ -27,8 +27,11 @@ styleFlagJsonOptions =
 instance FromJSON StyleFlag where
   parseJSON = genericParseJSON styleFlagJsonOptions
 
+instance ToJSON StyleFlag where
+  toJSON = genericToJSON styleFlagJsonOptions
+
 newtype HexColor = HexColor Text
-  deriving (Eq, Show, Generic, FromJSON)
+  deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
 data CustomAttr = CustomAttr
   { name :: String
@@ -37,3 +40,10 @@ data CustomAttr = CustomAttr
   , style :: Maybe (Set StyleFlag)
   }
   deriving (Eq, Show, Generic, FromJSON)
+
+instance ToJSON CustomAttr where
+  toJSON =
+    genericToJSON
+      defaultOptions
+        { omitNothingFields = True
+        }

--- a/src/Swarm/TUI/View/CustomStyling.hs
+++ b/src/Swarm/TUI/View/CustomStyling.hs
@@ -3,10 +3,10 @@
 module Swarm.TUI.View.CustomStyling where
 
 import Brick (AttrName, attrName)
+import Data.Colour.SRGB (Colour, RGB (..), sRGB24read, toSRGB24)
 import Data.Set (toList)
 import Data.Text qualified as T
 import Graphics.Vty.Attributes
-import Numeric (readHex)
 import Swarm.Game.Scenario.Style
 import Swarm.TUI.Attr (worldPrefix)
 
@@ -23,12 +23,11 @@ toStyle = \case
 
 toAttrColor :: HexColor -> Color
 toAttrColor (HexColor colorText) =
-  case nums of
-    [r, g, b] -> RGBColor r g b
-    _ -> RGBColor 255 255 255
+  RGBColor r g b
  where
-  chunks = T.chunksOf 2 $ T.dropWhile (== '#') colorText
-  nums = map (fst . head . readHex . T.unpack) chunks
+  RGB r g b = toSRGB24 c
+  c :: Colour Double
+  c = sRGB24read $ T.unpack colorText
 
 toAttrPair :: CustomAttr -> (AttrName, Attr)
 toAttrPair ca =

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -167,6 +167,7 @@ library
                       brick                         >= 1.5 && < 1.7,
                       bytestring                    >= 0.10 && < 0.12,
                       clock                         >= 0.8.2 && < 0.9,
+                      colour                        >= 2.3.6 && < 2.4,
                       containers                    >= 0.6.2 && < 0.7,
                       directory                     >= 1.3 && < 1.4,
                       dotgen                        >= 0.4 && < 0.5,


### PR DESCRIPTION
I happened upon these utility functions from the `colour` package while working on #1155.  Also adding some JSON instances for the purpose of the same PR.