### PR TITLE
Fix lambda precedence

### DIFF
--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -188,7 +188,7 @@ instance PrettyPrec Term where
   prettyPrec _ (TVar s) = pretty s
   prettyPrec _ (TDelay _ t) = group . encloseWithIndent 2 lbrace rbrace $ ppr t
   prettyPrec _ t@TPair {} = prettyTuple t
-  prettyPrec p t@(TLam {}) = 
+  prettyPrec p t@(TLam {}) =
     pparens (p > 9) $
       prettyLambdas t
   -- Special handling of infix operators - ((+) 2) 3 --> 2 + 3

--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -188,7 +188,9 @@ instance PrettyPrec Term where
   prettyPrec _ (TVar s) = pretty s
   prettyPrec _ (TDelay _ t) = group . encloseWithIndent 2 lbrace rbrace $ ppr t
   prettyPrec _ t@TPair {} = prettyTuple t
-  prettyPrec _ t@(TLam {}) = prettyLambdas t
+  prettyPrec p t@(TLam {}) = 
+    pparens (p > 9) $
+      prettyLambdas t
   -- Special handling of infix operators - ((+) 2) 3 --> 2 + 3
   prettyPrec p (TApp t@(TApp (TConst c) l) r) =
     let ci = constInfo c

--- a/test/unit/TestPretty.hs
+++ b/test/unit/TestPretty.hs
@@ -95,6 +95,18 @@ testPrettyConst =
         ( equalPretty "1 : int" $
             TAnnotate (TInt 1) (Forall [] TyInt)
         )
+    , testCase
+        "lambda precedence (#1468)"
+        ( equalPretty "\\m. case m (\\x. x + 1) (\\y. y * 2)" $
+            TLam
+              "m"
+              Nothing
+              ( TConst Case
+                  :$: STerm (TVar "m")
+                  :$: STerm (TLam "x" Nothing (mkOp' Add (TVar "x") (TInt 1)))
+                  :$: STerm (TLam "y" Nothing (mkOp' Mul (TVar "y") (TInt 2)))
+              )
+        )
     ]
  where
   equalPretty :: String -> Term -> Assertion


### PR DESCRIPTION
- give lambdas lower precedence (9) then application (10)
- closes #1468

Before (with #1459):
```
❯ cabal run swarm -O0 -- format <(echo '\\m. case m (\\x. x + 1) (\\y. y * 2)')
\m. case m \x. x + 1 \y. y * 2
```

After:
```
❯ cabal run swarm -O0 -- format <(echo '\\m. case m (\\x. x + 1) (\\y. y * 2)')
\m. case m (\x. x + 1) (\y. y * 2)
```