### PR TITLE
combine all cesk simplifications

### DIFF
--- a/src/Swarm/Game/CESK.hs
+++ b/src/Swarm/Game/CESK.hs
@@ -59,6 +59,7 @@ module Swarm.Game.CESK (
   RobotUpdate (..),
 
   -- * Store
+  SKPair (..),
   Store,
   Addr,
   emptyStore,
@@ -237,8 +238,12 @@ setCell n c (Store nxt m) = Store nxt (IM.insert n c m)
 -- CESK machine
 ------------------------------------------------------------
 
+-- | Represents the heap and the stack in a CESK machine
+data SKPair = SK Store Cont
+  deriving (Eq, Show, Generic, FromJSON, ToJSON)
+
 -- | The overall state of a CESK machine, which can actually be one of
---   three kinds of states. The CESK machine is named after the first
+--   four kinds of states. The CESK machine is named after the first
 --   kind of state, and it would probably be possible to inline a
 --   bunch of things and get rid of the second state, but I find it
 --   much more natural and elegant this way.  Most tutorial
@@ -253,7 +258,7 @@ data CESK
     --   currently focused term to evaluate in the environment, a store,
     --   and a continuation.  In this mode we generally pattern-match on the
     --   'Term' to decide what to do next.
-    In Term Env Store Cont
+    In Term Env SKPair
   | -- | Once we finish evaluating a term, we end up with a 'Value'
     --   and we switch into "out" mode, bringing the value back up
     --   out of the depths to the context that was expecting it.  In
@@ -264,12 +269,12 @@ data CESK
     --   with variables to evaluate at the moment, and we maintain the
     --   invariant that any unevaluated terms buried inside a 'Value'
     --   or 'Cont' must carry along their environment with them.
-    Out Value Store Cont
+    Out Value SKPair
   | -- | An exception has been raised.  Keep unwinding the
     --   continuation stack (until finding an enclosing 'Try' in the
     --   case of a command failure or a user-generated exception, or
     --   until the stack is empty in the case of a fatal exception).
-    Up Exn Store Cont
+    Up Exn SKPair
   | -- | The machine is waiting for the game to reach a certain time
     --   to resume its execution.
     Waiting TickNumber CESK
@@ -279,7 +284,7 @@ data CESK
 --   the final value and store.
 finalValue :: CESK -> Maybe (Value, Store)
 {-# INLINE finalValue #-}
-finalValue (Out v s []) = Just (v, s)
+finalValue (Out v (SK s [])) = Just (v, s)
 finalValue _ = Nothing
 
 -- | Initialize a machine state with a starting term along with its
@@ -297,13 +302,13 @@ initMachine' (ProcessedTerm (Module t' ctx) _ reqCtx) e s k =
       case ctx of
         -- ...but doesn't contain any definitions, just create a machine
         -- that will evaluate it and then execute it.
-        Empty -> In t e s (FExec : k)
+        Empty -> In t e $ SK s (FExec : k)
         -- Or, if it does contain definitions, then load the resulting
         -- context after executing it.
-        _ -> In t e s (FExec : FLoadEnv ctx reqCtx : k)
+        _ -> In t e $ SK s (FExec : FLoadEnv ctx reqCtx : k)
     -- Otherwise, for a term with a non-command type, just
     -- create a machine to evaluate it.
-    _ -> In t e s k
+    _ -> In t e $ SK s k
  where
   -- Erase all type and SrcLoc annotations from the term before
   -- putting it in the machine state, since those are irrelevant at
@@ -312,12 +317,12 @@ initMachine' (ProcessedTerm (Module t' ctx) _ reqCtx) e s k =
 
 -- | Cancel the currently running computation.
 cancel :: CESK -> CESK
-cancel cesk = Out VUnit s' []
+cancel cesk = Out VUnit $ SK s' []
  where
   s' = resetBlackholes $ getStore cesk
-  getStore (In _ _ s _) = s
-  getStore (Out _ s _) = s
-  getStore (Up _ s _) = s
+  getStore (In _ _ (SK s _)) = s
+  getStore (Out _ (SK s _)) = s
+  getStore (Up _ (SK s _)) = s
   getStore (Waiting _ c) = getStore c
 
 -- | Reset any 'Blackhole's in the 'Store'.  We need to use this any
@@ -334,9 +339,9 @@ resetBlackholes (Store n m) = Store n (IM.map resetBlackhole m)
 ------------------------------------------------------------
 
 instance PrettyPrec CESK where
