### PR TITLE
Replace/quarantine uses of `head` and `NE.fromList` functions

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -24,9 +24,9 @@
 #   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
 #   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
 #
-# - functions:
-#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
-
+- functions:
+  - {name: Data.List.head, within: []}
+  - {name: Prelude.head, within: []}
 
 # Add custom hints for this project
 #

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -27,6 +27,7 @@
 - functions:
   - {name: Data.List.head, within: []}
   - {name: Prelude.head, within: []}
+  - {name: Data.List.NonEmpty.fromList, within: [Swarm.Util, Swarm.Util.Parse]}
 
 # Add custom hints for this project
 #

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -24,6 +24,7 @@ module Swarm.Doc.Gen (
 ) where
 
 import Control.Effect.Lift
+import Control.Effect.Throw (throwError)
 import Control.Lens (view, (^.))
 import Control.Lens.Combinators (to)
 import Control.Monad (zipWithM, zipWithM_)
@@ -32,7 +33,7 @@ import Data.Foldable (find, toList)
 import Data.List (transpose)
 import Data.Map.Lazy (Map, (!))
 import Data.Map.Lazy qualified as Map
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, listToMaybe)
 import Data.Sequence (Seq)
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -44,7 +45,7 @@ import Swarm.Doc.Pedagogy
 import Swarm.Game.Display (displayChar)
 import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityDisplay, entityName, loadEntities)
 import Swarm.Game.Entity qualified as E
-import Swarm.Game.Failure (SystemFailure)
+import Swarm.Game.Failure (SystemFailure (CustomFailure))
 import Swarm.Game.Recipe (Recipe, loadRecipes, recipeCatalysts, recipeInputs, recipeOutputs, recipeTime, recipeWeight)
 import Swarm.Game.Robot (Robot, equippedDevices, instantiateRobot, robotInventory)
 import Swarm.Game.Scenario (Scenario, loadScenario, scenarioRobots)
@@ -419,6 +420,11 @@ recipeTable a rs = T.unlines $ header <> map (listToRow mw) recipeRows
 recipePage :: PageAddress -> [Recipe Entity] -> Text
 recipePage = recipeTable
 
+getBaseRobot :: Scenario -> Either Text Robot
+getBaseRobot s = case listToMaybe $ view scenarioRobots s of
+  Just r -> pure $ instantiateRobot 0 r
+  Nothing -> Left "Scenario contains no robots"
+
 -- ----------------------------------------------------------------------------
 -- GENERATE GRAPHVIZ: ENTITY DEPENDENCIES BY RECIPES
 -- ----------------------------------------------------------------------------
@@ -429,10 +435,11 @@ generateRecipe = simpleErrorHandle $ do
   recipes <- loadRecipes entities
   worlds <- ignoreWarnings @(Seq SystemFailure) $ loadWorlds entities
   classic <- fst <$> loadScenario "data/scenarios/classic.yaml" entities worlds
-  return . Dot.showDot $ recipesToDot classic (worlds ! "classic") entities recipes
+  baseRobot <- either (throwError . CustomFailure) return $ getBaseRobot classic
+  return . Dot.showDot $ recipesToDot baseRobot (worlds ! "classic") entities recipes
 
