### PR TITLE
get rid of XXX comment

### DIFF
--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -224,7 +224,6 @@ parseTypeAtom =
     <|> TyRcd <$> brackets (parseRecord (symbol ":" *> parseType))
     <|> parens parseType
 
--- XXX reserved words should be OK to use as record fields?
 parseRecord :: Parser a -> Parser (Map Var a)
 parseRecord p = (parseBinding `sepBy` symbol ",") >>= fromListUnique
  where


### PR DESCRIPTION
Let's not worry about using reserved words as record fields for now. It would technically work OK but I'm not sure how important it is.

See #1177 for the fix to the root issue that let this through the merge process.