### PR TITLE
fix `PrettyPrec Entry` instance

### DIFF
--- a/src/Swarm/Game/Failure.hs
+++ b/src/Swarm/Game/Failure.hs
@@ -86,7 +86,7 @@ instance PrettyPrec Asset where
     a -> pretty (showLowT a)
 
 instance PrettyPrec Entry where
-  prettyPrec = const . prettyShowLow
+  prettyPrec _ = prettyShowLow
 
 instance PrettyPrec LoadingFailure where
   prettyPrec _ = \case


### PR DESCRIPTION
Closes #1462.

To demonstrate, *e.g.* temporarily remove `names.txt`.  Without this patch, you will get an error message saying `The 0 is missing!`.  With this patch, it now correctly says `The file is missing!`.