### PR TITLE
Simplify skippable list api

### DIFF
--- a/src/Brick/Widget/List/Skippable.hs
+++ b/src/Brick/Widget/List/Skippable.hs
@@ -1,0 +1,97 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- A special modified version of 'Brick.Widgets.List.handleListEvent'
+-- to deal with skipping over separators.
+module Brick.Widget.List.Skippable (
+  Movement (..),
+  Amount (..),
+  FindDir (..),
+  navigateList,
+) where
+
+import Brick (EventM)
+import Brick.Widgets.List qualified as BL
+import Control.Lens (set, (&), (^.))
+import Control.Monad.State.Strict (modify)
+import Data.Foldable (toList)
+import Data.List (find)
+import Graphics.Vty qualified as V
+
+data Amount = Max | Page
+
+data Movement
+  = Single FindDir
+  | Multi Amount FindDir
+  | None
+
+navigateList ::
+  (Ord n, Foldable t, BL.Splittable t) =>
+  (e -> Bool) ->
+  (V.Event -> Movement) ->
+  V.Event ->
+  EventM n (BL.GenericList n t e) ()
+navigateList isSep evMap e = case evMap e of
+  Single d -> modify $ f d ExcludeCurrent
+  Multi amount d ->
+    let g = f d IncludeCurrent
+     in case amount of
+          Max ->
+            modify $
+              g . case d of
+                Up -> BL.listMoveToBeginning
+                Down -> BL.listMoveToEnd
+          Page -> precondition >> modify g
+           where
+            precondition = case d of
+              Up -> BL.listMovePageUp
+              Down -> BL.listMovePageDown
+  None -> return ()
+ where
+  f d x = listFindByStrategy (FindStrategy d x) $ not . isSep
+
+-- | Which direction to search: forward or backward from the current location.
+data FindDir = Down | Up deriving (Eq, Ord, Show, Enum)
+
+-- | Should we include or exclude the current location in the search?
+data FindStart = IncludeCurrent | ExcludeCurrent deriving (Eq, Ord, Show, Enum)
+
+-- | A 'FindStrategy' is a pair of a 'FindDir' and a 'FindStart'.
+data FindStrategy = FindStrategy FindDir FindStart
+
+-- | Starting from the currently selected element, attempt to find and
+--   select the next element matching the predicate. How the search
+--   proceeds depends on the 'FindStrategy': the 'FindDir' says
+--   whether to search forward or backward from the selected element,
+--   and the 'FindStart' says whether the currently selected element
+--   should be included in the search or not.
+listFindByStrategy ::
+  (Foldable t, BL.Splittable t) =>
+  FindStrategy ->
+  (e -> Bool) ->
+  BL.GenericList n t e ->
+  BL.GenericList n t e
+listFindByStrategy (FindStrategy dir cur) test l =
+  -- Figure out what index to split on.  We will call splitAt on
+  -- (current selected index + adj).
+  let adj =
+        -- If we're search forward, split on current index; if
+        -- finding backward, split on current + 1 (so that the
+        -- left-hand split will include the current index).
+        case dir of Down -> 0; Up -> 1
+          -- ... but if we're excluding the current index, swap that, so
+          -- the current index will be excluded rather than included in
+          -- the part of the split we're going to look at.
+          & case cur of IncludeCurrent -> id; ExcludeCurrent -> (1 -)
+
+      -- Split at the index we computed.
+      start = maybe 0 (+ adj) (l ^. BL.listSelectedL)
+      (h, t) = BL.splitAt start (l ^. BL.listElementsL)
+
+      -- Now look at either the right-hand split if searching
+      -- forward, or the reversed left-hand split if searching
+      -- backward.
+      headResult = find (test . snd) . reverse . zip [0 ..] . toList $ h
+      tailResult = find (test . snd) . zip [start ..] . toList $ t
+      result = case dir of Down -> tailResult; Up -> headResult
+   in maybe id (set BL.listSelectedL . Just . fst) result l

--- a/src/Swarm/TUI/List.hs
+++ b/src/Swarm/TUI/List.hs
@@ -6,19 +6,9 @@
 module Swarm.TUI.List (handleListEventWithSeparators) where
 
 import Brick (EventM)
+import Brick.Widget.List.Skippable
 import Brick.Widgets.List qualified as BL
-import Control.Lens (set, (&), (^.))
-import Control.Monad.State.Strict (modify)
-import Data.Foldable (toList)
-import Data.List (find)
 import Graphics.Vty qualified as V
-
-data Amount = Max | Page
-
-data Movement =
-    Single FindDir
-  | Multi Amount FindDir
-  | None
 
 -- | Handle a list event, taking an extra predicate to identify which
 --   list elements are separators; separators will be skipped if
@@ -30,7 +20,7 @@ handleListEventWithSeparators ::
   (e -> Bool) ->
   EventM n (BL.GenericList n t e) ()
 handleListEventWithSeparators e isSep =
-  updateList isSep eventMap e
+  navigateList isSep eventMap e
  where
   eventMap = \case
     V.EvKey V.KUp [] -> Single Up
@@ -42,71 +32,3 @@ handleListEventWithSeparators e isSep =
     V.EvKey V.KPageDown [] -> Multi Page Down
     V.EvKey V.KPageUp [] -> Multi Page Up
     _ -> None