-  prettyPrec _ (In c _ _ k) = prettyCont k (11, "▶" <> ppr c <> "◀")
-  prettyPrec _ (Out v _ k) = prettyCont k (11, "◀" <> ppr (valueToTerm v) <> "▶")
-  prettyPrec _ (Up e _ k) = prettyCont k (11, "!" <> (pretty (formatExn mempty e) <> "!"))
+  prettyPrec _ (In c _ (SK _ k)) = prettyCont k (11, "▶" <> ppr c <> "◀")
+  prettyPrec _ (Out v (SK _ k)) = prettyCont k (11, "◀" <> ppr (valueToTerm v) <> "▶")
+  prettyPrec _ (Up e (SK _ k)) = prettyCont k (11, "!" <> (pretty (formatExn mempty e) <> "!"))
   prettyPrec _ (Waiting t cesk) = "🕑" <> pretty t <> "(" <> ppr cesk <> ")"
 
 -- | Take a continuation, and the pretty-printed expression which is

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -509,7 +509,7 @@ instance FromJSONE EntityMap TRobot where
       <*> liftE (v .:? "heavy" .!= False)
       <*> pure 0
    where
-    mkMachine Nothing = Out VUnit emptyStore []
+    mkMachine Nothing = Out VUnit $ SK emptyStore []
     mkMachine (Just pt) = initMachine pt mempty emptyStore
 
 -- | Is the robot actively in the middle of a computation?

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -509,7 +509,7 @@ instance FromJSONE EntityMap TRobot where
       <*> liftE (v .:? "heavy" .!= False)
       <*> pure 0
    where
-    mkMachine Nothing = Out VUnit $ SK emptyStore []
+    mkMachine Nothing = Go (Out VUnit) $ SK emptyStore []
     mkMachine (Just pt) = initMachine pt mempty emptyStore
 
 -- | Is the robot actively in the middle of a computation?

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -912,7 +912,7 @@ stepCESK cesk = case cesk of
     robotContext . defReqs %= (`union` rctx)
     returnVal (SK s k) v
   Go (Out v) (SK s (FLoadEnv {} : k)) -> returnVal (SK s k) v
-  -- Any other type of value wiwth an FExec frame is an error (should
+  -- Any other type of value with an FExec frame is an error (should
   -- never happen).
   Go (Out _) (SK s (FExec : _)) -> badMachineState s "FExec frame with non-executable value"
   -- If we see a VResult in any other context, simply discard it.  For
@@ -1006,7 +1006,7 @@ stepCESK cesk = case cesk of
     FUnionEnv e2 : k -> FUnionEnv (e2 `union` e1) : k
     k -> FUnionEnv e1 : k
 
--- | Eexecute a constant, catching any exception thrown and returning
+-- | Execute a constant, catching any exception thrown and returning
 --   it via a CESK machine state.
 evalConst ::
   (Has (State GameState) sig m, Has (State Robot) sig m, Has (Lift IO) sig m) => Const -> [Value] -> SKPair -> m CESK
@@ -1845,7 +1845,7 @@ execConst c vs sk@(SK s k) = do
         -- the childRobot inherits the parent robot's environment
         -- and context which collectively mean all the variables
         -- declared in the parent robot
-        robotMap . at childRobotID . _Just . machine .= Go (In cmd e) (SK s [FExec])
+        robotMap . at childRobotID . _Just . machine .= initializeForExecution cmd e
         robotMap . at childRobotID . _Just . robotContext .= r ^. robotContext
 
         -- Provision the target robot with any required devices and
@@ -1905,7 +1905,7 @@ execConst c vs sk@(SK s k) = do
                   ? north
               )
               defaultRobotDisplay
-              (Go (In cmd e) $ SK s [FExec])
+              (initializeForExecution cmd e)
               []
               []
               False
@@ -2120,6 +2120,8 @@ execConst c vs sk@(SK s k) = do
       DRelative DForward -> "ahead of"
       DRelative DBack -> "behind"
       _ -> directionSyntax d <> " of"
+
+  initializeForExecution cmd e = Go (In cmd e) $ SK s [FExec]
 
   goAtomic :: HasRobotStepState sig m => m CESK
   goAtomic = case vs of

