### PR TITLE
generalize variables bound by `<-`

### DIFF
--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -680,14 +680,9 @@ infer s@(Syntax l t) = addLocToTypeErr l $ case t of
   SBind mx c1 c2 -> do
     c1' <- withFrame l TCBindL $ infer c1
     a <- decomposeCmdTy c1 (Actual, c1' ^. sType)
-    -- We do not need to generalize the type 'a' here (unlike
-    -- top-level binds) because a variable bound here (mx) can only
-    -- have local scope.  In other words, when we generalize at the
-    -- very end, the variable will no longer be in the context, so we
-    -- will be able to safely generalize over any unification
-    -- variables that occurred in its type.
+    genA <- generalize a
     c2' <-
-      maybe id ((`withBinding` Forall [] a) . lvVar) mx
+      maybe id ((`withBinding` genA) . lvVar) mx
         . withFrame l TCBindR
         $ infer c2
     _ <- decomposeCmdTy c2 (Actual, c2' ^. sType)

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -381,6 +381,15 @@ testLanguagePipeline =
                 "1:5: Type mismatch:\n  From context, expected `\\x. \\y. 3` to have type `int`,\n  but it is actually a function\n"
             )
         ]
+    , testGroup
+        "generalize top-level binds #351 #1501"
+        [ testCase
+            "top-level polymorphic bind is OK"
+            (valid "r <- return (\\x.x)")
+        , testCase
+            "top-level bind is polymorphic"
+            (valid "f <- return (\\x.x); return (f 3, f \"hi\")")
+        ]
     ]
  where
   valid = flip process ""

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -389,6 +389,9 @@ testLanguagePipeline =
         , testCase
             "top-level bind is polymorphic"
             (valid "f <- return (\\x.x); return (f 3, f \"hi\")")
+        , testCase
+            "local bind is polymorphic"
+            (valid "def foo : cmd (int * text) = f <- return (\\x.x); return (f 3, f \"hi\") end")
         ]
     ]
  where


### PR DESCRIPTION
Closes #351.

I sat down with @ccasin today to look at #351. He convinced me that it is actually fine to return `forall a. a -> a` as the type of `r` in `r <- return (\i.i)`, even though `return (\i.i)` has type `forall a. cmd (a -> a)` and we can never have a type `cmd (forall a. a -> a)`. Basically, in a Hindley-Milner-style system it is always safe to generalize at any time.

The real problem --- which I was very close to discovering in https://github.com/swarm-game/swarm/issues/351#issuecomment-1146274801 --- is simply that we need to generalize the type of variables bound by `<-`.  However, we need to make sure to do so before putting that variable in the context, which I apparently failed to do when I tried fixing this before.