### PR TITLE
Inventory search/filter mode

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -1333,35 +1333,50 @@ handleRobotPanelEvent bev = do
       CharKey '/' -> do
         uiState . uiInventoryShouldUpdate .= True
         uiState . uiInventorySearch .= Just ""
-      VtyEvent ev -> do
-        -- This does not work we want to skip redrawing in the no-list case
-        -- Brick.zoom (uiState . uiInventory . _Just . _2) (handleListEventWithSeparators ev (is _Separator))
-        mList <- preuse $ uiState . uiInventory . _Just . _2
-        case mList of
-          Nothing -> continueWithoutRedraw
-          Just l -> do
-            l' <- nestEventM' l (handleListEventWithSeparators ev (is _Separator))
-            uiState . uiInventory . _Just . _2 .= l'
+      VtyEvent ev -> handleInventoryListEvent ev
       _ -> continueWithoutRedraw
 
--- | XXX
+-- | Handle an event to navigate through the inventory list.
+handleInventoryListEvent :: V.Event -> EventM Name AppState ()
+handleInventoryListEvent ev = do
+
+  -- Note, refactoring like this is tempting:
+  --
+  --   Brick.zoom (uiState . uiInventory . _Just . _2) (handleListEventWithSeparators ev (is _Separator))
+  --
+  -- However, this does not work since we want to skip redrawing in the no-list case!
+
+  mList <- preuse $ uiState . uiInventory . _Just . _2
+  case mList of
+    Nothing -> continueWithoutRedraw
+    Just l -> do
+      l' <- nestEventM' l (handleListEventWithSeparators ev (is _Separator))
+      uiState . uiInventory . _Just . _2 .= l'
+
+-- | Handle a user input event in the robot/inventory panel, while in
+--   inventory search mode.
 handleInventorySearchEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleInventorySearchEvent = \case
+  -- Escape: stop filtering and go back to regular inventory mode
   EscapeKey -> do
     uiState . uiInventoryShouldUpdate .= True
     uiState . uiInventorySearch .= Nothing
+  -- Enter: return to regular inventory mode, and pop out the selected item
   Key V.KEnter -> do
     uiState . uiInventoryShouldUpdate .= True
     uiState . uiInventorySearch .= Nothing
     gets focusedEntity >>= maybe continueWithoutRedraw descriptionModal
+  -- Any old character: append to the current search string
   CharKey c -> do
     uiState . uiInventoryShouldUpdate .= True
     uiState . uiInventorySearch %= fmap (`snoc` c)
+  -- Backspace: chop the last character off the end of the current search string
   BackspaceKey -> do
     uiState . uiInventoryShouldUpdate .= True
     uiState . uiInventorySearch %= fmap (T.dropEnd 1)
-  -- XXX need to handle list events too, consider splitting out list handling stuff into a
-  -- helper function
+  -- Handle any other event as list navigation, so we can look through
+  -- the filtered inventory using e.g. arrow keys
+  VtyEvent ev -> handleInventoryListEvent ev
   _ -> continueWithoutRedraw
 
 -- | Attempt to make an entity selected from the inventory, if the

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -1326,6 +1326,12 @@ handleRobotPanelEvent = \case
   (CharKey ':') -> do
     uiState . uiInventoryShouldUpdate .= True
     uiState . uiInventorySort %= cycleSortDirection
+  (CharKey '/') -> do
+    uiState . uiInventoryShouldUpdate .= True
+    uiState . uiInventorySearch .= Just ""
+  EscapeKey -> do
+    uiState . uiInventoryShouldUpdate .= True
+    uiState . uiInventorySearch .= Nothing
   (VtyEvent ev) -> do
     -- This does not work we want to skip redrawing in the no-list case
     -- Brick.zoom (uiState . uiInventory . _Just . _2) (handleListEventWithSeparators ev (is _Separator))

--- a/src/Swarm/TUI/Controller/Util.hs
+++ b/src/Swarm/TUI/Controller/Util.hs
@@ -30,6 +30,9 @@ pattern ShiftKey k = VtyEvent (V.EvKey k [V.MShift])
 pattern EscapeKey :: BrickEvent n e
 pattern EscapeKey = VtyEvent (V.EvKey V.KEsc [])
 