-recipesToDot :: Scenario -> Some (TTerm '[]) -> EntityMap -> [Recipe Entity] -> Dot ()
-recipesToDot classic classicTerm emap recipes = do
+recipesToDot :: Robot -> Some (TTerm '[]) -> EntityMap -> [Recipe Entity] -> Dot ()
+recipesToDot baseRobot classicTerm emap recipes = do
   Dot.attribute ("rankdir", "LR")
   Dot.attribute ("ranksep", "2")
   world <- diamond "World"
@@ -450,8 +457,8 @@ recipesToDot classic classicTerm emap recipes = do
   -- --------------------------------------------------------------------------
   -- Get the starting inventories, entities present in the world and compute
   -- how hard each entity is to get - see 'recipeLevels'.
-  let devs = startingDevices classic
-      inv = startingInventory classic
+  let devs = startingDevices baseRobot
+      inv = startingInventory baseRobot
       worldEntities = case classicTerm of Some _ t -> extractEntities t
       levels = recipeLevels recipes (Set.unions [worldEntities, devs])
   -- --------------------------------------------------------------------------
@@ -547,14 +554,11 @@ recipeLevels recipes start = levels
             then ls
             else go (n : ls) (Set.union n known)
 
-startingHelper :: Scenario -> Robot
-startingHelper = instantiateRobot 0 . head . view scenarioRobots
+startingDevices :: Robot -> Set Entity
+startingDevices = Set.fromList . map snd . E.elems . view equippedDevices
 
-startingDevices :: Scenario -> Set Entity
-startingDevices = Set.fromList . map snd . E.elems . view equippedDevices . startingHelper
-
-startingInventory :: Scenario -> Map Entity Int
-startingInventory = Map.fromList . map swap . E.elems . view robotInventory . startingHelper
+startingInventory :: Robot -> Map Entity Int
+startingInventory = Map.fromList . map swap . E.elems . view robotInventory
 
 -- | Ignore utility entities that are just used for tutorials and challenges.
 ignoredEntities :: Set Text

--- a/src/Swarm/Game/Failure.hs
+++ b/src/Swarm/Game/Failure.hs
@@ -44,7 +44,7 @@ data Asset = Achievement | Data AssetData | History | Save
 data Entry = Directory | File
   deriving (Eq, Show)
 
--- | An error that occured while attempting to load some kind of asset.
+-- | An error that occurred while attempting to load some kind of asset.
 data LoadingFailure
   = DoesNotExist Entry
   | EntryNot Entry

--- a/src/Swarm/Game/Scenario/Topography/Cell.hs
+++ b/src/Swarm/Game/Scenario/Topography/Cell.hs
@@ -71,7 +71,7 @@ instance FromJSONE (EntityMap, RobotMap) Cell where
   parseJSONE = withArrayE "tuple" $ \v -> do
     let tupRaw = V.toList v
     tup <- case NE.nonEmpty tupRaw of
-      Nothing -> fail "palette entry must nonzero length (terrain, optional entity and then robots if any)"
+      Nothing -> fail "palette entry must have nonzero length (terrain, optional entity and then robots if any)"
       Just x -> return x
 
     terr <- liftE $ parseJSON (NE.head tup)

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -146,7 +146,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
-import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing, listToMaybe, mapMaybe)
 import Data.Sequence (Seq ((:<|)))
 import Data.Sequence qualified as Seq
 import Data.Set qualified as S
@@ -1244,7 +1244,7 @@ buildWorld :: WorldDescription -> ([IndexedTRobot], Seed -> WorldFun Int Entity)
 buildWorld WorldDescription {..} = (robots worldName, first fromEnum . wf)
  where
   rs = fromIntegral $ length area
-  cs = fromIntegral $ length (head area)
+  cs = fromIntegral $ maybe 0 length $ listToMaybe area
   Coords (ulr, ulc) = locToCoords ul
 
   worldGrid :: [[(TerrainType, Erasable Entity)]]

--- a/src/Swarm/Game/Terrain.hs
+++ b/src/Swarm/Game/Terrain.hs
@@ -14,11 +14,12 @@ module Swarm.Game.Terrain (
 ) where
 
 import Data.Aeson (FromJSON (..), withText)
+import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Swarm.Game.Display
-import Swarm.Util (failT)
+import Swarm.Util (failT, showEnum)
 import Text.Read (readMaybe)
 import Witch (into)
 
@@ -49,7 +50,7 @@ instance FromJSON TerrainType where
       Nothing -> failT ["Unknown terrain type:", t]
 
 getTerrainDefaultPaletteChar :: TerrainType -> Char
-getTerrainDefaultPaletteChar = head . show
+getTerrainDefaultPaletteChar = NE.head . showEnum
 
 getTerrainWord :: TerrainType -> T.Text
 getTerrainWord = T.toLower . T.pack . init . show

--- a/src/Swarm/Game/World/Parse.hs
+++ b/src/Swarm/Game/World/Parse.hs
@@ -10,17 +10,15 @@
 -- Parser for the Swarm world description DSL.
 module Swarm.Game.World.Parse where
 
-import Control.Monad (MonadPlus, void)
+import Control.Monad (void)
 import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
-import Data.List.NonEmpty (NonEmpty)
-import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Void
+import Data.Void (Void)
 import Data.Yaml (FromJSON (parseJSON), withText)
 import Swarm.Game.World.Syntax
 import Swarm.Util (failT, showT, squote)
-import Swarm.Util.Parse (fully)
+import Swarm.Util.Parse (fully, sepByNE)
 import Text.Megaparsec hiding (runParser)
 import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer qualified as L
@@ -28,12 +26,6 @@ import Witch (into)
 
 type Parser = Parsec Void Text
 type ParserError = ParseErrorBundle Text Void
-
-------------------------------------------------------------
--- Utility
-
-sepByNE :: (MonadPlus m) => m a -> m sep -> m (NonEmpty a)
-sepByNE p sep = NE.fromList <$> p `sepBy1` sep
 
 ------------------------------------------------------------
 -- Lexing

--- a/src/Swarm/Game/World/Parse.hs
+++ b/src/Swarm/Game/World/Parse.hs
@@ -12,13 +12,14 @@ module Swarm.Game.World.Parse where
 
 import Control.Monad (void)
 import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
+import Control.Monad.Combinators.NonEmpty qualified as CNE (sepBy1)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Void (Void)
 import Data.Yaml (FromJSON (parseJSON), withText)
 import Swarm.Game.World.Syntax
 import Swarm.Util (failT, showT, squote)
-import Swarm.Util.Parse (fully, sepByNE)
+import Swarm.Util.Parse (fully)
 import Text.Megaparsec hiding (runParser)
 import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer qualified as L
@@ -225,7 +226,7 @@ parseLet =
 parseOverlay :: Parser WExp
 parseOverlay = do
   reserved "overlay"
-  brackets $ WOverlay <$> parseWExp `sepByNE` comma
+  brackets $ WOverlay <$> parseWExp `CNE.sepBy1` comma
 
 parseMask :: Parser WExp
 parseMask = do

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -172,7 +172,7 @@ handleMainMenuEvent menu = \case
         NewGame -> do
           cheat <- use $ uiState . uiCheatMode
           ss <- use $ runtimeState . scenarios
-          uiState . uiMenu .= NewGameMenu (NE.fromList [mkScenarioList cheat ss])
+          uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList cheat ss)
         Tutorial -> do
           -- Set up the menu stack as if the user had chosen "New Game > Tutorials"
           cheat <- use $ uiState . uiCheatMode
