### PR TITLE
peg fourmolu version

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,5 +1,6 @@
-restylers_version: dev
+restylers_version: stable
 restylers:
   - fourmolu:
+      image: 'restyled/restyler-fourmolu:v0.10.1.0'
       arguments:
         []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,14 +216,30 @@ them!
 
 #### Formatting style
 
-We use [`fourmolu-0.9.0.0`](https://hackage.haskell.org/package/fourmolu)
+We use [`fourmolu-0.10.1.0`](https://hackage.haskell.org/package/fourmolu)
 with a [custom
 configuration](https://github.com/swarm-game/swarm/blob/main/fourmolu.yaml)
 for formatting Haskell code.
 
+To install the formatter, run:
+
+```bash
+cabal install fourmolu-0.10.1.0
+```
+
+If this installation does not work, you may have to set your GHC to a version supported by `fourmolu`:
+
+```bash
+ghcup install ghc 9.4.5
+```
+and/or:
+
+```bash
+ghcup set ghc 9.4.5
+```
+
 You can run the formatter from the shell:
 ```bash
-cabal install fourmolu-0.9.0.0
 cd path/to/the/root/of/swarm/repo
 find src/ app/ test/ -name "*.hs" | xargs fourmolu --mode=inplace
 ```

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -5,5 +5,6 @@ indent-wheres: false # 'false' means save space by only half-indenting the 'wher
 diff-friendly-import-export: true
 let-style: inline
 respectful: true
+single-constraint-parens: false
 haddock-style: single-line
 newlines-between-decls: 1


### PR DESCRIPTION
This is so that our PR's don't suddenly start failing when the restyled.io service bumps is `fourmolu` version.

## TODO

I wasn't actually able to install version `0.10.1.0`; both of these attempts failed:

    stack install fourmolu-0.10.1.0

and

    cabal install fourmolu-0.10.1.0