### PR TITLE
Don't step robots that are waiting, even during `instant`

### DIFF
--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -68,6 +68,7 @@ module Swarm.Game.Robot (
   -- ** Query
   robotKnows,
   isActive,
+  wantsToStep,
   waitingUntil,
   getResult,
 
@@ -516,6 +517,14 @@ instance FromJSONE EntityMap TRobot where
 isActive :: Robot -> Bool
 {-# INLINE isActive #-}
 isActive = isNothing . getResult
+
+-- | "Active" robots include robots that are waiting; 'wantsToStep' is
+--   true if the robot actually wants to take another step right now
+--   (this is a *subset* of active robots).
+wantsToStep :: TickNumber -> Robot -> Bool
+wantsToStep now robot
+  | not (isActive robot) = False
+  | otherwise = maybe True (now >=) (waitingUntil robot)
 
 -- | The time until which the robot is waiting, if any.
 waitingUntil :: Robot -> Maybe TickNumber

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -587,10 +586,9 @@ tickRobot r = do
 tickRobotRec :: (Has (State GameState) sig m, Has (Lift IO) sig m) => Robot -> m Robot
 tickRobotRec r = do
   time <- use ticks
-  if
-    | wantsToStep time r && (r ^. runningAtomic || r ^. tickSteps > 0) ->
-        stepRobot r >>= tickRobotRec
-    | otherwise -> return r
+  case wantsToStep time r && (r ^. runningAtomic || r ^. tickSteps > 0) of
+    True -> stepRobot r >>= tickRobotRec
+    False -> return r
 
 -- | Single-step a robot by decrementing its 'tickSteps' counter and
 --   running its CESK machine for one step.


### PR DESCRIPTION
This fixes #1267 in the best possible way (option 3): if a `wait` command is executed inside `instant`, then it goes into effect immediately, and any subsequent commands will be executed `instant`ly once the robot wakes up. For example, `instant (move; move; wait 1; move; move)` moves twice in one tick and then twice in the next tick.  Even calls to `wait` nested inside recursive function calls inside a call to `instant` work fine.