### PR TITLE
actually join with spaces in `failT`, not newlines

### DIFF
--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -201,7 +201,7 @@ replaceLast r t = T.append (T.dropWhileEnd isIdentChar t) r
 -- | Fail with a Text-based message, made out of phrases to be joined
 --   by spaces.
 failT :: MonadFail m => [Text] -> m a
-failT = fail . from @Text . T.unlines
+failT = fail . from @Text . T.unwords
 
 -- | Show a value, but as Text.
 showT :: Show a => a -> Text


### PR DESCRIPTION
Fix bug introduced in #1148 .  See https://github.com/swarm-game/swarm/pull/1148#discussion_r1148410290