### PR TITLE
Refactor `LogEntry` type

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,4 +4,4 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 
 # See https://github.com/swarm-game/swarm/issues/936
-STACK_WORK=.stack-work-test stack test "$@"
+STACK_WORK=.stack-work-test stack test --fast "$@"

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -19,8 +19,8 @@ import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Graphics.Vty qualified as V
 import Swarm.Game.Failure (SystemFailure)
-import Swarm.Game.Log (LogSource (SystemLog), Severity (..))
 import Swarm.Language.Pretty (prettyText)
+import Swarm.Log (LogSource (SystemLog), Severity (..))
 import Swarm.ReadableIORef (mkReadonly)
 import Swarm.TUI.Controller
 import Swarm.TUI.Model

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -19,7 +19,7 @@ import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Graphics.Vty qualified as V
 import Swarm.Game.Failure (SystemFailure)
-import Swarm.Game.Robot (ErrorLevel (..), LogSource (ErrorTrace, Said))
+import Swarm.Game.Log (LogSource (SystemLog), Severity (..))
 import Swarm.Language.Pretty (prettyText)
 import Swarm.ReadableIORef (mkReadonly)
 import Swarm.TUI.Controller
@@ -87,8 +87,8 @@ appMain opts = do
           (mkReadonly appStateRef)
           chan
 
-      let logP p = logEvent Said ("Web API", -2) ("started on :" <> T.pack (show p))
-      let logE e = logEvent (ErrorTrace Error) ("Web API", -2) (T.pack e)
+      let logP p = logEvent SystemLog Info "Web API" ("started on :" <> T.pack (show p))
+      let logE e = logEvent SystemLog Error "Web API" (T.pack e)
       let s' =
             s
               & runtimeState

