### PR TITLE
Improvements to scrolling

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -815,6 +815,7 @@ updateUI = do
       let itName = fromString $ "it" ++ show itIx
       let out = T.intercalate " " [itName, ":", prettyText finalType, "=", into (prettyValue v)]
       uiState . uiREPL . replHistory %= addREPLItem (REPLOutput out)
+      vScrollToEnd replScroll
       gameState . replStatus .= REPLDone (Just val)
       gameState . baseRobot . robotContext . at itName .= Just val
       gameState . replNextValueIndex %= (+ 1)
@@ -1113,59 +1114,64 @@ runBaseTerm topCtx =
 -- | Handle a user input event for the REPL.
 handleREPLEventTyping :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleREPLEventTyping = \case
-  Key V.KEnter -> do
-    s <- get
-    let topCtx = topContext s
-        repl = s ^. uiState . uiREPL
-        uinput = repl ^. replPromptText
-
-    if not $ s ^. gameState . replWorking
-      then case repl ^. replPromptType of
-        CmdPrompt _ -> runBaseCode topCtx uinput
-        SearchPrompt hist ->
-          case lastEntry uinput hist of
-            Nothing -> uiState %= resetREPL "" (CmdPrompt [])
-            Just found
-              | T.null uinput -> uiState %= resetREPL "" (CmdPrompt [])
-              | otherwise -> do
-                  uiState %= resetREPL found (CmdPrompt [])
-                  modify validateREPLForm
-      else continueWithoutRedraw
-  Key V.KUp -> modify $ adjReplHistIndex Older
-  Key V.KDown -> modify $ adjReplHistIndex Newer
-  ControlChar 'r' -> do
-    s <- get
-    let uinput = s ^. uiState . uiREPL . replPromptText
-    case s ^. uiState . uiREPL . replPromptType of
-      CmdPrompt _ -> uiState . uiREPL . replPromptType .= SearchPrompt (s ^. uiState . uiREPL . replHistory)
-      SearchPrompt rh -> case lastEntry uinput rh of
-        Nothing -> pure ()
-        Just found -> uiState . uiREPL . replPromptType .= SearchPrompt (removeEntry found rh)
-  CharKey '\t' -> do
-    s <- get
-    let names = s ^.. gameState . baseRobot . robotContext . defTypes . to assocs . traverse . _1
-    uiState . uiREPL %= tabComplete names (s ^. gameState . entityMap)
-    modify validateREPLForm
-  EscapeKey -> do
-    formSt <- use $ uiState . uiREPL . replPromptType
-    case formSt of
-      CmdPrompt {} -> continueWithoutRedraw
-      SearchPrompt _ ->
-        uiState %= resetREPL "" (CmdPrompt [])
-  ControlChar 'd' -> do
-    text <- use $ uiState . uiREPL . replPromptText
-    if text == T.empty
-      then toggleModal QuitModal
-      else continueWithoutRedraw
+  -- Scroll the REPL on PageUp or PageDown
   Key V.KPageUp -> vScrollPage replScroll Brick.Up
   Key V.KPageDown -> vScrollPage replScroll Brick.Down
-  -- finally if none match pass the event to the editor
-  ev -> do
-    Brick.zoom (uiState . uiREPL . replPromptEditor) (handleEditorEvent ev)
-    uiState . uiREPL . replPromptType %= \case
-      CmdPrompt _ -> CmdPrompt [] -- reset completions on any event passed to editor
-      SearchPrompt a -> SearchPrompt a
-    modify validateREPLForm
+  k -> do
+    -- On any other key event, jump to the bottom of the REPL then handle the event
+    vScrollToEnd replScroll
+    case k of
+      Key V.KEnter -> do
+        s <- get
+        let topCtx = topContext s
+            repl = s ^. uiState . uiREPL
+            uinput = repl ^. replPromptText
+
+        if not $ s ^. gameState . replWorking
+          then case repl ^. replPromptType of
+            CmdPrompt _ -> runBaseCode topCtx uinput
+            SearchPrompt hist ->
+              case lastEntry uinput hist of
+                Nothing -> uiState %= resetREPL "" (CmdPrompt [])
+                Just found
+                  | T.null uinput -> uiState %= resetREPL "" (CmdPrompt [])
+                  | otherwise -> do
+                      uiState %= resetREPL found (CmdPrompt [])
+                      modify validateREPLForm
+          else continueWithoutRedraw
+      Key V.KUp -> modify $ adjReplHistIndex Older
+      Key V.KDown -> modify $ adjReplHistIndex Newer
+      ControlChar 'r' -> do
+        s <- get
+        let uinput = s ^. uiState . uiREPL . replPromptText
+        case s ^. uiState . uiREPL . replPromptType of
+          CmdPrompt _ -> uiState . uiREPL . replPromptType .= SearchPrompt (s ^. uiState . uiREPL . replHistory)
+          SearchPrompt rh -> case lastEntry uinput rh of
+            Nothing -> pure ()
+            Just found -> uiState . uiREPL . replPromptType .= SearchPrompt (removeEntry found rh)
+      CharKey '\t' -> do
+        s <- get
+        let names = s ^.. gameState . baseRobot . robotContext . defTypes . to assocs . traverse . _1
+        uiState . uiREPL %= tabComplete names (s ^. gameState . entityMap)
+        modify validateREPLForm
+      EscapeKey -> do
+        formSt <- use $ uiState . uiREPL . replPromptType
+        case formSt of
+          CmdPrompt {} -> continueWithoutRedraw
+          SearchPrompt _ ->
+            uiState %= resetREPL "" (CmdPrompt [])
+      ControlChar 'd' -> do
+        text <- use $ uiState . uiREPL . replPromptText
+        if text == T.empty
+          then toggleModal QuitModal
+          else continueWithoutRedraw
+      -- finally if none match pass the event to the editor
+      ev -> do
+        Brick.zoom (uiState . uiREPL . replPromptEditor) (handleEditorEvent ev)
+        uiState . uiREPL . replPromptType %= \case
+          CmdPrompt _ -> CmdPrompt [] -- reset completions on any event passed to editor
+          SearchPrompt a -> SearchPrompt a
+        modify validateREPLForm
 
 data CompletionType
   = FunctionName

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -1157,6 +1157,8 @@ handleREPLEventTyping = \case
     if text == T.empty
       then toggleModal QuitModal
       else continueWithoutRedraw