+pattern BackspaceKey :: BrickEvent n e
+pattern BackspaceKey = VtyEvent (V.EvKey V.KBS [])
+
 pattern FKey :: Int -> BrickEvent n e
 pattern FKey c = VtyEvent (V.EvKey (V.KFun c) [])
 

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -107,6 +107,7 @@ module Swarm.TUI.Model (
   initRuntimeState,
 ) where
 
+import Text.Fuzzy qualified as Fuzzy
 import Brick
 import Brick.Widgets.List qualified as BL
 import Control.Lens hiding (from, (<.>))
@@ -264,13 +265,14 @@ populateInventoryList (Just r) = do
   mList <- preuse (uiInventory . _Just . _2)
   showZero <- use uiShowZero
   sortOptions <- use uiInventorySort
+  search <- use uiInventorySearch
   let mkInvEntry (n, e) = InventoryEntry n e
       mkInstEntry (_, e) = EquippedEntry e
       itemList isInventoryDisplay mk label =
         (\case [] -> []; xs -> Separator label : xs)
           . map mk
           . sortInventory sortOptions
-          . filter shouldDisplay
+          . filter ((&&) <$> matchesSearch <*> shouldDisplay)
           . elems
        where
         -- Display items if we have a positive number of them, or they
@@ -282,6 +284,9 @@ populateInventoryList (Just r) = do
             || isInventoryDisplay
               && showZero
               && not ((r ^. equippedDevices) `E.contains` e)
+
+      matchesSearch :: (Count, Entity) -> Bool
+      matchesSearch (_, e) = maybe (const True) Fuzzy.test search (e ^. E.entityName)
 
       items =
         (r ^. robotInventory . to (itemList True mkInvEntry "Inventory"))

