### PR TITLE
More typechecking error message improvements

### DIFF
--- a/src/Swarm/Language/LSP.hs
+++ b/src/Swarm/Language/LSP.hs
@@ -18,14 +18,14 @@ import Language.LSP.Server
 import Language.LSP.Types (Hover (Hover))
 import Language.LSP.Types qualified as J
 import Language.LSP.Types.Lens qualified as J
-import Language.LSP.VFS (VirtualFile(..), virtualFileText)
-import Swarm.Language.Typecheck (ContextualTypeErr(..))
+import Language.LSP.VFS (VirtualFile (..), virtualFileText)
 import Swarm.Language.LSP.Hover qualified as H
 import Swarm.Language.LSP.VarUsage qualified as VU
 import Swarm.Language.Parse
 import Swarm.Language.Pipeline
 import Swarm.Language.Pretty (prettyText)
-import Swarm.Language.Syntax (SrcLoc(..))
+import Swarm.Language.Syntax (SrcLoc (..))
+import Swarm.Language.Typecheck (ContextualTypeErr (..))
 import System.IO (stderr)
 import Witch
 
@@ -62,7 +62,7 @@ lspMain =
 diagnosticSourcePrefix :: Text
 diagnosticSourcePrefix = "swarm-lsp"
 
-debug :: MonadIO m => Text -> m ()
+debug :: (MonadIO m) => Text -> m ()
 debug msg = liftIO $ Text.hPutStrLn stderr $ "[swarm-lsp] " <> msg
 
 validateSwarmCode :: J.NormalizedUri -> J.TextDocumentVersion -> Text -> LspM () ()

--- a/src/Swarm/Language/LSP.hs
+++ b/src/Swarm/Language/LSP.hs
@@ -18,11 +18,14 @@ import Language.LSP.Server
 import Language.LSP.Types (Hover (Hover))
 import Language.LSP.Types qualified as J
 import Language.LSP.Types.Lens qualified as J
-import Language.LSP.VFS
+import Language.LSP.VFS (VirtualFile(..), virtualFileText)
+import Swarm.Language.Typecheck (ContextualTypeErr(..))
 import Swarm.Language.LSP.Hover qualified as H
 import Swarm.Language.LSP.VarUsage qualified as VU
 import Swarm.Language.Parse
 import Swarm.Language.Pipeline
+import Swarm.Language.Pretty (prettyText)
+import Swarm.Language.Syntax (SrcLoc(..))
 import System.IO (stderr)
 import Witch
 
@@ -124,6 +127,16 @@ validateSwarmCode doc version content = do
       msg
       Nothing -- tags
       (Just (J.List []))
+
+showTypeErrorPos :: Text -> ContextualTypeErr -> ((Int, Int), (Int, Int), Text)
+showTypeErrorPos code (CTE l _ te) = (minusOne start, minusOne end, msg)
+ where
+  minusOne (x, y) = (x - 1, y - 1)
+
+  (start, end) = case l of
+    SrcLoc s e -> getLocRange code (s, e)
+    NoLoc -> ((1, 1), (65535, 65535)) -- unknown loc spans the whole document
+  msg = prettyText te
 
 handlers :: Handlers (LspM ())
 handlers =

--- a/src/Swarm/Language/Pipeline.hs
+++ b/src/Swarm/Language/Pipeline.hs
@@ -45,7 +45,6 @@ import Witch
 --
 --   * The requirements context for any definitions embedded in the
 --     term ('ReqCtx')
-
 data ProcessedTerm = ProcessedTerm TModule Requirements ReqCtx
   deriving (Data, Show, Eq, Generic)
 

--- a/src/Swarm/Language/Pipeline.hs
+++ b/src/Swarm/Language/Pipeline.hs
@@ -35,15 +35,18 @@ import Swarm.Language.Types
 import Witch
 
 -- | A record containing the results of the language processing
