### PR TITLE
Better type error messages

### DIFF
--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -15,6 +15,8 @@ import Control.Unification.IntVar
 import Data.Bool (bool)
 import Data.Functor.Fixedpoint (Fix, unFix)
 import Data.Map.Strict qualified as M
+import Data.Set (Set)
+import Data.Set qualified as S
 import Data.String (fromString)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -50,6 +52,9 @@ prettyString = RS.renderString . layoutPretty defaultLayoutOptions . ppr
 pparens :: Bool -> Doc ann -> Doc ann
 pparens True = parens
 pparens False = id
+
+bquote :: Doc ann -> Doc ann
+bquote d = "`" <> d <> "`"
 
 instance PrettyPrec Text where
   prettyPrec _ = pretty
@@ -204,11 +209,17 @@ appliedTermPrec _ = 10
 instance PrettyPrec TypeErr where
   prettyPrec _ (UnifyErr ty1 ty2) =
     "Can't unify" <+> ppr ty1 <+> "and" <+> ppr ty2
-  prettyPrec _ (Mismatch _mt ty1 ty2) =
+  prettyPrec _ (Mismatch Nothing ty1 ty2) =
     "Type mismatch: expected" <+> ppr ty1 <> ", but got" <+> ppr ty2
+  prettyPrec _ (Mismatch (Just t) ty1 ty2) =
+    nest 2 . vcat $
+      [ "Type mismatch:"
+      , "From context, expected" <+> bquote (ppr t) <+> "to have type" <+> bquote (ppr ty1) <> ","
+      , "but it actually has type" <+> bquote (ppr ty2)
+      ]
   prettyPrec _ (LambdaArgMismatch ty1 ty2) =
     "Lambda argument has type annotation" <+> ppr ty2 <> ", but expected argument type" <+> ppr ty1
-  prettyPrec _ (FieldsMismatch _fs1 _fs2) = "Fields mismatch!!"
+  prettyPrec _ (FieldsMismatch expFs actFs) = fieldMismatchMsg expFs actFs
   prettyPrec _ (EscapedSkolem x) =
     "Skolem variable" <+> pretty x <+> "would escape its scope"
   prettyPrec _ (UnboundVar x) =
@@ -225,6 +236,17 @@ instance PrettyPrec TypeErr where
     "Record does not have a field with name" <+> pretty x <> ":" <+> ppr t
   prettyPrec _ (InvalidAtomic reason t) =
     "Invalid atomic block:" <+> ppr reason <> ":" <+> ppr t
+
+fieldMismatchMsg :: Set Var -> Set Var -> Doc a
+fieldMismatchMsg expFs actFs =
+  nest 2 . vcat $
+    ["Field mismatch; record literal has:"]
+      ++ ["- Extra field(s)" <+> prettyFieldSet extraFs | not (S.null extraFs)]
+      ++ ["- Missing field(s)" <+> prettyFieldSet missingFs | not (S.null missingFs)]
+ where
+  extraFs = actFs `S.difference` expFs
+  missingFs = expFs `S.difference` actFs
+  prettyFieldSet = hsep . punctuate "," . map (bquote . pretty) . S.toList
 
 instance PrettyPrec InvalidAtomicReason where
   prettyPrec _ (TooManyTicks n) = "block could take too many ticks (" <> pretty n <> ")"

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -94,7 +94,7 @@ testLanguagePipeline =
             "located type error"
             ( process
                 "def a =\n 42 + \"oops\"\nend"
-                "2:7: Type mismatch: expected int, but got text"
+                "2:7: Type mismatch:\n  From context, expected `\"oops\"` to have type `int`,\n  but it actually has type `text`"
             )
         , testCase
             "failure inside bind chain"
@@ -106,7 +106,7 @@ testLanguagePipeline =
             "failure inside function call"
             ( process
                 "if true \n{} \n(move)"
-                "3:1: Type mismatch: expected {u0}, but got cmd unit"
+                "3:1: Type mismatch:\n  From context, expected `move` to have type `{u0}`,\n  but it actually has type `cmd unit`"
             )
         , testCase
             "parsing operators #236 - report failure on invalid operator start"
@@ -286,13 +286,13 @@ testLanguagePipeline =
             (valid "(3 : int) + 5")
         , testCase
             "invalid type ascription"
-            (process "1 : text" "1:1: Type mismatch: expected text, but got int")
+            (process "1 : text" "1:1: Type mismatch:\n  From context, expected `1` to have type `text`,\n  but it actually has type `int`")
         , testCase
             "type ascription with a polytype"
             (valid "((\\x . x) : a -> a) 3")
         , testCase
             "type ascription too general"
-            (process "1 : a" "1:1: Type mismatch: expected s0, but got int")
+            (process "1 : a" "1:1: Type mismatch:\n  From context, expected `1` to have type `s0`,\n  but it actually has type `int`")
         , testCase
             "type specialization through type ascription"
             (valid "fst:(int + b) * a -> int + b")

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -249,12 +249,39 @@ testLanguagePipeline =
     , testGroup
         "void type"
         [ testCase
-            "void - isSimpleUType"
+            "isSimpleUType"
             ( assertBool "" $ isSimpleUType UTyVoid
             )
         , testCase
-            "void - valid type signature"
+            "valid type signature"
             (valid "def f : void -> a = \\x. undefined end")
+        ]
+    , testGroup
+        "record type"
+        [ testCase
+            "valid record"
+            (valid "\\x:int. ([y = \"hi\", x, z = \\x.x] : [x:int, y:text, z:bool -> bool])")
+        , testCase
+            "infer record type"
+            (valid "[x = 3, y = \"hi\"]")
+        , testCase
+            "field mismatch - missing"
+            ( process
+                "(\\r:[x:int, y:int]. r.x) [x = 3]"
+                "1:26: Field mismatch; record literal has:\n  - Missing field(s) `y`"
+            )
+        , testCase
+            "field mismatch - extra"
+            ( process
+                "(\\r:[x:int, y:int]. r.x) [x = 3, y = 4, z = 5]"
+                "1:26: Field mismatch; record literal has:\n  - Extra field(s) `z`"
+            )
+        , testCase
+            "field mismatch - both"
+            ( process
+                "(\\r:[x:int, y:int]. r.x) [x = 3, z = 5]"
+                "1:26: Field mismatch; record literal has:\n  - Extra field(s) `z`\n  - Missing field(s) `y`"
+            )
         ]
     , testGroup
         "type annotations"


### PR DESCRIPTION
Improvements to type inference and type error messages.  Includes:
- More informative error when record literal fields don't match the expected set of fields
- More informative type mismatch error which includes the term where the mismatch occurred.
- Reinstates a case for lambdas with explicit type annotations in inference mode (which was removed in #1283), which helps preserve better error messages in some cases.