### PR TITLE
`halt` command

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -1249,3 +1249,19 @@
     example `key "Down"` or `key "C-S-x"`.
   properties: [portable]
   capabilities: [handleinput]
+
+- name: halting oracle
+  display:
+    attr: device
+    char: '?'
+  description:
+  - A device to solve the halting problem. When asked if a
+    particular robot program will halt, it always answers YES.
+    And it is always correct... or else!
+  - |
+    Enables the command `halt : actor -> cmd unit` which takes
+    a robot as an argument and, if it is up to one cell away,
+    cancels its currently running program (if any).  In creative mode,
+    there is no distance limitation.
+  properties: [portable]
+  capabilities: [halt]

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -77,6 +77,7 @@
                "view"
                "appear"
                "create"
+               "halt"
                "time"
                "scout"
                "whereami"

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -58,7 +58,7 @@
 				},
 				{
 				"name": "keyword.other",
-				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|push|stride|turn|grab|harvest|place|give|equip|unequip|make|has|equipped|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|time|scout|whereami|detect|resonate|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|instant|installkeyhandler|teleport|as|robotnamed|robotnumbered|knows)\\b"
+				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|push|stride|turn|grab|harvest|place|give|equip|unequip|make|has|equipped|count|drill|build|salvage|reprogram|say|listen|log|view|appear|create|halt|time|scout|whereami|detect|resonate|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|instant|installkeyhandler|teleport|as|robotnamed|robotnumbered|knows)\\b"
 				}
 			]
 			},

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -149,6 +149,8 @@ data Capability
     CDebug
   | -- | Capability to handle keyboard input.
     CHandleinput
+  | -- | Capability to make other robots halt.
+    CHalt
   | -- | God-like capabilities.  For e.g. commands intended only for
     --   checking challenge mode win conditions, and not for use by
     --   players.
@@ -243,6 +245,7 @@ constCaps = \case
   Heading -> Just COrient
   Key -> Just CHandleinput
   InstallKeyHandler -> Just CHandleinput
+  Halt -> Just CHalt
   -- ----------------------------------------------------------------
   -- Text operations
   Format -> Just CText

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -257,7 +257,7 @@ data Const
   | -- | Create an entity out of thin air. Only
     --   available in creative mode.
     Create
-  | -- | Tell another robot to halt.
+  | -- | Tell a robot to halt.
     Halt
   | -- Sensing / generation
 
@@ -646,7 +646,7 @@ constInfo c = case c of
   Create ->
     command 1 short . doc "Create an item out of thin air." $
       ["Only available in creative mode."]
-  Halt -> command 1 short "Tell another robot to halt."
+  Halt -> command 1 short "Tell a robot to halt."
   Time -> command 0 Intangible "Get the current time."
   Scout ->
     command 1 short . doc "Detect whether a robot is within line-of-sight in a direction." $

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -257,6 +257,8 @@ data Const
   | -- | Create an entity out of thin air. Only
     --   available in creative mode.
     Create
+  | -- | Tell another robot to halt.
+    Halt
   | -- Sensing / generation
 
     -- | Get current time
@@ -644,6 +646,7 @@ constInfo c = case c of
   Create ->
     command 1 short . doc "Create an item out of thin air." $
       ["Only available in creative mode."]
+  Halt -> command 1 short "Tell another robot to halt."
   Time -> command 0 Intangible "Get the current time."
   Scout ->
     command 1 short . doc "Detect whether a robot is within line-of-sight in a direction." $

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -566,6 +566,7 @@ inferConst c = case c of
   View -> [tyQ| actor -> cmd unit |]
   Appear -> [tyQ| text -> cmd unit |]
   Create -> [tyQ| text -> cmd unit |]
+  Halt -> [tyQ| actor -> cmd unit |]
   Time -> [tyQ| cmd int |]
   Scout -> [tyQ| dir -> cmd bool |]
   Whereami -> [tyQ| cmd (int * int) |]


### PR DESCRIPTION
Closes #392 .  Adds a command `halt : actor -> cmd unit` which halts the given robot if it is within a distance of 1 (no distance limit for system robots or in creative mode).  `halt self` works too.

I'd love some help thinking up a good and/or reasonable and/or funny recipe for a `halting oracle`.  I think we actually want it to be available fairly early on, since making your robots stop when they get out of hand is very useful.