### PR TITLE
Decompose GameState into sub-records

### DIFF
--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -16,7 +16,7 @@ import Swarm.Game.CESK (emptyStore, initMachine)
 import Swarm.Game.Display (defaultRobotDisplay)
 import Swarm.Game.Location
 import Swarm.Game.Robot (TRobot, mkRobot)
-import Swarm.Game.State (GameState, addTRobot, creativeMode, multiWorld)
+import Swarm.Game.State (GameState, addTRobot, creativeMode, multiWorld, landscape)
 import Swarm.Game.Step (gameTick)
 import Swarm.Game.Terrain (TerrainType (DirtT))
 import Swarm.Game.Universe (Cosmic (..), SubworldName (DefaultRootSubworld))
@@ -88,7 +88,7 @@ mkGameState robotMaker numRobots = do
     (mapM addTRobot robots)
     ( (initAppState ^. gameState)
         & creativeMode .~ True
-        & multiWorld .~ M.singleton DefaultRootSubworld (newWorld (WF $ const (fromEnum DirtT, ENothing)))
+        & landscape . multiWorld .~ M.singleton DefaultRootSubworld (newWorld (WF $ const (fromEnum DirtT, ENothing)))
     )
 
 -- | Runs numGameTicks ticks of the game.

--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -16,7 +16,7 @@ import Swarm.Game.CESK (emptyStore, initMachine)
 import Swarm.Game.Display (defaultRobotDisplay)
 import Swarm.Game.Location
 import Swarm.Game.Robot (TRobot, mkRobot)
-import Swarm.Game.State (GameState, addTRobot, creativeMode, multiWorld, landscape)
+import Swarm.Game.State (GameState, addTRobot, creativeMode, landscape, multiWorld)
 import Swarm.Game.Step (gameTick)
 import Swarm.Game.Terrain (TerrainType (DirtT))
 import Swarm.Game.Universe (Cosmic (..), SubworldName (DefaultRootSubworld))

--- a/scripts/reformat-code.sh
+++ b/scripts/reformat-code.sh
@@ -3,4 +3,4 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 
-fourmolu --mode=inplace src app test
+fourmolu --mode=inplace src app test bench

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -51,8 +51,8 @@ module Swarm.Game.State (
   gensym,
   seed,
   randGen,
-  adjList,
-  nameList,
+  NameGenerator (..),
+  nameGenerator,
   initiallyRunCode,
   entityMap,
   recipesInfo,
@@ -395,6 +395,12 @@ messageQueue :: Lens' Messages (Seq LogEntry)
 -- | Last time message queue has been viewed (used for notification).
 lastSeenMessageTime :: Lens' Messages TickNumber
 
+-- | Read-only lists of adjectives and words for use in building random robot names
+data NameGenerator = NameGenerator
+  { adjList :: Array Int Text
+  , nameList :: Array Int Text
+  }
+
 -- | The main record holding the state for the game itself (as
 --   distinct from the UI).  See the lenses below for access to its
 --   fields.
@@ -432,8 +438,7 @@ data GameState = GameState
   , _gensym :: Int
   , _seed :: Seed
   , _randGen :: StdGen
-  , _adjList :: Array Int Text
-  , _nameList :: Array Int Text
+  , _nameGenerator :: NameGenerator
   , _initiallyRunCode :: Maybe ProcessedTerm
   , _entityMap :: EntityMap
   , _recipesInfo :: Recipes
@@ -466,7 +471,7 @@ makeLensesFor
   ]
   ''GameState
 
-makeLensesExcluding ['_viewCenter, '_focusedRobotID, '_viewCenterRule, '_activeRobots, '_waitingRobots, '_adjList, '_nameList] ''GameState
+makeLensesExcluding ['_viewCenter, '_focusedRobotID, '_viewCenterRule, '_activeRobots, '_waitingRobots, '_nameGenerator] ''GameState
 
 -- | Is the user in creative mode (i.e. able to do anything without restriction)?
 creativeMode :: Lens' GameState Bool
@@ -569,14 +574,9 @@ seed :: Lens' GameState Seed
 
 -- | Pseudorandom generator initialized at start.
 randGen :: Lens' GameState StdGen
-
--- | Read-only list of words, for use in building random robot names.
-adjList :: Getter GameState (Array Int Text)
-adjList = to _adjList
-
--- | Read-only list of words, for use in building random robot names.
-nameList :: Getter GameState (Array Int Text)
-nameList = to _nameList
+--- | Read-only list of words, for use in building random robot names.
+nameGenerator :: Getter GameState NameGenerator
+nameGenerator = to _nameGenerator
 
 -- | Code that is run upon scenario start, before any
 -- REPL interaction.
@@ -1065,8 +1065,11 @@ initGameState gsc =
     , _gensym = 0
     , _seed = 0
     , _randGen = mkStdGen 0
-    , _adjList = initAdjList gsc
-    , _nameList = initNameList gsc
+    , _nameGenerator =
+        NameGenerator
+          { adjList = initAdjList gsc
+          , nameList = initNameList gsc
+          }
     , _initiallyRunCode = Nothing
     , _entityMap = initEntities gsc
     , _recipesInfo =

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -388,6 +388,7 @@ recipesCat :: Lens' Recipes (IntMap [Recipe Entity])
 data Messages = Messages
   { _messageQueue :: Seq LogEntry
   , _lastSeenMessageTime :: TickNumber
+  , _announcementQueue :: Seq Announcement
   }
 
 makeLensesNoSigs ''Messages
@@ -399,6 +400,13 @@ messageQueue :: Lens' Messages (Seq LogEntry)
 
 -- | Last time message queue has been viewed (used for notification).
 lastSeenMessageTime :: Lens' Messages TickNumber
+
+-- | A queue of global announcements.
+-- Note that this is distinct from the "messageQueue",
+-- which is for messages emitted by robots.
+--
+-- Note that we put the newest entry to the right.
+announcementQueue :: Lens' Messages (Seq Announcement)
 
 -- | Read-only lists of adjectives and words for use in building random robot names
 data NameGenerator = NameGenerator
@@ -523,7 +531,6 @@ data GameState = GameState
   , _temporal :: TemporalState
   , _winCondition :: WinCondition
   , _winSolution :: Maybe ProcessedTerm
-  , _announcementQueue :: Seq Announcement
   , _robotMap :: IntMap Robot
   , -- A set of robots to consider for the next game tick. It is guaranteed to
     -- be a subset of the keys of robotMap. It may contain waiting or idle
@@ -586,13 +593,6 @@ winCondition :: Lens' GameState WinCondition
 -- | How to win (if possible). This is useful for automated testing
 --   and to show help to cheaters (or testers).
 winSolution :: Lens' GameState (Maybe ProcessedTerm)
-
--- | A queue of global announcements.
--- Note that this is distinct from the "messageQueue",
--- which is for messages emitted by robots.
---
--- Note that we put the newest entry to the right.
-announcementQueue :: Lens' GameState (Seq Announcement)
 
 -- | All the robots that currently exist in the game, indexed by ID.
 robotMap :: Lens' GameState (IntMap Robot)
@@ -1106,7 +1106,6 @@ initGameState gsc =
           }
     , _winCondition = NoWinCondition
     , _winSolution = Nothing
-    , _announcementQueue = mempty
     , _robotMap = IM.empty
     , _robotsByLocation = M.empty
     , _robotsWatching = mempty
