### PR TITLE
Include VS Code workspace settings in repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "yaml.schemas": {
+        "data/schema/scenario.json": [
+            "data/scenarios/**/*.yaml"
+        ],
+        "data/schema/entities.json": [
+            "data/entities.yaml"
+        ],
+        "data/schema/recipes.json": [
+            "data/recipes.yaml"
+        ],
+    }
+}

--- a/editors/README.md
+++ b/editors/README.md
@@ -30,23 +30,7 @@ You can get it by:
 
 ### YAML schema validation
 
-To configure YAML editor tabs for schema validation, install the [YAML plugin](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and add the following to `.vscode/settings.json` under the workspace root:
-
-```json
-{
-    "yaml.schemas": {
-        "data/schema/scenario.json": [
-            "data/scenarios/**/*.yaml"
-        ],
-        "data/schema/entities.json": [
-            "data/entities.yaml"
-        ],
-        "data/schema/recipes.json": [
-            "data/recipes.yaml"
-        ],
-    }
-}
-```
+To configure YAML editor tabs for schema validation, install the [YAML plugin](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml).  The appropriate settings are already included in `.vscode/settings.json` under the workspace root.
 
 ## Vim and Neovim
 


### PR DESCRIPTION
This saves a step in the development setup process.

Note that the settings file is included in the toplevel `.gitignore`, so any changes on top of this one will not result in a "dirty" repo.