### PR TITLE
Render markdown in entity descriptions

### DIFF
--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -75,7 +75,7 @@ circlerProgram =
 
 -- | Initializes a robot with program prog at location loc facing north.
 initRobot :: ProcessedTerm -> Location -> TRobot
-initRobot prog loc = mkRobot () Nothing "" [] (Just $ Cosmic DefaultRootSubworld loc) north defaultRobotDisplay (initMachine prog Context.empty emptyStore) [] [] False False 0
+initRobot prog loc = mkRobot () Nothing "" mempty (Just $ Cosmic DefaultRootSubworld loc) north defaultRobotDisplay (initMachine prog Context.empty emptyStore) [] [] False False 0
 
 -- | Creates a GameState with numRobot copies of robot on a blank map, aligned
 --   in a row starting at (0,0) and spreading east.

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -363,10 +363,7 @@
   - |
     Facilitates the concatenation of text values.
   - |
-    The infix operator
-    ```
-    ++ : text -> text -> text
-    ```
+    The infix operator `++ : text -> text -> text`{=snippet}
     can be used to concatenate two text values.  For example,
   - |
     "Number of widgets: " ++ format numWidgets
@@ -412,22 +409,23 @@
     also be woven into larger configurations such as cloth or nets.
   - |
     An equipped `string`{=entity} device enables several commands for working with
-    `text` values:
+    `text`{=type} values:
   - |
     `format : a -> text` can turn any value into a suitable text
     representation.
   - |
-    The infix operator `++ : text -> text -> text`
+    The infix operator `++ : text -> text -> text`{=snippet}
     can be used to concatenate two text values.  For example,
   - |
     ```
-    "Number of widgets: " ++ format numWidgets
+    let numWidgets = 42
+    in "Number of widgets: " ++ format numWidgets
     ```
   - |
     `chars : text -> int` computes the number of characters in a
-    `text` value.
+    `text`{=type} value.
   - |
-    `split : int -> text -> text * text` splits a `text` value into
+    `split : int -> text -> text * text` splits a `text`{=type} value into
     two pieces, one before the given index and one after.
   properties: [portable]
   capabilities: [format, concat, charcount, split]
@@ -443,9 +441,9 @@
     enables two functions:
   - |
     `charAt : int -> text -> int` returns the numeric code of the
-    character at a specific index in a (0-indexed) `text` value.
+    character at a specific index in a (0-indexed) `text`{=type} value.
   - |
-    `toChar : int -> text` creates a singleton (length-1) `text`
+    `toChar : int -> text` creates a singleton (length-1) `text`{=type}
     value containing a character with the given numeric code.
   properties: [portable]
   capabilities: [code]
@@ -462,7 +460,7 @@
     ```
     def thrice : cmd unit -> cmd unit = \c. c;c;c end
     ```
-  - defines the function `thrice` which repeats a command three times.
+  - defines the function `thrice`{=snippet} which repeats a command three times.
   properties: [portable, growable]
   growth: [100, 200]
   capabilities: [lambda]
@@ -797,7 +795,7 @@
     attr: device
     char: '%'
   description:
-  - A "tape drive" allows you to `backup`; that is, to `drive` in reverse.
+  - A "tape drive" allows you to `backup`; that is, to drive in reverse.
   capabilities: [backup]
   properties: [portable]
 
@@ -1014,7 +1012,8 @@
   - 'Example:'
   - |
     ```
-    if (x > 3) {move} {turn right; move}'
+    let x = 2 in
+    if (x > 3) {move} {turn right; move}
     ```
   properties: [portable]
   capabilities: [cond]
@@ -1129,7 +1128,7 @@
   - "To wait for a message and get the string value, use:"
   - |
     ```
-    l <- listen; log $ \"I have waited for someone to say \" ++ l
+    l <- listen; log $ "I have waited for someone to say " ++ l
     ```
   properties: [portable]
   capabilities: [listen]
@@ -1140,7 +1139,7 @@
     char: 'C'
   description:
   - |
-    A counter enables the command `count : string -> cmd int`,
+    A counter enables the command `count : text -> cmd int`,
     which counts how many occurrences of an entity are currently
     in the inventory.  This is an upgraded version of the `has`
     command, which returns a bool instead of an int and does
@@ -1170,21 +1169,21 @@
     addition to the usual arithmetic on numbers, an ADT calculator can
     also do arithmetic on types!  After all, the helpful typewritten manual
     explains, a type is just a collection of values, and a finite collection
-    of values is just a fancy number.  For example, the type `bool` is
+    of values is just a fancy number.  For example, the type `bool`{=type} is
     just a fancy version of the number 2, where the two things happen to be