---   pipeline.  Put a 'Term' in, and get one of these out.
-data ProcessedTerm
-  = ProcessedTerm
-      -- | The elaborated + type-annotated term, plus types of any embedded definitions
-      TModule
-      -- | Requirements of the term
-      Requirements
-      -- | Capability context for any definitions embedded in the term
-      ReqCtx
+--   pipeline.  Put a 'Term' in, and get one of these out.  A
+--   'ProcessedTerm' contains:
+--
+--   * The elaborated + type-annotated term, plus the types of any
+--     embedded definitions ('TModule')
+--
+--   * The 'Requirements' of the term
+--
+--   * The requirements context for any definitions embedded in the
+--     term ('ReqCtx')
+
+data ProcessedTerm = ProcessedTerm TModule Requirements ReqCtx
   deriving (Data, Show, Eq, Generic)
 
 processTermEither :: Text -> Either String ProcessedTerm

--- a/src/Swarm/Language/Pipeline.hs
+++ b/src/Swarm/Language/Pipeline.hs
@@ -78,7 +78,7 @@ processParsedTerm = processParsedTerm' empty empty
 processTerm' :: TCtx -> ReqCtx -> Text -> Either Text (Maybe ProcessedTerm)
 processTerm' ctx capCtx txt = do
   mt <- readTerm txt
