### PR TITLE
ensure progress gets saved

### DIFF
--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -110,7 +110,6 @@ startGameWithSeed userSeed siPair@(_scene, si) toRun = do
   t <- liftIO getZonedTime
   ss <- use $ runtimeState . scenarios
   p <- liftIO $ normalizeScenarioPath ss (si ^. scenarioPath)
-  gameState . currentScenarioPath .= Just p
   runtimeState
     . scenarios
     . scenarioItemByPath p
@@ -119,6 +118,9 @@ startGameWithSeed userSeed siPair@(_scene, si) toRun = do
     . scenarioStatus
     .= Played (Metric Attempted $ ProgressStats t emptyAttemptMetric) (prevBest t)
   scenarioToAppState siPair userSeed toRun
+  -- Beware: currentScenarioPath must be set so that progress/achievements can be saved.
+  -- It has just been cleared in scenarioToAppState.
+  gameState . currentScenarioPath .= Just p
  where
   prevBest t = case si ^. scenarioStatus of
     NotStarted -> emptyBest t


### PR DESCRIPTION
I believe that since #1277 the progress has not been saved when exiting a scenario back to the menu.

It is because `getNormalizedCurrentScenarioPath`, which is utilized by `saveScenarioInfoOnQuit`, was returning `Nothing`, in turn because `currentScenarioPath` was `Nothing`.  This is because `scenarioToAppState` was clearing it immediately after being set inside `startGameWithSeed`.

Foreshadowed by this comment: https://github.com/swarm-game/swarm/pull/1243#pullrequestreview-1411539743 .