-    labelled `false` and `true`.  There are also types `unit` and
-    `void` that correspond to 1 and 0, respectively.
+    labelled `false` and `true`.  There are also types `unit`{=type} and
+    `void`{=type} that correspond to 1 and 0, respectively.
   - |
     The product of two types is a type of pairs, since, for example,
-    if `t` is a type with three elements, then there are 2 * 3 = 6
-    different pairs containing a `bool` and a `t`, that is, 6 elements
-    of type `bool * t`.  For working with products of types, the ADT
-    calculator enables pair syntax `(a, b)` as well as the projection
+    if `t`{=type} is a type with three elements, then there are 2 * 3 = 6
+    different pairs containing a `bool`{=type} and a `t`{=type}, that is, 6 elements
+    of type `bool * t`{=type}.  For working with products of types, the ADT
+    calculator enables pair syntax `(1, "Hi!")` as well as the projection
     functions `fst : a * b -> a` and `snd : a * b -> b`.
   - |
     The sum of two types is a type with two options; for example, a
-    value of type `bool + t` is either a `bool` value or a `t` value,
-    and there are 2 + 3 = 5 such values.  For working with sums of
+    value of type `bool + t`{=type} is either a `bool`{=type} value or a `t`{=type} value,
+    and there are `2 + 3 == 5` such values.  For working with sums of
     types, the ADT calculator provides the injection functions `inl :
     a -> a + b` and `inr : b -> a + b`, as well as the case analysis
     function `case : (a + b) -> (a -> c) -> (b -> c) -> c`.  For
@@ -1279,7 +1278,7 @@
     robot A executes the following code:"
   - |
     ```
-    b <- ishere "rock"; if b {grab} {}
+    b <- ishere "rock"; if b {grab; return ()} {}
     ```
   - "This seems like a safe way to execute `grab` only when there is a
     rock to grab.  However, it is actually possible for the `grab` to
@@ -1289,7 +1288,7 @@
   - "To prevent this situation, robot A can wrap the commands in `atomic`, like so:"
   - |
     ```
-    atomic (b <- ishere "rock"; if b {grab} {})
+    atomic (b <- ishere "rock"; if b {grab; return ()} {})
     ```
 
   properties: [portable]
@@ -1323,16 +1322,17 @@
     waves off them and listening for the echo.  This capability can be
     accessed via two commands:
   - |
-    `meet : cmd (() + actor)` tries to locate a
+    `meet : cmd (unit + actor)` tries to locate a
     nearby actor (a robot, or... something else?) up to one cell away.
     It returns a reference to the nearest actor, or a unit value if
     none are found.
   - |
     `meetAll : (b -> actor -> cmd b) -> b -> cmd b` runs a command on
     every nearby actor (other than oneself), folding over the results
-    to compute a final result of type `b`.  For example, if `x`, `y`,
-    and `z` are nearby actors, then `meetAll f b0` is equivalent to
-    `b1 <- f b0 x; b2 <- f b1 y; f b2 z`.
+    to compute a final result of type `b`{=type}.  For example, if
+    `x`{=snippet}, `y`{=snippet}, and `z`{=snippet}
+    are nearby actors, then `meetAll f b0`{=snippet} is equivalent to
+    `b1 <- f b0 x; b2 <- f b1 y; f b2 z`{=snippet}.
   properties: [portable]
   capabilities: [meet]
 
@@ -1374,9 +1374,9 @@
   - |
     Also allows manipulating composite values consisting of a
     collection of named fields.  For example, `[x = 2, y = "hi"]`
-    is a value of type `[x : int, y : text]`.  Individual fields
+    is a value of type `[x : int, y : text]`{=type}.  Individual fields
     can be projected using dot notation.  For example,
-    `let r = [y="hi", x=2] in r.x` has the value 2.  The order
+    `let r = [y="hi", x=2] in r.x` has the value `2`.  The order
     of the fields does not matter.
   properties: [portable]
   capabilities: [record]

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -795,7 +795,7 @@
     attr: device
     char: '%'
   description:
-  - A "tape drive" allows you to `backup`; that is, to drive in reverse.
+  - A `tape drive`{=entity} allows you to `backup`; that is, to drive in reverse.
   capabilities: [backup]
   properties: [portable]
 

--- a/data/scenarios/Tutorials/craft.yaml
+++ b/data/scenarios/Tutorials/craft.yaml
@@ -19,7 +19,7 @@ objectives:
         Note: when used after opening quotes in the REPL, the Tab key can cycle through
         possible completions of a name. E.g., type:
       - |