@@ -183,7 +183,7 @@ handleMainMenuEvent menu = \case
                   ((== tutorialsDirname) . T.unpack . scenarioItemName)
                   (mkScenarioList cheat ss)
               tutorialMenu = mkScenarioList cheat tutorialCollection
-              menuStack = NE.fromList [tutorialMenu, topMenu]
+              menuStack = tutorialMenu :| pure topMenu
           uiState . uiMenu .= NewGameMenu menuStack
 
           -- Extract the first tutorial challenge and run it

--- a/src/Swarm/TUI/Model/Menu.hs
+++ b/src/Swarm/TUI/Model/Menu.hs
@@ -108,7 +108,7 @@ mkScenarioList cheat = flip (BL.list ScenarioList) 1 . V.fromList . filterTest .
 --   path to some folder or scenario, construct a 'NewGameMenu' stack
 --   focused on the given item, if possible.
 mkNewGameMenu :: Bool -> ScenarioCollection -> FilePath -> Maybe Menu
-mkNewGameMenu cheat sc path = NewGameMenu . NE.fromList <$> go (Just sc) (splitPath path) []
+mkNewGameMenu cheat sc path = fmap NewGameMenu $ NE.nonEmpty =<< go (Just sc) (splitPath path) []
  where
   go ::
     Maybe ScenarioCollection ->

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -15,6 +15,7 @@ module Swarm.Util (
   maximum0,
   cycleEnum,
   listEnums,
+  showEnum,
   indexWrapNonEmpty,
   uniq,
   binTuples,
@@ -141,6 +142,11 @@ cycleEnum e
 
 listEnums :: (Enum e, Bounded e) => [e]
 listEnums = [minBound .. maxBound]
+
+-- | We know by the syntax rules of Haskell that constructor
+--  names must consist of one or more symbols!
+showEnum :: (Show e, Enum e) => e -> NonEmpty Char
+showEnum = NE.fromList . show
 
 -- | Guaranteed to yield an element of the list
 indexWrapNonEmpty :: Integral b => NonEmpty a -> b -> a

--- a/src/Swarm/Util/Parse.hs
+++ b/src/Swarm/Util/Parse.hs
@@ -5,6 +5,10 @@
 module Swarm.Util.Parse where
 
 import Control.Applicative (optional)
+import Control.Monad (MonadPlus)
+import Control.Monad.Combinators (sepBy1)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
 import Text.Megaparsec (MonadParsec, eof)
 
 -- | Run a parser "fully", consuming leading whitespace and ensuring
@@ -17,3 +21,6 @@ fully sc p = sc *> p <* eof
 --   ensuring that the parser extends all the way to eof.
 fullyMaybe :: (MonadParsec e s f) => f () -> f a -> f (Maybe a)
 fullyMaybe sc = fully sc . optional
+
+sepByNE :: (MonadPlus m) => m a -> m sep -> m (NonEmpty a)
+sepByNE p sep = NE.fromList <$> p `sepBy1` sep

--- a/src/Swarm/Util/Parse.hs
+++ b/src/Swarm/Util/Parse.hs
@@ -5,10 +5,6 @@
 module Swarm.Util.Parse where
 
 import Control.Applicative (optional)
-import Control.Monad (MonadPlus)
-import Control.Monad.Combinators (sepBy1)
-import Data.List.NonEmpty (NonEmpty)
-import Data.List.NonEmpty qualified as NE
 import Text.Megaparsec (MonadParsec, eof)
 
 -- | Run a parser "fully", consuming leading whitespace and ensuring
@@ -21,6 +17,3 @@ fully sc p = sc *> p <* eof
 --   ensuring that the parser extends all the way to eof.
 fullyMaybe :: (MonadParsec e s f) => f () -> f a -> f (Maybe a)
 fullyMaybe sc = fully sc . optional
-
-sepByNE :: (MonadPlus m) => m a -> m sep -> m (NonEmpty a)
-sepByNE p sep = NE.fromList <$> p `sepBy1` sep


### PR DESCRIPTION
Towards #1494

* Totally eliminates partial `head`
* introduces an hlint rule to ban unsafe use of `head`
* restricts use of the partial `fromList` from `NonEmpty`