+  Key V.KPageUp -> vScrollPage replScroll Brick.Up
+  Key V.KPageDown -> vScrollPage replScroll Brick.Down
   -- finally if none match pass the event to the editor
   ev -> do
     Brick.zoom (uiState . uiREPL . replPromptEditor) (handleEditorEvent ev)

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -856,23 +856,6 @@ updateUI = do
         uiState . uiScrollToEnd .= True
         pure True
 
-  -- Decide whether the info panel has more content scrolled off the
-  -- top and/or bottom, so we can draw some indicators to show it if
-  -- so.  Note, because we only know the update size and position of
-  -- the viewport *after* it has been rendered, this means the top and
-  -- bottom indicators will only be updated one frame *after* the info
-  -- panel updates, but this isn't really that big of deal.
-  infoPanelUpdated <- do
-    mvp <- lookupViewport InfoViewport
-    case mvp of
-      Nothing -> return False
-      Just vp -> do
-        let topMore = (vp ^. vpTop) > 0
-            botMore = (vp ^. vpTop + snd (vp ^. vpSize)) < snd (vp ^. vpContentSize)
-        oldTopMore <- uiState . uiMoreInfoTop <<.= topMore
-        oldBotMore <- uiState . uiMoreInfoBot <<.= botMore
-        return $ oldTopMore /= topMore || oldBotMore /= botMore
-
   goalOrWinUpdated <- doGoalUpdates
 
   let redraw =
@@ -880,7 +863,6 @@ updateUI = do
           || inventoryUpdated
           || replUpdated
           || logUpdated
-          || infoPanelUpdated
           || goalOrWinUpdated
   pure redraw
 

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -815,6 +815,7 @@ updateUI = do
       let itName = fromString $ "it" ++ show itIx
       let out = T.intercalate " " [itName, ":", prettyText finalType, "=", into (prettyValue v)]
       uiState . uiREPL . replHistory %= addREPLItem (REPLOutput out)
+      invalidateCacheEntry REPLHistoryCache
       vScrollToEnd replScroll
       gameState . replStatus .= REPLDone (Just val)
       gameState . baseRobot . robotContext . at itName .= Just val
@@ -1129,7 +1130,9 @@ handleREPLEventTyping = \case
 
         if not $ s ^. gameState . replWorking
           then case repl ^. replPromptType of