-        > make "br[Tab][Tab]
+        `> make "br[Tab][Tab]`{=snippet}
     condition: |
       try {
         as base {has "branch predictor"}

--- a/scripts/autoplay-tutorials.sh
+++ b/scripts/autoplay-tutorials.sh
@@ -10,9 +10,10 @@ else
     SWARM="cabal run swarm -O0 --"
 fi
 
-for s in scenarios/Tutorials/*.yaml; do
-    $SWARM -i $s --autoplay;
-    echo -en "$s\tCONTINUE [Y/n]: "
+for tutorial in $(cat scenarios/Tutorials/00-ORDER.txt | xargs); do
+    echo -n "$tutorial"
+    $SWARM -i "scenarios/Tutorials/$tutorial" --autoplay --cheat;
+    echo -en "\tCONTINUE [Y/n]: "
     read answer;
     case "${answer:0:1}" in
         n|N )

--- a/scripts/run-scenarios.sh
+++ b/scripts/run-scenarios.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd $SCRIPT_DIR/..
+
+if command -v stack &> /dev/null; then
+    SWARM="stack exec swarm --"
+else
+    SWARM="cabal run swarm -O0 --"
+fi
+
+for s in scenarios/Tutorials/*.yaml; do
+    $SWARM -i $s --autoplay;
+    echo -en "$s\tCONTINUE [Y/n]: "
+    read answer;
+    case "${answer:0:1}" in
+        n|N )
+            exit 1
+        ;;
+        * )
+        ;;
+    esac
+done

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -55,13 +55,12 @@ import Swarm.Language.Key (specialKeyNames)
 import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Syntax (Const (..))
 import Swarm.Language.Syntax qualified as Syntax
+import Swarm.Language.Text.Markdown as Markdown (toText)
 import Swarm.Language.Typecheck (inferConst)
 import Swarm.Util (both, listEnums, quote)
 import Swarm.Util.Effect (simpleErrorHandle)
 import Text.Dot (Dot, NodeId, (.->.))
 import Text.Dot qualified as Dot
-import Witch (from)
-import Swarm.Language.Text.Markdown as Markdown (toText)
 
 -- ============================================================================
 -- MAIN ENTRYPOINT TO CLI DOCUMENTATION GENERATOR

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -55,7 +55,7 @@ import Swarm.Language.Key (specialKeyNames)
 import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Syntax (Const (..))
 import Swarm.Language.Syntax qualified as Syntax
-import Swarm.Language.Text.Markdown as Markdown (toText)
+import Swarm.Language.Text.Markdown as Markdown (docToMark)
 import Swarm.Language.Typecheck (inferConst)
 import Swarm.Util (both, listEnums, quote)
 import Swarm.Util.Effect (simpleErrorHandle)
@@ -360,7 +360,7 @@ entityToSection e =
       <> [" - Properties: " <> T.intercalate ", " (map tshow $ toList props) | not $ null props]
       <> [" - Capabilities: " <> T.intercalate ", " (Capability.capabilityName <$> caps) | not $ null caps]
       <> ["\n"]
-      <> [Markdown.toText $ view E.entityDescription e]
+      <> [Markdown.docToMark $ view E.entityDescription e]
  where
   props = view E.entityProperties e
   caps = Set.toList $ view E.entityCapabilities e

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -60,6 +60,8 @@ import Swarm.Util (both, listEnums, quote)
 import Swarm.Util.Effect (simpleErrorHandle)
 import Text.Dot (Dot, NodeId, (.->.))
 import Text.Dot qualified as Dot
+import Witch (from)
+import Swarm.Language.Text.Markdown as Markdown (toText)
 
 -- ============================================================================
 -- MAIN ENTRYPOINT TO CLI DOCUMENTATION GENERATOR
@@ -359,7 +361,7 @@ entityToSection e =
       <> [" - Properties: " <> T.intercalate ", " (map tshow $ toList props) | not $ null props]
       <> [" - Capabilities: " <> T.intercalate ", " (Capability.capabilityName <$> caps) | not $ null caps]
       <> ["\n"]
-      <> [T.intercalate "\n\n" $ view E.entityDescription e]
+      <> [Markdown.toText $ view E.entityDescription e]
  where
   props = view E.entityProperties e
   caps = Set.toList $ view E.entityCapabilities e

--- a/src/Swarm/Doc/Pedagogy.hs
+++ b/src/Swarm/Doc/Pedagogy.hs
@@ -90,7 +90,7 @@ extractCommandUsages idx siPair@(s, _si) =
 getDescCommands :: Scenario -> Set Const
 getDescCommands s = S.fromList $ concatMap filterConst allCode
  where
-  goalTextParagraphs = concatMap (view objectiveGoal) $ view scenarioObjectives s
+  goalTextParagraphs = view objectiveGoal <$> view scenarioObjectives s
   allCode = concatMap findCode goalTextParagraphs
   filterConst :: Syntax -> [Const]
   filterConst sx = mapMaybe toConst $ universe (sx ^. sTerm)

--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -110,7 +110,7 @@ import Swarm.Game.Location
 import Swarm.Game.ResourceLoading (getDataFileNameSafe)
 import Swarm.Language.Capability
 import Swarm.Language.Syntax (Syntax)
-import Swarm.Language.Text.Markdown (Document, toText)
+import Swarm.Language.Text.Markdown (Document, docToText)
 import Swarm.Util (binTuples, failT, findDup, plural, (?))
 import Swarm.Util.Effect (withThrow)
 import Swarm.Util.Yaml
@@ -248,7 +248,7 @@ instance Hashable Entity where
       `hashWithSalt` disp
       `hashWithSalt` nm
       `hashWithSalt` pl
-      `hashWithSalt` toText descr
+      `hashWithSalt` docToText descr
       `hashWithSalt` orient
       `hashWithSalt` grow
       `hashWithSalt` yld

--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -109,14 +109,14 @@ import Swarm.Game.Failure
 import Swarm.Game.Location
 import Swarm.Game.ResourceLoading (getDataFileNameSafe)
 import Swarm.Language.Capability
-import Swarm.Util (binTuples, failT, findDup, plural, quote, (?))
+import Swarm.Language.Syntax (Syntax)
+import Swarm.Language.Text.Markdown (Document, toText)
+import Swarm.Util (binTuples, failT, findDup, plural, (?))
 import Swarm.Util.Effect (withThrow)
 import Swarm.Util.Yaml
 import Text.Read (readMaybe)
 import Witch
 import Prelude hiding (lookup)
-import Swarm.Language.Text.Markdown (Document, toText)
-import Swarm.Language.Syntax (Syntax)
 
 ------------------------------------------------------------
 -- Properties

--- a/src/Swarm/Game/Exception.hs
+++ b/src/Swarm/Game/Exception.hs
@@ -107,8 +107,8 @@ formatIncapableFix = \case
 -- >>> import Control.Algebra (run)
 -- >>> import Swarm.Game.Failure (LoadingFailure)
 -- >>> :set -XTypeApplications
--- >>> w = mkEntity (defaultEntityDisplay 'l') "magic wand" [] [] [CAppear]
--- >>> r = mkEntity (defaultEntityDisplay 'o') "the one ring" [] [] [CAppear]
+-- >>> w = mkEntity (defaultEntityDisplay 'l') "magic wand" mempty mempty [CAppear]
+-- >>> r = mkEntity (defaultEntityDisplay 'o') "the one ring" mempty mempty [CAppear]
 -- >>> m = fromRight mempty . run . runThrow @LoadingFailure $ buildEntityMap [w,r]
 -- >>> incapableError cs t = putStr . unpack $ formatIncapable m FixByEquip cs t
 --

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -99,14 +99,14 @@ import Swarm.Game.Universe
 import Swarm.Language.Capability (Capability)
 import Swarm.Language.Context qualified as Ctx
 import Swarm.Language.Requirement (ReqCtx)
+import Swarm.Language.Syntax (Syntax)
+import Swarm.Language.Text.Markdown (Document)
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Types (TCtx)
 import Swarm.Language.Value as V
 import Swarm.Util.Lens (makeLensesExcluding)
 import Swarm.Util.Yaml
 import System.Clock (TimeSpec)
-import Swarm.Language.Text.Markdown (Document)
-import Swarm.Language.Syntax (Syntax)
 
 -- | A record that stores the information
 --   for all definitions stored in a 'Robot'

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -105,6 +105,8 @@ import Swarm.Language.Value as V
 import Swarm.Util.Lens (makeLensesExcluding)
 import Swarm.Util.Yaml
 import System.Clock (TimeSpec)
+import Swarm.Language.Text.Markdown (Document)
+import Swarm.Language.Syntax (Syntax)
 
 -- | A record that stores the information
 --   for all definitions stored in a 'Robot'
@@ -444,7 +446,7 @@ mkRobot ::
   -- | Name of the robot.
   Text ->
   -- | Description of the robot.
-  [Text] ->
+  Document Syntax ->
   -- | Initial location.
   RobotLocation phase ->
   -- | Initial heading/direction.
@@ -501,7 +503,7 @@ instance FromJSONE EntityMap TRobot where
 
     mkRobot () Nothing
       <$> liftE (v .: "name")
-      <*> liftE (v .:? "description" .!= [])
+      <*> liftE (v .:? "description" .!= mempty)
       <*> liftE (v .:? "loc")
       <*> liftE (v .:? "dir" .!= zero)
       <*> localE (const defDisplay) (v ..:? "display" ..!= defDisplay)

--- a/src/Swarm/Game/Scenario/Objective.hs
+++ b/src/Swarm/Game/Scenario/Objective.hs
@@ -66,7 +66,7 @@ instance FromJSON PrerequisiteConfig where
 -- | An objective is a condition to be achieved by a player in a
 --   scenario.
 data Objective = Objective
-  { _objectiveGoal :: [Markdown.Document Syntax]
+  { _objectiveGoal :: Markdown.Document Syntax
   , _objectiveTeaser :: Maybe Text
   , _objectiveCondition :: ProcessedTerm
   , _objectiveId :: Maybe ObjectiveLabel
@@ -84,7 +84,7 @@ instance ToSample Objective where
 
 -- | An explanation of the goal of the objective, shown to the player
 --   during play.  It is represented as a list of paragraphs.
-objectiveGoal :: Lens' Objective [Markdown.Document Syntax]
+objectiveGoal :: Lens' Objective (Markdown.Document Syntax)
 
 -- | A very short (3-5 words) description of the goal for
 -- displaying on the left side of the Objectives modal.
@@ -122,7 +122,7 @@ objectiveAchievement :: Lens' Objective (Maybe AchievementInfo)
 instance FromJSON Objective where
   parseJSON = withObject "objective" $ \v ->
     Objective
-      <$> (v .:? "goal" .!= [])
+      <$> (v .:? "goal" .!= mempty)
       <*> (v .:? "teaser")
       <*> (v .: "condition")
       <*> (v .:? "id")

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -83,6 +83,7 @@ import Swarm.Language.Capability
 import Swarm.Language.Context hiding (delete)
 import Swarm.Language.Key (parseKeyComboFull)
 import Swarm.Language.Parse (runParser)
+import Swarm.Language.Text.Markdown qualified as Markdown
 import Swarm.Language.Pipeline
 import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Pretty (BulletList (BulletList, bulletListItems), prettyText)
@@ -383,7 +384,7 @@ hypotheticalRobot c =
     (-1)
     Nothing
     "hypothesis"
-    []
+    mempty
     defaultCosmicLocation
     zero
     defaultRobotDisplay
@@ -1081,7 +1082,7 @@ addSeedBot e (minT, maxT) loc ts =
         ()
         Nothing
         "seed"
-        ["A growing seed."]
+        "A growing seed."
         (Just loc)
         zero
         ( defaultEntityDisplay '.'
@@ -1957,7 +1958,7 @@ execConst c vs s k = do
               ()
               (Just pid)
               displayName
-              ["A robot built by the robot named " <> r ^. robotName <> "."]
+              (Markdown.fromText $ "A robot built by the robot named " <> (r ^. robotName) <> ".")
               (Just (r ^. robotLocation))
               ( ((r ^. robotOrientation) >>= \dir -> guard (dir /= zero) >> return dir)
                   ? north

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -83,12 +83,12 @@ import Swarm.Language.Capability
 import Swarm.Language.Context hiding (delete)
 import Swarm.Language.Key (parseKeyComboFull)
 import Swarm.Language.Parse (runParser)
-import Swarm.Language.Text.Markdown qualified as Markdown
 import Swarm.Language.Pipeline
 import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Pretty (BulletList (BulletList, bulletListItems), prettyText)
 import Swarm.Language.Requirement qualified as R
 import Swarm.Language.Syntax
+import Swarm.Language.Text.Markdown qualified as Markdown
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Value
 import Swarm.Util hiding (both)

--- a/src/Swarm/Language/Text/Markdown.hs
+++ b/src/Swarm/Language/Text/Markdown.hs
@@ -56,7 +56,7 @@ import GHC.Exts qualified (IsList (..), IsString (..))
 import Swarm.Language.Module (moduleAST)
 import Swarm.Language.Parse (readTerm)
 import Swarm.Language.Pipeline (ProcessedTerm (..), processParsedTerm)
-import Swarm.Language.Pretty (prettyText, prettyTypeErrText, PrettyPrec (..))
+import Swarm.Language.Pretty (PrettyPrec (..), prettyText, prettyTypeErrText)
 import Swarm.Language.Syntax (Syntax)
 
 -- | The top-level markdown document.
@@ -317,7 +317,7 @@ instance PrettyPrec a => ToStream (Paragraph a) where
   toStream = concatMap toStream . nodes
 
 --------------------------------------------------------------
--- Markdown 
+-- Markdown
 --------------------------------------------------------------
 
 nodeToMark :: PrettyPrec a => Node a -> Text

--- a/src/Swarm/Language/Text/Markdown.hs
+++ b/src/Swarm/Language/Text/Markdown.hs
@@ -327,7 +327,7 @@ nodeToMark = \case
   LeafCode c -> wrap "`" (prettyText c)
   LeafCodeBlock f c -> codeBlock f $ prettyText c
  where
-  codeBlock f t = "```" <> T.pack f <> "\n" <> t <> "\n```"
+  codeBlock f t = wrap "```" $ T.pack f <> "\n" <> t <> "\n"
   wrap c t = c <> t <> c
   attr t a = case a of
     Emphasis -> wrap "_" t

--- a/src/Swarm/Language/Text/Markdown.hs
+++ b/src/Swarm/Language/Text/Markdown.hs
@@ -37,7 +37,9 @@ import Commonmark qualified as Mark
 import Commonmark.Extensions qualified as Mark (rawAttributeSpec)
 import Control.Applicative ((<|>))
 import Control.Arrow (left)
+import Control.Lens ((%~), (&), _head, _last)
 import Control.Monad (void)
+import Data.Char (isSpace)
 import Data.Functor.Identity (Identity (..))
 import Data.List qualified as List
 import Data.List.Split (chop)
@@ -49,12 +51,12 @@ import Data.Text qualified as T
 import Data.Tuple.Extra (both, first)
 import Data.Vector (toList)
 import Data.Yaml
+import GHC.Exts qualified (IsList (..), IsString (..))
 import Swarm.Language.Module (moduleAST)
 import Swarm.Language.Parse (readTerm)
 import Swarm.Language.Pipeline (ProcessedTerm (..), processParsedTerm)
 import Swarm.Language.Pretty (prettyText, prettyTypeErrText)
 import Swarm.Language.Syntax (Syntax)
-import GHC.Exts qualified (IsList(..), IsString(..)) 
 
 -- | The top-level markdown document.
 newtype Document c = Document {paragraphs :: [Paragraph c]}
@@ -94,6 +96,18 @@ txt = LeafText mempty
 addTextAttribute :: TxtAttr -> Node c -> Node c
 addTextAttribute a (LeafText as t) = LeafText (Set.insert a as) t
 addTextAttribute _ n = n
+
+normalise :: (Eq c, Semigroup c) => Paragraph c -> Paragraph c
+normalise (Paragraph a) = Paragraph $ go a
+ where
+  go = \case
+    [] -> []
+    (n : ns) -> let (n', ns') = mergeSame n ns in n' : go ns'
+  mergeSame = \case
+    l@(LeafText attrs1 t1) -> \case
+      (LeafText attrs2 t2 : rss) | attrs1 == attrs2 -> mergeSame (LeafText attrs1 $ t1 <> t2) rss
+      rs -> (l, rs)
+    l -> (l,)
 
 -- | Simple text attributes that make it easier to find key info in descriptions.
 data TxtAttr = Strong | Emphasis
@@ -202,7 +216,8 @@ fromTextPure :: Text -> Either String (Document Text)
 fromTextPure t = do
   let spec = Mark.rawAttributeSpec <> Mark.defaultSyntaxSpec <> Mark.rawAttributeSpec
   let runSimple = left show . runIdentity
-  runSimple $ Mark.commonmarkWith spec "markdown" t
+  Document tokenizedDoc <- runSimple $ Mark.commonmarkWith spec "markdown" t
+  return . Document $ normalise <$> tokenizedDoc
 
 --------------------------------------------------------------
 -- DIY STREAM
@@ -251,13 +266,16 @@ chunksOf n = chop (splitter True n)
   cut :: Bool -> Int -> StreamNode -> (StreamNode, StreamNode)
   cut start i tn =
     let (con, t) = unStream tn
-     in case splitWordsAt i (T.words t) of
+        endSpace = T.takeWhileEnd isSpace t
+        startSpace = T.takeWhile isSpace t
+        twords = T.words t & _head %~ (startSpace <>) & _last %~ (<> endSpace)
+     in case splitWordsAt i twords of
           ([], []) -> (con "", con "")
           ([], ws@(ww : wws)) ->
             both (con . T.unwords) $
               -- In case single word (e.g. web link) does not fit on line we must put
               -- it there and guarantee progress (otherwise chop will cycle)
-              if start then ([ww], wws) else ([], ws)
+              if start then ([T.take i ww], T.drop i ww : wws) else ([], ws)
           splitted -> both (con . T.unwords) splitted
 
 splitWordsAt :: Int -> [Text] -> ([Text], [Text])

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -964,8 +964,8 @@ doGoalUpdates = do
         -- automatically popped up.
         gameState . announcementQueue .= mempty
 
-        isAutoplaying <- use $ uiState . uiIsAutoplay
-        unless (isAutoplaying && not isCheating) $
+        hideGoals <- use $ uiState . uiHideGoals
+        unless hideGoals $
           openModal GoalModal
 
       return goalWasUpdated

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -965,7 +965,7 @@ doGoalUpdates = do
         gameState . announcementQueue .= mempty
 
         isAutoplaying <- use $ uiState . uiIsAutoplay
-        unless isAutoplaying $
+        unless (isAutoplaying && not isCheating) $
           openModal GoalModal
 
       return goalWasUpdated

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -105,7 +105,7 @@ initPersistentState ::
 initPersistentState opts@(AppOpts {..}) = do
   (warnings :: Seq SystemFailure, (initRS, initUI)) <- runAccum mempty $ do
     rs <- initRuntimeState
-    ui <- initUIState speed (not (skipMenu opts)) (cheatMode || autoPlay)
+    ui <- initUIState speed (not (skipMenu opts)) cheatMode
     return (rs, ui)
   let initRS' = addWarnings initRS (F.toList warnings)
   return (initRS', initUI)
@@ -243,7 +243,8 @@ scenarioToUIState isAutoplaying siPair@(scenario, _) gs u = do
     u
       & uiPlaying .~ True
       & uiGoal .~ emptyGoalDisplay
-      & uiIsAutoplay .~ isAutoplaying
+      & uiCheatMode ||~ isAutoplaying
+      & uiHideGoals .~ (isAutoplaying && not (u ^. uiCheatMode))
       & uiFocusRing .~ initFocusRing
       & uiInventory .~ Nothing
       & uiInventorySort .~ defaultSortOptions

--- a/src/Swarm/TUI/Model/UI.hs
+++ b/src/Swarm/TUI/Model/UI.hs
@@ -26,7 +26,7 @@ module Swarm.TUI.Model.UI (
   uiError,
   uiModal,
   uiGoal,
-  uiIsAutoplay,
+  uiHideGoals,
   uiAchievements,
   lgTicksPerSecond,
   lastFrameTime,
@@ -113,7 +113,7 @@ data UIState = UIState
   , _uiError :: Maybe Text
   , _uiModal :: Maybe Modal
   , _uiGoal :: GoalDisplay
-  , _uiIsAutoplay :: Bool
+  , _uiHideGoals :: Bool
   , _uiAchievements :: Map CategorizedAchievement Attainment
   , _uiShowFPS :: Bool
   , _uiShowREPL :: Bool
@@ -199,8 +199,10 @@ uiModal :: Lens' UIState (Maybe Modal)
 --   has been displayed to the user initially.
 uiGoal :: Lens' UIState GoalDisplay
 
--- | When running with --autoplay, suppress the goal dialogs
-uiIsAutoplay :: Lens' UIState Bool
+-- | When running with --autoplay, suppress the goal dialogs.
+--
+-- For developement, the --cheat flag shows goals again.
+uiHideGoals :: Lens' UIState Bool
 
 -- | Map of achievements that were attained
 uiAchievements :: Lens' UIState (Map CategorizedAchievement Attainment)
@@ -333,7 +335,7 @@ initUIState speedFactor showMainMenu cheatMode = do
           , _uiError = Nothing
           , _uiModal = Nothing
           , _uiGoal = emptyGoalDisplay
-          , _uiIsAutoplay = False
+          , _uiHideGoals = False
           , _uiAchievements = M.fromList $ map (view achievement &&& id) achievements
           , _uiShowFPS = False
           , _uiShowREPL = True

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -1105,7 +1105,7 @@ explainEntry :: AppState -> Entity -> Widget Name
 explainEntry s e =
   vBox $
     [ displayProperties $ Set.toList (e ^. entityProperties)
-    , displayParagraphs (e ^. entityDescription)
+    , drawMarkdown (e ^. entityDescription)
     , explainRecipes s e
     ]
       <> [drawRobotMachine s False | e ^. entityCapabilities . Lens.contains CDebug]
@@ -1251,7 +1251,7 @@ drawRecipe me inv (Recipe ins outs reqs time _weight) =
 
 -- | Ad-hoc entity to represent time - only used in recipe drawing
 timeE :: Entity
-timeE = mkEntity (defaultEntityDisplay '.') "ticks" [] [] []
+timeE = mkEntity (defaultEntityDisplay '.') "ticks" mempty [] []
 
 drawReqs :: IngredientList Entity -> Widget Name
 drawReqs = vBox . map (hCenter . drawReq)

--- a/src/Swarm/TUI/View/Objective.hs
+++ b/src/Swarm/TUI/View/Objective.hs
@@ -15,7 +15,6 @@ import Control.Lens hiding (Const, from)
 import Data.List (intercalate)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as M
-import Data.Maybe (listToMaybe)
 import Data.Vector qualified as V
 import Swarm.Game.Scenario.Objective
 import Swarm.Language.Text.Markdown qualified as Markdown
@@ -88,11 +87,11 @@ drawGoalListItem _isSelected e = case e of
   Header gs -> withAttr boldAttr $ str $ show gs
   Goal gs obj -> getCompletionIcon obj gs <+> titleWidget
    where
-    textSource = obj ^. objectiveTeaser <|> obj ^. objectiveId <|> listToMaybe (Markdown.toText <$> obj ^. objectiveGoal)
+    textSource = obj ^. objectiveTeaser <|> obj ^. objectiveId <|> Just (Markdown.docToText $ obj ^. objectiveGoal)
     titleWidget = maybe (txt "?") (withEllipsis End) textSource
 
 singleGoalDetails :: GoalEntry -> Widget Name
 singleGoalDetails = \case
-  Goal _gs obj -> layoutParagraphs $ drawMarkdown <$> obj ^. objectiveGoal
+  Goal _gs obj -> drawMarkdown $ obj ^. objectiveGoal
   -- Only Goal entries are selectable, so we should never see this:
   _ -> emptyWidget

--- a/src/Swarm/TUI/View/Util.hs
+++ b/src/Swarm/TUI/View/Util.hs
@@ -130,10 +130,14 @@ drawMarkdown d = do
   mTxt = \case
     Markdown.TextNode as t -> foldr applyAttr (txt t) as
     Markdown.CodeNode t -> withAttr highlightAttr $ txt t
-    Markdown.RawNode _f t -> withAttr highlightAttr $ txt t
+    Markdown.RawNode f t -> withAttr (rawAttr f) $ txt t
   applyAttr a = withAttr $ case a of
     Markdown.Strong -> boldAttr
     Markdown.Emphasis -> italicAttr
+  rawAttr = \case
+    "entity" -> greenAttr
+    "type" -> magentaAttr
+    _snippet -> highlightAttr -- same as plain code
 
 drawLabeledTerrainSwatch :: TerrainType -> Widget Name
 drawLabeledTerrainSwatch a =

--- a/src/Swarm/TUI/View/Util.hs
+++ b/src/Swarm/TUI/View/Util.hs
@@ -124,14 +124,13 @@ drawMarkdown d = do
   Widget Greedy Fixed $ do
     ctx <- getContext
     let w = ctx ^. availWidthL
-    let docLines = Markdown.chunksOf w $ Markdown.toStream d
-    render $ vBox $ map (hBox . map mTxt) docLines
+    let docLines = Markdown.chunksOf w . Markdown.toStream <$> Markdown.paragraphs d
+    render . layoutParagraphs $ vBox . map (hBox . map mTxt) <$> docLines
  where
   mTxt = \case
     Markdown.TextNode as t -> foldr applyAttr (txt t) as
     Markdown.CodeNode t -> withAttr highlightAttr $ txt t
     Markdown.RawNode _f t -> withAttr highlightAttr $ txt t
-    Markdown.ParagraphBreak -> txt ""
   applyAttr a = withAttr $ case a of
     Markdown.Strong -> boldAttr
     Markdown.Emphasis -> italicAttr

--- a/test/unit/TestInventory.hs
+++ b/test/unit/TestInventory.hs
@@ -109,6 +109,6 @@ testInventory =
         )
     ]
  where
-  x = E.mkEntity (defaultEntityDisplay 'X') "fooX" [] [] []
-  y = E.mkEntity (defaultEntityDisplay 'Y') "fooY" [] [] []
-  z = E.mkEntity (defaultEntityDisplay 'Z') "fooZ" [] [] []
+  x = E.mkEntity (defaultEntityDisplay 'X') "fooX" mempty [] []
+  y = E.mkEntity (defaultEntityDisplay 'Y') "fooY" mempty [] []
+  z = E.mkEntity (defaultEntityDisplay 'Z') "fooZ" mempty [] []


### PR DESCRIPTION
* use `Markdown.Document` as `entityDescription`
* add missing spaces in `chunksOf`
* fix code in `entities.yaml` (mostly types and few outdated snippets)
* add code markdown in craft tutorial
* use colours for types and entities

- closes #1408
- closes #1409 