--- a/src/Swarm/Game/Log.hs
+++ b/src/Swarm/Game/Log.hs
@@ -27,12 +27,13 @@
 -- message queue.
 module Swarm.Game.Log (
   Severity (..),
-  LogCommand (..),
+  RobotLogSource (..),
   LogSource (..),
   LogLocation (..),
   LogEntry (..),
   leTime,
   leSource,
+  leSeverity,
   leName,
   leLocation,
   leText,
@@ -51,21 +52,23 @@ import Swarm.Game.Universe (Cosmic)
 data Severity = Info | Debug | Warning | Error | Critical
   deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
--- | Which robot command produced a log message.
-data LogCommand
+-- | How a robot log entry was produced.
+data RobotLogSource
   = -- | Produced by 'Swarm.Language.Syntax.Say'
     Said
   | -- | Produced by 'Swarm.Language.Syntax.Log'
     Logged
+  | -- | Produced as the result of an error.
+    RobotError
   deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
 -- | Source of a log entry.
 data LogSource
   = -- | Log produced by a robot.  Stores information about which
-    --   command was used, and the name and ID of the producing robot.
-    RobotLog LogCommand Text Int
+    --   command was used and the ID of the producing robot.
+    RobotLog RobotLogSource Int
   | -- | Log produced by an exception or system.
-    SystemLog Severity
+    SystemLog
   deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
 data LogLocation a = Omnipresent | Located a
@@ -78,6 +81,8 @@ data LogEntry = LogEntry
   --   Note that this is the first field we sort on.
   , _leSource :: LogSource
   -- ^ Where this log message came from.
+  , _leSeverity :: Severity
+  -- ^ Severity level of this log message.
   , _leName :: Text
   -- ^ Name of the robot or subsystem that generated this log entry.
   , _leLocation :: LogLocation (Cosmic Location)

--- a/src/Swarm/Game/Log.hs
+++ b/src/Swarm/Game/Log.hs
@@ -4,6 +4,17 @@
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
+-- XXX move this to Swarm.Log, update documentation to make it more
+-- generic --- used both in robots as well as in RuntimeState.eventLog
+--
+-- XXX or make a separate 'SystemLogEntry' type, as suggested by the
+-- TODO below?
+--
+-- XXX Also make 'Notification' documentation more generic
+--
+-- XXX eventLog uses negative numbers for robot ID?  Make robot ID
+-- optional perhaps?
+--
 -- A data type to represent in-game logs by robots.
 --
 -- Because of the use of system robots, we sometimes

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -97,7 +97,6 @@ import Swarm.Game.CESK
 import Swarm.Game.Display (Display, curOrientation, defaultRobotDisplay, invisible)
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Location (Heading, Location, toDirection)
-import Swarm.Game.Log
 import Swarm.Game.Universe
 import Swarm.Language.Capability (Capability)
 import Swarm.Language.Context qualified as Ctx
@@ -107,6 +106,7 @@ import Swarm.Language.Text.Markdown (Document)
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Types (TCtx)
 import Swarm.Language.Value as V
+import Swarm.Log
 import Swarm.Util.Lens (makeLensesExcluding, makeLensesNoSigs)
 import Swarm.Util.WindowedCounter
 import Swarm.Util.Yaml

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -13,9 +13,6 @@
 module Swarm.Game.Robot (
   -- * Robots data
 
-  -- * Robot log entries
-  module Swarm.Game.Log,
-
   -- * Robots
   RobotPhase (..),
   RID,

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -165,6 +165,7 @@ import Swarm.Game.CESK (CESK (Waiting), TickNumber (..), addTicks, emptyStore, f
 import Swarm.Game.Entity
 import Swarm.Game.Failure (SystemFailure (..))
 import Swarm.Game.Location
+import Swarm.Game.Log
 import Swarm.Game.Recipe (
   Recipe,
   catRecipeMap,
@@ -690,7 +691,7 @@ messageNotifications = to getNotif
     latestMsg = messageIsRecent gs
     closeMsg = messageIsFromNearby (gs ^. viewCenter)
     generatedBy rid logEntry = case logEntry ^. leSource of
-      RobotLog _ _ rid' -> rid == rid'
+      RobotLog _ rid' -> rid == rid'
       _ -> False
 
     focusedOrLatestClose mq =

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -165,7 +165,6 @@ import Swarm.Game.CESK (CESK (Waiting), TickNumber (..), addTicks, emptyStore, f
 import Swarm.Game.Entity
 import Swarm.Game.Failure (SystemFailure (..))
 import Swarm.Game.Location
-import Swarm.Game.Log
 import Swarm.Game.Recipe (
   Recipe,
   catRecipeMap,
@@ -192,6 +191,7 @@ import Swarm.Language.Syntax (Const, SrcLoc (..), Syntax' (..), allConst)
 import Swarm.Language.Typed (Typed (Typed))
 import Swarm.Language.Types
 import Swarm.Language.Value (Value)
+import Swarm.Log
 import Swarm.Util (applyWhen, binTuples, surfaceEmpty, uniq, (<+=), (<<.=), (?))
 import Swarm.Util.Erasable
 import Swarm.Util.Lens (makeLensesExcluding)

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -689,15 +689,19 @@ messageNotifications = to getNotif
     -- other they have to get from log
     latestMsg = messageIsRecent gs
     closeMsg = messageIsFromNearby (gs ^. viewCenter)
+    generatedBy rid logEntry = case logEntry ^. leSource of
+      RobotLog _ _ rid' -> rid == rid'
+      _ -> False
+
     focusedOrLatestClose mq =
       (Seq.take 1 . Seq.reverse . Seq.filter closeMsg $ Seq.takeWhileR latestMsg mq)
-        <> Seq.filter ((== gs ^. focusedRobotID) . view leRobotID) mq
+        <> Seq.filter (generatedBy (gs ^. focusedRobotID)) mq
 
 messageIsRecent :: GameState -> LogEntry -> Bool
 messageIsRecent gs e = addTicks 1 (e ^. leTime) >= gs ^. ticks
 
 -- | Reconciles the possibilities of log messages being
--- omnipresent and robots being in different worlds
+--   omnipresent and robots being in different worlds
 messageIsFromNearby :: Cosmic Location -> LogEntry -> Bool
 messageIsFromNearby l e = case e ^. leLocation of
   Omnipresent -> True

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -273,7 +273,9 @@ data RunStatus
 toggleRunStatus :: RunStatus -> RunStatus
 toggleRunStatus s = if s == Running then ManualPause else Running
 
--- | A data type to keep track of discovered recipes and commands
+-- | A data type to keep track of some kind of log or sequence, with
+--   an index to remember which ones are "new" and which ones have
+--   "already been seen".
 data Notifications a = Notifications
   { _notificationsCount :: Int
   , _notificationsContent :: [a]

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -693,7 +693,7 @@ messageNotifications = to getNotif
     latestMsg = messageIsRecent gs
     closeMsg = messageIsFromNearby (gs ^. viewCenter)
     generatedBy rid logEntry = case logEntry ^. leSource of
-      RobotLog _ rid' -> rid == rid'
+      RobotLog _ rid' _ -> rid == rid'
       _ -> False
 
     focusedOrLatestClose mq =
@@ -706,9 +706,9 @@ messageIsRecent gs e = addTicks 1 (e ^. leTime) >= gs ^. ticks
 -- | Reconciles the possibilities of log messages being
 --   omnipresent and robots being in different worlds
 messageIsFromNearby :: Cosmic Location -> LogEntry -> Bool
-messageIsFromNearby l e = case e ^. leLocation of
-  Omnipresent -> True
-  Located x -> f x
+messageIsFromNearby l e = case e ^. leSource of
+  SystemLog -> True
+  RobotLog _ _ loc -> f loc
  where
   f logLoc = case cosmoMeasure manhattan l logLoc of
     InfinitelyFar -> False

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1518,7 +1518,9 @@ execConst c vs s k = do
       [VText msg] -> do
         isPrivileged <- isPrivilegedBot
         loc <- use robotLocation
-        m <- traceLog Said Info msg -- current robot will inserted to robot set, so it needs the log
+
+        -- current robot will be inserted into the robot set, so it needs the log
+        m <- traceLog Said Info msg
         emitMessage m
         let measureToLog robLoc rawLogLoc = case rawLogLoc of
               Located logLoc -> cosmoMeasure manhattan robLoc logLoc

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -67,7 +67,6 @@ import Swarm.Game.Entity qualified as E
 import Swarm.Game.Exception
 import Swarm.Game.Failure
 import Swarm.Game.Location
-import Swarm.Game.Log
 import Swarm.Game.Recipe
 import Swarm.Game.ResourceLoading (getDataFileNameSafe)
 import Swarm.Game.Robot
@@ -93,6 +92,7 @@ import Swarm.Language.Syntax
 import Swarm.Language.Text.Markdown qualified as Markdown
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Value
+import Swarm.Log
 import Swarm.Util hiding (both)
 import Swarm.Util.Effect (throwToMaybe)
 import Swarm.Util.WindowedCounter qualified as WC

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -418,25 +418,27 @@ runCESK cesk = case finalValue cesk of
 -- Debugging
 ------------------------------------------------------------
 
--- | Create a log entry given current robot and game time in ticks noting whether it has been said.
+-- | Create a log entry given current robot and game time in ticks
+--   noting whether it has been said.
 --
---   This is the more generic version used both for (recorded) said messages and normal logs.
+--   This is the more generic version used both for (recorded) said
+--   messages and normal logs.
 createLogEntry ::
   (Has (State GameState) sig m, Has (State Robot) sig m) =>
-  LogSource ->
+  LogCommand ->
   Text ->
   m LogEntry
-createLogEntry source msg = do
+createLogEntry cmd msg = do
   rid <- use robotID
   rn <- use robotName
   time <- use ticks
   loc <- use robotLocation
-  pure $ LogEntry time source rn rid (Located loc) msg
+  pure $ LogEntry time (RobotLog cmd rn rid) (Located loc) msg
 
 -- | Print some text via the robot's log.
-traceLog :: (Has (State GameState) sig m, Has (State Robot) sig m) => LogSource -> Text -> m LogEntry
-traceLog source msg = do
-  m <- createLogEntry source msg
+traceLog :: (Has (State GameState) sig m, Has (State Robot) sig m) => LogCommand -> Text -> m LogEntry
+traceLog cmd msg = do
+  m <- createLogEntry cmd msg
   robotLog %= (Seq.|> m)
   return m
 

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -161,6 +161,12 @@ getJoin (Join j) = (j Expected, j Actual)
 --   monad transformer provided by the @unification-fd@ library which
 --   supports various operations such as generating fresh variables
 --   and unifying things.
+--
+--   Note that we are sort of constrained to use a concrete monad stack by
+--   @unification-fd@, which has some strange types on some of its exported
+--   functions that actually require various monad transformers to be stacked
+--   in certain ways.  For example, see <https://hackage.haskell.org/package/unification-fd-0.11.2/docs/Control-Unification.html#v:unify>.  I don't really see a way
+--   to use "capability style" like we do elsewhere in the codebase.
 type TC = ReaderT UCtx (ReaderT TCStack (ExceptT ContextualTypeErr (IntBindingT TypeF Identity)))
 
 -- | Push a frame on the typechecking stack within a local 'TC'

--- a/src/Swarm/Log.hs
+++ b/src/Swarm/Log.hs
@@ -4,18 +4,8 @@
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- XXX Also make 'Notification' documentation more generic
---
--- A data type to represent in-game logs by robots.
---
--- Because of the use of system robots, we sometimes
--- want to use special kinds of logs that will be
--- shown to the player.
---
--- TODO: #1039 Currently we abuse this system for system
--- logs, which is fun, but we should eventually make
--- a dedicated `SystemLogEntry` type for 'RuntimeState'
--- message queue.
+-- A data type to represent log messages, both for robot logs and
+-- the system log.
 module Swarm.Log (
   Severity (..),
   RobotLogSource (..),
@@ -30,7 +20,7 @@ module Swarm.Log (
   leText,
 ) where
 
-import Control.Lens hiding (contains)
+import Control.Lens (makeLenses)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
 import GHC.Generics (Generic)

--- a/src/Swarm/Log.hs
+++ b/src/Swarm/Log.hs
@@ -4,16 +4,7 @@
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- XXX move this to Swarm.Log, update documentation to make it more
--- generic --- used both in robots as well as in RuntimeState.eventLog
---
--- XXX or make a separate 'SystemLogEntry' type, as suggested by the
--- TODO below?
---
 -- XXX Also make 'Notification' documentation more generic
---
--- XXX eventLog uses negative numbers for robot ID?  Make robot ID
--- optional perhaps?
 --
 -- A data type to represent in-game logs by robots.
 --
@@ -25,7 +16,7 @@
 -- logs, which is fun, but we should eventually make
 -- a dedicated `SystemLogEntry` type for 'RuntimeState'
 -- message queue.
-module Swarm.Game.Log (
+module Swarm.Log (
   Severity (..),
   RobotLogSource (..),
   LogSource (..),

--- a/src/Swarm/Log.hs
+++ b/src/Swarm/Log.hs
@@ -10,13 +10,11 @@ module Swarm.Log (
   Severity (..),
   RobotLogSource (..),
   LogSource (..),
-  LogLocation (..),
   LogEntry (..),
   leTime,
   leSource,
   leSeverity,
   leName,
-  leLocation,
   leText,
 ) where
 
@@ -46,13 +44,11 @@ data RobotLogSource
 -- | Source of a log entry.
 data LogSource
   = -- | Log produced by a robot.  Stores information about which
-    --   command was used and the ID of the producing robot.
-    RobotLog RobotLogSource Int
+    --   command was used and the ID and location of the producing
+    --   robot.
+    RobotLog RobotLogSource Int (Cosmic Location)
   | -- | Log produced by an exception or system.
     SystemLog
-  deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
-
-data LogLocation a = Omnipresent | Located a
   deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
 -- | A log entry.
@@ -66,8 +62,6 @@ data LogEntry = LogEntry
   -- ^ Severity level of this log message.
   , _leName :: Text
   -- ^ Name of the robot or subsystem that generated this log entry.
-  , _leLocation :: LogLocation (Cosmic Location)
-  -- ^ Location associated with this log message.
   , _leText :: Text
   -- ^ The text of the log entry.
   }

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -74,7 +74,6 @@ import Swarm.Game.Achievement.Persistence
 import Swarm.Game.CESK (CESK (Out), Frame (FApp, FExec), cancel, emptyStore, initMachine)
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Location
-import Swarm.Game.Log
 import Swarm.Game.ResourceLoading (getSwarmHistoryPath)
 import Swarm.Game.Robot
 import Swarm.Game.ScenarioInfo
@@ -93,6 +92,7 @@ import Swarm.Language.Syntax hiding (Key)
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Types
 import Swarm.Language.Value (Value (VKey, VUnit), prettyValue, stripVResult)
+import Swarm.Log
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Editor.Controller qualified as EC
 import Swarm.TUI.Editor.Model

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -143,6 +143,7 @@ import Network.Wai.Handler.Warp (Port)
 import Swarm.Game.CESK (TickNumber (..))
 import Swarm.Game.Entity as E
 import Swarm.Game.Failure
+import Swarm.Game.Log
 import Swarm.Game.Recipe (Recipe, loadRecipes)
 import Swarm.Game.ResourceLoading (readAppData)
 import Swarm.Game.Robot
@@ -288,13 +289,13 @@ stdNameList :: Lens' RuntimeState (Array Int Text)
 -- Utility
 
 -- | Simply log to the runtime event log.
-logEvent :: LogSource -> Text -> Text -> Notifications LogEntry -> Notifications LogEntry
-logEvent src who msg el =
+logEvent :: LogSource -> Severity -> Text -> Text -> Notifications LogEntry -> Notifications LogEntry
+logEvent src sev who msg el =
   el
     & notificationsCount %~ succ
     & notificationsContent %~ (l :)
  where
-  l = LogEntry (TickNumber 0) src who Omnipresent msg
+  l = LogEntry (TickNumber 0) src sev who Omnipresent msg
 
 -- | Create a 'GameStateConfig' record from the 'RuntimeState'.
 mkGameStateConfig :: RuntimeState -> GameStateConfig

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -143,7 +143,6 @@ import Network.Wai.Handler.Warp (Port)
 import Swarm.Game.CESK (TickNumber (..))
 import Swarm.Game.Entity as E
 import Swarm.Game.Failure
-import Swarm.Game.Log
 import Swarm.Game.Recipe (Recipe, loadRecipes)
 import Swarm.Game.ResourceLoading (readAppData)
 import Swarm.Game.Robot
@@ -152,6 +151,7 @@ import Swarm.Game.ScenarioInfo (ScenarioCollection, loadScenarios, _SISingle)
 import Swarm.Game.State
 import Swarm.Game.World.Load (loadWorlds)
 import Swarm.Game.World.Typecheck (WorldMap)
+import Swarm.Log
 import Swarm.TUI.Inventory.Sorting
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -288,13 +288,13 @@ stdNameList :: Lens' RuntimeState (Array Int Text)
 -- Utility
 
 -- | Simply log to the runtime event log.
-logEvent :: LogSource -> (Text, RID) -> Text -> Notifications LogEntry -> Notifications LogEntry
-logEvent src (who, rid) msg el =
+logEvent :: LogSource -> Text -> Text -> Notifications LogEntry -> Notifications LogEntry
+logEvent src who msg el =
   el
     & notificationsCount %~ succ
     & notificationsContent %~ (l :)
  where
-  l = LogEntry (TickNumber 0) src who rid Omnipresent msg
+  l = LogEntry (TickNumber 0) src who Omnipresent msg
 
 -- | Create a 'GameStateConfig' record from the 'RuntimeState'.
 mkGameStateConfig :: RuntimeState -> GameStateConfig

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -295,7 +295,7 @@ logEvent src sev who msg el =
     & notificationsCount %~ succ
     & notificationsContent %~ (l :)
  where
-  l = LogEntry (TickNumber 0) src sev who Omnipresent msg
+  l = LogEntry (TickNumber 0) src sev who msg
 
 -- | Create a 'GameStateConfig' record from the 'RuntimeState'.
 mkGameStateConfig :: RuntimeState -> GameStateConfig

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -43,7 +43,6 @@ import Swarm.Game.Achievement.Attainment
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
 import Swarm.Game.Failure (SystemFailure)
-import Swarm.Game.Log (LogSource (SystemLog), Severity (..))
 import Swarm.Game.Scenario (loadScenario, scenarioAttrs, scenarioWorlds)
 import Swarm.Game.Scenario.Scoring.Best
 import Swarm.Game.Scenario.Scoring.ConcreteMetrics
@@ -58,6 +57,7 @@ import Swarm.Game.ScenarioInfo (
  )
 import Swarm.Game.State
 import Swarm.Language.Pretty (prettyText)
+import Swarm.Log (LogSource (SystemLog), Severity (..))
 import Swarm.TUI.Editor.Model qualified as EM
 import Swarm.TUI.Editor.Util qualified as EU
 import Swarm.TUI.Inventory.Sorting

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -43,7 +43,7 @@ import Swarm.Game.Achievement.Attainment
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
 import Swarm.Game.Failure (SystemFailure)
-import Swarm.Game.Log (Severity (..), LogSource (SystemLog))
+import Swarm.Game.Log (LogSource (SystemLog), Severity (..))
 import Swarm.Game.Scenario (loadScenario, scenarioAttrs, scenarioWorlds)
 import Swarm.Game.Scenario.Scoring.Best
 import Swarm.Game.Scenario.Scoring.ConcreteMetrics
@@ -85,7 +85,7 @@ initAppState opts = do
 addWarnings :: RuntimeState -> [SystemFailure] -> RuntimeState
 addWarnings = List.foldl' logWarning
  where
-  logWarning rs' w = rs' & eventLog %~ logEvent (SystemLog Error) "UI Loading" (prettyText w)
+  logWarning rs' w = rs' & eventLog %~ logEvent SystemLog Error "UI Loading" (prettyText w)
 
 -- | Based on the command line options, should we skip displaying the
 --   menu?

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -43,7 +43,7 @@ import Swarm.Game.Achievement.Attainment
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
 import Swarm.Game.Failure (SystemFailure)
-import Swarm.Game.Log (ErrorLevel (..), LogSource (ErrorTrace))
+import Swarm.Game.Log (Severity (..), LogSource (SystemLog))
 import Swarm.Game.Scenario (loadScenario, scenarioAttrs, scenarioWorlds)
 import Swarm.Game.Scenario.Scoring.Best
 import Swarm.Game.Scenario.Scoring.ConcreteMetrics
@@ -85,7 +85,7 @@ initAppState opts = do
 addWarnings :: RuntimeState -> [SystemFailure] -> RuntimeState
 addWarnings = List.foldl' logWarning
  where
-  logWarning rs' w = rs' & eventLog %~ logEvent (ErrorTrace Error) ("UI Loading", -8) (prettyText w)
+  logWarning rs' w = rs' & eventLog %~ logEvent (SystemLog Error) "UI Loading" (prettyText w)
 
 -- | Based on the command line options, should we skip displaying the
 --   menu?

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -76,7 +76,6 @@ import Swarm.Game.CESK (CESK (..), TickNumber (..), addTicks)
 import Swarm.Game.Display
 import Swarm.Game.Entity as E
 import Swarm.Game.Location
-import Swarm.Game.Log
 import Swarm.Game.Recipe
 import Swarm.Game.Robot
 import Swarm.Game.Scenario (
@@ -101,6 +100,7 @@ import Swarm.Language.Capability (Capability (..), constCaps)
 import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Syntax
 import Swarm.Language.Typecheck (inferConst)
+import Swarm.Log
 import Swarm.TUI.Border
 import Swarm.TUI.Controller (ticksPerFrameCap)
 import Swarm.TUI.Editor.Model

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -885,7 +885,7 @@ messagesWidget gs = widgetList
 colorLogs :: LogEntry -> AttrName
 colorLogs e = case e ^. leSource of
   SystemLog -> colorSeverity (e ^. leSeverity)
-  RobotLog rls rid -> case rls of
+  RobotLog rls rid _loc -> case rls of
     Said -> robotColor rid
     Logged -> notifAttr
     RobotError -> colorSeverity (e ^. leSeverity)
@@ -1328,7 +1328,7 @@ drawRobotLog s =
 
   allMe = all me logEntries
   me le = case le ^. leSource of
-    RobotLog _ i -> Just i == rid
+    RobotLog _ i _ -> Just i == rid
     _ -> False
 
   drawEntry i e =
@@ -1361,7 +1361,7 @@ drawLogEntry addName e =
       <> view leName e
       <> "] "
       <> case e ^. leSource of
-        RobotLog Said _ -> "said " <> quote t
+        RobotLog Said _ _ -> "said " <> quote t
         _ -> t
 
 ------------------------------------------------------------

--- a/src/Swarm/TUI/View/Attribute/Attr.hs
+++ b/src/Swarm/TUI/View/Attribute/Attr.hs
@@ -89,7 +89,7 @@ swarmAttrMap =
          , (focusedFormInputAttr, V.defAttr)
          , (customEditFocusedAttr, V.black `on` V.yellow)
          , (listSelectedFocusedAttr, bg V.blue)
-         , (infoAttr, fg (V.rgbColor @Int 50 50 50))
+         , (infoAttr, fg (V.rgbColor @Int 100 100 100))
          , (buttonSelectedAttr, bg V.blue)
          , (notifAttr, fg V.yellow `V.withStyle` V.bold)
          , (dimAttr, V.defAttr `V.withStyle` V.dim)

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -111,13 +111,13 @@ library
                       Swarm.Game.Entity
                       Swarm.Game.Exception
                       Swarm.Game.Location
-                      Swarm.Game.Log
                       Swarm.Game.Recipe
                       Swarm.Game.ResourceLoading
                       Swarm.Game.Robot
                       Swarm.Game.Scenario
                       Swarm.Game.Scenario.Topography.Cell
                       Swarm.Game.Universe
+                      Swarm.Log
                       Swarm.TUI.Launch.Controller
                       Swarm.TUI.Launch.Model
                       Swarm.TUI.Launch.Prep

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -31,7 +31,6 @@ import Swarm.Doc.Gen qualified as DocGen
 import Swarm.Game.CESK (emptyStore, getTickNumber, initMachine)
 import Swarm.Game.Entity (EntityMap, lookupByName)
 import Swarm.Game.Failure (SystemFailure)
-import Swarm.Game.Log
 import Swarm.Game.Robot (activityCounts, commandsHistogram, defReqs, equippedDevices, lifetimeStepCount, machine, robotContext, robotLog, systemRobot, tangibleCommandCount, waitingUntil)
 import Swarm.Game.Scenario (Scenario)
 import Swarm.Game.State (
@@ -53,6 +52,7 @@ import Swarm.Game.World.Typecheck (WorldMap)
 import Swarm.Language.Context qualified as Ctx
 import Swarm.Language.Pipeline (ProcessedTerm (..), processTerm)
 import Swarm.Language.Pretty (prettyString)
+import Swarm.Log
 import Swarm.TUI.Model (
   RuntimeState,
   defaultAppOpts,

--- a/test/unit/TestNotification.hs
+++ b/test/unit/TestNotification.hs
@@ -10,9 +10,9 @@ import Control.Lens (Getter, Ixed (ix), view, (&), (.~), (^.), (^?!))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Game.CESK (TickNumber (..))
-import Swarm.Game.Log
 import Swarm.Game.Robot
 import Swarm.Game.State
+import Swarm.Log
 import Test.Tasty
 import Test.Tasty.HUnit
 import TestUtil

--- a/test/unit/TestNotification.hs
+++ b/test/unit/TestNotification.hs
@@ -10,6 +10,7 @@ import Control.Lens (Getter, Ixed (ix), view, (&), (.~), (^.), (^?!))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Game.CESK (TickNumber (..))
+import Swarm.Game.Log
 import Swarm.Game.Robot
 import Swarm.Game.State
 import Test.Tasty


### PR DESCRIPTION
In preparation for #1483.   `LogEntry` started life as something specific to robot logs.  It then evolved to be used in the system log as well (see #1039 and #652), but in a sort of hacky way.  This PR refactors `LogEntry` to be more generic.

- Move `Swarm.Game.Log` -> `Swarm.Log` since it's not specific to gameplay.
- Rename `ErrorLevel` to `Severity`, add a new `Info` level, and add a top-level `leSeverity` field
- Rename `leRobotName` to just `leName`, since it was already being used to name both robots and system components anyway
- Move robot-specific fields (*e.g.* robot ID) into the new `RobotLogSource` type, and add `LogSource` to differentiate between robot and system logs
- Various other minor improvements and tweaks