-            CmdPrompt _ -> runBaseCode topCtx uinput
+            CmdPrompt _ -> do
+              runBaseCode topCtx uinput
+              invalidateCacheEntry REPLHistoryCache
             SearchPrompt hist ->
               case lastEntry uinput hist of
                 Nothing -> uiState %= resetREPL "" (CmdPrompt [])

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -78,6 +78,7 @@ module Swarm.TUI.Model (
   populateInventoryList,
   infoScroll,
   modalScroll,
+  replScroll,
 
   -- * Runtime state
   RuntimeState,
@@ -185,6 +186,9 @@ infoScroll = viewportScroll InfoViewport
 
 modalScroll :: ViewportScroll Name
 modalScroll = viewportScroll ModalViewport
+
+replScroll :: ViewportScroll Name
+replScroll = viewportScroll REPLViewport
 
 -- ----------------------------------------------------------------------------
 --                                Runtime state                              --

--- a/src/Swarm/TUI/Model/Name.hs
+++ b/src/Swarm/TUI/Model/Name.hs
@@ -97,6 +97,8 @@ data Name
     InfoViewport
   | -- | The scrollable viewport for any modal dialog.
     ModalViewport
+  | -- | The scrollable viewport for the REPL.
+    REPLViewport
   | -- | A clickable button in a modal dialog.
     Button Button
   deriving (Eq, Ord, Show, Read)

--- a/src/Swarm/TUI/Model/Name.hs
+++ b/src/Swarm/TUI/Model/Name.hs
@@ -64,6 +64,8 @@ data Name
     WorldEditorPanelControl WorldEditorFocusable
   | -- | The REPL input form.
     REPLInput
+  | -- | The REPL history cache.
+    REPLHistoryCache
   | -- | The render cache for the world view.
     WorldCache
   | -- | The cached extent for the world view.

--- a/src/Swarm/TUI/Model/Repl.hs
+++ b/src/Swarm/TUI/Model/Repl.hs
@@ -188,8 +188,8 @@ getLatestREPLHistoryItems n h = toList latestN
 
 -- | Get only the items from the REPL history that were entered during
 --   the current session.
-getSessionREPLHistoryItems :: REPLHistory -> [REPLHistItem]
-getSessionREPLHistoryItems h = toList $ Seq.drop (h ^. replStart) (h ^. replSeq)
+getSessionREPLHistoryItems :: REPLHistory -> Seq REPLHistItem
+getSessionREPLHistoryItems h = Seq.drop (h ^. replStart) (h ^. replSeq)
 
 data TimeDir = Newer | Older deriving (Eq, Ord, Show)
 

--- a/src/Swarm/TUI/Model/Repl.hs
+++ b/src/Swarm/TUI/Model/Repl.hs
@@ -21,6 +21,7 @@ module Swarm.TUI.Model.Repl (
   addREPLItem,
   restartREPLHistory,
   getLatestREPLHistoryItems,
+  getSessionREPLHistoryItems,
   moveReplHistIndex,
   getCurrentItemText,
   replIndexIsAtInput,
@@ -184,6 +185,11 @@ getLatestREPLHistoryItems n h = toList latestN
  where
   latestN = Seq.drop oldestIndex $ h ^. replSeq
   oldestIndex = max (h ^. replStart) $ length (h ^. replSeq) - n
+
+-- | Get only the items from the REPL history that were entered during
+--   the current session.
+getSessionREPLHistoryItems :: REPLHistory -> [REPLHistItem]
+getSessionREPLHistoryItems h = toList $ Seq.drop (h ^. replStart) (h ^. replSeq)
 
 data TimeDir = Newer | Older deriving (Eq, Ord, Show)
 

--- a/src/Swarm/TUI/Model/UI.hs
+++ b/src/Swarm/TUI/Model/UI.hs
@@ -20,8 +20,6 @@ module Swarm.TUI.Model.UI (
   uiInventory,
   uiInventorySort,
   uiInventorySearch,
-  uiMoreInfoTop,
-  uiMoreInfoBot,
   uiScrollToEnd,
   uiError,
   uiModal,
@@ -107,8 +105,6 @@ data UIState = UIState
   , _uiInventory :: Maybe (Int, BL.List Name InventoryListEntry)
   , _uiInventorySort :: InventorySortOptions
   , _uiInventorySearch :: Maybe Text
-  , _uiMoreInfoTop :: Bool
-  , _uiMoreInfoBot :: Bool
   , _uiScrollToEnd :: Bool
   , _uiError :: Maybe Text
   , _uiModal :: Maybe Modal
@@ -176,12 +172,6 @@ uiInventorySearch :: Lens' UIState (Maybe Text)
 --   inventory changed) along with a list of the items in the
 --   focused robot's inventory.
 uiInventory :: Lens' UIState (Maybe (Int, BL.List Name InventoryListEntry))
-
--- | Does the info panel contain more content past the top of the panel?
-uiMoreInfoTop :: Lens' UIState Bool
-
--- | Does the info panel contain more content past the bottom of the panel?
-uiMoreInfoBot :: Lens' UIState Bool
 
 -- | A flag telling the UI to scroll the info panel to the very end
 --   (used when a new log message is appended).
@@ -329,8 +319,6 @@ initUIState speedFactor showMainMenu cheatMode = do
           , _uiInventory = Nothing
           , _uiInventorySort = defaultSortOptions
           , _uiInventorySearch = Nothing
-          , _uiMoreInfoTop = False
-          , _uiMoreInfoBot = False
           , _uiScrollToEnd = False
           , _uiError = Nothing
           , _uiModal = Nothing

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -952,6 +952,7 @@ drawKeyMenu s =
       ++ [("^c", "cancel") | isReplWorking]
       ++ [("M-p", renderPilotModeSwitch ctrlMode) | creative]
       ++ [("M-k", renderHandlerModeSwitch ctrlMode) | handlerInstalled]
+      ++ [("PgUp/Dn", "scroll")]
   keyCmdsFor (Just (FocusablePanel WorldPanel)) =
     [ ("←↓↑→ / hjkl", "scroll") | canScroll
     ]

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -51,6 +51,7 @@ import Control.Lens as Lens hiding (Const, from)
 import Control.Monad (guard)
 import Data.Array (range)
 import Data.Bits (shiftL, shiftR, (.&.))
+import Data.Foldable (toList)
 import Data.Foldable qualified as F
 import Data.Functor (($>))
 import Data.IntMap qualified as IM
@@ -1330,13 +1331,16 @@ renderREPLPrompt focus repl = ps1 <+> replE
 drawREPL :: AppState -> Widget Name
 drawREPL s =
   vBox
-    [ withLeftPaddedVScrollBars . viewport REPLViewport Vertical . vBox $ history <> [currentPrompt]
+    [ withLeftPaddedVScrollBars
+        . viewport REPLViewport Vertical
+        . vBox
+        $ [cached REPLHistoryCache (vBox history), currentPrompt]
     , vBox mayDebug
     ]
  where
   -- rendered history lines fitting above REPL prompt
   history :: [Widget n]
-  history = map fmt . getSessionREPLHistoryItems $ repl ^. replHistory
+  history = map fmt . toList . getSessionREPLHistoryItems $ repl ^. replHistory
   currentPrompt :: Widget Name
   currentPrompt = case (isActive <$> base, repl ^. replControlMode) of
     (_, Handling) -> padRight Max $ txt "[key handler running, M-k to toggle]"

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,12 +3,11 @@ extra-deps:
 - hsnoise-0.0.3@sha256:260b39175b8a3e3b1719ad3987b7d72a3fd7a0fa99be8639b91cf4dc3f1c8796,1476
 - simple-enumeration-0.2.1@sha256:8625b269c1650d3dd0e3887351c153049f4369853e0d525219e07480ea004b9f,1178
 - boolexpr-0.2@sha256:07f38a0206ad63c2c893e3c6271a2e45ea25ab4ef3a9e973edc746876f0ab9e8,853
-- brick-list-skip-0.1.1.4
+- brick-1.10
+- brick-list-skip-0.1.1.5
 # We should update to lsp-2.0 and lsp-types-2.0 but it involves some
 # breaking changes; see https://github.com/swarm-game/swarm/issues/1350
 - lsp-1.6.0.0
 - lsp-types-1.6.0.0
-- github: jtdaugherty/brick
-  commit: 6b7195cf6e5bc95f9f3f588b0ec68103c0c5cd6d
 resolver: lts-21.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,5 +8,7 @@ extra-deps:
 # breaking changes; see https://github.com/swarm-game/swarm/issues/1350
 - lsp-1.6.0.0
 - lsp-types-1.6.0.0
+- github: jtdaugherty/brick
+  commit: 6b7195cf6e5bc95f9f3f588b0ec68103c0c5cd6d
 resolver: lts-21.0
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -213,7 +213,7 @@ library
                       array                         >= 0.5.4 && < 0.6,
                       blaze-html                    >= 0.9.1 && < 0.9.2,
                       boolexpr                      >= 0.2 && < 0.3,
-                      brick                         >= 1.5 && < 1.10,
+                      brick                         >= 1.10 && < 1.11,
                       bytestring                    >= 0.10 && < 0.12,
                       clock                         >= 0.8.2 && < 0.9,
                       colour                        >= 2.3.6 && < 2.4,


### PR DESCRIPTION
- Add scrollbars on both the inventory and info panels
- Get rid of `. . .` at top and bottom of info panel, since we now have scrollbar as a visual indicator when there is more content
- Allow scrolling the REPL history (closes #60)
    - PgUp/PgDown can be used to scroll (Shift+PgUp/Dn were not recognized on my system)
    - Hitting any other key causes the view to jump back to the very bottom
    - A computation finishing + printing an output also causes the view to jump to the bottom
    - The REPL history is cached so that it only gets re-rendered whenever a new history entry (i.e. input or output) is added; this is needed since the history could get quite large.
- Also, fix the height of the key hint menus to 2 lines, even when the panel-specific menu (second line) is blank, so the world panel does not keep resizing as we move the focus between panels.

Thanks to @jtdaugherty for releasing `brick-1.10` with a new ability to specify blank space to the side of scrollbars; see https://github.com/jtdaugherty/brick/discussions/484 .

Also towards #1461 .