### PR TITLE
implement stride command

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -31,3 +31,4 @@
 1171-chirp-command.yaml
 1171-resonate-command.yaml
 1207-scout-command.yaml
+1218-stride-command.yaml

--- a/data/scenarios/Testing/1218-stride-command.yaml
+++ b/data/scenarios/Testing/1218-stride-command.yaml
@@ -1,0 +1,102 @@
+version: 1
+name: Stride test
+creative: false
+description: Move multiple cells at once
+objectives:
+  - goal:
+      - Grab the tree, but not a flower
+    condition: |
+      as base {has "tree"}
+    prerequisite:
+        logic:
+          not:
+            id: grab_flower
+  - id: grab_flower
+    teaser: Grab flower
+    goal:
+      - Grab a flower
+    condition: |
+      as base {has "flower"}
+solution: |
+  stride 0;
+  stride (-1);
+
+  turn north;
+  try {
+    stride 5;
+    grab;
+    return ();
+  } {
+    log "Could not grab northern flower";
+  };
+
+  turn west;
+  try {    
+    stride 1;
+  } {
+    log "Could not stride west";
+  };
+
+  turn south;
+  try {
+    stride 5;
+    grab;
+    return ();
+  } {
+    log "Could not grab southern flower";
+  };
+  
+  turn east;
+  stride 5;
+  grab;
+robots:
+  - name: base
+    dir: [1, 0]
+    display:
+      char: Ω
+      attr: robot
+    devices:
+      - branch predictor
+      - calculator
+      - compass
+      - dictionary
+      - grabber
+      - logger
+      - net
+      - scanner
+      - treads
+      - turbocharger
+entities:
+- name: turbocharger
+  display:
+    attr: silver
+    char: 't'
+  description:
+  - Allows one to "stride" across multiple cells
+  properties: [known, portable]
+  capabilities: [movemultiple]
+known: [tree, flower, boulder, water]
+world:
+  default: [blank]
+  palette:
+    'Ω': [grass, null, base]
+    '.': [grass]
+    '@': [grass, boulder]
+    'T': [grass, tree]
+    '*': [grass, flower]
+    'w': [grass, water]
+  upperleft: [0, 0]
+  map: |
+   ..............
+   ......*.......
+   ..............
+   ......w.......
+   ..............
+   ...www........
+   .*.wwwΩ....T..
+   ...www@.......
+   ..............
+   ..............
+   ..............
+   ......*.......
+   ..............

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -54,6 +54,7 @@
                "wait"
                "selfdestruct"
                "move"
+               "stride"
                "turn"
                "grab"
                "harvest"

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -58,7 +58,7 @@
 				},
 				{
 				"name": "keyword.other",
-				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|turn|grab|harvest|place|give|equip|unequip|make|has|equipped|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|time|scout|whereami|detect|resonate|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|installkeyhandler|teleport|as|robotnamed|robotnumbered|knows)\\b"
+				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|stride|turn|grab|harvest|place|give|equip|unequip|make|has|equipped|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|time|scout|whereami|detect|resonate|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|installkeyhandler|teleport|as|robotnamed|robotnumbered|knows)\\b"
 				}
 			]
 			},

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1068,6 +1068,18 @@ execConst c vs s k = do
       return $ Out VUnit s k
     Stride -> case vs of
       [VInt d] -> do
+        when (d > fromIntegral maxStrideRange) $
+          throwError $
+            CmdFailed
+              Stride
+              ( T.unwords
+                  [ "Can only stride up to"
+                  , T.pack $ show maxStrideRange
+                  , "units."
+                  ]
+              )
+              Nothing
+
         -- Figure out where we're going
         loc <- use robotLocation
         orient <- use robotOrientation

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1066,6 +1066,37 @@ execConst c vs s k = do
           }
       updateRobotLocation loc nextLoc
       return $ Out VUnit s k
