### PR TITLE
Publish VSCode extension under swarm-game everywhere

### DIFF
--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -29,3 +29,8 @@ jobs:
           packagePath: editors/vscode
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          packagePath: editors/vscode
+          pat: ${{ secrets.VSX_MARKETPLACE_TOKEN }}

--- a/editors/README.md
+++ b/editors/README.md
@@ -24,10 +24,9 @@ LSP client. That is if you have `swarm` executable in PATH, then
 the executable will be used as LSP server to show errors as you type.
 
 You can get it by:
-- installing from MS marketplace ([link](https://marketplace.visualstudio.com/items?itemName=xsebek.swarm-language))
+- installing from the MS marketplace ([link](https://marketplace.visualstudio.com/items?itemName=swarm-game.swarm-language))
+- installing from the Open VSX Registry ([link](https://open-vsx.org/extension/swarm-game/swarm-language))
 - building from source in the [vscode folder](./vscode/DEVELOPING.md)
-- **TBD** get the VSIX from GitHub releases
-- **TBD** installing from the VS codium free marketplace
 
 ## Vim and Neovim
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "swarm-language" extension will be documented in this file.
 
+## version 0.1.1
+- Move the extension under "swarm-game" org
+
 ## version 0.0.9
 - [Highlighter] add `unit` and `actor` types
 - [Highlighter] add many new commands:

--- a/editors/vscode/client/package.json
+++ b/editors/vscode/client/package.json
@@ -4,8 +4,8 @@
 	"description": "VSCode part of the swarm language server",
 	"author": "Ondřej Šebek",
 	"license": "MIT",
-	"version": "0.0.3",
-	"publisher": "xsebek",
+	"version": "0.1.1",
+	"publisher": "swarm-game",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/swarm-game/swarm"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,9 +2,9 @@
     "name": "swarm-language",
     "displayName": "swarm-language",
     "description": "VSCode support for swarm (the game) programming language.",
-    "version": "0.0.9",
+    "version": "0.1.1",
     "icon": "images/swarm-logo.png",
-    "publisher": "xsebek",
+    "publisher": "swarm-game",
     "repository": {
         "url": "https://github.com/swarm-game/swarm"
     },


### PR DESCRIPTION
* move the VSCode extension under "swarm-game" organisation
* add Open VSX Registry to "Deploy Extension" GitHub Action
* bump version, so it gets pushed once tagged
* closes #1453