### PR TITLE
system robots should build system robots

### DIFF
--- a/data/scenarios/Testing/1430-built-robot-ownership.yaml
+++ b/data/scenarios/Testing/1430-built-robot-ownership.yaml
@@ -1,0 +1,44 @@
+version: 1
+name: Ownership of system-built robots
+creative: true
+description: Demo of system robot construction
+robots:
+  - name: base
+    dir: [1, 0]
+    display:
+      char: Ω
+      attr: robot
+    devices:
+      - logger
+  - name: sysbot
+    dir: [0, 1]
+    system: true
+    display:
+      char: j
+      attr: robot
+      invisible: true
+    devices:
+      - treads
+      - solar panel
+      - logger
+      - 3D printer
+    inventory:
+      - [1, solar panel]
+      - [1, logger]
+      - [1, treads]
+      - [1, string]
+    program: |
+      build {move; move; x <- as parent {whoami}; log x}
+known: []
+world:
+  palette:
+    'Ω': [grass, null, base]
+    'r': [stone, null, sysbot]
+    '.': [grass]
+  upperleft: [0, 0]
+  map: |
+   .........
+   .........
+   ...Ω..r..
+   .........
+   .........

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1949,6 +1949,7 @@ execConst c vs s k = do
         -- Pick a random display name.
         displayName <- randomName
         createdAt <- getNow
+        isSystemRobot <- use systemRobot
 
         -- Construct the new robot and add it to the world.
         parentCtx <- use robotContext
@@ -1967,7 +1968,7 @@ execConst c vs s k = do
               (In cmd e s [FExec])
               []
               []
-              False
+              isSystemRobot
               False
               createdAt
 


### PR DESCRIPTION
Closes #1430.

# Demo

    scripts/play.sh -i data/scenarios/Testing/1430-built-robot-ownership.yaml

Before, pressing `F2` would show two robots: the `base` and the system-built robot.
Now, only the `base` is shown, as the built robot is properly classified as another system robot.