### PR TITLE
Update to LTS-21, GHC 9.4.5, brick-1.9

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,11 @@ extra-deps:
 - fused-effects-lens-1.2.0.1@sha256:675fddf183215b6f3c1f2a0823359a648756435fd1966284e61830ec28ad61fa,1466
 - hsnoise-0.0.3@sha256:260b39175b8a3e3b1719ad3987b7d72a3fd7a0fa99be8639b91cf4dc3f1c8796,1476
 - simple-enumeration-0.2.1@sha256:8625b269c1650d3dd0e3887351c153049f4369853e0d525219e07480ea004b9f,1178
-- servant-docs-0.12@sha256:f63abafd79f53c8cf1f14a2b9d2835cf4f46212ce798a20437b9fbffc45933a4,3383
 - boolexpr-0.2@sha256:07f38a0206ad63c2c893e3c6271a2e45ea25ab4ef3a9e973edc746876f0ab9e8,853
-- brick-list-skip-0.1.1.2
-resolver: nightly-2023-01-11
+- brick-list-skip-0.1.1.4
+# We should update to lsp-2.0 and lsp-types-2.0 but it involves some
+# breaking changes
+- lsp-1.6.0.0
+- lsp-types-1.6.0.0
+resolver: lts-21.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ extra-deps:
 - boolexpr-0.2@sha256:07f38a0206ad63c2c893e3c6271a2e45ea25ab4ef3a9e973edc746876f0ab9e8,853
 - brick-list-skip-0.1.1.4
 # We should update to lsp-2.0 and lsp-types-2.0 but it involves some
-# breaking changes
+# breaking changes; see https://github.com/swarm-game/swarm/issues/1350
 - lsp-1.6.0.0
 - lsp-types-1.6.0.0
 resolver: lts-21.0

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -18,7 +18,7 @@ maintainer:         byorgey@gmail.com
 bug-reports:        https://github.com/swarm-game/swarm/issues
 copyright:          Brent Yorgey 2021
 category:           Game
-tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2
+tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.5
 extra-source-files: CHANGELOG.md
                     example/*.sw
                     editors/emacs/*.el
@@ -193,7 +193,7 @@ library
                       array                         >= 0.5.4 && < 0.6,
                       blaze-html                    >= 0.9.1 && < 0.9.2,
                       boolexpr                      >= 0.2 && < 0.3,
-                      brick                         >= 1.5 && < 1.7,
+                      brick                         >= 1.5 && < 1.10,
                       bytestring                    >= 0.10 && < 0.12,
                       clock                         >= 0.8.2 && < 0.9,
                       cmark-gfm                     >= 0.2 && < 0.3,


### PR DESCRIPTION
[Stackage LTS 21](https://www.stackage.org/blog/2023/06/announce-lts-21-nightly-ghc9.6) was just released, which is great news for us because it includes GHC 9.4.5 (GHC 9.4.4 was no longer supported by HLS) and we no longer have to rely on a specific "nightly" version.  This PR updates a few things to build with LTS-21.

The biggest thing I *didn't* update was our `lsp` dependency: LTS-21 comes with `lsp-2.0` and `lsp-types-2.0`, but those apparently introduce some breaking changes and it wasn't immediately apparent to me what would need to change.  I filed https://github.com/swarm-game/swarm/issues/1350 to track that issue.