### PR TITLE
Fix build error regarding 'tasty' bounds

### DIFF
--- a/swarm.cabal
+++ b/swarm.cabal
@@ -329,7 +329,7 @@ test-suite swarm-unit
                       TestScoring
                       TestUtil
 
-    build-depends:    tasty                         >= 0.10 && < 1.5,
+    build-depends:    tasty                         >= 0.10 && < 1.6,
                       tasty-hunit                   >= 0.10 && < 0.11,
                       tasty-quickcheck              >= 0.10 && < 0.11,
                       QuickCheck                    >= 2.14 && < 2.15,
@@ -357,7 +357,7 @@ test-suite swarm-integration
     main-is:          Main.hs
     type:             exitcode-stdio-1.0
 
-    build-depends:    tasty                         >= 0.10 && < 1.5,
+    build-depends:    tasty                         >= 0.10 && < 1.6,
                       tasty-hunit                   >= 0.10 && < 0.11,
                       tasty-expected-failure        >= 0.12 && < 0.13,
                       -- Imports shared with the library don't need bounds


### PR DESCRIPTION
[Build error](https://github.com/swarm-game/swarm/actions/runs/6133922036/job/16646223425?pr=1503) was:
```
Test/Tasty/QuickCheck.hs:30:43: error:
    Module ‘Test.Tasty.Runners’ does not export ‘emptyProgress’
   |
30 | import Test.Tasty.Runners (formatMessage, emptyProgress)
   |                                           ^^^^^^^^^^^^^
Error: cabal-3.10.1.0: Failed to build tasty-quickcheck-0.10.3. See the build log above for details.
```