### PR TITLE
resonate command

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -28,3 +28,4 @@
 1157-drill-return-value.yaml
 1171-sniff-command.yaml
 1171-chirp-command.yaml
+1171-resonate-command.yaml

--- a/data/scenarios/Testing/1171-resonate-command.yaml
+++ b/data/scenarios/Testing/1171-resonate-command.yaml
@@ -1,0 +1,49 @@
+version: 1
+name: Resonate test
+creative: true
+description: Count trees in an area
+objectives:
+  - goal:
+      - Place 7 trees.
+    condition: |
+      j <- robotnamed "judge";
+      as j {
+        c <- resonate "tree" ((0, 0), (8, -2));
+        return $ c >= 7;
+      };
+solution: |
+  def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
+  doN 7 (place "tree"; move)
+robots:
+  - name: base
+    dir: [1, 0]
+    display:
+      char: Ω
+      attr: robot
+    devices:
+      - logger
+      - string
+      - grabber
+      - compass
+      - treads
+      - ADT calculator
+    inventory:
+      - [7, "tree"]
+  - name: judge
+    dir: [1, 0]
+    system: true
+    display:
+      invisible: false
+      char: J
+known: []
+world:
+  default: [blank, boulder]
+  palette:
+    'Ω': [grass, null, base]
+    'J': [grass, null, judge]
+    '.': [grass]
+  upperleft: [4, -1]
+  map: |
+   J........
+   .Ω.......
+   .........

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -77,6 +77,7 @@
                "time"
                "whereami"
                "detect"
+               "resonate"
                "sniff"
                "chirp"
                "heading"

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -58,7 +58,7 @@
 				},
 				{
 				"name": "keyword.other",
-				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|equip|unequip|make|has|equipped|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|time|whereami|detect|sniff|chirp|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|teleport|as|robotnamed|robotnumbered|knows)\\b"
+				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|equip|unequip|make|has|equipped|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|time|whereami|detect|resonate|sniff|chirp|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|teleport|as|robotnamed|robotnumbered|knows)\\b"
 				}
 			]
 			},

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1243,18 +1243,18 @@ execConst c vs s k = do
       let Location x y = loc
       return $ Out (VPair (VInt (fromIntegral x)) (VInt (fromIntegral y))) s k
     Detect -> case vs of
-      [VText name, r] -> do
+      [VText name, VRect x1 y1 x2 y2] -> do
         loc <- use robotLocation
-        let locs = rectCells r
+        let locs = rectCells x1 y1 x2 y2
         -- sort offsets by (Manhattan) distance so that we return the closest occurrence
         let sortedLocs = sortOn (\(V2 x y) -> abs x + abs y) locs
         firstOne <- findM (fmap (maybe False $ isEntityNamed name) . entityAt . (loc .+^)) sortedLocs
         return $ Out (asValue firstOne) s k
       _ -> badConst
     Resonate -> case vs of
-      [VText name, r] -> do
+      [VText name, VRect x1 y1 x2 y2] -> do
         loc <- use robotLocation
-        let locs = rectCells r
+        let locs = rectCells x1 y1 x2 y2
         hits <- mapM (fmap (fromEnum . maybe False (isEntityNamed name)) . entityAt . (loc .+^)) locs
         return $ Out (VInt $ fromIntegral $ sum hits) s k
       _ -> badConst
@@ -1919,8 +1919,8 @@ execConst c vs s k = do
       , prettyText (Out (VCApp c (reverse vs)) s k)
       ]
 
-  rectCells :: VRect -> [V2 Int32]
-  rectCells (VRect x1 y1 x2 y2) = [V2 x y | x <- [fromIntegral xMin .. fromIntegral xMax], y <- [fromIntegral yMin .. fromIntegral yMax]]
+  rectCells :: Integer -> Integer -> Integer -> Integer -> [V2 Int32]
+  rectCells x1 y1 x2 y2 = [V2 x y | x <- [fromIntegral xMin .. fromIntegral xMax], y <- [fromIntegral yMin .. fromIntegral yMax]]
    where
     (xMin, xMax) = sortPair (x1, x2)
     (yMin, yMax) = sortPair (y1, y2)

