### PR TITLE
Separate entities for each text operation

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -336,6 +336,62 @@
   properties: [portable, growable]
   growth: [100, 800]
 
+- name: linotype
+  display:
+    attr: silver
+    char: 't'
+  description:
+  - Employs hot lead typesetting to arrange glyphs into a mold for printing.
+  - |
+    An equipped `linotype` device enables the `format` command:
+  - |
+    `format : a -> text` can turn any value into a suitable text
+    representation.
+  properties: [portable]
+  capabilities: [format]
+
+- name: Elmer's glue
+  display:
+    attr: snow
+    char: 'g'
+  description:
+  - Polyvinyl acetate. Popular adhesive for crafting. Of dubious nutritional value.
+  - |
+    Facilitates the concatenation of text values.
+  - |
+    The infix operator `++ : text -> text -> text`
+    can be used to concatenate two text values.  For example,
+  - |
+    "Number of widgets: " ++ format numWidgets
+  properties: [portable]
+  capabilities: [concat]
+
+- name: caliper
+  display:
+    attr: silver
+    char: 'C'
+  description:
+  - Simple, yet accurate measuring device. Can determine the length of a text value.
+  - |
+    `chars : text -> int` computes the number of characters in a
+    `text` value.
+  properties: [portable]
+  capabilities: [charcount]
+
+- name: wedge
+  display:
+    attr: silver
+    char: 'v'
+  description:
+  - A simple machine for the textually-inclined; plain but effective.
+  - |
+    An equipped `wedge` enables the `split` command:
+  - |
+    `split : int -> text -> text * text` splits a `text` value into
+    two pieces, one before the given index and one after.
+  properties: [portable]
+  capabilities: [split]
+
 - name: string
   display:
     attr: silver
@@ -362,7 +418,7 @@
     `split : int -> text -> text * text` splits a `text` value into
     two pieces, one before the given index and one after.
   properties: [portable]
-  capabilities: [text]
+  capabilities: [format, concat, charcount, split]
 
 - name: decoder ring
   display:

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -98,8 +98,14 @@ data Capability
     CListen
   | -- | Execute the 'Log' command
     CLog
-  | -- | Manipulate text values
-    CText
+  | -- | Format values as text
+    CFormat
+  | -- | Split text into two pieces
+    CConcat
+  | -- | Join two text values into one
+    CSplit
+  | -- | Count the characters in a text value
+    CCharcount
   | -- | Convert between characters/text and Unicode values
     CCode
   | -- | Don't drown in liquid
@@ -252,10 +258,10 @@ constCaps = \case
   Halt -> Just CHalt
   -- ----------------------------------------------------------------
   -- Text operations
-  Format -> Just CText
-  Concat -> Just CText
-  Split -> Just CText
-  Chars -> Just CText
+  Format -> Just CFormat
+  Concat -> Just CConcat
+  Split -> Just CSplit
+  Chars -> Just CCharcount
   CharAt -> Just CCode
   ToChar -> Just CCode
   -- ----------------------------------------------------------------


### PR DESCRIPTION
Closes #1239

The `string` device maintains all four of the split capabilities for backwards compatibility.