--- a/src/Swarm/Game/Value.hs
+++ b/src/Swarm/Game/Value.hs
@@ -29,6 +29,8 @@ pattern VRect x1 y1 x2 y2 = VPair (VPair (VInt x1) (VInt y1)) (VPair (VInt x2) (
 -- implementing swarm
 -- <https://github.com/swarm-game/swarm/wiki/Commands-Cheat-Sheet commands>
 -- in Haskell.
+--
+-- Compare to "Swarm.Language.Value.valueToTerm"
 class Valuable a where
   asValue :: a -> Value
 

--- a/src/Swarm/Language/Value.hs
+++ b/src/Swarm/Language/Value.hs
@@ -100,6 +100,7 @@ prettyValue :: Value -> Text
 prettyValue = prettyText . valueToTerm
 
 -- | Inject a value back into a term.
+-- Compare to "Swarm.Game.Value.asValue"
 valueToTerm :: Value -> Term
 valueToTerm VUnit = TUnit
 valueToTerm (VInt n) = TInt n

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -69,7 +69,7 @@ import Graphics.Vty qualified as V
 import Linear
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
-import Swarm.Game.CESK (CESK (Out), Frame (FApp, FExec), SKPair (SK), cancel, emptyStore, initMachine)
+import Swarm.Game.CESK (CESK (Go), Frame (FApp, FExec), Go (Out), SKPair (SK), cancel, emptyStore, initMachine)
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Location
 import Swarm.Game.ResourceLoading (getSwarmHistoryPath)
@@ -998,7 +998,7 @@ runInputHandler kc = do
       unless working $ do
         s <- get
         let topCtx = topContext s
-            handlerCESK = Out (VKey kc) $ SK (topCtx ^. defStore) [FApp handler, FExec]
+            handlerCESK = Go (Out (VKey kc)) $ SK (topCtx ^. defStore) [FApp handler, FExec]
         gameState . baseRobot . machine .= handlerCESK
         gameState %= execState (activateRobot 0)
 

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -69,7 +69,7 @@ import Graphics.Vty qualified as V
 import Linear
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
-import Swarm.Game.CESK (CESK (Out), Frame (FApp, FExec), cancel, emptyStore, initMachine)
+import Swarm.Game.CESK (CESK (Out), Frame (FApp, FExec), SKPair (SK), cancel, emptyStore, initMachine)
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Location
 import Swarm.Game.ResourceLoading (getSwarmHistoryPath)
@@ -998,7 +998,7 @@ runInputHandler kc = do
       unless working $ do
         s <- get
         let topCtx = topContext s
-            handlerCESK = Out (VKey kc) (topCtx ^. defStore) [FApp handler, FExec]
+            handlerCESK = Out (VKey kc) $ SK (topCtx ^. defStore) [FApp handler, FExec]
         gameState . baseRobot . machine .= handlerCESK
         gameState %= execState (activateRobot 0)
 

--- a/test/unit/TestUtil.hs
+++ b/test/unit/TestUtil.hs
@@ -43,7 +43,7 @@ evalCESK g cesk =
   orderResult ((res, rr), rg) = (rg, rr, res)
 
 runCESK :: Int -> CESK -> StateT Robot (StateT GameState IO) (Either Text (Value, Int))
-runCESK _ (Up exn _ []) = Left . flip formatExn exn <$> lift (use entityMap)
+runCESK _ (Up exn (SK _ [])) = Left . flip formatExn exn <$> lift (use entityMap)
 runCESK !steps cesk = case finalValue cesk of
   Just (v, _) -> return (Right (v, steps))
   Nothing -> stepCESK cesk >>= runCESK (steps + 1)

--- a/test/unit/TestUtil.hs
+++ b/test/unit/TestUtil.hs
@@ -43,7 +43,7 @@ evalCESK g cesk =
   orderResult ((res, rr), rg) = (rg, rr, res)
 
 runCESK :: Int -> CESK -> StateT Robot (StateT GameState IO) (Either Text (Value, Int))
-runCESK _ (Up exn (SK _ [])) = Left . flip formatExn exn <$> lift (use entityMap)
+runCESK _ (Go (Up exn) (SK _ [])) = Left . flip formatExn exn <$> lift (use entityMap)
 runCESK !steps cesk = case finalValue cesk of
   Just (v, _) -> return (Right (v, steps))
   Nothing -> stepCESK cesk >>= runCESK (steps + 1)


### PR DESCRIPTION
This is a flattening of the three stacked PRs:
1. #1276
2. #1281
3. #1302

As I was working on this, I realized that certain adjacent cases inside the `stepCESK` function read like a dialogue (e.g. evaluating the terms of a pair), so it wouldn't make sense to separate them by grouping all of the `In` and all of the `Out` cases together.

I also realized that the pattern matching in `stepCESK` often considers the *combination* of the `Go` and `SKPair` fields, so this limits the opportunities to group into sub-cases by field.

The obvious wins in this refactoring are in `prettyPrec` and `getStore`, but in terms of code volume they may be overshadowed by the extra constructors in the `stepCESK` function.

To mitigate the overhead of these extra constructors, I introduced helper functions where possible: `returnVal`, `returnResult`, `returnException`, and `pushFrame`.  Eventually, applying Pattern Synonyms may get us even more mileage out of this refactoring.

Overall, @byorgey I'll let you be the judge if this refactoring as a whole is worth it, or if perhaps just parts of it should be split off.