### PR TITLE
Render contiguous boundaries

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -36,6 +36,7 @@ Achievements
 1218-stride-command.yaml
 1234-push-command.yaml
 1256-halt-command.yaml
+1271-wall-boundaries.yaml
 1262-display-device-commands.yaml
 1295-density-command.yaml
 1138-structures

--- a/data/scenarios/Testing/1271-wall-boundaries.yaml
+++ b/data/scenarios/Testing/1271-wall-boundaries.yaml
@@ -1,0 +1,96 @@
+version: 1
+name: Wall boundary display
+creative: false
+description: |
+  Demonstrate rendering of contiguous boundaries.
+
+  Only adjacent with the 'boundary' property
+  will be rendered with box border glyphs.
+attrs:
+  - name: purpleWall
+    fg: '#ff00ff'
+  - name: cyanWall
+    fg: '#00ffff'
+objectives:
+  - goal:
+      - Place all fences
+    condition: |
+      as base {
+        hasFence <- has "fence";
+        return $ not hasFence;
+      }
+solution: |
+  def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
+
+  doN 4 (
+    doN 6 (place "fence"; move);
+    turn left;
+  );
+
+  doN 2 move;
+  turn left;
+
+  doN 2 (
+    doN 2 move;
+    place "fence";
+  );
+  turn right;
+  move;
+  turn right;
+  move;
+  place "fence";
+  move;
+  place "fence";
+  move;
+robots:
+  - name: base
+    dir: east
+    display:
+      attr: robot
+    devices:
+      - branch predictor
+      - comparator
+      - compass
+      - dictionary
+      - grabber
+      - logger
+      - treads
+      - antenna
+      - ADT calculator
+    inventory:
+      - [28, fence]
+entities:
+  - name: wall
+    display:
+      char: 'x'
+      attr: purpleWall
+    description:
+      - A wall
+    properties: [known, boundary]
+  - name: fence
+    display:
+      char: 'F'
+      attr: cyanWall
+    description:
+      - A fence
+    properties: [known, boundary]
+known: [boulder]
+world:
+  default: [blank]
+  palette:
+    'Ω': [grass, null, base]
+    '.': [grass]
+    '#': [grass, wall]
+    '@': [grass, boulder]
+  upperleft: [0, 0]
+  map: |
+    Ω.........
+    ....#.....
+    ..####..##
+    ..#.##....
+    ..#..#..#.
+    ..####..#.
+    ..........
+    ...@@@....
+    ...@.@....
+    ...@@@....

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -157,6 +157,8 @@ data EntityProperty
     Pushable
   | -- | Obstructs the view of robots that attempt to "scout"
     Opaque
+  | -- | Is automatically rendered as a contiguous border
+    Boundary
   | -- | Regrows from a seed after it is harvested.
     Growable
   | -- | Can burn when ignited (either via 'Swarm.Language.Syntax.Ignite' or by

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -1105,6 +1105,7 @@ displayProperties = displayList . mapMaybe showProperty
   showProperty Liquid = Just "liquid"
   showProperty Unwalkable = Just "blocking"
   showProperty Opaque = Just "opaque"
+  showProperty Boundary = Just "boundary"
   -- Most things are pickable so we don't show that.
   showProperty Pickable = Nothing
   -- 'Known' is just a technical detail of how we handle some entities

--- a/src/swarm-tui/Swarm/TUI/View/CellDisplay.hs
+++ b/src/swarm-tui/Swarm/TUI/View/CellDisplay.hs
@@ -23,14 +23,17 @@ import Linear.Affine ((.-.))
 import Swarm.Game.Display (
   Attribute (AEntity),
   Display,
+  boundaryOverride,
   defaultEntityDisplay,
   displayAttr,
   displayChar,
   displayPriority,
+  getBoundaryDisplay,
   hidden,
  )
 import Swarm.Game.Entity
 import Swarm.Game.Land
+import Swarm.Game.Location (Point (..), toHeading)
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Topography.EntityFacade
 import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures, recognitionState)
@@ -44,6 +47,7 @@ import Swarm.Game.Tick (TickNumber (..))
 import Swarm.Game.Universe
 import Swarm.Game.World qualified as W
 import Swarm.Game.World.Coords
+import Swarm.Language.Syntax.Direction (AbsoluteDir (..))
 import Swarm.TUI.Editor.Masking
 import Swarm.TUI.Editor.Model
 import Swarm.TUI.Editor.Util qualified as EU
@@ -51,6 +55,7 @@ import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.UI.Gameplay
 import Swarm.TUI.View.Attribute.Attr
 import Swarm.Util (applyWhen)
+import Swarm.Util.Content (getContentAt)
 import Witch (from)
 import Witch.Encoding qualified as Encoding
 
@@ -140,9 +145,20 @@ displayEntityCell ::
   Cosmic Coords ->
   [Display]
 displayEntityCell worldEditor ri coords =
-  maybeToList $ displayForEntity <$> maybeEntity
+  maybeToList $ assignBoundaryOverride . displayForEntity <$> maybeEntityPaint
  where
-  (_, maybeEntity) = EU.getEditorContentAt (terrMap ri) worldEditor (multiworldInfo ri) coords
+  maybeEntityPaint = getEntPaintAtCoord coords
+
+  getEntPaintAtCoord = snd . EU.getEditorContentAt (terrMap ri) worldEditor (multiworldInfo ri)
+  coordHasBoundary = maybe False (`hasProperty` Boundary) . snd . getContentAt (terrMap ri) (multiworldInfo ri)
+
+  assignBoundaryOverride = applyWhen (coordHasBoundary coords) (boundaryOverride .~ getBoundaryDisplay checkPresence)
+   where
+    checkPresence :: AbsoluteDir -> Bool
+    checkPresence d = coordHasBoundary offsettedCoord
+     where
+      offsettedCoord = (`addTuple` xy) <$> coords
+      Coords xy = locToCoords $ P $ toHeading d
 
   displayForEntity :: EntityPaint -> Display
   displayForEntity e = (if isKnownFunc ri e then id else hidden) $ getDisplay e

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -377,6 +377,7 @@ testScenarioSolutions rs ui key =
         , testSolution Default "Testing/1533-sow-seed-maturation"
         , testSolution Default "Testing/2085-toplevel-mask"
         , testSolution Default "Testing/2086-structure-palette"
+        , testSolution Default "Testing/1271-wall-boundaries"
         , testGroup
             -- Note that the description of the classic world in
             -- data/worlds/classic.yaml (automatically tested to some


### PR DESCRIPTION
Closes #1271

## Demo

    scripts/play.sh --scenario data/scenarios/Testing/1271-wall-boundaries.yaml --autoplay

![Screenshot from 2024-09-18 09-27-14](https://github.com/user-attachments/assets/5e4ac74f-3f8c-487a-97d2-78e2320f93bb)

## Implementation

This implements neighbor-aware boundary rendering strictly on the display layer.  Underlying entities remain unchanged (for the purpose of world cell contents and e.g. `scan`).  Eventually we should be able to retire all of the niche boundary glyph entities.

Only a single function `getBoundaryDisplay` is exposed for computing the glyph appropriate for adjacent boundaries.  It takes a function from `AbsoluteDir -> Bool` indicating whether the neighbor cell in a particular direction is (also) a "boundary" entity.

The internal `glyphForNeighbors` function is implemented with pattern-matching such that exhaustive coverage of cases is guaranteed.