### PR TITLE
Add a pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,16 @@
+Thanks for contributing to Swarm!  Please replace this template with a
+description of the changes in this pull request.
+
+- Note that when the pull request is merged, the pull request
+  description will be used as the description of a single resulting
+  squashed commit.  So you should write your PR description with an
+  audience of future developers and users in mind.
+
+- If your PR fixes a specific issue or issues, be sure to include a
+  phrase like "fixes #nnn" or "closes #nnn" somewhere in the
+  description, so GitHub will automatically close the relevant issue
+  when your PR is merged.
+
+- If your PR is a substantial user-facing change (i.e. something other
+  than a typo fix, refactoring, etc.), give it the CHANGELOG label to
+  suggest it for mention in the next release changelog.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,8 +1,8 @@
 Thanks for contributing to Swarm!  Please replace this template with a
-description of the changes in this pull request.
+description of the changes in your pull request.
 
-- Note that when the pull request is merged, the pull request
-  description will be used as the description of a single resulting
+- Note that when the pull request is merged, this pull request
+  description will be used as the message on the resulting single
   squashed commit.  So you should write your PR description with an
   audience of future developers and users in mind.
 


### PR DESCRIPTION
Adds a pull request template with some reminders for anyone opening a pull request.   They are phrased as reminders, not a checklist, since I don't want to make this a barrier to contributions.

Closes #1429.