+    Stride -> case vs of
+      [VInt d] -> do
+        -- Figure out where we're going
+        loc <- use robotLocation
+        orient <- use robotOrientation
+        let heading = orient ? zero
+
+        -- Excludes the base location.
+        let locsInDirection :: [Location]
+            locsInDirection =
+              take (min (fromIntegral d) maxStrideRange) $
+                drop 1 $
+                  iterate (.+^ heading) loc
+
+        failureMaybes <- mapM checkMoveFailure locsInDirection
+        let maybeFirstFailure = asum failureMaybes
+
+        applyMoveFailureEffect maybeFirstFailure $
+          MoveFailure
+            { failIfBlocked = ThrowExn
+            , failIfDrown = Destroy
+            }
+
+        let maybeLastLoc = do
+              guard $ null maybeFirstFailure
+              listToMaybe $ reverse locsInDirection
+
+        forM_ maybeLastLoc $ updateRobotLocation loc
+
+        return $ Out VUnit s k
+      _ -> badConst
     Teleport -> case vs of
       [VRobot rid, VPair (VInt x) (VInt y)] -> do
         -- Make sure the other robot exists and is close
@@ -2228,30 +2259,54 @@ execConst c vs s k = do
       mAch
     selfDestruct .= True
 
-  -- Make sure nothing is in the way. Note that system robots implicitly ignore and base throws on failure.
-  checkMoveAhead :: HasRobotStepState sig m => Location -> MoveFailure -> m ()
-  checkMoveAhead nextLoc MoveFailure {..} = do
+  -- Make sure nothing is in the way. Note that system robots implicitly ignore
+  -- and base throws on failure.
+  checkMoveFailure :: HasRobotStepState sig m => Location -> m (Maybe MoveFailureDetails)
+  checkMoveFailure nextLoc = do
     me <- entityAt nextLoc
     systemRob <- use systemRobot
-    case me of
-      Nothing -> return ()
-      Just e
-        | systemRob -> return ()
-        | otherwise -> do
-            -- robots can not walk through walls
-            when (e `hasProperty` Unwalkable) $
-              case failIfBlocked of
-                Destroy -> destroyIfNotBase Nothing
-                ThrowExn -> throwError $ cmdExn c ["There is a", e ^. entityName, "in the way!"]
-                IgnoreFail -> return ()
+    caps <- use robotCapabilities
+    return $ do
+      e <- me
+      guard $ not systemRob
+      go caps e
+   where
+    go caps e
+      -- robots can not walk through walls
+      | e `hasProperty` Unwalkable = Just $ MoveFailureDetails e PathBlocked
+      -- robots drown if they walk over liquid without boat
+      | e `hasProperty` Liquid && CFloat `S.notMember` caps =
+          Just $ MoveFailureDetails e PathLiquid
+      | otherwise = Nothing
 
-            -- robots drown if they walk over liquid without boat
-            caps <- use robotCapabilities
-            when (e `hasProperty` Liquid && CFloat `S.notMember` caps) $
-              case failIfDrown of
-                Destroy -> destroyIfNotBase Nothing
-                ThrowExn -> throwError $ cmdExn c ["There is a dangerous liquid", e ^. entityName, "in the way!"]
-                IgnoreFail -> return ()
+  applyMoveFailureEffect ::
+    HasRobotStepState sig m =>
+    Maybe MoveFailureDetails ->
+    MoveFailure ->
+    m ()
+  applyMoveFailureEffect maybeFailure MoveFailure {..} =
+    case maybeFailure of
+      Nothing -> return ()
+      Just (MoveFailureDetails e failureMode) -> case failureMode of
+        PathBlocked ->
+          handleFailure
+            failIfBlocked
+            ["There is a", e ^. entityName, "in the way!"]
+        PathLiquid ->
+          handleFailure
+            failIfDrown
+            ["There is a dangerous liquid", e ^. entityName, "in the way!"]
+   where
+    handleFailure behavior message = case behavior of
+      Destroy -> destroyIfNotBase Nothing
+      ThrowExn -> throwError $ cmdExn c message
+      IgnoreFail -> return ()
+
+  -- Determine the move failure mode and apply the corresponding effect.
+  checkMoveAhead :: HasRobotStepState sig m => Location -> MoveFailure -> m ()
+  checkMoveAhead nextLoc failureHandlers = do
+    maybeFailure <- checkMoveFailure nextLoc
+    applyMoveFailureEffect maybeFailure failureHandlers
 
   getRobotWithinTouch :: HasRobotStepState sig m => RID -> m Robot
   getRobotWithinTouch rid = do