-  first (prettyTypeErr txt) $ traverse (processParsedTerm' ctx capCtx) mt
+  first (prettyTypeErrText txt) $ traverse (processParsedTerm' ctx capCtx) mt
 
 -- | Like 'processTerm'', but use a term that has already been parsed.
 processParsedTerm' :: TCtx -> ReqCtx -> Syntax -> Either ContextualTypeErr ProcessedTerm

--- a/src/Swarm/Language/Pipeline.hs
+++ b/src/Swarm/Language/Pipeline.hs
@@ -82,16 +82,18 @@ processTerm' ctx capCtx txt = do
   mt <- readTerm txt
   first (prettyTypeErr txt) $ traverse (processParsedTerm' ctx capCtx) mt
 
+-- | XXX
 prettyTypeErr :: Text -> ContextualTypeErr -> Text
-prettyTypeErr code (CTE l te) = teLoc <> prettyText te
+prettyTypeErr code (CTE l _stk te) = teLoc <> prettyText te  -- TODO show stk info
  where
   teLoc = case l of
     SrcLoc s e -> (into @Text . showLoc . fst $ getLocRange code (s, e)) <> ": "
     NoLoc -> ""
   showLoc (r, c) = show r ++ ":" ++ show c
 
+-- | XXX
 showTypeErrorPos :: Text -> ContextualTypeErr -> ((Int, Int), (Int, Int), Text)
-showTypeErrorPos code (CTE l te) = (minusOne start, minusOne end, msg)
+showTypeErrorPos code (CTE l _ te) = (minusOne start, minusOne end, msg)
  where
   minusOne (x, y) = (x - 1, y - 1)
 

--- a/src/Swarm/Language/Pipeline.hs
+++ b/src/Swarm/Language/Pipeline.hs
@@ -14,8 +14,6 @@ module Swarm.Language.Pipeline (
   processParsedTerm,
   processTerm',
   processParsedTerm',
-  prettyTypeErr,
-  showTypeErrorPos,
   processTermEither,
 ) where
 
@@ -81,26 +79,6 @@ processTerm' :: TCtx -> ReqCtx -> Text -> Either Text (Maybe ProcessedTerm)
 processTerm' ctx capCtx txt = do
   mt <- readTerm txt
   first (prettyTypeErr txt) $ traverse (processParsedTerm' ctx capCtx) mt
-
--- | XXX
-prettyTypeErr :: Text -> ContextualTypeErr -> Text
-prettyTypeErr code (CTE l _stk te) = teLoc <> prettyText te  -- TODO show stk info
- where
-  teLoc = case l of
-    SrcLoc s e -> (into @Text . showLoc . fst $ getLocRange code (s, e)) <> ": "
-    NoLoc -> ""
-  showLoc (r, c) = show r ++ ":" ++ show c
-
--- | XXX
-showTypeErrorPos :: Text -> ContextualTypeErr -> ((Int, Int), (Int, Int), Text)
-showTypeErrorPos code (CTE l _ te) = (minusOne start, minusOne end, msg)
- where
-  minusOne (x, y) = (x - 1, y - 1)
-
-  (start, end) = case l of
-    SrcLoc s e -> getLocRange code (s, e)
-    NoLoc -> ((1, 1), (65535, 65535)) -- unknown loc spans the whole document
-  msg = prettyText te
 
 -- | Like 'processTerm'', but use a term that has already been parsed.
 processParsedTerm' :: TCtx -> ReqCtx -> Syntax -> Either ContextualTypeErr ProcessedTerm

--- a/src/Swarm/Language/Pipeline.hs
+++ b/src/Swarm/Language/Pipeline.hs
@@ -38,12 +38,12 @@ import Witch
 --   pipeline.  Put a 'Term' in, and get one of these out.
 data ProcessedTerm
   = ProcessedTerm
+      -- | The elaborated + type-annotated term, plus types of any embedded definitions
       TModule
-      -- ^ The elaborated + type-annotated term, plus types of any embedded definitions
+      -- | Requirements of the term
       Requirements
-      -- ^ Requirements of the term
+      -- | Capability context for any definitions embedded in the term
       ReqCtx
-      -- ^ Capability context for any definitions embedded in the term
   deriving (Data, Show, Eq, Generic)
 
 processTermEither :: Text -> Either String ProcessedTerm

--- a/src/Swarm/Language/Pipeline/QQ.hs
+++ b/src/Swarm/Language/Pipeline/QQ.hs
@@ -42,7 +42,7 @@ quoteTermExp s = do
         )
   parsed <- runParserTH pos parseTerm s
   case processParsedTerm parsed of
-    Left err -> failT [prettyTypeErr (from s) err]
+    Left err -> failT [prettyTypeErrText (from s) err]
     Right ptm -> dataToExpQ ((fmap liftText . cast) `extQ` antiTermExp) ptm
 
 antiTermExp :: Term' Polytype -> Maybe TH.ExpQ

--- a/src/Swarm/Language/Pipeline/QQ.hs
+++ b/src/Swarm/Language/Pipeline/QQ.hs
@@ -9,6 +9,7 @@ import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Quote
 import Swarm.Language.Parse
 import Swarm.Language.Pipeline
+import Swarm.Language.Pretty
 import Swarm.Language.Syntax
 import Swarm.Language.Types (Polytype)
 import Swarm.Util (failT, liftText)

--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -209,17 +209,17 @@ appliedTermPrec _ = 10
 instance PrettyPrec TypeErr where
   prettyPrec _ (UnifyErr ty1 ty2) =
     "Can't unify" <+> ppr ty1 <+> "and" <+> ppr ty2
-  prettyPrec _ (Mismatch Nothing ty1 ty2) =
+  prettyPrec _ (Mismatch Nothing (getJoin -> (ty1,ty2))) =
     "Type mismatch: expected" <+> ppr ty1 <> ", but got" <+> ppr ty2
-  prettyPrec _ (Mismatch (Just t) ty1 ty2) =
+  prettyPrec _ (Mismatch (Just t) (getJoin -> (ty1,ty2))) =
     nest 2 . vcat $
       [ "Type mismatch:"
       , "From context, expected" <+> bquote (ppr t) <+> "to have type" <+> bquote (ppr ty1) <> ","
       , "but it actually has type" <+> bquote (ppr ty2)
       ]
-  prettyPrec _ (LambdaArgMismatch ty1 ty2) =
+  prettyPrec _ (LambdaArgMismatch (getJoin -> (ty1,ty2))) =
     "Lambda argument has type annotation" <+> ppr ty2 <> ", but expected argument type" <+> ppr ty1
-  prettyPrec _ (FieldsMismatch expFs actFs) = fieldMismatchMsg expFs actFs
+  prettyPrec _ (FieldsMismatch (getJoin -> (expFs,actFs))) = fieldMismatchMsg expFs actFs
   prettyPrec _ (EscapedSkolem x) =
     "Skolem variable" <+> pretty x <+> "would escape its scope"
   prettyPrec _ (UnboundVar x) =

--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -40,7 +40,7 @@ class PrettyPrec a where
   prettyPrec :: Int -> a -> Doc ann -- can replace with custom ann type later if desired
 
 -- | Pretty-print a thing, with a context precedence level of zero.
-ppr :: PrettyPrec a => a -> Doc ann
+ppr :: (PrettyPrec a) => a -> Doc ann
 ppr = prettyPrec 0
 
 -- | Render a pretty-printed document as @Text@.
@@ -48,7 +48,7 @@ docToText :: Doc a -> Text
 docToText = RT.renderStrict . layoutPretty defaultLayoutOptions
 
 -- | Pretty-print something and render it as @Text@.
-prettyText :: PrettyPrec a => a -> Text
+prettyText :: (PrettyPrec a) => a -> Text
 prettyText = docToText . ppr
 
 -- | Render a pretty-printed document as a @String@.
@@ -56,7 +56,7 @@ docToString :: Doc a -> String
 docToString = RS.renderString . layoutPretty defaultLayoutOptions
 
 -- | Pretty-print something and render it as a @String@.
-prettyString :: PrettyPrec a => a -> String
+prettyString :: (PrettyPrec a) => a -> String
 prettyString = docToString . ppr
 
 -- | Optionally surround a document with parentheses depending on the
@@ -77,7 +77,7 @@ data BulletList i = BulletList
   , bulletListItems :: [i]
   }
 
-instance PrettyPrec i => PrettyPrec (BulletList i) where
+instance (PrettyPrec i) => PrettyPrec (BulletList i) where
   prettyPrec _ (BulletList hdr items) =
     nest 2 . vcat $ hdr : map (("-" <+>) . ppr) items
 
@@ -100,14 +100,14 @@ instance PrettyPrec BaseTy where
 instance PrettyPrec IntVar where
   prettyPrec _ = pretty . mkVarName "u"
 
-instance PrettyPrec (t (Fix t)) => PrettyPrec (Fix t) where
+instance (PrettyPrec (t (Fix t))) => PrettyPrec (Fix t) where
   prettyPrec p = prettyPrec p . unFix
 
 instance (PrettyPrec (t (UTerm t v)), PrettyPrec v) => PrettyPrec (UTerm t v) where
   prettyPrec p (UTerm t) = prettyPrec p t
   prettyPrec p (UVar v) = prettyPrec p v
 
-instance PrettyPrec t => PrettyPrec (TypeF t) where
+instance (PrettyPrec t) => PrettyPrec (TypeF t) where
   prettyPrec _ (TyBaseF b) = ppr b
   prettyPrec _ (TyVarF v) = pretty v
   prettyPrec p (TySumF ty1 ty2) =
@@ -131,7 +131,7 @@ instance PrettyPrec UPolytype where
   prettyPrec _ (Forall [] t) = ppr t
   prettyPrec _ (Forall xs t) = hsep ("∀" : map pretty xs) <> "." <+> ppr t
 
-instance PrettyPrec t => PrettyPrec (Ctx t) where
+instance (PrettyPrec t) => PrettyPrec (Ctx t) where
   prettyPrec _ Empty = emptyDoc
   prettyPrec _ (assocs -> bs) = brackets (hsep (punctuate "," (map prettyBinding bs)))
 
@@ -245,10 +245,10 @@ prettyTypeErrText code = docToText . prettyTypeErr code
 -- | Format a 'ContextualTypeError' for the user.
 prettyTypeErr :: Text -> ContextualTypeErr -> Doc ann
 prettyTypeErr code (CTE l tcStack te) =
-   vcat
-   [ teLoc <> ppr te
-   , ppr (BulletList "" tcStack)
-   ]
+  vcat
+    [ teLoc <> ppr te
+    , ppr (BulletList "" tcStack)
+    ]
  where
   teLoc = case l of
     SrcLoc s e -> (showLoc . fst $ getLocRange code (s, e)) <> ": "
@@ -258,17 +258,17 @@ prettyTypeErr code (CTE l tcStack te) =
 instance PrettyPrec TypeErr where
   prettyPrec _ (UnifyErr ty1 ty2) =
     "Can't unify" <+> ppr ty1 <+> "and" <+> ppr ty2
-  prettyPrec _ (Mismatch Nothing (getJoin -> (ty1,ty2))) =
+  prettyPrec _ (Mismatch Nothing (getJoin -> (ty1, ty2))) =
     "Type mismatch: expected" <+> ppr ty1 <> ", but got" <+> ppr ty2
-  prettyPrec _ (Mismatch (Just t) (getJoin -> (ty1,ty2))) =
+  prettyPrec _ (Mismatch (Just t) (getJoin -> (ty1, ty2))) =
     nest 2 . vcat $
       [ "Type mismatch:"
       , "From context, expected" <+> bquote (ppr t) <+> "to have type" <+> bquote (ppr ty1) <> ","
       , "but it actually has type" <+> bquote (ppr ty2)
       ]
-  prettyPrec _ (LambdaArgMismatch (getJoin -> (ty1,ty2))) =
+  prettyPrec _ (LambdaArgMismatch (getJoin -> (ty1, ty2))) =
     "Lambda argument has type annotation" <+> ppr ty2 <> ", but expected argument type" <+> ppr ty1
-  prettyPrec _ (FieldsMismatch (getJoin -> (expFs,actFs))) = fieldMismatchMsg expFs actFs
+  prettyPrec _ (FieldsMismatch (getJoin -> (expFs, actFs))) = fieldMismatchMsg expFs actFs
   prettyPrec _ (EscapedSkolem x) =
     "Skolem variable" <+> pretty x <+> "would escape its scope"
   prettyPrec _ (UnboundVar x) =
@@ -309,5 +309,5 @@ instance PrettyPrec LocatedTCFrame where
 
 instance PrettyPrec TCFrame where
   prettyPrec _ (TCDef x) = "While checking the definition of" <+> pretty x
-  prettyPrec _ TCBindL   = "While checking the left-hand side of a semicolon"
-  prettyPrec _ TCBindR   = "While checking the right-hand side of a semicolon"
+  prettyPrec _ TCBindL = "While checking the left-hand side of a semicolon"
+  prettyPrec _ TCBindR = "While checking the right-hand side of a semicolon"

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -117,7 +117,7 @@ data Source
 type Sourced a = (Source, a)
 
 -- | A "join" where an expected thing meets an actual thing.
-data Join a = Join (Source -> a)
+newtype Join a = Join (Source -> a)
 
 instance (Show a) => Show (Join a) where
   show (getJoin -> (e, a)) = "(expected: " <> show e <> ", actual: " <> show a <> ")"

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -265,11 +265,8 @@ noSkolems l (Forall xs upty) = do
 infix 4 =:=
 
 -- | @unify t expTy actTy@ ensures that the given two types are equal.
---   The first type is the expected type (passed down from the
---   context) whereas the second is the actual type (extracted from a
---   term). If we know the actual term @t@ which is supposed to have
---   these types, we can use it to generate better error
---   messages.
+--   If we know the actual term @t@ which is supposed to have these
+--   types, we can use it to generate better error messages.
 --
 --   We first do a quick-and-dirty check to see whether we know for
 --   sure the types either are or cannot be equal, generating an
@@ -363,10 +360,7 @@ generalize uty = do
 -- Type errors
 
 -- | A type error along with various contextual information to help us
---   generate better error messages.  For now there is only a SrcLoc
---   but there will be additional context in the future, such as a
---   stack of stuff we were in the middle of doing, relevant names in
---   scope, etc. (#1297).
+--   generate better error messages.
 data ContextualTypeErr = CTE {cteSrcLoc :: SrcLoc, cteStack :: TCStack, cteTypeErr :: TypeErr}
   deriving (Show)
 
@@ -443,7 +437,9 @@ instance Fallible TypeF IntVar ContextualTypeErr where
 ------------------------------------------------------------
 -- Type decomposition
 
--- | Decompose a type that is supposed to be a delay type.
+-- | Decompose a type that is supposed to be a delay type.  Also take
+--   the term which is supposed to have that type, for use in error
+--   messages.
 decomposeDelayTy :: Syntax -> Sourced UType -> TC UType
 decomposeDelayTy _ (_, UTyDelay a) = return a
 decomposeDelayTy t ty = do
@@ -451,7 +447,9 @@ decomposeDelayTy t ty = do
   _ <- unify (Just t) (mkJoin ty (UTyDelay a))
   return a
 
--- | Decompose a type that is supposed to be a command type.
+-- | Decompose a type that is supposed to be a command type. Also take
+--   the term which is supposed to have that type, for use in error
+--   messages.
 decomposeCmdTy :: Syntax -> Sourced UType -> TC UType
 decomposeCmdTy _ (_, UTyCmd a) = return a
 decomposeCmdTy t ty = do
@@ -459,7 +457,9 @@ decomposeCmdTy t ty = do
   _ <- unify (Just t) (mkJoin ty (UTyCmd a))
   return a
 
--- | Decompose a type that is supposed to be a function type.
+-- | Decompose a type that is supposed to be a function type. Also take
+--   the term which is supposed to have that type, for use in error
+--   messages.
 decomposeFunTy :: Syntax -> Sourced UType -> TC (UType, UType)
 decomposeFunTy _ (_, UTyFun ty1 ty2) = return (ty1, ty2)
 decomposeFunTy t ty = do
@@ -468,7 +468,9 @@ decomposeFunTy t ty = do
   _ <- unify (Just t) (mkJoin ty (UTyFun ty1 ty2))
   return (ty1, ty2)
 
--- | Decompose a type that is supposed to be a product type.
+-- | Decompose a type that is supposed to be a product type. Also take
+--   the term which is supposed to have that type, for use in error
+--   messages.
 decomposeProdTy :: Syntax -> Sourced UType -> TC (UType, UType)
 decomposeProdTy _ (_, UTyProd ty1 ty2) = return (ty1, ty2)
 decomposeProdTy t ty = do

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -627,7 +627,7 @@ infer s@(Syntax l t) = addLocToTypeErr l $ case t of
     -- functions such as 'if'.  Without this call to 'applyBindings',
     -- type mismatches between the branches of an 'if' tend to get
     -- caught in the unifier, resulting in vague "can't unify"
-    -- messages (for example, "if true then {3} {move}" yields "can't
+    -- messages (for example, "if true {3} {move}" yields "can't
     -- unify int and cmd unit").  With this 'applyBindings' call, we
     -- get more specific errors about how the second branch was
     -- expected to have the same type as the first (e.g. "expected

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -119,7 +119,7 @@ type Sourced a = (Source, a)
 -- | A "join" where an expected thing meets an actual thing.
 data Join a = Join (Source -> a)
 
-instance Show a => Show (Join a) where
+instance (Show a) => Show (Join a) where
   show (getJoin -> (e, a)) = "(expected: " <> show e <> ", actual: " <> show a <> ")"
 
 type TypeJoin = Join UType
@@ -213,7 +213,7 @@ instance FreeVars UType where
   freeVars ut = fmap S.fromList . lift . lift . lift $ getFreeVars ut
 
 -- | We can also get the free variables of a polytype.
-instance FreeVars t => FreeVars (Poly t) where
+instance (FreeVars t) => FreeVars (Poly t) where
   freeVars (Forall _ t) = freeVars t
 
 -- | We can get the free variables in any polytype in a context.

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -78,10 +78,14 @@ import Prelude hiding (lookup)
 ------------------------------------------------------------
 -- Typechecking stack
 
+-- | A frame to keep track of something we were in the middle of doing
+--   during typechecking.
 data TCFrame where
   TCDef :: Var -> TCFrame
   deriving (Show)
 
+-- | A typechecking stack keeps track of what we are currently in the
+--   middle of doing during typechecking.
 type TCStack = [(SrcLoc, TCFrame)]
 
 ------------------------------------------------------------
@@ -162,7 +166,7 @@ lookup loc x = do
   ctx <- getCtx
   maybe (throwTypeErr loc $ UnboundVar x) instantiate (Ctx.lookup x ctx)
 
--- | XXX
+-- | Get the current type context.
 getCtx :: TC UCtx
 getCtx = ask
 

--- a/src/Swarm/Language/Typecheck/Unify.hs
+++ b/src/Swarm/Language/Typecheck/Unify.hs
@@ -52,8 +52,8 @@ instance Monoid UnifyStatus where
 --   'Equal'.  In case (1), we can generate a much better error
 --   message at the instant the two types come together than we could
 --   if we threw a constraint into the unifier.  In case (2), we don't
---   have to bother with generating a constraint. If we don't know for
---   sure whether they will unify, return 'MightUnify'.
+--   have to bother with generating a trivial constraint. If we don't
+--   know for sure whether they will unify, return 'MightUnify'.
 unifyCheck :: UType -> UType -> UnifyStatus
 unifyCheck ty1 ty2 = case (ty1, ty2) of
   (UVar x, UVar y)

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -336,7 +336,35 @@ testLanguagePipeline =
                 "1:1: Lambda argument has type annotation int, but expected argument type text"
             )
         ]
+    , testGroup
+        "typechecking errors"
+        [ testCase
+            "applying a pair"
+            ( process
+                "(1,2) \"hi\""
+                "1:1: Type mismatch:\n  From context, expected `(1, 2)` to have type `u3 -> u4`,\n  but it actually has type `u1 * u2`"
+            )
+        , testCase
+            "providing a pair as an argument"
+            ( process
+                "(\\x:int. x + 1) (1,2)"
+                "1:17: Type mismatch:\n  From context, expected `(1, 2)` to have type `int`,\n  but it actually has type `u0 * u1`"
+            )
+        , testCase
+            "mismatched if branches"
+            ( process
+                "if true {grab} {}"
+                "1:16: Type mismatch:\n  From context, expected `{}` to have type `cmd text`,\n  but it actually has type `cmd unit`"
+            )
+        , testCase
+            "definition with wrong result"
+            ( process
+                "def m : int -> int -> int = \\x. \\y. {3} end"
+                "1:37: Type mismatch:\n  From context, expected `{3}` to have type `int`,\n  but it actually has type `{u0}`"
+            )
+        ]
     ]
+
  where
   valid = flip process ""
 

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -100,7 +100,7 @@ testLanguagePipeline =
             "failure inside bind chain"
             ( process
                 "move;\n1;\nmove"
-                "2:1: Type mismatch: expected cmd u0, but got int"
+                "2:1: Type mismatch:\n  From context, expected `1` to have type `cmd u0`,\n  but it actually has type `int`"
             )
         , testCase
             "failure inside function call"

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -364,7 +364,6 @@ testLanguagePipeline =
             )
         ]
     ]
