### PR TITLE
More efficient gopher solution using 'watch'

### DIFF
--- a/data/scenarios/Challenges/_gopher/solution.sw
+++ b/data/scenarios/Challenges/_gopher/solution.sw
@@ -20,6 +20,13 @@ def getDirection = \n.
     };
     end;
 
+def watchDir = \n.
+    watch $ getDirection n;
+    if (n > 0) {
+        watchDir $ n - 1;
+    } {};
+    end;
+
 /**
 Loops forever
 */
@@ -42,9 +49,8 @@ def scanDirections = \n.
         if (n > 0) {
             scanDirections $ n - 1;
         } {
-            // Inserting this "wait" speeds up the
-            // integration test significantly (more than 3x)
-            wait 64;
+            watchDir 4;
+            wait 1000;
             scanDirections 4;
         };
     } {};

--- a/data/scenarios/Challenges/gopher.yaml
+++ b/data/scenarios/Challenges/gopher.yaml
@@ -73,6 +73,7 @@ robots:
       - [120, swivel]
       - [120, branch predictor]
       - [120, drill]
+      - [120, rolex]
       - [120, flower]
   - name: gopher
     system: true
@@ -117,6 +118,14 @@ entities:
     description:
       - Unearthed by industrious gophers.
     properties: [known, portable]
+  - name: rolex
+    display:
+      char: 'R'
+      attr: silver
+    description:
+      - Enables robots to use the 'watch' command.
+    properties: [known, portable]
+    capabilities: [wakeself]
 recipes:
   - in:
       - [1, mound]

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -190,7 +190,7 @@ testScenarioSolution _ci _em =
         , testSolution (Sec 3) "Challenges/word-search"
         , testSolution (Sec 5) "Challenges/bridge-building"
         , testSolution (Sec 3) "Challenges/ice-cream"
-        , testSolution (Sec 20) "Challenges/gopher"
+        , testSolution (Sec 5) "Challenges/gopher"
         , testSolution (Sec 5) "Challenges/hackman"
         , testSolution (Sec 10) "Challenges/hanoi"
         , testSolution Default "Challenges/friend"


### PR DESCRIPTION
Tested using:

    scripts/run-tests.sh --test-arguments '--pattern "gopher"'

| Before | After |
| --- | --- |
| 6.28s | 1.33s |