--- a/src/Swarm/Game/Value.hs
+++ b/src/Swarm/Game/Value.hs
@@ -21,8 +21,6 @@ type VRect = Value
 pattern VRect :: Integer -> Integer -> Integer -> Integer -> VRect
 pattern VRect x1 y1 x2 y2 = VPair (VPair (VInt x1) (VInt y1)) (VPair (VInt x2) (VInt y2))
 
-{-# COMPLETE VRect #-}
-
 -- * Conversions
 
 -- | Conversion from native Haskell types

--- a/src/Swarm/Game/Value.hs
+++ b/src/Swarm/Game/Value.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -13,6 +14,16 @@ import Linear (V2 (..))
 import Swarm.Game.Entity
 import Swarm.Game.Robot
 import Swarm.Language.Value
+
+-- * Patterns
+
+type VRect = Value
+pattern VRect :: Integer -> Integer -> Integer -> Integer -> VRect
+pattern VRect x1 y1 x2 y2 = VPair (VPair (VInt x1) (VInt y1)) (VPair (VInt x2) (VInt y2))
+
+{-# COMPLETE VRect #-}
+
+-- * Conversions
 
 -- | Conversion from native Haskell types
 -- to their swarm-lang equivalents, useful for

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -72,6 +72,8 @@ data Capability
     CSensehere
   | -- | Execute the 'Detect' command
     CDetectloc
+  | -- | Execute the 'Resonate' command
+    CDetectcount
   | -- | Execute the 'Sniff' command
     CDetectdistance
   | -- | Execute the 'Chirp' command
@@ -220,6 +222,7 @@ constCaps = \case
   Wait -> Just CTime
   Whereami -> Just CSenseloc
   Detect -> Just CDetectloc
+  Resonate -> Just CDetectcount
   Sniff -> Just CDetectdistance
   Chirp -> Just CDetectdirection
   Heading -> Just COrient

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -251,6 +251,9 @@ data Const
   | -- | Locate the closest instance of a given entity within the rectangle
     -- specified by opposite corners, relative to the current location.
     Detect
+  | -- | Count the number of a given entity within the rectangle
+    -- specified by opposite corners, relative to the current location.
+    Resonate
   | -- | Get the distance to the closest instance of the specified entity.
     Sniff
   | -- | Get the direction to the closest instance of the specified entity.
@@ -608,6 +611,11 @@ constInfo c = case c of
   Detect ->
     command 2 Intangible . doc "Detect an entity within a rectangle." $
       ["Locate the closest instance of a given entity within the rectangle specified by opposite corners, relative to the current location."]
+  Resonate ->
+    command 2 Intangible . doc "Count entities within a rectangle." $
+      [ "Applies a strong magnetic field over a given area and stimulates the matter within, generating a non-directional radio signal. A receiver tuned to the resonant frequency of the target entity is able to measure its quantity."
+      , "Counts the entities within the rectangle specified by opposite corners, relative to the current location."
+      ]
   Sniff ->
     command 1 short . doc "Determine distance to entity." $
       [ "Measures concentration of airborne particles to infer distance to a certain kind of entity."

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -563,6 +563,7 @@ inferConst c = case c of
   Time -> [tyQ| cmd int |]
   Whereami -> [tyQ| cmd (int * int) |]
   Detect -> [tyQ| text -> ((int * int) * (int * int)) -> cmd (unit + (int * int)) |]
+  Resonate -> [tyQ| text -> ((int * int) * (int * int)) -> cmd int |]
   Sniff -> [tyQ| text -> cmd int |]
   Chirp -> [tyQ| text -> cmd dir |]
   Heading -> [tyQ| cmd dir |]

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -10,6 +10,7 @@
 module Swarm.Util (
   -- * Miscellaneous utilities
   (?),
+  sortPair,
   maxOn,
   maximum0,
   cycleEnum,
@@ -106,6 +107,10 @@ infix 4 %%=, <+=, <%=, <<.=, <>=
 --   defaulting to @def@ as a last resort.
 (?) :: Maybe a -> a -> a
 (?) = flip fromMaybe
+
+-- | Ensure the smaller value in a pair is the first element.
+sortPair :: Ord b => (b, b) -> (b, b)
+sortPair (x, y) = if x <= y then (x, y) else (y, x)
 
 -- | Find the maximum of two values, comparing them according to a
 --   custom projection function.


### PR DESCRIPTION
Towards #1171

The `resonate` command counts entities of a given type within a rectangle.

This PR also fixes a bug in `detect` when the rectangle coords are non-ascending.