@@ -2405,6 +2460,9 @@ grantAchievement a = do
       (<>)
       a
       (Attainment (GameplayAchievement a) scenarioPath currentTime)
+
+data MoveFailureMode = PathBlocked | PathLiquid
+data MoveFailureDetails = MoveFailureDetails Entity MoveFailureMode
 
 -- | How to handle failure, for example when moving to blocked location
 data RobotFailure = ThrowExn | Destroy | IgnoreFail

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -34,6 +34,8 @@ data Capability
     CPower
   | -- | Execute the 'Move' command
     CMove
+  | -- | Execute the 'Stride' command
+    CMovemultiple
   | -- | Execute the 'Move' command for a heavy robot
     CMoveheavy
   | -- | Execute the 'Turn' command
@@ -193,6 +195,7 @@ constCaps = \case
   Log -> Just CLog
   Selfdestruct -> Just CSelfdestruct
   Move -> Just CMove
+  Stride -> Just CMovemultiple
   Turn -> Just CTurn
   Grab -> Just CGrab
   Harvest -> Just CHarvest

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -563,7 +563,10 @@ constInfo c = case c of
       , "This destroys the robot's inventory, so consider `salvage` as an alternative."
       ]
   Move -> command 0 short "Move forward one step."
-  Stride -> command 1 short "Move forward multiple steps."
+  Stride ->
+    command 1 short . doc "Move forward multiple steps." $
+      [ T.unwords ["Has a max range of", T.pack $ show maxStrideRange, "units."]
+      ]
   Turn -> command 1 short "Turn in some direction."
   Grab -> command 0 short "Grab an item from the current location."
   Harvest ->
@@ -632,7 +635,9 @@ constInfo c = case c of
   Time -> command 0 Intangible "Get the current time."
   Scout ->
     command 1 short . doc "Detect whether a robot is within line-of-sight in a direction." $
-      ["Perception is blocked by 'Opaque' entities."]
+      [ "Perception is blocked by 'Opaque' entities."
+      , T.unwords ["Has a max range of", T.pack $ show maxScoutRange, "units."]
+      ]
   Whereami -> command 0 Intangible "Get the current x and y coordinates."
   Detect ->
     command 2 Intangible . doc "Detect an entity within a rectangle." $

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -38,6 +38,7 @@ module Swarm.Language.Syntax (
   isLong,
   maxSniffRange,
   maxScoutRange,
+  maxStrideRange,
 
   -- * Syntax
   Syntax' (..),
@@ -111,6 +112,9 @@ maxSniffRange = 256
 
 maxScoutRange :: Int
 maxScoutRange = 64
+
+maxStrideRange :: Int
+maxStrideRange = 64
 
 ------------------------------------------------------------
 -- Directions
@@ -202,6 +206,8 @@ data Const
 
     -- | Move forward one step.
     Move
+  | -- | Move forward multiple steps.
+    Stride
   | -- | Turn in some direction.
     Turn
   | -- | Grab an item from the current location.
@@ -557,6 +563,7 @@ constInfo c = case c of
       , "This destroys the robot's inventory, so consider `salvage` as an alternative."
       ]
   Move -> command 0 short "Move forward one step."
+  Stride -> command 1 short "Move forward multiple steps."
   Turn -> command 1 short "Turn in some direction."
   Grab -> command 0 short "Grab an item from the current location."
   Harvest ->

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -539,6 +539,7 @@ inferConst c = case c of
   Noop -> [tyQ| cmd unit |]
   Selfdestruct -> [tyQ| cmd unit |]
   Move -> [tyQ| cmd unit |]
+  Stride -> [tyQ| int -> cmd unit |]
   Turn -> [tyQ| dir -> cmd unit |]
   Grab -> [tyQ| cmd text |]
   Harvest -> [tyQ| cmd text |]


### PR DESCRIPTION
Closes #1218

    scripts/play.sh --scenario data/scenarios/Testing/1218-stride-command.yaml --autoplay

I decided to implement this command with the same exception behaviors as the `move` command.
If any obstructions exist on the path, then an exception is thrown and no movement is made.

The implications of this are:
1. With `try`, one can learn in `O(1)` time whether any obstructions exist along a line of up to 64 units long
2. One can learn in `O(log N)` time the exact distance of the nearest obstruction along that line.