### PR TITLE
Immediately flag world for redraw when scanning/uploading

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -622,7 +622,8 @@ runFrameTicks dt = do
   a <- use (uiState . accumulatedTime)
   t <- use (uiState . frameTickCount)
 
-  -- Is there still time left?  Or have we hit the cap on ticks per frame?
+  -- Ensure there is still enough time left, and we haven't hit the
+  -- tick limit for this frame.
   when (a >= dt && t < ticksPerFrameCap) $ do
     -- If so, do a tick, count it, subtract dt from the accumulated time,
     -- and loop!
@@ -700,7 +701,7 @@ updateUI = do
   -- If the robot moved in or out of range, or hashes don't match
   -- (either because which robot (or whether any robot) is focused
   -- changed, or the focused robot's inventory changed), or the
-  -- inventory was flagged to be updated, regenerate the list.
+  -- inventory was flagged to be updated, regenerate the inventory list.
   inventoryUpdated <-
     if farChanged || (not farChanged && listRobotHash /= focusedRobotHash) || shouldUpdate
       then do


### PR DESCRIPTION
Executing `scan` or `upload` may change the way the world is drawn, so we need to flag a redraw.  Fixes #758.

I also included a few updated/improved comments I made while trying to understand various bits of code (though they were ultimately unrelated to this issue).