### PR TITLE
decouple relative and absolute time capabilities

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -1087,7 +1087,18 @@
   - |
     `wait : int -> cmd unit` causes a robot to sleep for a specified amount of time (measured in game ticks).
   properties: [portable]
-  capabilities: [time]
+  capabilities: [timeabs, timerel]
+
+- name: hourglass
+  display:
+    attr: device
+    char: '8'
+  description:
+  - An hourglass can measure the relative passage of time.  It enables the `wait` command.
+  - |
+    `wait : int -> cmd unit` causes a robot to sleep for a specified amount of time (measured in game ticks).
+  properties: [portable]
+  capabilities: [timerel]
 
 - name: comparator
   display:

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -134,9 +134,11 @@ data Capability
     CAtomic
   | -- | Capability to execute swap (grab and place atomically at the same time).
     CSwap
-  | -- | Capabiltiy to do time-related things, like `wait` and get the
-    --   current time.
-    CTime
+  | -- | Capability to obtain absolute time, namely via the `time` command.
+    CTimeabs
+  | -- | Capability to utilize relative passage of time, namely via the `wait` command.
+    --   This is strictly weaker than "CTimeAbs".
+    CTimerel
   | -- | Capability to execute `try`.
     CTry
   | -- | Capability for working with sum types.
@@ -231,8 +233,8 @@ constCaps = \case
   Swap -> Just CSwap
   Atomic -> Just CAtomic
   Instant -> Just CGod
-  Time -> Just CTime
-  Wait -> Just CTime
+  Time -> Just CTimeabs
+  Wait -> Just CTimerel
   Scout -> Just CRecondir
   Whereami -> Just CSenseloc
   Detect -> Just CDetectloc


### PR DESCRIPTION
`time` now requires `CTimeabs`, and `wait` now requires `CTimerel`.
Introduced a new `hourglass` device to provide `CTimerel` capability.

The `clock` device remains backward compatible, providing both relative and absolute time capabilities.