-
  where
   valid = flip process ""
 

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -106,7 +106,7 @@ testLanguagePipeline =
             "failure inside function call"
             ( process
                 "if true \n{} \n(move)"
-                "3:1: Type mismatch:\n  From context, expected `move` to have type `{u0}`,\n  but it actually has type `cmd unit`"
+                "3:1: Type mismatch:\n  From context, expected `move` to have type `{cmd unit}`,\n  but it actually has type `cmd unit`"
             )
         , testCase
             "parsing operators #236 - report failure on invalid operator start"
@@ -354,7 +354,7 @@ testLanguagePipeline =
             "mismatched if branches"
             ( process
                 "if true {grab} {}"
-                "1:16: Type mismatch:\n  From context, expected `{}` to have type `cmd text`,\n  but it actually has type `cmd unit`"
+                "1:16: Type mismatch:\n  From context, expected `noop` to have type `cmd text`,\n  but it actually has type `cmd unit`"
             )
         , testCase
             "definition with wrong result"


### PR DESCRIPTION
Towards #1297 .  In this PR:

- Moves some functions out of `Pipeline` and into more appropriate modules
- Adds a new type `Join` to represent two types or other things, one "expected" and one "actual", at the point where they join + we check whether they are equal; a bunch of refactoring to use this new type.  This way we don't have to remember which argument is which when calling a function that takes one "expected" thing and one "actual" thing.
- Refactors all the `decomposeXXX` functions to take a `Syntax` node to use in error messages, and to take a `Sourced UType` (*i.e.* a `UType` along with whether it is "expected" or "actual") instead of just a `UType` so we can generate accurate error messages
- Introduce a basic typechecking stack that keeps track of "what we are currently in the middle of checking", so that when we encounter an error we can say things like "while checking the definition of `foo`".  Currently this is just a basic proof of concept.
- A few other miscellaneous error message improvements.