@@ -1161,6 +1160,7 @@ initGameState gsc =
         Messages
           { _messageQueue = Empty
           , _lastSeenMessageTime = TickNumber (-1)
+          , _announcementQueue = mempty
           }
     , _focusedRobotID = 0
     }

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -29,16 +29,8 @@ module Swarm.Game.State (
 
   -- ** GameState fields
   creativeMode,
-  temporal,
-  gameStep,
-  runStatus,
-  ticks,
-  robotStepsPerTick,
   winCondition,
   winSolution,
-  gameAchievements,
-  announcementQueue,
-  paused,
   robotMap,
   robotsByLocation,
   robotsAtLocation,
@@ -47,42 +39,75 @@ module Swarm.Game.State (
   baseRobot,
   activeRobots,
   waitingRobots,
-  availableRecipes,
-  availableCommands,
   messageNotifications,
-  allDiscoveredEntities,
-  NameGenerator (..),
-  nameGenerator,
-  robotNaming,
-  gensym,
-  discovery,
   seed,
   randGen,
-  initiallyRunCode,
-  entityMap,
-  recipesInfo,
-  recipesOut,
-  recipesIn,
-  recipesCat,
   currentScenarioPath,
-  knownEntities,
-  landscape,
-  worldNavigation,
-  multiWorld,
-  worldScrollable,
   viewCenterRule,
   viewCenter,
   needsRedraw,
+  focusedRobotID,
+
+  -- *** Subrecord accessors
+  temporal,
+  robotNaming,
+  recipesInfo,
+  messageInfo,
   gameControls,
+  discovery,
+  landscape,
+
+  -- ** GameState subrecords
+
+  -- *** Temporal state
+  TemporalState,
+  gameStep,
+  runStatus,
+  ticks,
+  robotStepsPerTick,
+  paused,
+
+  -- *** Robot naming
+  RobotNaming,
+  NameGenerator (..),
+  nameGenerator,
+  gensym,
+
+  -- *** Recipes
+  Recipes,
+  recipesOut,
+  recipesIn,
+  recipesCat,
+
+  -- *** Messages
+  Messages,
+  messageQueue,
+  lastSeenMessageTime,
+  announcementQueue,
+
+  -- *** Controls
+  GameControls,
+  initiallyRunCode,
   replStatus,
   replNextValueIndex,
   replWorking,
   replActiveType,
   inputHandler,
-  messageInfo,
-  messageQueue,
-  lastSeenMessageTime,
-  focusedRobotID,
+
+  -- *** Discovery
+  Discovery,
+  allDiscoveredEntities,
+  availableRecipes,
+  availableCommands,
+  knownEntities,
+  gameAchievements,
+
+  -- *** Landscape
+  Landscape,
+  worldNavigation,
+  multiWorld,
+  worldScrollable,
+  entityMap,
 
   -- ** Notifications
   Notifications (..),

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -447,6 +447,7 @@ robotStepsPerTick :: Lens' TemporalState Int
 data REPLData = REPLData
   { _replStatus :: REPLStatus
   , _replNextValueIndex :: Integer
+  , _inputHandler :: Maybe (Text, Value)
   }
 
 makeLensesNoSigs ''REPLData
@@ -456,6 +457,9 @@ replStatus :: Lens' REPLData REPLStatus
 
 -- | The index of the next it{index} value
 replNextValueIndex :: Lens' REPLData Integer
+
+-- | The currently installed input handler and hint text.
+inputHandler :: Lens' REPLData (Maybe (Text, Value))
 
 -- | The main record holding the state for the game itself (as
 --   distinct from the UI).  See the lenses below for access to its
@@ -505,7 +509,6 @@ data GameState = GameState
   , _viewCenter :: Cosmic Location
   , _needsRedraw :: Bool
   , _repl :: REPLData
-  , _inputHandler :: Maybe (Text, Value)
   , _messageInfo :: Messages
   , _focusedRobotID :: RID
   }
@@ -664,9 +667,6 @@ needsRedraw :: Lens' GameState Bool
 
 -- | Info about the REPL
 repl :: Lens' GameState REPLData
-
--- | The currently installed input handler and hint text.
-inputHandler :: Lens' GameState (Maybe (Text, Value))
 
 -- | Message info
 messageInfo :: Lens' GameState Messages
@@ -1129,8 +1129,8 @@ initGameState gsc =
         REPLData
           { _replStatus = REPLDone Nothing
           , _replNextValueIndex = 0
+          , _inputHandler = Nothing
           }
-    , _inputHandler = Nothing
     , _messageInfo =
         Messages
           { _messageQueue = Empty

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -505,6 +505,7 @@ gameAchievements :: Lens' Discovery (Map GameplayAchievement Attainment)
 data Landscape = Landscape
   { _worldNavigation :: Navigation (M.Map SubworldName) Location
   , _multiWorld :: W.MultiWorld Int Entity
+  , _entityMap :: EntityMap
   , _worldScrollable :: Bool
   }
 
@@ -519,6 +520,9 @@ worldNavigation :: Lens' Landscape (Navigation (M.Map SubworldName) Location)
 --   'TerrainType' because we need to be able to store terrain values in
 --   unboxed tile arrays.
 multiWorld :: Lens' Landscape (W.MultiWorld Int Entity)
+
+-- | The catalog of all entities that the game knows about.
+entityMap :: Lens' Landscape EntityMap
 
 -- | Whether the world map is supposed to be scrollable or not.
 worldScrollable :: Lens' Landscape Bool
@@ -555,7 +559,6 @@ data GameState = GameState
   , _seed :: Seed
   , _randGen :: StdGen
   , _robotNaming :: RobotNaming
-  , _entityMap :: EntityMap
   , _recipesInfo :: Recipes
   , _currentScenarioPath :: Maybe FilePath
   , _landscape :: Landscape
@@ -659,9 +662,6 @@ randGen :: Lens' GameState StdGen
 
 -- | State and data for assigning identifiers to robots
 robotNaming :: Lens' GameState RobotNaming
-
--- | The catalog of all entities that the game knows about.
-entityMap :: Lens' GameState EntityMap
 
 -- | Collection of recipe info
 recipesInfo :: Lens' GameState Recipes
@@ -1132,7 +1132,6 @@ initGameState gsc =
                 }
           , _gensym = 0
           }
