### PR TITLE
CLI option to set initial speed

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,6 +18,7 @@ import Swarm.Doc.Gen (EditorType (..), GenerateDocs (..), PageAddress (..), Shee
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Pipeline (processTerm)
 import Swarm.TUI.Model (AppOpts (..), ColorMode (..))
+import Swarm.TUI.Model.UI (defaultInitLgTicksPerSecond)
 import Swarm.Version
 import Swarm.Web (defaultPort)
 import System.Exit (exitFailure, exitSuccess)
@@ -55,6 +56,7 @@ cliParser =
               <*> scenario
               <*> run
               <*> autoplay
+              <*> speedFactor
               <*> cheat
               <*> color
               <*> webPort
@@ -119,6 +121,8 @@ cliParser =
   run = optional $ strOption (long "run" <> short 'r' <> metavar "FILE" <> help "Run the commands in a file at startup")
   autoplay :: Parser Bool
   autoplay = switch (long "autoplay" <> short 'a' <> help "Automatically run the solution defined in the scenario, if there is one. Mutually exclusive with --run.")
+  speedFactor :: Parser Int
+  speedFactor = option auto (long "speed" <> short 'm' <> value defaultInitLgTicksPerSecond <> help "Initial game speed multiplier")
   cheat :: Parser Bool
   cheat = switch (long "cheat" <> short 'x' <> help "Enable cheat mode. This allows toggling Creative Mode with Ctrl+v and unlocks \"Testing\" scenarios in the menu.")
   color :: Parser (Maybe ColorMode)

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -20,7 +20,7 @@ import Swarm.ReadableIORef (mkReadonly)
 import Swarm.TUI.Controller
 import Swarm.TUI.Model
 import Swarm.TUI.Model.StateUpdate
-import Swarm.TUI.Model.UI (uiAttrMap)
+import Swarm.TUI.Model.UI (defaultInitLgTicksPerSecond, uiAttrMap)
 import Swarm.TUI.View
 import Swarm.Version (getNewerReleaseVersion)
 import Swarm.Web
@@ -117,6 +117,7 @@ demoWeb = do
           , userScenario = demoScenario
           , scriptToRun = Nothing
           , autoPlay = False
+          , speed = defaultInitLgTicksPerSecond
           , cheatMode = False
           , colorMode = Nothing
           , userWebPort = Nothing

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -327,6 +327,8 @@ data AppOpts = AppOpts
   -- ^ Code to be run on base.
   , autoPlay :: Bool
   -- ^ Automatically run the solution defined in the scenario file
+  , speed :: Int
+  -- ^ Initial game speed (logarithm)
   , cheatMode :: Bool
   -- ^ Should cheat mode be enabled?
   , colorMode :: Maybe ColorMode

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -55,12 +55,12 @@ initAppState AppOpts {..} = do
   let isRunningInitialProgram = isJust scriptToRun || autoPlay
       skipMenu = isJust userScenario || isRunningInitialProgram || isJust userSeed
   (gsWarnings, gs) <- initGameState
-  (uiWarnings, ui) <- initUIState (not skipMenu) (cheatMode || autoPlay)
+  (uiWarnings, ui) <- initUIState speed (not skipMenu) (cheatMode || autoPlay)
   let logWarning rs' w = rs' & eventLog %~ logEvent (ErrorTrace Error) ("UI Loading", -8) (prettyFailure w)
       addWarnings = List.foldl' logWarning
       rs = addWarnings initRuntimeState $ gsWarnings <> uiWarnings
   case skipMenu of
-    False -> return $ AppState gs ui rs
+    False -> return $ AppState gs (ui & lgTicksPerSecond .~ defaultInitLgTicksPerSecond) rs
     True -> do
       (scenario, path) <- loadScenario (fromMaybe "classic" userScenario) (gs ^. entityMap)
       maybeRunScript <- getParsedInitialCode scriptToRun
@@ -171,7 +171,6 @@ scenarioToUIState siPair u = do
       & uiInventorySort .~ defaultSortOptions
       & uiShowFPS .~ False
       & uiShowZero .~ True
-      & lgTicksPerSecond .~ initLgTicksPerSecond
       & uiREPL .~ initREPLState (u ^. uiREPL . replHistory)
       & uiREPL . replHistory %~ restartREPLHistory
       & uiAttrMap .~ applyAttrMappings (map toAttrPair $ fst siPair ^. scenarioAttrs) swarmAttrMap

--- a/src/Swarm/TUI/Model/UI.hs
+++ b/src/Swarm/TUI/Model/UI.hs
@@ -46,7 +46,7 @@ module Swarm.TUI.Model.UI (
 
   -- ** Initialization
   initFocusRing,
-  initLgTicksPerSecond,
+  defaultInitLgTicksPerSecond,
   initUIState,
 ) where
 
@@ -276,16 +276,16 @@ initFocusRing :: FocusRing Name
 initFocusRing = focusRing $ map FocusablePanel listEnums
 
 -- | The initial tick speed.
-initLgTicksPerSecond :: Int
-initLgTicksPerSecond = 4 -- 2^4 = 16 ticks / second
+defaultInitLgTicksPerSecond :: Int
+defaultInitLgTicksPerSecond = 4 -- 2^4 = 16 ticks / second
 
 -- | Initialize the UI state.  This needs to be in the IO monad since
 --   it involves reading a REPL history file, getting the current
 --   time, and loading text files from the data directory.  The @Bool@
 --   parameter indicates whether we should start off by showing the
 --   main menu.
-initUIState :: Bool -> Bool -> ExceptT Text IO ([SystemFailure], UIState)
-initUIState showMainMenu cheatMode = do
+initUIState :: Int -> Bool -> Bool -> ExceptT Text IO ([SystemFailure], UIState)
+initUIState speedFactor showMainMenu cheatMode = do
   historyT <- liftIO $ readFileMayT =<< getSwarmHistoryPath False
   appDataMap <- withExceptT prettyFailure readAppData
   let history = maybe [] (map REPLEntry . T.lines) historyT
@@ -316,7 +316,7 @@ initUIState showMainMenu cheatMode = do
           , _uiInventoryShouldUpdate = False
           , _uiTPF = 0
           , _uiFPS = 0
-          , _lgTicksPerSecond = initLgTicksPerSecond
+          , _lgTicksPerSecond = speedFactor
           , _lastFrameTime = startTime
           , _accumulatedTime = 0
           , _lastInfoTime = 0


### PR DESCRIPTION
When supplying initial code with `--run` or `--autoplay`, a lot can happen in the first few moments of play such that it can be a tricky feat to smash CTRL+z fast enough to slow down the game to observe.

Now, one can pass e.g. `--speed 0` to begin the game at 1 tick per second:

    scripts/play.sh --scenario data/scenarios/Challenges/maypole.yaml --autoplay --speed 0