-
-updateList :: (Ord n, Foldable t, BL.Splittable t) =>
-  (e -> Bool) ->
-  (V.Event -> Movement) ->
-  V.Event ->
-  EventM n (BL.GenericList n t e) ()
-updateList isSep evMap e = case evMap e of
-  Single d -> modify $ f d ExcludeCurrent
-  Multi amount d ->
-    let g = f d IncludeCurrent in
-    case amount of
-      Max -> modify $ g . case d of
-        Up -> BL.listMoveToBeginning
-        Down -> BL.listMoveToEnd
-      Page -> precondition >> modify g
-        where
-          precondition = case d of
-            Up -> BL.listMovePageUp
-            Down -> BL.listMovePageDown
-  None -> return ()
-  where
-    f d x = listFindByStrategy (FindStrategy d x) $ not . isSep
-
--- | Which direction to search: forward or backward from the current location.
-data FindDir = Down | Up deriving (Eq, Ord, Show, Enum)
-
--- | Should we include or exclude the current location in the search?
-data FindStart = IncludeCurrent | ExcludeCurrent deriving (Eq, Ord, Show, Enum)
-
--- | A 'FindStrategy' is a pair of a 'FindDir' and a 'FindStart'.
-data FindStrategy = FindStrategy FindDir FindStart
-
--- | Starting from the currently selected element, attempt to find and
---   select the next element matching the predicate. How the search
---   proceeds depends on the 'FindStrategy': the 'FindDir' says
---   whether to search forward or backward from the selected element,
---   and the 'FindStart' says whether the currently selected element
---   should be included in the search or not.
-listFindByStrategy ::
-  (Foldable t, BL.Splittable t) =>
-  FindStrategy ->
-  (e -> Bool) ->
-  BL.GenericList n t e ->
-  BL.GenericList n t e
-listFindByStrategy (FindStrategy dir cur) test l =
-  -- Figure out what index to split on.  We will call splitAt on
-  -- (current selected index + adj).
-  let adj =
-        -- If we're search forward, split on current index; if
-        -- finding backward, split on current + 1 (so that the
-        -- left-hand split will include the current index).
-        case dir of Down -> 0; Up -> 1
-          -- ... but if we're excluding the current index, swap that, so
-          -- the current index will be excluded rather than included in
-          -- the part of the split we're going to look at.
-          & case cur of IncludeCurrent -> id; ExcludeCurrent -> (1 -)
-
-      -- Split at the index we computed.
-      start = maybe 0 (+ adj) (l ^. BL.listSelectedL)
-      (h, t) = BL.splitAt start (l ^. BL.listElementsL)
-
-      -- Now look at either the right-hand split if searching
-      -- forward, or the reversed left-hand split if searching
-      -- backward.
-      headResult = find (test . snd) . reverse . zip [0 ..] . toList $ h
-      tailResult = find (test . snd) . zip [start ..] . toList $ t
-      result = case dir of Down -> tailResult; Up -> headResult
-   in maybe id (set BL.listSelectedL . Just . fst) result l

--- a/src/Swarm/TUI/List.hs
+++ b/src/Swarm/TUI/List.hs
@@ -20,15 +20,13 @@ handleListEventWithSeparators ::
   (e -> Bool) ->
   EventM n (BL.GenericList n t e) ()
 handleListEventWithSeparators e isSep =
-  navigateList isSep eventMap e
- where
-  eventMap = \case
+  navigateList isSep e $ \case
     V.EvKey V.KUp [] -> Single Up
     V.EvKey (V.KChar 'k') [] -> Single Up
     V.EvKey V.KDown [] -> Single Down
     V.EvKey (V.KChar 'j') [] -> Single Down
-    V.EvKey V.KHome [] -> Multi Max Up
-    V.EvKey V.KEnd [] -> Multi Max Down
-    V.EvKey V.KPageDown [] -> Multi Page Down
-    V.EvKey V.KPageUp [] -> Multi Page Up
+    V.EvKey V.KHome [] -> Multi Up Max
+    V.EvKey V.KEnd [] -> Multi Down Max
+    V.EvKey V.KPageDown [] -> Multi Down Page
+    V.EvKey V.KPageUp [] -> Multi Up Page
     _ -> None

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -81,7 +81,8 @@ common ghc2021-extensions
 
 library
     import:           stan-config, common, ghc2021-extensions
-    exposed-modules:  Data.BoolExpr.Simplify
+    exposed-modules:  Brick.Widget.List.Skippable
+                      Data.BoolExpr.Simplify
                       Swarm.App
                       Swarm.DocGen
                       Swarm.Game.Failure


### PR DESCRIPTION
The purpose of this refactoring is to decouple the key mapping from imperative list movement instructions.  In the new API (a function named `navigateList`), one supplies a declarative mapping of key events to a sum type that represents the desired movement.

As a client of the API, one's code reduces to this:
```
navigateList isSep e $ \case
    V.EvKey V.KUp [] -> Single Up
    V.EvKey V.KDown [] -> Single Down
    V.EvKey V.KHome [] -> Multi Up Max
    V.EvKey V.KEnd [] -> Multi Down Max
    V.EvKey V.KPageUp [] -> Multi Up Page
    V.EvKey V.KPageDown [] -> Multi Down Page
    _ -> None
```