-    , _entityMap = initEntities gsc
     , _recipesInfo =
         Recipes
           { _recipesOut = outRecipeMap (initRecipes gsc)
@@ -1144,6 +1143,7 @@ initGameState gsc =
         Landscape
           { _worldNavigation = Navigation mempty mempty
           , _multiWorld = mempty
+          , _entityMap = initEntities gsc
           , _worldScrollable = True
           }
     , _viewCenterRule = VCRobot 0
@@ -1204,8 +1204,8 @@ scenarioToGameState scenario (LaunchParams (Identity userSeed) (Identity toRun))
       & robotNaming . gensym .~ initGensym
       & seed .~ theSeed
       & randGen .~ mkStdGen theSeed
-      & entityMap .~ em
       & recipesInfo %~ modifyRecipesInfo
+      & landscape . entityMap .~ em
       & landscape . worldNavigation .~ scenario ^. scenarioNavigation
       & landscape . multiWorld .~ allSubworldsMap theSeed
       -- TODO (#1370): Should we allow subworlds to have their own scrollability?

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -2568,7 +2568,7 @@ grantAchievement ::
 grantAchievement a = do
   currentTime <- sendIO getZonedTime
   scenarioPath <- use currentScenarioPath
-  gameAchievements
+  discovery . gameAchievements
     %= M.insertWith
       (<>)
       a
@@ -2788,14 +2788,14 @@ safeExp a b
 -- | Update the global list of discovered entities, and check for new recipes.
 updateDiscoveredEntities :: (HasRobotStepState sig m) => Entity -> m ()
 updateDiscoveredEntities e = do
-  allDiscovered <- use allDiscoveredEntities
+  allDiscovered <- use $ discovery . allDiscoveredEntities
   if E.contains0plus e allDiscovered
     then pure ()
     else do
       let newAllDiscovered = E.insertCount 1 e allDiscovered
       updateAvailableRecipes (newAllDiscovered, newAllDiscovered) e
       updateAvailableCommands e
-      allDiscoveredEntities .= newAllDiscovered
+      discovery . allDiscoveredEntities .= newAllDiscovered
 
 -- | Update the availableRecipes list.
 -- This implementation is not efficient:
@@ -2810,10 +2810,10 @@ updateAvailableRecipes invs e = do
   allInRecipes <- use $ recipesInfo . recipesIn
   let entityRecipes = recipesFor allInRecipes e
       usableRecipes = filter (knowsIngredientsFor invs) entityRecipes
-  knownRecipes <- use (availableRecipes . notificationsContent)
+  knownRecipes <- use $ discovery . availableRecipes . notificationsContent
   let newRecipes = filter (`notElem` knownRecipes) usableRecipes
       newCount = length newRecipes
-  availableRecipes %= mappend (Notifications newCount newRecipes)
+  discovery . availableRecipes %= mappend (Notifications newCount newRecipes)
   updateAvailableCommands e
 
 updateAvailableCommands :: Has (State GameState) sig m => Entity -> m ()
@@ -2823,7 +2823,7 @@ updateAvailableCommands e = do
         Just cap -> cap `S.member` newCaps
         Nothing -> False
       entityConsts = filter (keepConsts . constCaps) allConst
-  knownCommands <- use (availableCommands . notificationsContent)
+  knownCommands <- use $ discovery . availableCommands . notificationsContent
   let newCommands = filter (`notElem` knownCommands) entityConsts
       newCount = length newCommands
-  availableCommands %= mappend (Notifications newCount newCommands)
+  discovery . availableCommands %= mappend (Notifications newCount newCommands)

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -124,11 +124,11 @@ gameTick = do
   mr <- use (robotMap . at 0)
   case mr of
     Just r -> do
-      res <- use $ repl . replStatus
+      res <- use $ gameControls . replStatus
       case res of
         REPLWorking (Typed Nothing ty req) -> case getResult r of
           Just (v, s) -> do
-            repl . replStatus .= REPLWorking (Typed (Just v) ty req)
+            gameControls . replStatus .= REPLWorking (Typed (Just v) ty req)
             baseRobot . robotContext . defStore .= s
           Nothing -> pure ()
         _otherREPLStatus -> pure ()
@@ -1756,7 +1756,7 @@ execConst c vs s k = do
       _ -> badConst
     InstallKeyHandler -> case vs of
       [VText hint, handler] -> do
-        repl . inputHandler .= Just (hint, handler)
+        gameControls . inputHandler .= Just (hint, handler)
         return $ Out VUnit s k
       _ -> badConst
     Reprogram -> case vs of

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1233,7 +1233,7 @@ execConst c vs s k = do
           lookupEntityName name em
             `isJustOrFail` ["I've never heard of", indefiniteQ name <> "."]
 
-        outRs <- use recipesOut
+        outRs <- use $ recipesInfo . recipesOut
 
         creative <- use creativeMode
         let create l = l <> ["You can use 'create \"" <> name <> "\"' instead." | creative]
@@ -2025,7 +2025,7 @@ execConst c vs s k = do
 
   applyDevice ins verbPhrase d tool = do
     (nextLoc, nextE) <- getDeviceTarget verbPhrase d
-    inRs <- use recipesIn
+    inRs <- use $ recipesInfo . recipesIn
 
     let recipes = filter isApplicableRecipe (recipesFor inRs nextE)
         isApplicableRecipe = any ((== tool) . snd) . view recipeCatalysts
@@ -2806,7 +2806,7 @@ updateDiscoveredEntities e = do
 --   But it probably doesn't really make that much difference until we get up to thousands of recipes.
 updateAvailableRecipes :: Has (State GameState) sig m => (Inventory, Inventory) -> Entity -> m ()
 updateAvailableRecipes invs e = do
-  allInRecipes <- use recipesIn
+  allInRecipes <- use $ recipesInfo . recipesIn
   let entityRecipes = recipesFor allInRecipes e
       usableRecipes = filter (knowsIngredientsFor invs) entityRecipes
   knownRecipes <- use (availableRecipes . notificationsContent)

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -539,7 +539,7 @@ updateWorld ::
   WorldUpdate Entity ->
   m ()
 updateWorld c (ReplaceEntity loc eThen down) = do
-  w <- use multiWorld
+  w <- use $ landscape . multiWorld
   let eNow = W.lookupCosmicEntity (fmap W.locToCoords loc) w
   -- Can fail if a robot started a multi-tick "drill" operation on some entity
   -- and meanwhile another entity swaps it out from under them.
@@ -1337,7 +1337,7 @@ execConst c vs s k = do
       return $ Out (asValue $ loc ^. planar) s k
     Waypoint -> case vs of
       [VText name, VInt idx] -> do
-        lm <- use worldNavigation
+        lm <- use $ landscape . worldNavigation
         Cosmic swName _ <- use robotLocation
         case M.lookup (WaypointName name) $ M.findWithDefault mempty swName $ waypoints lm of
           Nothing -> throwError $ CmdFailed Waypoint (T.unwords ["No waypoint named", name]) Nothing
@@ -1576,7 +1576,7 @@ execConst c vs s k = do
             -- If the robot does not exist...
             Nothing -> do
               cr <- use creativeMode
-              ws <- use worldScrollable
+              ws <- use $ landscape . worldScrollable
               case cr || ws of
                 -- If we are in creative mode or allowed to scroll, then we are allowed
                 -- to learn that the robot doesn't exist.
@@ -2652,7 +2652,7 @@ updateRobotLocation oldLoc newLoc
       flagRedraw
  where
   applyPortal loc = do
-    lms <- use worldNavigation
+    lms <- use $ landscape . worldNavigation
     let maybePortalInfo = M.lookup loc $ portals lms
         updatedLoc = maybe loc destination maybePortalInfo
         maybeTurn = reorientation <$> maybePortalInfo

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1756,7 +1756,7 @@ execConst c vs s k = do
       _ -> badConst
     InstallKeyHandler -> case vs of
       [VText hint, handler] -> do
-        inputHandler .= Just (hint, handler)
+        repl . inputHandler .= Just (hint, handler)
         return $ Out VUnit s k
       _ -> badConst
     Reprogram -> case vs of

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1548,7 +1548,7 @@ execConst c vs s k = do
       loc <- use robotLocation
       rid <- use robotID
       isPrivileged <- isPrivilegedBot
-      mq <- use messageQueue
+      mq <- use $ messageInfo . messageQueue
       let isClose e = isPrivileged || messageIsFromNearby loc e
       let notMine e = rid /= e ^. leRobotID
       let limitLast = \case

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -305,7 +305,7 @@ hypotheticalWinCheck em g ws oc = do
       grantAchievement LoseScenario
     _ -> return ()
 
-  announcementQueue %= (>< Seq.fromList (map ObjectiveCompleted $ completionAnnouncementQueue finalAccumulator))
+  messageInfo . announcementQueue %= (>< Seq.fromList (map ObjectiveCompleted $ completionAnnouncementQueue finalAccumulator))
 
   mapM_ handleException $ exceptions finalAccumulator
  where

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -143,7 +143,7 @@ gameTick = do
     case wc of
       WinConditions winState oc -> do
         g <- get @GameState
-        em <- use entityMap
+        em <- use $ landscape . entityMap
         hypotheticalWinCheck em g winState oc
       _ -> pure ()
   return ticked
@@ -729,7 +729,7 @@ stepCESK cesk = case cesk of
   -- listing the requirements of the given expression.
   Out (VRequirements src t _) s (FExec : k) -> do
     currentContext <- use $ robotContext . defReqs
-    em <- use entityMap
+    em <- use $ landscape . entityMap
     let (R.Requirements caps devs inv, _) = R.requirements currentContext t
 
         devicesForCaps, requiredDevices :: Set (Set Text)
@@ -889,7 +889,7 @@ stepCESK cesk = case cesk of
     -- cells which were in the middle of being evaluated will be reset.
     let s' = resetBlackholes s
     h <- hasCapability CLog
-    em <- use entityMap
+    em <- use $ landscape . entityMap
     if h
       then do
         void $ traceLog (ErrorTrace Error) (formatExn em exn)
@@ -1229,7 +1229,7 @@ execConst c vs s k = do
       [VText name] -> do
         inv <- use robotInventory
         ins <- use equippedDevices
-        em <- use entityMap
+        em <- use $ landscape . entityMap
         e <-
           lookupEntityName name em
             `isJustOrFail` ["I've never heard of", indefiniteQ name <> "."]
@@ -1612,7 +1612,7 @@ execConst c vs s k = do
       _ -> badConst
     Create -> case vs of
       [VText name] -> do
-        em <- use entityMap
+        em <- use $ landscape . entityMap
         e <-
           lookupEntityName name em
             `isJustOrFail` ["I've never heard of", indefiniteQ name <> "."]
@@ -1895,7 +1895,7 @@ execConst c vs s k = do
 
             -- Copy over the salvaged robot's log, if we have one
             inst <- use equippedDevices
-            em <- use entityMap
+            em <- use $ landscape . entityMap
             isPrivileged <- isPrivilegedBot
             logger <-
               lookupEntityName "logger" em
@@ -2228,7 +2228,7 @@ execConst c vs s k = do
     m (Set Entity, Inventory)
   checkRequirements parentInventory childInventory childDevices cmd subject fixI = do
     currentContext <- use $ robotContext . defReqs
-    em <- use entityMap
+    em <- use $ landscape . entityMap
     creative <- use creativeMode
     let -- Note that _capCtx must be empty: at least at the
         -- moment, definitions are only allowed at the top level,
@@ -2513,7 +2513,7 @@ execConst c vs s k = do
     let yieldName = e ^. entityYields
     e' <- case yieldName of
       Nothing -> return e
-      Just n -> fromMaybe e <$> uses entityMap (lookupEntityName n)
+      Just n -> fromMaybe e <$> uses (landscape . entityMap) (lookupEntityName n)
 
     robotInventory %= insert e'
     updateDiscoveredEntities e'

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -110,10 +110,10 @@ gameTick = do
   focusedRob <- use focusedRobotID
 
   ticked <-
-    use gameStep >>= \case
+    use (temporal . gameStep) >>= \case
       WorldTick -> do
         runRobotIDs active
-        ticks %= addTicks 1
+        temporal . ticks %= addTicks 1
         pure True
       RobotStep ss -> singleStep ss focusedRob active
 
@@ -153,16 +153,16 @@ gameTick = do
 -- Use this function if you need to unpause the game.
 finishGameTick :: (Has (State GameState) sig m, Has (Lift IO) sig m) => m ()
 finishGameTick =
-  use gameStep >>= \case
+  use (temporal . gameStep) >>= \case
     WorldTick -> pure ()
-    RobotStep SBefore -> gameStep .= WorldTick
+    RobotStep SBefore -> temporal . gameStep .= WorldTick
     RobotStep _ -> void gameTick >> finishGameTick
 
 -- Insert the robot back to robot map.
 -- Will selfdestruct or put the robot to sleep if it has that set.
 insertBackRobot :: Has (State GameState) sig m => RID -> Robot -> m ()
 insertBackRobot rn rob = do
-  time <- use ticks
+  time <- use $ temporal . ticks
   if rob ^. selfDestruct
     then deleteRobot rn
     else do
@@ -192,9 +192,9 @@ singleStep ss focRID robotSet = do
     -- run robots from the beginning until focused robot
     SBefore -> do
       runRobotIDs preFoc
-      gameStep .= RobotStep (SSingle focRID)
+      temporal . gameStep .= RobotStep (SSingle focRID)
       -- also set ticks of focused robot
-      steps <- use robotStepsPerTick
+      steps <- use $ temporal . robotStepsPerTick
       robotMap . ix focRID . activityCounts . tickStepBudget .= steps
       -- continue to focused robot if there were no previous robots
       -- DO NOT SKIP THE ROBOT SETUP above
@@ -211,8 +211,8 @@ singleStep ss focRID robotSet = do
         Nothing | rid == focRID -> do
           debugLog "The debugged robot does not exist! Exiting single step mode."
           runRobotIDs postFoc
-          gameStep .= WorldTick
-          ticks %= addTicks 1
+          temporal . gameStep .= WorldTick
+          temporal . ticks %= addTicks 1
           return True
         Nothing | otherwise -> do
           debugLog "The previously debugged robot does not exist!"
@@ -223,7 +223,8 @@ singleStep ss focRID robotSet = do
           insertBackRobot focRID newR
           if rid == focRID
             then do
-              when (newR ^. activityCounts . tickStepBudget == 0) $ gameStep .= RobotStep (SAfter focRID)
+              when (newR ^. activityCounts . tickStepBudget == 0) $
+                temporal . gameStep .= RobotStep (SAfter focRID)
               return False
             else do
               -- continue to newly focused
@@ -236,8 +237,8 @@ singleStep ss focRID robotSet = do
       -- 2. changed focus and the newly focused robot has previously run
       --    so we just finish the tick the same way
       runRobotIDs postFoc
-      gameStep .= RobotStep SBefore
-      ticks %= addTicks 1
+      temporal . gameStep .= RobotStep SBefore
+      temporal . ticks %= addTicks 1
       return True
     SAfter rid | otherwise -> do
       -- go to single step if new robot is focused
@@ -429,7 +430,7 @@ createLogEntry ::
 createLogEntry source msg = do
   rid <- use robotID
   rn <- use robotName
-  time <- use ticks
+  time <- use $ temporal . ticks
   loc <- use robotLocation
   pure $ LogEntry time source rn rid (Located loc) msg
 
@@ -504,7 +505,7 @@ withExceptions s k m = do
 --   command execution, whichever comes first.
 tickRobot :: (Has (State GameState) sig m, Has (Lift IO) sig m) => Robot -> m Robot
 tickRobot r = do
-  steps <- use robotStepsPerTick
+  steps <- use $ temporal . robotStepsPerTick
   tickRobotRec (r & activityCounts . tickStepBudget .~ steps)
 
 -- | Recursive helper function for 'tickRobot', which checks if the
@@ -513,7 +514,7 @@ tickRobot r = do
 --   stepping the robot.
 tickRobotRec :: (Has (State GameState) sig m, Has (Lift IO) sig m) => Robot -> m Robot
 tickRobotRec r = do
-  time <- use ticks
+  time <- use $ temporal . ticks
   case wantsToStep time r && (r ^. runningAtomic || r ^. activityCounts . tickStepBudget > 0) of
     True -> stepRobot r >>= tickRobotRec
     False -> return r
@@ -524,7 +525,7 @@ stepRobot :: (Has (State GameState) sig m, Has (Lift IO) sig m) => Robot -> m Ro
 stepRobot r = do
   (r', cesk') <- runState (r & activityCounts . tickStepBudget -~ 1) (stepCESK (r ^. machine))
   -- sendIO $ appendFile "out.txt" (prettyString cesk' ++ "\n")
-  t <- use ticks
+  t <- use $ temporal . ticks
   return $
     r'
       & machine .~ cesk'
@@ -597,7 +598,7 @@ stepCESK cesk = case cesk of
   -- We wake up robots whose wake-up time has been reached. If it hasn't yet
   -- then stepCESK is a no-op.
   Waiting wakeupTime cesk' -> do
-    time <- use ticks
+    time <- use $ temporal . ticks
     if wakeupTime <= time
       then stepCESK cesk'
       else return cesk
@@ -1019,7 +1020,7 @@ execConst c vs s k = do
       _ -> badConst
     Wait -> case vs of
       [VInt d] -> do
-        time <- use ticks
+        time <- use $ temporal . ticks
         purgeFarAwayWatches
         return $ Waiting (addTicks d time) (Out VUnit s k)
       _ -> badConst
@@ -1406,7 +1407,7 @@ execConst c vs s k = do
       -- otherwise have anything reasonable to return.
       return $ Out (VDir (fromMaybe (DRelative DDown) $ mh >>= toDirection)) s k
     Time -> do
-      TickNumber t <- use ticks
+      TickNumber t <- use $ temporal . ticks
       return $ Out (VInt t) s k
     Drill -> case vs of
       [VDir d] -> doDrill d
@@ -1928,7 +1929,7 @@ execConst c vs s k = do
             activateRobot (target ^. robotID)
 
             -- Now wait the right amount of time for it to finish.
-            time <- use ticks
+            time <- use $ temporal . ticks
             return $ Waiting (addTicks (fromIntegral numItems + 1) time) (Out VUnit s k)
       _ -> badConst
     -- run can take both types of text inputs
@@ -2171,7 +2172,7 @@ execConst c vs s k = do
         updateWorldAndRobots c wf rf
         return $ Out v s k
       else do
-        time <- use ticks
+        time <- use $ temporal . ticks
         return . (if remTime <= 1 then id else Waiting (addTicks remTime time)) $
           Out v s (FImmediate c wf rf : k)
    where

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -124,11 +124,11 @@ gameTick = do
   mr <- use (robotMap . at 0)
   case mr of
     Just r -> do
-      res <- use replStatus
+      res <- use $ repl . replStatus
       case res of
         REPLWorking (Typed Nothing ty req) -> case getResult r of
           Just (v, s) -> do
-            replStatus .= REPLWorking (Typed (Just v) ty req)
+            repl . replStatus .= REPLWorking (Typed (Just v) ty req)
             baseRobot . robotContext . defStore .= s
           Nothing -> pure ()
         _otherREPLStatus -> pure ()

--- a/src/Swarm/Game/Step/Combustion.hs
+++ b/src/Swarm/Game/Step/Combustion.hs
@@ -89,7 +89,7 @@ addCombustionBot inputEntity combustibility ts loc = do
   botInventory <- case maybeCombustionProduct of
     Nothing -> return []
     Just n -> do
-      maybeE <- uses entityMap (lookupEntityName n)
+      maybeE <- uses (landscape . entityMap) (lookupEntityName n)
       return $ maybe [] (pure . (1,)) maybeE
   combustionDurationRand <- uniform durationRange
   let combustionProg = combustionProgram combustionDurationRand combustibility

--- a/src/Swarm/Game/Step/Util.hs
+++ b/src/Swarm/Game/Step/Util.hs
@@ -174,8 +174,7 @@ weightedChoice weight as = do
 -- | Generate a random robot name in the form @adjective_name@.
 randomName :: Has (State GameState) sig m => m Text
 randomName = do
-  adjs <- use @GameState adjList
-  names <- use @GameState nameList
+  NameGenerator adjs names <- use @GameState nameGenerator
   i <- uniform (bounds adjs)
   j <- uniform (bounds names)
   return $ T.concat [adjs ! i, "_", names ! j]

--- a/src/Swarm/Game/Step/Util.hs
+++ b/src/Swarm/Game/Step/Util.hs
@@ -174,7 +174,7 @@ weightedChoice weight as = do
 -- | Generate a random robot name in the form @adjective_name@.
 randomName :: Has (State GameState) sig m => m Text
 randomName = do
-  NameGenerator adjs names <- use @GameState nameGenerator
+  NameGenerator adjs names <- use $ robotNaming . nameGenerator
   i <- uniform (bounds adjs)
   j <- uniform (bounds names)
   return $ T.concat [adjs ! i, "_", names ! j]

--- a/src/Swarm/Game/Step/Util.hs
+++ b/src/Swarm/Game/Step/Util.hs
@@ -125,10 +125,10 @@ zoomWorld ::
   StateC (W.World Int Entity) Identity b ->
   m (Maybe b)
 zoomWorld swName n = do
-  mw <- use multiWorld
+  mw <- use $ landscape . multiWorld
   forM (M.lookup swName mw) $ \w -> do
     let (w', a) = run (runState w n)
-    multiWorld %= M.insert swName w'
+    landscape . multiWorld %= M.insert swName w'
     return a
 
 -- | Get the entity (if any) at a given location.

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -313,7 +313,7 @@ handleMainEvent ev = do
           -- message modal is not autopaused, so update notifications when leaving it
           case m ^. modalType of
             MessagesModal -> do
-              gameState . lastSeenMessageTime .= s ^. gameState . ticks
+              gameState . messageInfo . lastSeenMessageTime .= s ^. gameState . ticks
             _ -> return ()
     FKey 1 -> toggleModal HelpModal
     FKey 2 -> toggleModal RobotsModal
@@ -325,7 +325,7 @@ handleMainEvent ev = do
       gameState . availableCommands . notificationsCount .= 0
     FKey 5 | not (null (s ^. gameState . messageNotifications . notificationsContent)) -> do
       toggleModal MessagesModal
-      gameState . lastSeenMessageTime .= s ^. gameState . ticks
+      gameState . messageInfo . lastSeenMessageTime .= s ^. gameState . ticks
     -- show goal
     ControlChar 'g' ->
       if hasAnythingToShow $ s ^. uiState . uiGoal . goalsContent

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -804,10 +804,10 @@ updateUI = do
       else pure False
 
   -- Now check if the base finished running a program entered at the REPL.
-  replUpdated <- case g ^. replStatus of
+  replUpdated <- case g ^. repl . replStatus of
     -- It did, and the result was the unit value.  Just reset replStatus.
     REPLWorking (Typed (Just VUnit) typ reqs) -> do
-      gameState . replStatus .= REPLDone (Just $ Typed VUnit typ reqs)
+      gameState . repl . replStatus .= REPLDone (Just $ Typed VUnit typ reqs)
       pure True
 
     -- It did, and returned some other value.  Pretty-print the
@@ -815,15 +815,15 @@ updateUI = do
     REPLWorking (Typed (Just v) pty reqs) -> do
       let finalType = stripCmd pty
       let val = Typed (stripVResult v) finalType reqs
-      itIx <- use (gameState . replNextValueIndex)
+      itIx <- use (gameState . repl . replNextValueIndex)
       let itName = fromString $ "it" ++ show itIx
       let out = T.intercalate " " [itName, ":", prettyText finalType, "=", into (prettyValue v)]
       uiState . uiREPL . replHistory %= addREPLItem (REPLOutput out)
       invalidateCacheEntry REPLHistoryCache
       vScrollToEnd replScroll
-      gameState . replStatus .= REPLDone (Just val)
+      gameState . repl . replStatus .= REPLDone (Just val)
       gameState . baseRobot . robotContext . at itName .= Just val
-      gameState . replNextValueIndex %= (+ 1)
+      gameState . repl . replNextValueIndex %= (+ 1)
       pure True
 
     -- Otherwise, do nothing.
@@ -979,9 +979,9 @@ resetREPL t r ui =
 handleREPLEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleREPLEvent x = do
   s <- get
-  let repl = s ^. uiState . uiREPL
-      controlMode = repl ^. replControlMode
-      uinput = repl ^. replPromptText
+  let theRepl = s ^. uiState . uiREPL
+      controlMode = theRepl ^. replControlMode
+      uinput = theRepl ^. replPromptText
   case x of
     -- Handle Ctrl-c here so we can always cancel the currently running
     -- base program no matter what REPL control mode we are in.
@@ -1031,7 +1031,7 @@ runInputHandler kc = do
       -- Make sure the base is currently idle; if so, apply the
       -- installed input handler function to a `key` value
       -- representing the typed input.
-      working <- use $ gameState . replWorking
+      working <- use $ gameState . repl . replWorking
       unless working $ do
         s <- get
         let topCtx = topContext s
@@ -1066,8 +1066,8 @@ handleREPLEventPiloting x = case x of
     modify validateREPLForm
     handleREPLEventTyping $ Key V.KEnter
 
-  setCmd nt repl =
-    repl
+  setCmd nt theRepl =
+    theRepl
       & replPromptText .~ nt
       & replPromptType .~ CmdPrompt []
 
@@ -1075,7 +1075,7 @@ runBaseWebCode :: (MonadState AppState m) => T.Text -> m ()
 runBaseWebCode uinput = do
   s <- get
   let topCtx = topContext s
-  unless (s ^. gameState . replWorking) $
+  unless (s ^. gameState . repl . replWorking) $
     runBaseCode topCtx uinput
 
 runBaseCode :: (MonadState AppState m) => RobotContext -> T.Text -> m ()
@@ -1098,7 +1098,7 @@ runBaseTerm topCtx =
   -- input is valid) and sets up the base robot to run it.
   startBaseProgram t@(ProcessedTerm (Module tm _) reqs reqCtx) =
     -- Set the REPL status to Working
-    (gameState . replStatus .~ REPLWorking (Typed Nothing (tm ^. sType) reqs))
+    (gameState . repl . replStatus .~ REPLWorking (Typed Nothing (tm ^. sType) reqs))
       -- The `reqCtx` maps names of variables defined in the
       -- term (by `def` statements) to their requirements.
       -- E.g. if we had `def m = move end`, the reqCtx would
@@ -1130,11 +1130,11 @@ handleREPLEventTyping = \case
       Key V.KEnter -> do
         s <- get
         let topCtx = topContext s
-            repl = s ^. uiState . uiREPL
-            uinput = repl ^. replPromptText
+            theRepl = s ^. uiState . uiREPL
+            uinput = theRepl ^. replPromptText
 
-        if not $ s ^. gameState . replWorking
-          then case repl ^. replPromptType of
+        if not $ s ^. gameState . repl . replWorking
+          then case theRepl ^. replPromptType of
             CmdPrompt _ -> do
               runBaseCode topCtx uinput
               invalidateCacheEntry REPLHistoryCache
@@ -1190,8 +1190,8 @@ data CompletionType
 --   reserved words and names in scope (in the case of function names) or
 --   entity names (in the case of string literals).
 tabComplete :: [Var] -> EntityMap -> REPLState -> REPLState
-tabComplete names em repl = case repl ^. replPromptType of
-  SearchPrompt _ -> repl
+tabComplete names em theRepl = case theRepl ^. replPromptType of
+  SearchPrompt _ -> theRepl
   CmdPrompt mms
     -- Case 1: If completion candidates have already been
     -- populated via case (3), cycle through them.
@@ -1239,9 +1239,9 @@ tabComplete names em repl = case repl ^. replPromptType of
 
   entityNames = M.keys $ entitiesByName em
 
-  t = repl ^. replPromptText
+  t = theRepl ^. replPromptText
   setCmd nt ms =
-    repl
+    theRepl
       & replPromptText .~ nt
       & replPromptType .~ CmdPrompt ms
 
@@ -1252,7 +1252,7 @@ validateREPLForm s =
   case replPrompt of
     CmdPrompt _
       | T.null uinput ->
-          let theType = s ^. gameState . replStatus . replActiveType
+          let theType = s ^. gameState . repl . replStatus . replActiveType
            in s & uiState . uiREPL . replType .~ theType
     CmdPrompt _
       | otherwise ->
@@ -1277,20 +1277,20 @@ adjReplHistIndex d s =
     & validateREPLForm
  where
   moveREPL :: REPLState -> REPLState
-  moveREPL repl =
+  moveREPL theRepl =
     newREPL
-      & (if replIndexIsAtInput (repl ^. replHistory) then saveLastEntry else id)
+      & (if replIndexIsAtInput (theRepl ^. replHistory) then saveLastEntry else id)
       & (if oldEntry /= newEntry then showNewEntry else id)
    where
     -- new AppState after moving the repl index
     newREPL :: REPLState
-    newREPL = repl & replHistory %~ moveReplHistIndex d oldEntry
+    newREPL = theRepl & replHistory %~ moveReplHistIndex d oldEntry
 
-    saveLastEntry = replLast .~ (repl ^. replPromptText)
+    saveLastEntry = replLast .~ (theRepl ^. replPromptText)
     showNewEntry = (replPromptEditor .~ newREPLEditor newEntry) . (replPromptType .~ CmdPrompt [])
     -- get REPL data
-    getCurrEntry = fromMaybe (repl ^. replLast) . getCurrentItemText . view replHistory
-    oldEntry = getCurrEntry repl
+    getCurrEntry = fromMaybe (theRepl ^. replLast) . getCurrentItemText . view replHistory
+    oldEntry = getCurrEntry theRepl
     newEntry = getCurrEntry newREPL
 
 ------------------------------------------------------------
@@ -1443,7 +1443,7 @@ makeEntity e = do
 
   case isActive <$> (s ^? gameState . baseRobot) of
     Just False -> do
-      gameState . replStatus .= REPLWorking (Typed Nothing PolyUnit (R.singletonCap CMake))
+      gameState . repl . replStatus .= REPLWorking (Typed Nothing PolyUnit (R.singletonCap CMake))
       gameState . baseRobot . machine .= initMachine mkPT empty topStore
       gameState %= execState (activateRobot 0)
     _ -> continueWithoutRedraw

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -889,7 +889,7 @@ doGoalUpdates = do
   curGoal <- use (uiState . uiGoal . goalsContent)
   isCheating <- use (uiState . uiCheatMode)
   curWinCondition <- use (gameState . winCondition)
-  announcementsSeq <- use (gameState . announcementQueue)
+  announcementsSeq <- use (gameState . messageInfo . announcementQueue)
   let announcementsList = toList announcementsSeq
 
   -- Decide whether we need to update the current goal text and pop
@@ -950,7 +950,7 @@ doGoalUpdates = do
 
         -- This clears the "flag" that indicate that the goals dialog needs to be
         -- automatically popped up.
-        gameState . announcementQueue .= mempty
+        gameState . messageInfo . announcementQueue .= mempty
 
         hideGoals <- use $ uiState . uiHideGoals
         unless hideGoals $

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -1004,7 +1004,7 @@ handleREPLEvent x = do
                 uiState . uiREPL . replHistory %= addREPLItem err
                 invalidateCacheEntry REPLHistoryCache
     MetaChar 'k' -> do
-      when (isJust (s ^. gameState . inputHandler)) $ do
+      when (isJust (s ^. gameState . repl . inputHandler)) $ do
         curMode <- use $ uiState . uiREPL . replControlMode
         (uiState . uiREPL . replControlMode) .= case curMode of Handling -> Typing; _ -> Handling
 
@@ -1022,7 +1022,7 @@ handleREPLEvent x = do
 -- | Run the installed input handler on a key combo entered by the user.
 runInputHandler :: KeyCombo -> EventM Name AppState ()
 runInputHandler kc = do
-  mhandler <- use $ gameState . inputHandler
+  mhandler <- use $ gameState . repl . inputHandler
   case mhandler of
     -- Shouldn't be possible to get here if there is no input handler, but
     -- if we do somehow, just do nothing.

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -317,12 +317,12 @@ handleMainEvent ev = do
             _ -> return ()
     FKey 1 -> toggleModal HelpModal
     FKey 2 -> toggleModal RobotsModal
-    FKey 3 | not (null (s ^. gameState . availableRecipes . notificationsContent)) -> do
+    FKey 3 | not (null (s ^. gameState . discovery . availableRecipes . notificationsContent)) -> do
       toggleModal RecipesModal
-      gameState . availableRecipes . notificationsCount .= 0
-    FKey 4 | not (null (s ^. gameState . availableCommands . notificationsContent)) -> do
+      gameState . discovery . availableRecipes . notificationsCount .= 0
+    FKey 4 | not (null (s ^. gameState . discovery . availableCommands . notificationsContent)) -> do
       toggleModal CommandsModal
-      gameState . availableCommands . notificationsCount .= 0
+      gameState . discovery . availableCommands . notificationsCount .= 0
     FKey 5 | not (null (s ^. gameState . messageNotifications . notificationsContent)) -> do
       toggleModal MessagesModal
       gameState . messageInfo . lastSeenMessageTime .= s ^. gameState . temporal . ticks
@@ -741,7 +741,7 @@ zoomGameState f = do
 updateAchievements :: EventM Name AppState ()
 updateAchievements = do
   -- Merge the in-game achievements with the master list in UIState
-  achievementsFromGame <- use $ gameState . gameAchievements
+  achievementsFromGame <- use $ gameState . discovery . gameAchievements
   let wrappedGameAchievements = M.mapKeys GameplayAchievement achievementsFromGame
 
   oldMasterAchievementsList <- use $ uiState . uiAchievements

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -787,7 +787,7 @@ updateUI = do
   -- Whether the focused robot is too far away to sense, & whether
   -- that has recently changed
   dist <- use (gameState . to focusedRange)
-  farOK <- liftA2 (||) (use (gameState . creativeMode)) (use (gameState . worldScrollable))
+  farOK <- liftA2 (||) (use (gameState . creativeMode)) (use (gameState . landscape . worldScrollable))
   let tooFar = not farOK && dist == Just Far
       farChanged = tooFar /= isNothing listRobotHash
 
@@ -1311,7 +1311,7 @@ handleWorldEvent = \case
   Key k
     | k `elem` moveKeys -> do
         c <- use $ gameState . creativeMode
-        s <- use $ gameState . worldScrollable
+        s <- use $ gameState . landscape . worldScrollable
         when (c || s) $ scrollView (.+^ (worldScrollDist *^ keyToDir k))
   CharKey 'c' -> do
     invalidateCacheEntry WorldCache

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -1160,7 +1160,7 @@ handleREPLEventTyping = \case
       CharKey '\t' -> do
         s <- get
         let names = s ^.. gameState . baseRobot . robotContext . defTypes . to assocs . traverse . _1
-        uiState . uiREPL %= tabComplete names (s ^. gameState . entityMap)
+        uiState . uiREPL %= tabComplete names (s ^. gameState . landscape . entityMap)
         modify validateREPLForm
       EscapeKey -> do
         formSt <- use $ uiState . uiREPL . replPromptType

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -515,7 +515,7 @@ getNormalizedCurrentScenarioPath =
 
 saveScenarioInfoOnFinish :: (MonadIO m, MonadState AppState m) => FilePath -> m (Maybe ScenarioInfo)
 saveScenarioInfoOnFinish p = do
-  initialRunCode <- use $ gameState . initiallyRunCode
+  initialRunCode <- use $ gameState . gameControls . initiallyRunCode
   t <- liftIO getZonedTime
   wc <- use $ gameState . winCondition
   let won = case wc of

--- a/src/Swarm/TUI/Controller/Util.hs
+++ b/src/Swarm/TUI/Controller/Util.hs
@@ -53,9 +53,9 @@ openModal mt = do
  where
   -- Set the game to AutoPause if needed
   ensurePause = do
-    pause <- use $ gameState . paused
+    pause <- use $ gameState . temporal . paused
     unless (pause || isRunningModal mt) $ do
-      gameState . runStatus .= AutoPause
+      gameState . temporal . runStatus .= AutoPause
 
 -- | The running modals do not autopause the game.
 isRunningModal :: ModalType -> Bool

--- a/src/Swarm/TUI/Controller/Util.hs
+++ b/src/Swarm/TUI/Controller/Util.hs
@@ -80,7 +80,7 @@ loadVisibleRegion = do
   forM_ mext $ \(Extent _ _ size) -> do
     gs <- use gameState
     let vr = viewingRegion gs (over both fromIntegral size)
-    gameState . multiWorld %= M.adjust (W.loadRegion (vr ^. planar)) (vr ^. subworld)
+    gameState . landscape . multiWorld %= M.adjust (W.loadRegion (vr ^. planar)) (vr ^. subworld)
 
 mouseLocToWorldCoords :: Brick.Location -> EventM Name GameState (Maybe (Cosmic W.Coords))
 mouseLocToWorldCoords (Brick.Location mouseLoc) = do

--- a/src/Swarm/TUI/Editor/Controller.hs
+++ b/src/Swarm/TUI/Editor/Controller.hs
@@ -80,7 +80,7 @@ handleMiddleClick :: B.Location -> EventM Name AppState ()
 handleMiddleClick mouseLoc = do
   worldEditor <- use $ uiState . uiWorldEditor
   when (worldEditor ^. isWorldEditorEnabled) $ do
-    w <- use $ gameState . multiWorld
+    w <- use $ gameState . landscape . multiWorld
     let setTerrainPaint coords = do
           let (terrain, maybeElementPaint) =
                 EU.getContentAt
@@ -141,7 +141,7 @@ saveMapFile :: EventM Name AppState ()
 saveMapFile = do
   worldEditor <- use $ uiState . uiWorldEditor
   maybeBounds <- use $ uiState . uiWorldEditor . editingBounds . boundsRect
-  w <- use $ gameState . multiWorld
+  w <- use $ gameState . landscape . multiWorld
   let mapCellGrid = EU.getEditedMapRectangle worldEditor maybeBounds w
 
   let fp = worldEditor ^. outputFilePath

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -481,6 +481,6 @@ topContext s = ctxPossiblyWithIt
  where
   ctx = fromMaybe emptyRobotContext $ s ^? gameState . baseRobot . robotContext
 
-  ctxPossiblyWithIt = case s ^. gameState . repl . replStatus of
+  ctxPossiblyWithIt = case s ^. gameState . gameControls . replStatus of
     REPLDone (Just p) -> ctx & at "it" ?~ p
     _ -> ctx

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -481,6 +481,6 @@ topContext s = ctxPossiblyWithIt
  where
   ctx = fromMaybe emptyRobotContext $ s ^? gameState . baseRobot . robotContext
 
-  ctxPossiblyWithIt = case s ^. gameState . replStatus of
+  ctxPossiblyWithIt = case s ^. gameState . repl . replStatus of
     REPLDone (Just p) -> ctx & at "it" ?~ p
     _ -> ctx

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -123,7 +123,7 @@ constructAppState rs ui opts@(AppOpts {..}) = do
   case skipMenu opts of
     False -> return $ AppState gs (ui & lgTicksPerSecond .~ defaultInitLgTicksPerSecond) rs
     True -> do
-      (scenario, path) <- loadScenario (fromMaybe "classic" userScenario) (gs ^. entityMap) (rs ^. worlds)
+      (scenario, path) <- loadScenario (fromMaybe "classic" userScenario) (gs ^. landscape . entityMap) (rs ^. worlds)
       maybeRunScript <- traverse parseCodeFile scriptToRun
 
       let maybeAutoplay = do
@@ -258,7 +258,7 @@ scenarioToUIState isAutoplaying siPair@(scenario, _) gs u = do
       & uiWorldEditor . EM.entityPaintList %~ BL.listReplace entityList Nothing
       & uiWorldEditor . EM.editingBounds . EM.boundsRect %~ setNewBounds
  where
-  entityList = EU.getEntitiesForList $ gs ^. entityMap
+  entityList = EU.getEntitiesForList $ gs ^. landscape . entityMap
 
   (isEmptyArea, newBounds) = EU.getEditingBounds $ NE.head $ scenario ^. scenarioWorlds
   setNewBounds maybeOldBounds =

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -498,8 +498,8 @@ drawWorldCursorInfo worldEditor g cCoords =
 drawClockDisplay :: Int -> GameState -> Widget n
 drawClockDisplay lgTPS gs = hBox . intersperse (txt " ") $ catMaybes [clockWidget, pauseWidget]
  where
-  clockWidget = maybeDrawTime (gs ^. ticks) (gs ^. paused || lgTPS < 3) gs
-  pauseWidget = guard (gs ^. paused) $> txt "(PAUSED)"
+  clockWidget = maybeDrawTime (gs ^. temporal . ticks) (gs ^. temporal . paused || lgTPS < 3) gs
+  pauseWidget = guard (gs ^. temporal . paused) $> txt "(PAUSED)"
 
 -- | Check whether the currently focused robot (if any) has a clock
 --   device equipped.
@@ -619,7 +619,7 @@ renderDutyCycle :: GameState -> Robot -> Widget Name
 renderDutyCycle gs robot =
   withAttr dutyCycleAttr . str . flip (showFFloat (Just 1)) "%" $ dutyCyclePercentage
  where
-  curTicks = gs ^. ticks
+  curTicks = gs ^. temporal . ticks
   window = robot ^. activityCounts . activityWindow
 
   -- Rewind to previous tick
@@ -866,7 +866,7 @@ messagesWidget :: GameState -> [Widget Name]
 messagesWidget gs = widgetList
  where
   widgetList = focusNewest . map drawLogEntry' $ gs ^. messageNotifications . notificationsContent
-  focusNewest = if gs ^. paused then id else over _last visible
+  focusNewest = if gs ^. temporal . paused then id else over _last visible
   drawLogEntry' e =
     withAttr (colorLogs e) $
       hBox
@@ -941,7 +941,7 @@ drawKeyMenu s =
       $ s
 
   isReplWorking = s ^. gameState . replWorking
-  isPaused = s ^. gameState . paused
+  isPaused = s ^. gameState . temporal . paused
   hasDebug = fromMaybe creative $ s ^? gameState . to focusedRobot . _Just . robotCapabilities . Lens.contains CDebug
   viewingBase = (s ^. gameState . viewCenterRule) == VCRobot 0
   creative = s ^. gameState . creativeMode

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -1203,7 +1203,7 @@ explainRecipes s e
 -- | Return all recipes that involve a given entity.
 recipesWith :: AppState -> Entity -> [Recipe Entity]
 recipesWith s e =
-  let getRecipes select = recipesFor (s ^. gameState . select) e
+  let getRecipes select = recipesFor (s ^. gameState . recipesInfo . select) e
    in -- The order here is chosen intentionally.  See https://github.com/swarm-game/swarm/issues/418.
       --
       --   1. Recipes where the entity is an input --- these should go
@@ -1215,7 +1215,12 @@ recipesWith s e =
       --   3. Recipes where it is an output --- these should go last,
       --      since if you have it, you probably already figured out how
       --      to make it.
-      L.nub $ getRecipes recipesIn ++ getRecipes recipesCat ++ getRecipes recipesOut
+      L.nub $
+        concat
+          [ getRecipes recipesIn
+          , getRecipes recipesCat
+          , getRecipes recipesOut
+          ]
 
 -- | Draw an ASCII art representation of a recipe.  For now, the
 --   weight is not shown.

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -790,7 +790,7 @@ availableListWidget :: GameState -> NotificationList -> Widget Name
 availableListWidget gs nl = padTop (Pad 1) $ vBox widgetList
  where
   widgetList = case nl of
-    RecipeList -> mkAvailableList gs availableRecipes renderRecipe
+    RecipeList -> mkAvailableList gs (discovery . availableRecipes) renderRecipe
     MessageList -> messagesWidget gs
   renderRecipe = padLeftRight 18 . drawRecipe Nothing (fromMaybe E.empty inv)
   inv = gs ^? to focusedRobot . _Just . robotInventory
@@ -816,7 +816,7 @@ commandsListWidget gs =
       , txt wikiCheatSheet
       ]
  where
-  commands = gs ^. availableCommands . notificationsContent
+  commands = gs ^. discovery . availableCommands . notificationsContent
   table =
     BT.renderTable
       . BT.surroundingBorder False
@@ -906,8 +906,8 @@ drawModalMenu s = vLimit 1 . hBox $ map (padLeftRight 1 . drawKeyCmd) globalKeyC
     catMaybes
       [ Just (NoHighlight, "F1", "Help")
       , Just (NoHighlight, "F2", "Robots")
-      , notificationKey availableRecipes "F3" "Recipes"
-      , notificationKey availableCommands "F4" "Commands"
+      , notificationKey (discovery . availableRecipes) "F3" "Recipes"
+      , notificationKey (discovery . availableCommands) "F4" "Commands"
       , notificationKey messageNotifications "F5" "Messages"
       ]
 

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -940,7 +940,7 @@ drawKeyMenu s =
       . view (uiState . uiFocusRing)
       $ s
 
-  isReplWorking = s ^. gameState . replWorking
+  isReplWorking = s ^. gameState . repl . replWorking
   isPaused = s ^. gameState . temporal . paused
   hasDebug = fromMaybe creative $ s ^? gameState . to focusedRobot . _Just . robotCapabilities . Lens.contains CDebug
   viewingBase = (s ^. gameState . viewCenterRule) == VCRobot 0
@@ -1361,11 +1361,11 @@ replPromptAsWidget t (SearchPrompt rh) =
       | otherwise -> txt $ "[found: \"" <> lastentry <> "\"] "
 
 renderREPLPrompt :: FocusRing Name -> REPLState -> Widget Name
-renderREPLPrompt focus repl = ps1 <+> replE
+renderREPLPrompt focus theRepl = ps1 <+> replE
  where
-  prompt = repl ^. replPromptType
-  replEditor = repl ^. replPromptEditor
-  color = if repl ^. replValid then id else withAttr redAttr
+  prompt = theRepl ^. replPromptType
+  replEditor = theRepl ^. replPromptEditor
+  color = if theRepl ^. replValid then id else withAttr redAttr
   ps1 = replPromptAsWidget (T.concat $ getEditContents replEditor) prompt
   replE =
     renderEditor
@@ -1386,13 +1386,13 @@ drawREPL s =
  where
   -- rendered history lines fitting above REPL prompt
   history :: [Widget n]
-  history = map fmt . toList . getSessionREPLHistoryItems $ repl ^. replHistory
+  history = map fmt . toList . getSessionREPLHistoryItems $ theRepl ^. replHistory
   currentPrompt :: Widget Name
-  currentPrompt = case (isActive <$> base, repl ^. replControlMode) of
+  currentPrompt = case (isActive <$> base, theRepl ^. replControlMode) of
     (_, Handling) -> padRight Max $ txt "[key handler running, M-k to toggle]"
-    (Just False, _) -> renderREPLPrompt (s ^. uiState . uiFocusRing) repl
+    (Just False, _) -> renderREPLPrompt (s ^. uiState . uiFocusRing) theRepl
     _running -> padRight Max $ txt "..."
-  repl = s ^. uiState . uiREPL
+  theRepl = s ^. uiState . uiREPL
   base = s ^. gameState . robotMap . at 0
   fmt (REPLEntry e) = txt $ "> " <> e
   fmt (REPLOutput t) = txt t

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -931,7 +931,7 @@ drawKeyMenu s =
   mkCmdRow = hBox . map drawPaddedCmd
   drawPaddedCmd = padLeftRight 1 . drawKeyCmd
   contextCmds
-    | ctrlMode == Handling = txt $ fromMaybe "" (s ^? gameState . inputHandler . _Just . _1)
+    | ctrlMode == Handling = txt $ fromMaybe "" (s ^? gameState . repl . inputHandler . _Just . _1)
     | otherwise = mkCmdRow focusedPanelCmds
   focusedPanelCmds =
     map highlightKeyCmds
@@ -952,7 +952,7 @@ drawKeyMenu s =
   inventorySearch = s ^. uiState . uiInventorySearch
   ctrlMode = s ^. uiState . uiREPL . replControlMode
   canScroll = creative || (s ^. gameState . worldScrollable)
-  handlerInstalled = isJust (s ^. gameState . inputHandler)
+  handlerInstalled = isJust (s ^. gameState . repl . inputHandler)
 
   renderPilotModeSwitch :: ReplControlMode -> T.Text
   renderPilotModeSwitch = \case

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -951,7 +951,7 @@ drawKeyMenu s =
   inventorySort = s ^. uiState . uiInventorySort
   inventorySearch = s ^. uiState . uiInventorySearch
   ctrlMode = s ^. uiState . uiREPL . replControlMode
-  canScroll = creative || (s ^. gameState . worldScrollable)
+  canScroll = creative || (s ^. gameState . landscape . worldScrollable)
   handlerInstalled = isJust (s ^. gameState . repl . inputHandler)
 
   renderPilotModeSwitch :: ReplControlMode -> T.Text

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -931,7 +931,7 @@ drawKeyMenu s =
   mkCmdRow = hBox . map drawPaddedCmd
   drawPaddedCmd = padLeftRight 1 . drawKeyCmd
   contextCmds
-    | ctrlMode == Handling = txt $ fromMaybe "" (s ^? gameState . repl . inputHandler . _Just . _1)
+    | ctrlMode == Handling = txt $ fromMaybe "" (s ^? gameState . gameControls . inputHandler . _Just . _1)
     | otherwise = mkCmdRow focusedPanelCmds
   focusedPanelCmds =
     map highlightKeyCmds
@@ -940,7 +940,7 @@ drawKeyMenu s =
       . view (uiState . uiFocusRing)
       $ s
 
-  isReplWorking = s ^. gameState . repl . replWorking
+  isReplWorking = s ^. gameState . gameControls . replWorking
   isPaused = s ^. gameState . temporal . paused
   hasDebug = fromMaybe creative $ s ^? gameState . to focusedRobot . _Just . robotCapabilities . Lens.contains CDebug
   viewingBase = (s ^. gameState . viewCenterRule) == VCRobot 0
@@ -952,7 +952,7 @@ drawKeyMenu s =
   inventorySearch = s ^. uiState . uiInventorySearch
   ctrlMode = s ^. uiState . uiREPL . replControlMode
   canScroll = creative || (s ^. gameState . landscape . worldScrollable)
-  handlerInstalled = isJust (s ^. gameState . repl . inputHandler)
+  handlerInstalled = isJust (s ^. gameState . gameControls . inputHandler)
 
   renderPilotModeSwitch :: ReplControlMode -> T.Text
   renderPilotModeSwitch = \case

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -172,7 +172,7 @@ getStatic g coords
     murmur3 1 . unTagged . from @String @(Encoding.UTF_8 ByteString) . show $
       -- include the current tick count / 16 in the hash, so the pattern of static
       -- changes once every 16 ticks
-      (offset, getTickNumber (g ^. ticks) `div` 16)
+      (offset, getTickNumber (g ^. temporal . ticks) `div` 16)
 
   -- Hashed probability, i.e. convert the hash into a floating-point number between 0 and 1
   hp :: Double

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -56,7 +56,7 @@ displayTerrainCell ::
   Cosmic W.Coords ->
   Display
 displayTerrainCell worldEditor g coords =
-  terrainMap M.! EU.getTerrainAt worldEditor (g ^. multiWorld) coords
+  terrainMap M.! EU.getTerrainAt worldEditor (g ^. landscape . multiWorld) coords
 
 displayRobotCell ::
   GameState ->
@@ -70,7 +70,7 @@ displayEntityCell :: WorldEditor Name -> GameState -> Cosmic W.Coords -> [Displa
 displayEntityCell worldEditor g coords =
   maybeToList $ displayForEntity <$> maybeEntity
  where
-  (_, maybeEntity) = EU.getContentAt worldEditor (g ^. multiWorld) coords
+  (_, maybeEntity) = EU.getContentAt worldEditor (g ^. landscape . multiWorld) coords
 
   displayForEntity :: EntityPaint -> Display
   displayForEntity e = (if known e then id else hidden) $ getDisplay e

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -80,7 +80,7 @@ displayEntityCell worldEditor g coords =
     e
       `hasProperty` Known
       || (e ^. entityName)
-        `elem` (g ^. knownEntities)
+        `elem` (g ^. discovery . knownEntities)
       || case hidingMode g of
         HideAllEntities -> False
         HideNoEntity -> True

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -41,6 +41,7 @@ import Swarm.Game.State (
   WinStatus (Won),
   activeRobots,
   baseRobot,
+  discovery,
   gameAchievements,
   messageInfo,
   messageQueue,
@@ -253,7 +254,7 @@ testScenarioSolutions rs ui =
         [ testSolution' Default "Testing/Achievements/RobotIntoWater" CheckForBadErrors $ \g ->
             assertBool
               "Did not get RobotIntoWater achievement!"
-              (isJust $ g ^? gameAchievements . at RobotIntoWater)
+              (isJust $ g ^? discovery . gameAchievements . at RobotIntoWater)
         ]
     , testGroup
         "Regression tests"

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -42,9 +42,11 @@ import Swarm.Game.State (
   activeRobots,
   baseRobot,
   gameAchievements,
+  messageInfo,
   messageQueue,
   notificationsContent,
   robotMap,
+  temporal,
   ticks,
   waitingRobots,
   winCondition,
@@ -259,7 +261,7 @@ testScenarioSolutions rs ui =
         , testSolution Default "Testing/373-drill"
         , testSolution Default "Testing/428-drowning-destroy"
         , testSolution' Default "Testing/475-wait-one" CheckForBadErrors $ \g -> do
-            let t = g ^. ticks
+            let t = g ^. temporal . ticks
                 r1Waits = g ^?! robotMap . ix 1 . to waitingUntil
                 active = IS.member 1 $ g ^. activeRobots
                 waiting = elem 1 . concat . M.elems $ g ^. waitingRobots
@@ -300,7 +302,7 @@ testScenarioSolutions rs ui =
         , testSolution Default "Testing/955-heading"
         , testSolution' Default "Testing/397-wrong-missing" CheckForBadErrors $ \g -> do
             let msgs =
-                  (g ^. messageQueue . to seqToTexts)
+                  (g ^. messageInfo . messageQueue . to seqToTexts)
                     <> (g ^.. robotMap . traverse . robotLog . to seqToTexts . traverse)
 
             assertBool "Should be some messages" (not (null msgs))
@@ -419,7 +421,7 @@ badErrorsInLogs g =
   concatMap
     (\r -> filter isBad (seqToTexts $ r ^. robotLog))
     (g ^. robotMap)
-    <> filter isBad (seqToTexts $ g ^. messageQueue)
+    <> filter isBad (seqToTexts $ g ^. messageInfo . messageQueue)
  where
   isBad m = "Fatal error:" `T.isInfixOf` m || "swarm/issues" `T.isInfixOf` m
 

--- a/test/unit/TestNotification.hs
+++ b/test/unit/TestNotification.hs
@@ -21,22 +21,22 @@ testNotification gs =
   testGroup
     "Notifications"
     [ testCase "notifications at start" $ do
-        assertBool "There should be no messages in queue" (null (gs ^. messageQueue))
+        assertBool "There should be no messages in queue" (null (gs ^. messageInfo . messageQueue))
         assertNew gs 0 "messages at game start" messageNotifications
-        assertNew gs 0 "recipes at game start" availableRecipes
-        assertNew gs 0 "commands at game start" availableCommands
+        assertNew gs 0 "recipes at game start" (discovery . availableRecipes)
+        assertNew gs 0 "commands at game start" (discovery . availableCommands)
     , testCase "new message after say" $ do
         gs' <- goodPlay "say \"Hello world!\""
-        assertBool "There should be one message in queue" (length (gs' ^. messageQueue) == 1)
+        assertBool "There should be one message in queue" (length (gs' ^. messageInfo . messageQueue) == 1)
         assertNew gs' 1 "message" messageNotifications
     , testCase "two new messages after say twice" $ do
         gs' <- goodPlay "say \"Hello!\"; say \"Goodbye!\""
-        assertBool "There should be two messages in queue" (length (gs' ^. messageQueue) == 2)
+        assertBool "There should be two messages in queue" (length (gs' ^. messageInfo . messageQueue) == 2)
         assertNew gs' 2 "messages" messageNotifications
     , testCase "one new message and one old message" $ do
         gs' <- goodPlay "say \"Hello!\"; say \"Goodbye!\""
         assertEqual "There should be two messages in queue" [TickNumber 0, TickNumber 1] (view leTime <$> gs' ^. messageNotifications . notificationsContent)
-        assertNew (gs' & lastSeenMessageTime .~ TickNumber 0) 1 "message" messageNotifications
+        assertNew (gs' & messageInfo . lastSeenMessageTime .~ TickNumber 0) 1 "message" messageNotifications
     , testCase "new message after log" $ do
         gs' <- goodPlay "create \"logger\"; equip \"logger\"; log \"Hello world!\""
         let r = gs' ^?! robotMap . ix (-1)
@@ -46,7 +46,7 @@ testNotification gs =
         assertNew gs' 1 "message" messageNotifications
     , testCase "new message after build say" $ do
         gs' <- goodPlay "build {say \"Hello world!\"}; turn back; turn back;"
-        assertBool "There should be one message in queue" (length (gs' ^. messageQueue) == 1)
+        assertBool "There should be one message in queue" (length (gs' ^. messageInfo . messageQueue) == 1)
         assertNew gs' 1 "message" messageNotifications
     , testCase "no new message after build log" $ do
         gs' <- goodPlay "build {log \"Hello world!\"}; turn back; turn back;"

--- a/test/unit/TestUtil.hs
+++ b/test/unit/TestUtil.hs
@@ -44,7 +44,7 @@ evalCESK g cesk =
   orderResult ((res, rr), rg) = (rg, rr, res)
 
 runCESK :: Int -> CESK -> StateT Robot (StateT GameState IO) (Either Text (Value, Int))
-runCESK _ (Up exn _ []) = Left . flip formatExn exn <$> lift (use entityMap)
+runCESK _ (Up exn _ []) = Left . flip formatExn exn <$> lift (use $ landscape . entityMap)
 runCESK !steps cesk = case finalValue cesk of
   Just (v, _) -> return (Right (v, steps))
   Nothing -> stepCESK cesk >>= runCESK (steps + 1)


### PR DESCRIPTION
Towards #872

Previously, the `GameState` record had `41` toplevel members.  It now has `22`.   Logical grouping of the fields makes it easier to peruse the code and paves the way to split `State.hs` into smaller modules.  Some functions now may even be able to operate exclusively on subsets of the game state, rather than having to pass in `GameState` as a whole.

There is potential to go even farther, by extracting view-related and robot-related members to their own records, but I figured I'd pursue this refactoring incrementally.