### PR TITLE
use Int64 for time

### DIFF
--- a/src/Swarm/Game/CESK.hs
+++ b/src/Swarm/Game/CESK.hs
@@ -83,6 +83,7 @@ module Swarm.Game.CESK (
 import Control.Lens ((^.))
 import Control.Lens.Combinators (pattern Empty)
 import Data.Aeson (FromJSON, ToJSON)
+import Data.Int (Int64)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IM
 import GHC.Generics (Generic)
@@ -102,15 +103,15 @@ import Swarm.Util.WindowedCounter (Offsettable (..))
 
 -- | A newtype representing a count of ticks (typically since the
 --   start of a game).
-newtype TickNumber = TickNumber {getTickNumber :: Integer}
+newtype TickNumber = TickNumber {getTickNumber :: Int64}
   deriving (Eq, Ord, Show, Read, Generic, FromJSON, ToJSON)
 
 -- | Add an offset to a 'TickNumber'.
-addTicks :: Integer -> TickNumber -> TickNumber
-addTicks i (TickNumber n) = TickNumber $ n + i
+addTicks :: Int -> TickNumber -> TickNumber
+addTicks i (TickNumber n) = TickNumber $ n + fromIntegral i
 
 instance Offsettable TickNumber where
-  offsetBy = addTicks . fromIntegral
+  offsetBy = addTicks
 
 instance Pretty TickNumber where
   pretty (TickNumber i) = pretty i

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1037,7 +1037,7 @@ execConst c vs s k = do
       [VInt d] -> do
         time <- use $ temporal . ticks
         purgeFarAwayWatches
-        return $ Waiting (addTicks d time) (Out VUnit s k)
+        return $ Waiting (addTicks (fromIntegral d) time) (Out VUnit s k)
       _ -> badConst
     Selfdestruct -> do
       destroyIfNotBase $ \case False -> Just AttemptSelfDestructBase; _ -> Nothing
@@ -1461,7 +1461,7 @@ execConst c vs s k = do
       return $ Out (VDir (fromMaybe (DRelative DDown) $ mh >>= toDirection)) s k
     Time -> do
       TickNumber t <- use $ temporal . ticks
-      return $ Out (VInt t) s k
+      return $ Out (VInt $ fromIntegral t) s k
     Drill -> case vs of
       [VDir d] -> doDrill d
       _ -> badConst
@@ -1988,7 +1988,7 @@ execConst c vs s k = do
 
             -- Now wait the right amount of time for it to finish.
             time <- use $ temporal . ticks
-            return $ Waiting (addTicks (fromIntegral numItems + 1) time) (Out VUnit s k)
+            return $ Waiting (addTicks (numItems + 1) time) (Out VUnit s k)
       _ -> badConst
     -- run can take both types of text inputs
     -- with and without file extension as in
@@ -2231,7 +2231,7 @@ execConst c vs s k = do
         return $ Out v s k
       else do
         time <- use $ temporal . ticks
-        return . (if remTime <= 1 then id else Waiting (addTicks remTime time)) $
+        return . (if remTime <= 1 then id else Waiting (addTicks (fromIntegral remTime) time)) $
           Out v s (FImmediate c wf rf : k)
    where
     remTime = r ^. recipeTime


### PR DESCRIPTION
Should benchmark this to see if it's faster than `Integer`.

# `stack bench` output
Personally, I'm not sure what the best way to benchmark this particular change, but here's the output of `stack bench` anyway:
## Before
```
benchmarking run 1000 game ticks/idlers/10
time                 2.634 ms   (2.629 ms .. 2.641 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.636 ms   (2.634 ms .. 2.640 ms)
std dev              10.45 μs   (6.667 μs .. 15.88 μs)
                   
benchmarking run 1000 game ticks/idlers/20
time                 2.660 ms   (2.653 ms .. 2.668 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.661 ms   (2.657 ms .. 2.667 ms)
std dev              18.53 μs   (12.24 μs .. 30.77 μs)
                   
benchmarking run 1000 game ticks/idlers/30
time                 2.660 ms   (2.653 ms .. 2.670 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.685 ms   (2.678 ms .. 2.696 ms)
std dev              29.12 μs   (20.64 μs .. 42.37 μs)
                   
benchmarking run 1000 game ticks/idlers/40
time                 2.693 ms   (2.686 ms .. 2.700 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.694 ms   (2.689 ms .. 2.705 ms)
std dev              26.61 μs   (17.81 μs .. 45.78 μs)
                   
benchmarking run 1000 game ticks/trees/10
time                 2.627 ms   (2.623 ms .. 2.632 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.625 ms   (2.622 ms .. 2.629 ms)
std dev              12.55 μs   (8.749 μs .. 18.38 μs)
                   
benchmarking run 1000 game ticks/trees/20
time                 2.647 ms   (2.642 ms .. 2.653 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.648 ms   (2.645 ms .. 2.656 ms)
std dev              17.86 μs   (10.58 μs .. 31.07 μs)
                   
benchmarking run 1000 game ticks/trees/30
time                 2.672 ms   (2.667 ms .. 2.676 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.673 ms   (2.668 ms .. 2.683 ms)
std dev              22.85 μs   (14.67 μs .. 38.46 μs)
                   
benchmarking run 1000 game ticks/trees/40
time                 2.697 ms   (2.693 ms .. 2.700 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.699 ms   (2.694 ms .. 2.708 ms)
std dev              23.96 μs   (16.47 μs .. 38.01 μs)
                   
benchmarking run 1000 game ticks/circlers/10
time                 229.9 ms   (229.0 ms .. 230.8 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 230.3 ms   (230.0 ms .. 230.8 ms)
std dev              639.7 μs   (458.4 μs .. 842.9 μs)
variance introduced by outliers: 11% (moderately inflated)
                   
benchmarking run 1000 game ticks/circlers/20
time                 434.7 ms   (433.9 ms .. 435.2 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 435.7 ms   (435.2 ms .. 436.5 ms)
std dev              800.9 μs   (432.2 μs .. 1.072 ms)
variance introduced by outliers: 14% (moderately inflated)
                   
benchmarking run 1000 game ticks/circlers/30
time                 637.5 ms   (634.5 ms .. 641.2 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 640.5 ms   (639.2 ms .. 641.6 ms)
std dev              1.553 ms   (1.244 ms .. 1.907 ms)
variance introduced by outliers: 16% (moderately inflated)
                   
benchmarking run 1000 game ticks/circlers/40
time                 851.5 ms   (NaN s .. 864.0 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 852.1 ms   (850.0 ms .. 853.4 ms)
std dev              2.138 ms   (657.7 μs .. 2.908 ms)
variance introduced by outliers: 19% (moderately inflated)
                   
benchmarking run 1000 game ticks/movers/10
time                 382.4 ms   (379.9 ms .. 384.1 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 383.9 ms   (382.8 ms .. 385.1 ms)
std dev              1.601 ms   (973.2 μs .. 2.420 ms)
variance introduced by outliers: 14% (moderately inflated)
                   
benchmarking run 1000 game ticks/movers/20
time                 721.9 ms   (712.2 ms .. 729.8 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 722.6 ms   (720.4 ms .. 725.9 ms)
std dev              3.234 ms   (1.128 ms .. 4.250 ms)
variance introduced by outliers: 19% (moderately inflated)
                   
benchmarking run 1000 game ticks/movers/30
time                 1.076 s    (1.063 s .. 1.095 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.071 s    (1.067 s .. 1.074 s)
std dev              4.317 ms   (2.285 ms .. 5.464 ms)
variance introduced by outliers: 19% (moderately inflated)
                   
benchmarking run 1000 game ticks/movers/40
time                 1.440 s    (1.436 s .. 1.446 s)
                     1.000 R²   (NaN R² .. 1.000 R²)
mean                 1.436 s    (1.435 s .. 1.438 s)
std dev              1.923 ms   (544.1 μs .. 2.572 ms)
variance introduced by outliers: 19% (moderately inflated)
```
## After
```
benchmarking run 1000 game ticks/idlers/10
time                 2.559 ms   (2.515 ms .. 2.626 ms)
                     0.996 R²   (0.994 R² .. 0.999 R²)
mean                 2.557 ms   (2.539 ms .. 2.583 ms)
std dev              83.13 μs   (63.17 μs .. 120.2 μs)
variance introduced by outliers: 20% (moderately inflated)
                   
benchmarking run 1000 game ticks/idlers/20
time                 2.518 ms   (2.508 ms .. 2.528 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.534 ms   (2.526 ms .. 2.546 ms)
std dev              36.80 μs   (30.33 μs .. 51.03 μs)
                   
benchmarking run 1000 game ticks/idlers/30
time                 2.544 ms   (2.527 ms .. 2.565 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 2.540 ms   (2.533 ms .. 2.551 ms)
std dev              35.25 μs   (23.47 μs .. 54.64 μs)
                   
benchmarking run 1000 game ticks/idlers/40
time                 2.598 ms   (2.578 ms .. 2.627 ms)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 2.693 ms   (2.660 ms .. 2.733 ms)
std dev              135.0 μs   (110.1 μs .. 169.4 μs)
variance introduced by outliers: 38% (moderately inflated)
                   
benchmarking run 1000 game ticks/trees/10
time                 2.590 ms   (2.538 ms .. 2.642 ms)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 2.548 ms   (2.538 ms .. 2.566 ms)
std dev              49.94 μs   (39.27 μs .. 67.19 μs)
                   
benchmarking run 1000 game ticks/trees/20
time                 2.617 ms   (2.568 ms .. 2.679 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 2.562 ms   (2.541 ms .. 2.585 ms)
std dev              78.13 μs   (63.71 μs .. 95.38 μs)
variance introduced by outliers: 19% (moderately inflated)
                   
benchmarking run 1000 game ticks/trees/30
time                 2.559 ms   (2.533 ms .. 2.591 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 2.555 ms   (2.544 ms .. 2.573 ms)
std dev              49.00 μs   (34.54 μs .. 65.61 μs)
                   
benchmarking run 1000 game ticks/trees/40
time                 2.820 ms   (2.729 ms .. 2.906 ms)
                     0.994 R²   (0.991 R² .. 0.996 R²)
mean                 2.620 ms   (2.594 ms .. 2.666 ms)
std dev              121.2 μs   (86.30 μs .. 167.3 μs)
variance introduced by outliers: 34% (moderately inflated)
                   
benchmarking run 1000 game ticks/circlers/10
time                 230.6 ms   (228.8 ms .. 232.5 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 233.5 ms   (231.7 ms .. 236.0 ms)
std dev              3.275 ms   (1.853 ms .. 5.093 ms)
variance introduced by outliers: 11% (moderately inflated)
                   
benchmarking run 1000 game ticks/circlers/20
time                 448.8 ms   (433.6 ms .. 464.6 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 441.1 ms   (437.3 ms .. 446.1 ms)
std dev              5.991 ms   (3.879 ms .. 8.282 ms)
variance introduced by outliers: 14% (moderately inflated)
                   
benchmarking run 1000 game ticks/circlers/30
time                 655.5 ms   (646.9 ms .. 666.9 ms)
                     1.000 R²   (NaN R² .. 1.000 R²)
mean                 652.3 ms   (650.6 ms .. 654.5 ms)
std dev              2.448 ms   (1.442 ms .. 3.702 ms)
variance introduced by outliers: 16% (moderately inflated)
                   
benchmarking run 1000 game ticks/circlers/40
time                 863.8 ms   (861.6 ms .. 868.3 ms)
                     1.000 R²   (1.000 R² .. NaN R²)
mean                 865.5 ms   (864.4 ms .. 867.3 ms)
std dev              1.833 ms   (84.64 μs .. 2.435 ms)
variance introduced by outliers: 19% (moderately inflated)
                   
benchmarking run 1000 game ticks/movers/10
time                 397.4 ms   (382.4 ms .. 412.7 ms)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 395.7 ms   (391.2 ms .. 400.5 ms)
std dev              6.397 ms   (4.350 ms .. 8.877 ms)
variance introduced by outliers: 14% (moderately inflated)
                   
benchmarking run 1000 game ticks/movers/20
time                 721.3 ms   (698.4 ms .. 742.5 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 722.5 ms   (719.8 ms .. 725.4 ms)
std dev              3.533 ms   (1.527 ms .. 4.427 ms)
variance introduced by outliers: 19% (moderately inflated)
                   
benchmarking run 1000 game ticks/movers/30
time                 1.053 s    (1.014 s .. 1.114 s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.067 s    (1.059 s .. 1.081 s)
std dev              13.55 ms   (1.042 ms .. 17.01 ms)
variance introduced by outliers: 19% (moderately inflated)
                   
benchmarking run 1000 game ticks/movers/40
time                 1.392 s    (1.333 s .. 1.421 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.439 s    (1.417 s .. 1.481 s)
std dev              42.42 ms   (222.2 μs .. 49.25 ms)
variance introduced by outliers: 19% (moderately inflated)
```