### PR TITLE
reduce lag in monitor bot for Maypole scenario

### DIFF
--- a/data/scenarios/Challenges/_maypole/monitor.sw
+++ b/data/scenarios/Challenges/_maypole/monitor.sw
@@ -58,6 +58,18 @@ def getCurrentQuadrant : (int * int) -> cmd int = \myLoc.
   return $ getQuadrant baseLoc myLoc;
   end;
 
+def checkNewQuadrant = \myLoc. \prevQuadrant. \quadrantTraversalCount.
+  currentQuadrant <- getCurrentQuadrant myLoc;
+  let changeCount = getQuadrantIncrement prevQuadrant currentQuadrant in
+  let newQuadrantCount = quadrantTraversalCount + changeCount in
+
+  if (changeCount != 0) {
+    swap $ "maypole " ++ format currentQuadrant;
+    return ();
+  } {};
+  return (currentQuadrant, newQuadrantCount);
+  end;
+
 /*
 Although conceivably the current quadrant could
 be derived from the quadrant traversal count,
@@ -70,15 +82,9 @@ with the absolute quadrant index.
 */
 def monitorAngle : (int * int) -> int -> int -> int -> cmd unit =
     \myLoc. \targetQuadrantCount. \prevQuadrant. \quadrantTraversalCount.
-  
-  currentQuadrant <- getCurrentQuadrant myLoc;
-  let changeCount = getQuadrantIncrement prevQuadrant currentQuadrant in
-  let newQuadrantCount = quadrantTraversalCount + changeCount in
-
-  if (changeCount != 0) {
-    swap $ "maypole " ++ format currentQuadrant;
-    return ();
-  } {};
+  result <- instant $ checkNewQuadrant myLoc prevQuadrant quadrantTraversalCount;
+  let currentQuadrant = fst result in
+  let newQuadrantCount = snd result in
 
   if (newQuadrantCount < targetQuadrantCount) {
     monitorAngle myLoc targetQuadrantCount currentQuadrant newQuadrantCount;


### PR DESCRIPTION
As I was testing #1010, I observed that the `maypole.yaml` scenario (#1158) would reach the "won" condition if launched from the command line via `--autoplay`, for which the `solution` content is the following code:

    run "scenarios/Challenges/_maypole/solution.sw"

but would **not** achieve a win if executed via `--run` with the solution file:

    scripts/play.sh --scenario data/scenarios/Challenges/maypole.yaml --run data/scenarios/Challenges/_maypole/solution.sw

Placing a `wait 16` at the beginning of the solution script was enough to fix the `--run` invocation.  Presumably, the overhead of the `run` command for the player's `solution` code had previously given the system robot enough of a head start in counting the player's loops to reach the goal count.

Ultimately, instead of placing a delay in the solution, I sped up the system robot with an `instant` command (#1231).  However, inserting `instant` requires some care; it can cause the game to freeze if it gets tangled with a recursion.

Perhaps a better solution in the long term would be to have some way to make system robots (in particular, invisible "judge" robots) execute *all* commands in zero ticks.  This should not be the default for all system robots, especially those that are not `invisible`; sometimes we prefer that their commands have finite duration to interact plausibly with the player.