--- a/src/Swarm/TUI/Model/UI.hs
+++ b/src/Swarm/TUI/Model/UI.hs
@@ -17,6 +17,7 @@ module Swarm.TUI.Model.UI (
   uiREPL,
   uiInventory,
   uiInventorySort,
+  uiInventorySearch,
   uiMoreInfoTop,
   uiMoreInfoBot,
   uiScrollToEnd,
@@ -94,6 +95,7 @@ data UIState = UIState
   , _uiREPL :: REPLState
   , _uiInventory :: Maybe (Int, BL.List Name InventoryListEntry)
   , _uiInventorySort :: InventorySortOptions
+  , _uiInventorySearch :: Maybe Text
   , _uiMoreInfoTop :: Bool
   , _uiMoreInfoBot :: Bool
   , _uiScrollToEnd :: Bool
@@ -155,6 +157,9 @@ uiREPL :: Lens' UIState REPLState
 
 -- | The order and direction of sorting inventory list.
 uiInventorySort :: Lens' UIState InventorySortOptions
+
+-- | The current search string used to narrow the inventory view.
+uiInventorySearch :: Lens' UIState (Maybe Text)
 
 -- | The hash value of the focused robot entity (so we can tell if its
 --   inventory changed) along with a list of the items in the
@@ -296,6 +301,7 @@ initUIState showMainMenu cheatMode = do
           , _uiREPL = initREPLState $ newREPLHistory history
           , _uiInventory = Nothing
           , _uiInventorySort = defaultSortOptions
+          , _uiInventorySearch = Nothing
           , _uiMoreInfoTop = False
           , _uiMoreInfoBot = False
           , _uiScrollToEnd = False

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -909,8 +909,8 @@ drawKeyMenu s =
       ++ [("c", "recenter") | not viewingBase]
       ++ [("f", "FPS")]
   keyCmdsFor (Just (FocusablePanel RobotPanel)) =
-    [("Enter", "pop out")]
-      ++ if isJust inventorySearch
+    ("Enter", "pop out")
+      : if isJust inventorySearch
         then [("Esc", "exit search")]
         else
           [ ("m", "make")

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -56,7 +56,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.List.Split (chunksOf)
 import Data.Map qualified as M
-import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, mapMaybe, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, isJust, mapMaybe, maybeToList)
 import Data.Semigroup (sconcat)
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set (toList)

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -358,7 +358,18 @@ drawGameUI s =
       hBox
         [ hLimitPercent 25 $
             vBox
-              [ vLimitPercent 50 $ panel highlightAttr fr (FocusablePanel RobotPanel) plainBorder $ drawRobotPanel s
+              [ vLimitPercent 50 $
+                panel
+                  highlightAttr
+                  fr
+                  (FocusablePanel RobotPanel)
+                  ( plainBorder
+                      & bottomLabels . centerLabel
+                        .~ fmap
+                             (txt . (" Search: " <>) . (<>" "))
+                             (s ^. uiState . uiInventorySearch)
+                  )
+                  $ drawRobotPanel s
               , panel
                   highlightAttr
                   fr

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -56,7 +56,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.List.Split (chunksOf)
 import Data.Map qualified as M
-import Data.Maybe (catMaybes, fromMaybe, isJust, mapMaybe, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, mapMaybe, maybeToList)
 import Data.Semigroup (sconcat)
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set (toList)
@@ -846,6 +846,7 @@ drawKeyMenu s =
   goal = hasAnythingToShow $ s ^. uiState . uiGoal . goalsContent
   showZero = s ^. uiState . uiShowZero
   inventorySort = s ^. uiState . uiInventorySort
+  inventorySearch = s ^. uiState . uiInventorySearch
   ctrlMode = s ^. uiState . uiREPL . replControlMode
   canScroll = creative || (s ^. gameState . worldScrollable)
   handlerInstalled = isJust (s ^. gameState . inputHandler)
@@ -902,6 +903,8 @@ drawKeyMenu s =
     , ("0", (if showZero then "hide" else "show") <> " 0")
     , (":/;", T.unwords ["Sort:", renderSortMethod inventorySort])
     ]
+      ++ [("/", "search") | isNothing inventorySearch]
+      ++ [("Esc", "exit search") | isJust inventorySearch]
   keyCmdsFor (Just (FocusablePanel InfoPanel)) = []
   keyCmdsFor _ = []
 

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -909,13 +909,15 @@ drawKeyMenu s =
       ++ [("c", "recenter") | not viewingBase]
       ++ [("f", "FPS")]
   keyCmdsFor (Just (FocusablePanel RobotPanel)) =
-    [ ("Enter", "pop out")
-    , ("m", "make")
-    , ("0", (if showZero then "hide" else "show") <> " 0")
-    , (":/;", T.unwords ["Sort:", renderSortMethod inventorySort])
-    ]
-      ++ [("/", "search") | isNothing inventorySearch]
-      ++ [("Esc", "exit search") | isJust inventorySearch]
+    [ ("Enter", "pop out") ]
+    ++ if isJust inventorySearch
+         then [("Esc", "exit search")]
+         else
+           [ ("m", "make")
+           , ("0", (if showZero then "hide" else "show") <> " 0")
+           , (":/;", T.unwords ["Sort:", renderSortMethod inventorySort])
+           , ("/", "search")
+           ]
   keyCmdsFor (Just (FocusablePanel InfoPanel)) = []
   keyCmdsFor _ = []
 

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -140,7 +140,9 @@ getStatic g coords
   isStatic = case focusedRange g of
     -- If we're not viewing a robot, display static.  This
     -- can happen if e.g. the robot we were viewing drowned.
-    Nothing -> True
+    -- This is overridden by creative mode, e.g. when no robots
+    -- have been defined for the scenario.
+    Nothing -> not $ g ^. creativeMode
     -- Don't display static if the robot is close, or when we're in
     -- creative mode or the player is allowed to scroll the world.
     Just Close -> False

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -189,6 +189,7 @@ library
                       filepath                      >= 1.4 && < 1.5,
                       fused-effects                 >= 1.1.1.1 && < 1.2,
                       fused-effects-lens            >= 1.2.0.1 && < 1.3,
+                      fuzzy                         >= 0.1 && < 0.2,
                       githash                       >= 0.1.6 && < 0.2,
                       hashable                      >= 1.3.4 && < 1.5,
                       hsnoise                       >= 0.0.3 && < 0.1,


### PR DESCRIPTION
When the inventory panel is focused, hit `/` to enter search mode (maybe "search" is a bit of a misnomer, it's really more of a "filter" mode).  Then type stuff to modify the current search term, shown at the bottom of the inventory panel.  You can still navigate the filtered inventory list with arrow keys etc. Hit Esc to exit search mode or Enter to pop out the focused item (and also exit search mode).

Closes #126.