### PR TITLE
Render map preview on scenario selection screen

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,7 +17,7 @@ import Prettyprinter
 import Prettyprinter.Render.Text qualified as RT
 import Swarm.App (appMain)
 import Swarm.Doc.Gen (EditorType (..), GenerateDocs (..), PageAddress (..), SheetType (..), generateDocs)
-import Swarm.Game.World.Render (renderScenarioMap)
+import Swarm.Game.World.Render (printScenarioMap, renderScenarioMap)
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Parse (readTerm)
 import Swarm.Language.Pretty (ppr)
@@ -200,6 +200,6 @@ main = do
     Run opts -> appMain opts
     DocGen g -> generateDocs g
     Format fo w -> formatFile fo w
-    RenderMap mapPath -> renderScenarioMap mapPath
+    RenderMap mapPath -> printScenarioMap =<< renderScenarioMap mapPath
     LSP -> lspMain
     Version -> showVersion

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,6 +17,7 @@ import Prettyprinter
 import Prettyprinter.Render.Text qualified as RT
 import Swarm.App (appMain)
 import Swarm.Doc.Gen (EditorType (..), GenerateDocs (..), PageAddress (..), SheetType (..), generateDocs)
+import Swarm.Game.World.Render (renderScenarioMap)
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Parse (readTerm)
 import Swarm.Language.Pretty (ppr)
@@ -44,6 +45,7 @@ data CLI
   = Run AppOpts
   | Format Input (Maybe Width)
   | DocGen GenerateDocs
+  | RenderMap FilePath
   | LSP
   | Version
 
@@ -53,6 +55,7 @@ cliParser =
     ( mconcat
         [ command "format" (info (Format <$> format <*> optional widthOpt <**> helper) (progDesc "Format a file"))
         , command "generate" (info (DocGen <$> docgen <**> helper) (progDesc "Generate docs"))
+        , command "map" (info (RenderMap <$> strArgument (metavar "FILE")) (progDesc "Render a scenario world map."))
         , command "lsp" (info (pure LSP) (progDesc "Start the LSP"))
         , command "version" (info (pure Version) (progDesc "Get current and upstream version."))
         ]
@@ -85,6 +88,7 @@ cliParser =
       , command "cheatsheet" (info (CheatSheet <$> address <*> cheatsheet <**> helper) $ progDesc "Output nice Wiki tables")
       , command "pedagogy" (info (pure TutorialCoverage) $ progDesc "Output tutorial coverage")
       ]
+
   editor :: Parser (Maybe EditorType)
   editor =
     Data.Foldable.asum
@@ -196,5 +200,6 @@ main = do
     Run opts -> appMain opts
     DocGen g -> generateDocs g
     Format fo w -> formatFile fo w
+    RenderMap mapPath -> renderScenarioMap mapPath
     LSP -> lspMain
     Version -> showVersion

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -49,7 +49,7 @@ import Swarm.Game.Entity qualified as E
 import Swarm.Game.Failure (SystemFailure (CustomFailure))
 import Swarm.Game.Recipe (Recipe, loadRecipes, recipeCatalysts, recipeInputs, recipeOutputs, recipeTime, recipeWeight)
 import Swarm.Game.Robot (Robot, equippedDevices, instantiateRobot, robotInventory)
-import Swarm.Game.Scenario (Scenario, loadScenario, scenarioRobots, loadStandaloneScenario)
+import Swarm.Game.Scenario (Scenario, loadScenario, loadStandaloneScenario, scenarioRobots)
 import Swarm.Game.World.Gen (extractEntities)
 import Swarm.Game.World.Load (loadWorlds)
 import Swarm.Game.World.Typecheck (Some (..), TTerm, WorldMap)

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -35,7 +35,6 @@ import Data.List (transpose)
 import Data.Map.Lazy (Map, (!))
 import Data.Map.Lazy qualified as Map
 import Data.Maybe (fromMaybe, isJust, listToMaybe)
-import Data.Sequence (Seq)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text, unpack)
@@ -49,10 +48,9 @@ import Swarm.Game.Entity qualified as E
 import Swarm.Game.Failure (SystemFailure (CustomFailure))
 import Swarm.Game.Recipe (Recipe, loadRecipes, recipeCatalysts, recipeInputs, recipeOutputs, recipeTime, recipeWeight)
 import Swarm.Game.Robot (Robot, equippedDevices, instantiateRobot, robotInventory)
-import Swarm.Game.Scenario (Scenario, loadScenario, loadStandaloneScenario, scenarioRobots)
+import Swarm.Game.Scenario (Scenario, loadStandaloneScenario, scenarioRobots)
 import Swarm.Game.World.Gen (extractEntities)
-import Swarm.Game.World.Load (loadWorlds)
-import Swarm.Game.World.Typecheck (Some (..), TTerm, WorldMap)
+import Swarm.Game.World.Typecheck (Some (..), TTerm)
 import Swarm.Language.Capability (Capability)
 import Swarm.Language.Capability qualified as Capability
 import Swarm.Language.Key (specialKeyNames)
@@ -62,7 +60,7 @@ import Swarm.Language.Syntax qualified as Syntax
 import Swarm.Language.Text.Markdown as Markdown (docToMark)
 import Swarm.Language.Typecheck (inferConst)
 import Swarm.Util (both, listEnums, quote)
-import Swarm.Util.Effect (ignoreWarnings, simpleErrorHandle)
+import Swarm.Util.Effect (simpleErrorHandle)
 import Text.Dot (Dot, NodeId, (.->.))
 import Text.Dot qualified as Dot
 

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -12,6 +12,7 @@ module Swarm.Doc.Gen (
   GenerateDocs (..),
   EditorType (..),
   SheetType (..),
+  loadStandaloneScenario,
 
   -- ** Formatted keyword lists
   keywordsCommands,
@@ -51,7 +52,7 @@ import Swarm.Game.Robot (Robot, equippedDevices, instantiateRobot, robotInventor
 import Swarm.Game.Scenario (Scenario, loadScenario, scenarioRobots)
 import Swarm.Game.World.Gen (extractEntities)
 import Swarm.Game.World.Load (loadWorlds)
-import Swarm.Game.World.Typecheck (Some (..), TTerm)
+import Swarm.Game.World.Typecheck (Some (..), TTerm, WorldMap)
 import Swarm.Language.Capability (Capability)
 import Swarm.Language.Capability qualified as Capability
 import Swarm.Language.Key (specialKeyNames)
@@ -437,12 +438,20 @@ getBaseRobot s = case listToMaybe $ view scenarioRobots s of
 -- GENERATE GRAPHVIZ: ENTITY DEPENDENCIES BY RECIPES
 -- ----------------------------------------------------------------------------
 
-generateRecipe :: IO String
-generateRecipe = simpleErrorHandle $ do
+loadStandaloneScenario ::
+  (Has (Throw SystemFailure) sig m, Has (Lift IO) sig m) =>
+  FilePath ->
+  m (Scenario, (WorldMap, EntityMap, [Recipe Entity]))
+loadStandaloneScenario fp = do
   entities <- loadEntities
   recipes <- loadRecipes entities
   worlds <- ignoreWarnings @(Seq SystemFailure) $ loadWorlds entities
-  classic <- fst <$> loadScenario "data/scenarios/classic.yaml" entities worlds
+  scene <- fst <$> loadScenario fp entities worlds
+  return (scene, (worlds, entities, recipes))
+
+generateRecipe :: IO String
+generateRecipe = simpleErrorHandle $ do
+  (classic, (worlds, entities, recipes)) <- loadStandaloneScenario "data/scenarios/classic.yaml"
   baseRobot <- getBaseRobot classic
   return . Dot.showDot $ recipesToDot baseRobot (worlds ! "classic") entities recipes
 

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -49,7 +49,7 @@ import Swarm.Game.Entity qualified as E
 import Swarm.Game.Failure (SystemFailure (CustomFailure))
 import Swarm.Game.Recipe (Recipe, loadRecipes, recipeCatalysts, recipeInputs, recipeOutputs, recipeTime, recipeWeight)
 import Swarm.Game.Robot (Robot, equippedDevices, instantiateRobot, robotInventory)
-import Swarm.Game.Scenario (Scenario, loadScenario, scenarioRobots)
+import Swarm.Game.Scenario (Scenario, loadScenario, scenarioRobots, loadStandaloneScenario)
 import Swarm.Game.World.Gen (extractEntities)
 import Swarm.Game.World.Load (loadWorlds)
 import Swarm.Game.World.Typecheck (Some (..), TTerm, WorldMap)
@@ -437,17 +437,6 @@ getBaseRobot s = case listToMaybe $ view scenarioRobots s of
 -- ----------------------------------------------------------------------------
 -- GENERATE GRAPHVIZ: ENTITY DEPENDENCIES BY RECIPES
 -- ----------------------------------------------------------------------------
-
-loadStandaloneScenario ::
-  (Has (Throw SystemFailure) sig m, Has (Lift IO) sig m) =>
-  FilePath ->
-  m (Scenario, (WorldMap, EntityMap, [Recipe Entity]))
-loadStandaloneScenario fp = do
-  entities <- loadEntities
-  recipes <- loadRecipes entities
-  worlds <- ignoreWarnings @(Seq SystemFailure) $ loadWorlds entities
-  scene <- fst <$> loadScenario fp entities worlds
-  return (scene, (worlds, entities, recipes))
 
 generateRecipe :: IO String
 generateRecipe = simpleErrorHandle $ do

--- a/src/Swarm/Game/ResourceLoading.hs
+++ b/src/Swarm/Game/ResourceLoading.hs
@@ -134,12 +134,7 @@ readAppData = do
   filesList <- sendIO $ forM fs (\f -> (into @Text (dropExtension f),) <$> readFileMayT (d </> f))
   return $ M.fromList . mapMaybe sequenceA $ filesList
 
-initNameGenerator ::
-  ( Has (Throw SystemFailure) sig m
-  , Has (Lift IO) sig m
-  ) =>
-  Map Text Text ->
-  m NameGenerator
+initNameGenerator :: Has (Throw SystemFailure) sig m => Map Text Text -> m NameGenerator
 initNameGenerator appDataMap = do
   adjs <- getDataLines "adjectives"
   names <- getDataLines "names"

--- a/src/Swarm/Game/ResourceLoading.hs
+++ b/src/Swarm/Game/ResourceLoading.hs
@@ -12,6 +12,7 @@ import Control.Effect.Throw (Throw, liftEither, throwError)
 import Control.Exception (catch)
 import Control.Exception.Base (IOException)
 import Control.Monad (forM, when, (<=<))
+import Data.Array (Array, listArray)
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (mapMaybe)
@@ -30,6 +31,12 @@ import System.Directory (
  )
 import System.FilePath
 import Witch
+
+-- | Read-only lists of adjectives and words for use in building random robot names
+data NameGenerator = NameGenerator
+  { adjList :: Array Int Text
+  , nameList :: Array Int Text
+  }
 
 -- | Get subdirectory from swarm data directory.
 --
@@ -126,3 +133,25 @@ readAppData = do
 
   filesList <- sendIO $ forM fs (\f -> (into @Text (dropExtension f),) <$> readFileMayT (d </> f))
   return $ M.fromList . mapMaybe sequenceA $ filesList
+
+initNameGenerator ::
+  ( Has (Throw SystemFailure) sig m
+  , Has (Lift IO) sig m
+  ) =>
+  Map Text Text ->
+  m NameGenerator
+initNameGenerator appDataMap = do
+  adjs <- getDataLines "adjectives"
+  names <- getDataLines "names"
+  return $
+    NameGenerator
+      { adjList = makeArr adjs
+      , nameList = makeArr names
+      }
+ where
+  makeArr xs = listArray (0, length xs - 1) xs
+  getDataLines f = case M.lookup f appDataMap of
+    Nothing ->
+      throwError $
+        AssetNotLoaded (Data NameGeneration) (into @FilePath f <.> "txt") (DoesNotExist File)
+    Just content -> return . tail . T.lines $ content

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -339,7 +339,7 @@ robotDisplay = lens getDisplay setDisplay
       & curOrientation .~ ((r ^. robotOrientation) >>= toDirection)
   setDisplay r d = r & robotEntity . entityDisplay .~ d
 
--- | The robot's current location, represented as (x,y).  This is only
+-- | The robot's current location, represented as @(x,y)@.  This is only
 --   a getter, since when changing a robot's location we must remember
 --   to update the 'robotsByLocation' map as well.  You can use the
 --   'updateRobotLocation' function for this purpose.

--- a/src/Swarm/Game/Scenario.hs
+++ b/src/Swarm/Game/Scenario.hs
@@ -49,7 +49,6 @@ module Swarm.Game.Scenario (
 
 import Control.Arrow ((&&&))
 import Control.Carrier.Throw.Either (runThrow)
-import Swarm.Game.World.Load (loadWorlds)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Throw
 import Control.Lens hiding (from, (.=), (<.>))
@@ -59,9 +58,9 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
 import Data.Maybe (catMaybes, isNothing, listToMaybe)
+import Data.Sequence (Seq)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Sequence (Seq)
 import Swarm.Game.Entity
 import Swarm.Game.Failure
 import Swarm.Game.Location
@@ -77,13 +76,14 @@ import Swarm.Game.Scenario.Topography.Navigation.Portal
 import Swarm.Game.Scenario.Topography.Structure qualified as Structure
 import Swarm.Game.Scenario.Topography.WorldDescription
 import Swarm.Game.Universe
+import Swarm.Game.World.Load (loadWorlds)
 import Swarm.Game.World.Typecheck (WorldMap)
 import Swarm.Language.Pipeline (ProcessedTerm)
 import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Syntax (Syntax)
 import Swarm.Language.Text.Markdown (Document)
 import Swarm.Util (binTuples, failT)
-import Swarm.Util.Effect (throwToMaybe, withThrow, ignoreWarnings)
+import Swarm.Util.Effect (ignoreWarnings, throwToMaybe, withThrow)
 import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Util.Yaml
 import System.Directory (doesFileExist)

--- a/src/Swarm/Game/Scenario.hs
+++ b/src/Swarm/Game/Scenario.hs
@@ -44,10 +44,12 @@ module Swarm.Game.Scenario (
   loadScenario,
   loadScenarioFile,
   getScenarioPath,
+  loadStandaloneScenario,
 ) where
 
 import Control.Arrow ((&&&))
 import Control.Carrier.Throw.Either (runThrow)
+import Swarm.Game.World.Load (loadWorlds)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Throw
 import Control.Lens hiding (from, (.=), (<.>))
@@ -59,6 +61,7 @@ import Data.Map qualified as M
 import Data.Maybe (catMaybes, isNothing, listToMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Sequence (Seq)
 import Swarm.Game.Entity
 import Swarm.Game.Failure
 import Swarm.Game.Location
@@ -80,7 +83,7 @@ import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Syntax (Syntax)
 import Swarm.Language.Text.Markdown (Document)
 import Swarm.Util (binTuples, failT)
-import Swarm.Util.Effect (throwToMaybe, withThrow)
+import Swarm.Util.Effect (throwToMaybe, withThrow, ignoreWarnings)
 import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Util.Yaml
 import System.Directory (doesFileExist)
@@ -289,3 +292,14 @@ loadScenarioFile em worldMap fileName =
     decodeFileEitherE (em, worldMap) fileName
  where
   adaptError = AssetNotLoaded (Data Scenarios) fileName . CanNotParseYaml
+
+loadStandaloneScenario ::
+  (Has (Throw SystemFailure) sig m, Has (Lift IO) sig m) =>
+  FilePath ->
+  m (Scenario, (WorldMap, EntityMap, [Recipe Entity]))
+loadStandaloneScenario fp = do
+  entities <- loadEntities
+  recipes <- loadRecipes entities
+  worlds <- ignoreWarnings @(Seq SystemFailure) $ loadWorlds entities
+  scene <- fst <$> loadScenario fp entities worlds
+  return (scene, (worlds, entities, recipes))

--- a/src/Swarm/Game/Scenario/Status.hs
+++ b/src/Swarm/Game/Scenario/Status.hs
@@ -67,9 +67,12 @@ instance ToJSON ScenarioStatus where
   toEncoding = genericToEncoding scenarioOptions
   toJSON = genericToJSON scenarioOptions
 
+emptyLaunchParams :: Applicative f => ParameterizableLaunchParams a f
+emptyLaunchParams = LaunchParams (pure Nothing) (pure Nothing)
+
 getLaunchParams :: ScenarioStatus -> SerializableLaunchParams
 getLaunchParams = \case
-  NotStarted -> LaunchParams (pure Nothing) (pure Nothing)
+  NotStarted -> emptyLaunchParams
   Played x _ _ -> x
 
 -- | A 'ScenarioInfo' record stores metadata about a scenario: its

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -1194,14 +1194,14 @@ initGameState gsc =
     , _focusedRobotID = 0
     }
 
-type WorldTuples = NonEmpty (SubworldName, ([IndexedTRobot], Seed -> WorldFun Int Entity))
+type SubworldDescription = (SubworldName, ([IndexedTRobot], Seed -> WorldFun Int Entity))
 
-buildWorldTuples :: Scenario -> WorldTuples
+buildWorldTuples :: Scenario -> NonEmpty SubworldDescription
 buildWorldTuples s =
   NE.map (worldName &&& buildWorld) $
     s ^. scenarioWorlds
 
-genMultiWorld :: WorldTuples -> Seed -> W.MultiWorld Int Entity
+genMultiWorld :: NonEmpty SubworldDescription -> Seed -> W.MultiWorld Int Entity
 genMultiWorld worldTuples s =
   M.map genWorld
     . M.fromList

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -252,11 +252,12 @@ makePrisms ''ViewCenterRule
 data REPLStatus
   = -- | The REPL is not doing anything actively at the moment.
     --   We persist the last value and its type though.
-    --   INVARIANT: the Value stored here is not a VResult.
+    --
+    --   INVARIANT: the 'Value' stored here is not a 'VResult'.
     REPLDone (Maybe (Typed Value))
   | -- | A command entered at the REPL is currently being run.  The
     --   'Polytype' represents the type of the expression that was
-    --   entered.  The @Maybe Value@ starts out as @Nothing@ and gets
+    --   entered.  The @Maybe Value@ starts out as 'Nothing' and gets
     --   filled in with a result once the command completes.
     REPLWorking (Typed (Maybe Value))
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
@@ -304,7 +305,7 @@ data RunStatus
 -- | Switch (auto or manually) paused game to running and running to manually paused.
 --
 --   Note that this function is not safe to use in the app directly, because the UI
---   also tracks time between ticks - use 'Swarm.TUI.Controller.safeTogglePause' instead.
+--   also tracks time between ticks---use 'Swarm.TUI.Controller.safeTogglePause' instead.
 toggleRunStatus :: RunStatus -> RunStatus
 toggleRunStatus s = if s == Running then ManualPause else Running
 
@@ -367,9 +368,9 @@ parseCodeFile filepath = do
 defaultRobotStepsPerTick :: Int
 defaultRobotStepsPerTick = 100
 
--- | Type for remebering which robots will be run next in a robot step mode.
+-- | Type for remembering which robots will be run next in a robot step mode.
 --
--- Once some robots have run, we need to store RID to know which ones should go next.
+-- Once some robots have run, we need to store 'RID' to know which ones should go next.
 -- At 'SBefore' no robots were run yet, so it is safe to transition to and from 'WorldTick'.
 --
 -- @
@@ -433,7 +434,7 @@ messageQueue :: Lens' Messages (Seq LogEntry)
 lastSeenMessageTime :: Lens' Messages TickNumber
 
 -- | A queue of global announcements.
--- Note that this is distinct from the "messageQueue",
+-- Note that this is distinct from the 'messageQueue',
 -- which is for messages emitted by robots.
 --
 -- Note that we put the newest entry to the right.
@@ -462,7 +463,7 @@ data TemporalState = TemporalState
 
 makeLensesNoSigs ''TemporalState
 
--- | How to step the game - 'WorldTick' or 'RobotStep' for debugging the 'CESK' machine.
+-- | How to step the game: 'WorldTick' or 'RobotStep' for debugging the 'CESK' machine.
 gameStep :: Lens' TemporalState Step
 
 -- | The current 'RunStatus'.
@@ -491,7 +492,7 @@ makeLensesNoSigs ''GameControls
 -- | The current status of the REPL.
 replStatus :: Lens' GameControls REPLStatus
 
--- | The index of the next it{index} value
+-- | The index of the next @it{index}@ value
 replNextValueIndex :: Lens' GameControls Integer
 
 -- | The currently installed input handler and hint text.
@@ -524,7 +525,7 @@ availableCommands :: Lens' Discovery (Notifications Const)
 --   robots know what they are without having to scan them.
 knownEntities :: Lens' Discovery [Text]
 
--- | Map of in-game achievements that were attained
+-- | Map of in-game achievements that were obtained
 gameAchievements :: Lens' Discovery (Map GameplayAchievement Attainment)
 
 data Landscape = Landscape
@@ -537,7 +538,7 @@ data Landscape = Landscape
 makeLensesNoSigs ''Landscape
 
 -- | Includes a 'Map' of named locations and an
--- "Edge list" (graph) that maps portal entrances to exits
+-- "edge list" (graph) that maps portal entrances to exits
 worldNavigation :: Lens' Landscape (Navigation (M.Map SubworldName) Location)
 
 -- | The current state of the world (terrain and entities only; robots
@@ -562,8 +563,8 @@ data GameState = GameState
   , _winSolution :: Maybe ProcessedTerm
   , _robotMap :: IntMap Robot
   , -- A set of robots to consider for the next game tick. It is guaranteed to
-    -- be a subset of the keys of robotMap. It may contain waiting or idle
-    -- robots. But robots that are present in robotMap and not in activeRobots
+    -- be a subset of the keys of 'robotMap'. It may contain waiting or idle
+    -- robots. But robots that are present in 'robotMap' and not in 'activeRobots'
     -- are guaranteed to be either waiting or idle.
     _activeRobots :: IntSet
   , -- A set of probably waiting robots, indexed by probable wake-up time. It
@@ -571,9 +572,9 @@ data GameState = GameState
     -- that do not exist anymore. Its only guarantee is that once a robot name
     -- with its wake up time is inserted in it, it will remain there until the
     -- wake-up time is reached, at which point it is removed via
-    -- wakeUpRobotsDoneSleeping.
+    -- 'wakeUpRobotsDoneSleeping'.
     -- Waiting robots for a given time are a list because it is cheaper to
-    -- prepend to a list than insert into a Set.
+    -- prepend to a list than insert into a 'Set'.
     _waitingRobots :: Map TickNumber [RID]
   , _robotsByLocation :: Map SubworldName (Map Location IntSet)
   , -- This member exists as an optimization so
@@ -626,7 +627,7 @@ winSolution :: Lens' GameState (Maybe ProcessedTerm)
 robotMap :: Lens' GameState (IntMap Robot)
 
 -- | The names of all robots that currently exist in the game, indexed by
---   location (which we need both for /e.g./ the 'Salvage' command as
+--   location (which we need both for /e.g./ the @salvage@ command as
 --   well as for actually drawing the world).  Unfortunately there is
 --   no good way to automatically keep this up to date, since we don't
 --   just want to completely rebuild it every time the 'robotMap'
@@ -671,7 +672,7 @@ activeRobots = internalActiveRobots
 
 -- | The names of the robots that are currently sleeping, indexed by wake up
 --   time. Note that this may not include all sleeping robots, particularly
---   those that are only taking a short nap (e.g. wait 1).
+--   those that are only taking a short nap (e.g. @wait 1@).
 waitingRobots :: Getter GameState (Map TickNumber [RID])
 waitingRobots = internalWaitingRobots
 
@@ -731,8 +732,8 @@ focusedRobotID = to _focusedRobotID
 ------------------------------------------------------------
 
 -- | The current rule for determining the center of the world view.
---   It updates also, viewCenter and focusedRobotName to keep
---   everything synchronize.
+--   It updates also, viewCenter and 'focusedRobotName' to keep
+--   everything synchronized.
 viewCenterRule :: Lens' GameState ViewCenterRule
 viewCenterRule = lens getter setter
  where
@@ -815,7 +816,7 @@ applyViewCenterRule :: ViewCenterRule -> IntMap Robot -> Maybe (Cosmic Location)
 applyViewCenterRule (VCLocation l) _ = Just l
 applyViewCenterRule (VCRobot name) m = m ^? at name . _Just . robotLocation
 
--- | Recalculate the veiw center (and cache the result in the
+-- | Recalculate the view center (and cache the result in the
 --   'viewCenter' field) based on the current 'viewCenterRule'.  If
 --   the 'viewCenterRule' specifies a robot which does not exist,
 --   simply leave the current 'viewCenter' as it is. Set 'needsRedraw'
@@ -882,18 +883,22 @@ data RobotRange
 --   * If we are in creative or scroll-enabled mode, the focused robot is
 --   always considered 'Close'.
 --   * Otherwise, there is a "minimum radius" and "maximum radius".
---       - If the robot is within the minimum radius, it is 'Close'.
---       - If the robot is between the minimum and maximum radii, it
+--
+--       * If the robot is within the minimum radius, it is 'Close'.
+--       * If the robot is between the minimum and maximum radii, it
 --         is 'MidRange', with a 'Double' value ranging linearly from
 --         0 to 1 proportional to the distance from the minimum to
---         maximum radius.  For example, 'MidRange 0.5' would indicate
+--         maximum radius.  For example, @MidRange 0.5@ would indicate
 --         a robot exactly halfway between the minimum and maximum
 --         radii.
---       - If the robot is beyond the maximum radius, it is 'Far'.
+--       * If the robot is beyond the maximum radius, it is 'Far'.
+--
 --   * By default, the minimum radius is 16, and maximum is 64.
---   * If the focused robot has an @antenna@ installed, it doubles
---     both radii.
---   * If the base has an @antenna@ installed, it also doubles both radii.
+--   * Device augmentations
+--
+--       * If the focused robot has an @antenna@ installed, it doubles
+--         both radii.
+--       * If the base has an @antenna@ installed, it also doubles both radii.
 focusedRange :: GameState -> Maybe RobotRange
 focusedRange g = checkRange <$ focusedRobot g
  where
@@ -934,7 +939,7 @@ clearFocusedRobotLogUpdated = do
   robotMap . ix n . robotLogUpdated .= False
 
 -- | Add a concrete instance of a robot template to the game state:
---   first, generate a unique ID number for it.  Then, add it to the
+--   First, generate a unique ID number for it.  Then, add it to the
 --   main robot map, the active robot set, and to to the index of
 --   robots by location. Return the updated robot.
 addTRobot :: (Has (State GameState) sig m) => TRobot -> m Robot
@@ -975,24 +980,24 @@ emitMessage msg = messageInfo . messageQueue %= (|> msg) . dropLastIfLong
   dropLastIfLong whole@(_oldest :<| newer) = if tooLong whole then newer else whole
   dropLastIfLong emptyQueue = emptyQueue
 
--- | Takes a robot out of the activeRobots set and puts it in the waitingRobots
+-- | Takes a robot out of the 'activeRobots' set and puts it in the 'waitingRobots'
 --   queue.
 sleepUntil :: (Has (State GameState) sig m) => RID -> TickNumber -> m ()
 sleepUntil rid time = do
   internalActiveRobots %= IS.delete rid
   internalWaitingRobots . at time . non [] %= (rid :)
 
--- | Takes a robot out of the activeRobots set.
+-- | Takes a robot out of the 'activeRobots' set.
 sleepForever :: (Has (State GameState) sig m) => RID -> m ()
 sleepForever rid = internalActiveRobots %= IS.delete rid
 
--- | Adds a robot to the activeRobots set.
+-- | Adds a robot to the 'activeRobots' set.
 activateRobot :: (Has (State GameState) sig m) => RID -> m ()
 activateRobot rid = internalActiveRobots %= IS.insert rid
 
 -- | Removes robots whose wake up time matches the current game ticks count
---   from the waitingRobots queue and put them back in the activeRobots set
---   if they still exist in the keys of robotMap.
+--   from the 'waitingRobots' queue and put them back in the 'activeRobots' set
+--   if they still exist in the keys of 'robotMap'.
 wakeUpRobotsDoneSleeping :: (Has (State GameState) sig m) => m ()
 wakeUpRobotsDoneSleeping = do
   time <- use $ temporal . ticks
@@ -1005,7 +1010,7 @@ wakeUpRobotsDoneSleeping = do
       internalActiveRobots %= IS.union (IS.fromList aliveRids)
 
       -- These robots' wake times may have been moved "forward"
-      -- by "wakeWatchingRobots".
+      -- by 'wakeWatchingRobots'.
       clearWatchingRobots rids
 
 -- | Clear the "watch" state of all of the
@@ -1017,11 +1022,11 @@ clearWatchingRobots ::
 clearWatchingRobots rids = do
   robotsWatching %= M.map (`S.difference` S.fromList rids)
 
--- | Iterates through all of the currently "wait"-ing robots,
--- and moves forward the wake time of the ones that are watching this location.
+-- | Iterates through all of the currently @wait@-ing robots,
+-- and moves forward the wake time of the ones that are @watch@-ing this location.
 --
--- NOTE: Clearing "TickNumber" map entries from "internalWaitingRobots"
--- upon wakeup is handled by "wakeUpRobotsDoneSleeping" in State.hs
+-- NOTE: Clearing 'TickNumber' map entries from 'internalWaitingRobots'
+-- upon wakeup is handled by 'wakeUpRobotsDoneSleeping'
 wakeWatchingRobots :: (Has (State GameState) sig m) => Cosmic Location -> m ()
 wakeWatchingRobots loc = do
   currentTick <- use $ temporal . ticks
@@ -1209,30 +1214,33 @@ genMultiWorld worldTuples s =
 -- Returns a list of robots, ordered by decreasing preference
 -- to serve as the "base".
 --
--- ## Rules for selecting the "base" robot:
+-- = Rules for selecting the "base" robot:
 --
 -- What follows is a thorough description of how the base
 -- choice is made as of the most recent study of the code.
 -- This level of detail is not meant to be public-facing.
 --
 -- For an abbreviated explanation, see the "Base robot" section of the
--- "Scenario Authoring Guide".
--- https://github.com/swarm-game/swarm/tree/main/data/scenarios#base-robot
+-- <https://github.com/swarm-game/swarm/tree/main/data/scenarios#base-robot Scenario Authoring Guide>.
 --
--- Precedence rules:
--- 1. Prefer those robots defined with a loc in the Scenario file
---   1.a. If multiple robots define a loc, use the robot that is defined
---        first within the Scenario file.
---   1.b. Note that if a robot is both given a loc AND is specified in the
+-- == Precedence rules
+--
+-- 1. Prefer those robots defined with a @loc@ ('robotLocation') in the scenario file
+--
+--     1. If multiple robots define a @loc@, use the robot that is defined
+--        first within the scenario file.
+--     2. Note that if a robot is both given a @loc@ AND is specified in the
 --        world map, then two instances of the robot shall be created. The
---        instance with the loc shall be preferred as the base.
+--        instance with the @loc@ shall be preferred as the base.
+--
 -- 2. Fall back to robots generated from templates via the map and palette.
---   2.a. If multiple robots are specified in the map, prefer the one that
---        is defined first within the Scenario file.
---   2.b. If multiple robots are instantiated from the same template, then
+--
+--     1. If multiple robots are specified in the map, prefer the one that
+--        is defined first within the scenario file.
+--     2. If multiple robots are instantiated from the same template, then
 --        prefer the one with a lower-indexed subworld. Note that the root
 --        subworld is always first.
---   2.c. If multiple robots instantiated from the same template are in the
+--     3. If multiple robots instantiated from the same template are in the
 --        same subworld, then
 --        prefer the one closest to the upper-left of the screen, with higher
 --        rows given precedence over columns (i.e. first in row-major order).

--- a/src/Swarm/Game/Step/Util.hs
+++ b/src/Swarm/Game/Step/Util.hs
@@ -26,6 +26,7 @@ import Linear (zero)
 import Swarm.Game.Entity hiding (empty, lookup, singleton, union)
 import Swarm.Game.Exception
 import Swarm.Game.Location
+import Swarm.Game.ResourceLoading (NameGenerator (..))
 import Swarm.Game.Robot
 import Swarm.Game.State
 import Swarm.Game.Universe

--- a/src/Swarm/Game/World/Render.hs
+++ b/src/Swarm/Game/World/Render.hs
@@ -6,14 +6,13 @@ module Swarm.Game.World.Render where
 
 import Control.Effect.Lift (sendIO)
 import Control.Lens (view)
-import Control.Monad (forM_)
 import Data.List.NonEmpty qualified as NE
 import Swarm.Doc.Gen (loadStandaloneScenario)
 import Swarm.Game.Display (defaultChar)
 import Swarm.Game.ResourceLoading (initNameGenerator, readAppData)
 import Swarm.Game.Scenario (Scenario, area, scenarioWorlds, ul, worldName)
 import Swarm.Game.Scenario.Status (emptyLaunchParams)
-import Swarm.Game.Scenario.Topography.Area (getAreaDimensions, upperLeftToBottomRight)
+import Swarm.Game.Scenario.Topography.Area (AreaDimensions (..), getAreaDimensions, isEmpty, upperLeftToBottomRight)
 import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.EntityFacade (EntityFacade (..), mkFacade)
 import Swarm.Game.State
@@ -40,7 +39,11 @@ getDisplayGrid myScenario gs =
   firstScenarioWorld = NE.head $ view scenarioWorlds myScenario
   worldArea = area firstScenarioWorld
   upperLeftLocation = ul firstScenarioWorld
-  areaDims = getAreaDimensions worldArea
+  rawAreaDims = getAreaDimensions worldArea
+  areaDims =
+    if isEmpty rawAreaDims
+      then AreaDimensions 20 10
+      else rawAreaDims
   lowerRightLocation = upperLeftToBottomRight areaDims upperLeftLocation
 
   mkCosmic = Cosmic $ worldName firstScenarioWorld
@@ -58,5 +61,5 @@ renderScenarioMap fp = simpleErrorHandle $ do
   return $ map (map getDisplayChar) grid
 
 printScenarioMap :: [String] -> IO ()
-printScenarioMap grid =
-  sendIO $ forM_ grid putStrLn
+printScenarioMap =
+  sendIO . mapM_ putStrLn

--- a/src/Swarm/Game/World/Render.hs
+++ b/src/Swarm/Game/World/Render.hs
@@ -1,0 +1,59 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- TUI-independent world rendering.
+module Swarm.Game.World.Render where
+
+import Control.Effect.Lift (sendIO)
+import Control.Lens (view)
+import Control.Monad (forM_)
+import Data.List.NonEmpty qualified as NE
+import Swarm.Doc.Gen (loadStandaloneScenario)
+import Swarm.Game.Display (defaultChar)
+import Swarm.Game.ResourceLoading (initNameGenerator, readAppData)
+import Swarm.Game.Scenario (Scenario, area, scenarioWorlds, ul, worldName)
+import Swarm.Game.Scenario.Status (emptyLaunchParams)
+import Swarm.Game.Scenario.Topography.Area (getAreaDimensions, upperLeftToBottomRight)
+import Swarm.Game.Scenario.Topography.Cell
+import Swarm.Game.Scenario.Topography.EntityFacade (EntityFacade (..), mkFacade)
+import Swarm.Game.State
+import Swarm.Game.Universe
+import Swarm.Game.World qualified as W
+import Swarm.TUI.Editor.Util (getContentAt, getMapRectangle)
+import Swarm.Util.Effect (simpleErrorHandle)
+import Swarm.Util.Erasable (erasableToMaybe)
+
+getDisplayChar :: PCell EntityFacade -> Char
+getDisplayChar = maybe ' ' facadeChar . erasableToMaybe . cellEntity
+ where
+  facadeChar (EntityFacade _ d) = view defaultChar d
+
+getDisplayGrid :: Scenario -> GameState -> [[PCell EntityFacade]]
+getDisplayGrid myScenario gs =
+  getMapRectangle
+    mkFacade
+    (getContentAt worlds . mkCosmic)
+    boundingBox
+ where
+  worlds = view (landscape . multiWorld) gs
+
+  firstScenarioWorld = NE.head $ view scenarioWorlds myScenario
+  worldArea = area firstScenarioWorld
+  upperLeftLocation = ul firstScenarioWorld
+  areaDims = getAreaDimensions worldArea
+  lowerRightLocation = upperLeftToBottomRight areaDims upperLeftLocation
+
+  mkCosmic = Cosmic $ worldName firstScenarioWorld
+  boundingBox = (W.locToCoords upperLeftLocation, W.locToCoords lowerRightLocation)
+
+renderScenarioMap :: FilePath -> IO ()
+renderScenarioMap fp = simpleErrorHandle $ do
+  (myScenario, (worldDefs, entities, recipes)) <- loadStandaloneScenario fp
+  appDataMap <- readAppData
+  nameGen <- initNameGenerator appDataMap
+  let gsc = GameStateConfig nameGen entities recipes worldDefs
+  gs <- sendIO $ scenarioToGameState myScenario emptyLaunchParams gsc
+  let grid = getDisplayGrid myScenario gs
+
+  sendIO $ forM_ grid $ \line ->
+    putStrLn $ map getDisplayChar line

--- a/src/Swarm/Game/World/Render.hs
+++ b/src/Swarm/Game/World/Render.hs
@@ -46,7 +46,7 @@ getDisplayGrid myScenario gs =
   mkCosmic = Cosmic $ worldName firstScenarioWorld
   boundingBox = (W.locToCoords upperLeftLocation, W.locToCoords lowerRightLocation)
 
-renderScenarioMap :: FilePath -> IO ()
+renderScenarioMap :: FilePath -> IO [String]
 renderScenarioMap fp = simpleErrorHandle $ do
   (myScenario, (worldDefs, entities, recipes)) <- loadStandaloneScenario fp
   appDataMap <- readAppData
@@ -55,5 +55,8 @@ renderScenarioMap fp = simpleErrorHandle $ do
   gs <- sendIO $ scenarioToGameState myScenario emptyLaunchParams gsc
   let grid = getDisplayGrid myScenario gs
 
-  sendIO $ forM_ grid $ \line ->
-    putStrLn $ map getDisplayChar line
+  return $ map (map getDisplayChar) grid
+
+printScenarioMap :: [String] -> IO ()
+printScenarioMap grid =
+  sendIO $ forM_ grid putStrLn

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -380,7 +380,7 @@ handleMainEvent ev = do
     -- toggle world editor mode if in "cheat mode"
     ControlChar 'e'
       | s ^. uiState . uiCheatMode -> do
-          uiState . uiWorldEditor . isWorldEditorEnabled %= not
+          uiState . uiWorldEditor . worldOverdraw . isWorldEditorEnabled %= not
           setFocus WorldEditorPanel
     MouseDown WorldPositionIndicator _ _ _ -> uiState . uiWorldCursor .= Nothing
     MouseDown (FocusablePanel WorldPanel) V.BMiddle _ mouseLoc ->

--- a/src/Swarm/TUI/Controller/Util.hs
+++ b/src/Swarm/TUI/Controller/Util.hs
@@ -79,7 +79,7 @@ loadVisibleRegion = do
   mext <- lookupExtent WorldExtent
   forM_ mext $ \(Extent _ _ size) -> do
     gs <- use gameState
-    let vr = viewingRegion gs (over both fromIntegral size)
+    let vr = viewingRegion (gs ^. viewCenter) (over both fromIntegral size)
     gameState . landscape . multiWorld %= M.adjust (W.loadRegion (vr ^. planar)) (vr ^. subworld)
 
 mouseLocToWorldCoords :: Brick.Location -> EventM Name GameState (Maybe (Cosmic W.Coords))
@@ -88,7 +88,7 @@ mouseLocToWorldCoords (Brick.Location mouseLoc) = do
   case mext of
     Nothing -> pure Nothing
     Just ext -> do
-      region <- gets $ flip viewingRegion (bimap fromIntegral fromIntegral (extentSize ext))
+      region <- gets $ flip viewingRegion (bimap fromIntegral fromIntegral (extentSize ext)) . view viewCenter
       let regionStart = W.unCoords (fst $ region ^. planar)
           mouseLoc' = bimap fromIntegral fromIntegral mouseLoc
           mx = snd mouseLoc' + fst regionStart

--- a/src/Swarm/TUI/Editor/Controller.hs
+++ b/src/Swarm/TUI/Editor/Controller.hs
@@ -53,14 +53,14 @@ handleCtrlLeftClick :: B.Location -> EventM Name AppState ()
 handleCtrlLeftClick mouseLoc = do
   worldEditor <- use $ uiState . uiWorldEditor
   _ <- runMaybeT $ do
-    guard $ worldEditor ^. isWorldEditorEnabled
+    guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     let getSelected x = snd <$> BL.listSelectedElement x
         maybeTerrainType = getSelected $ worldEditor ^. terrainList
         maybeEntityPaint = getSelected $ worldEditor ^. entityPaintList
     -- TODO (#1151): Use hoistMaybe when available
     terrain <- MaybeT . pure $ maybeTerrainType
     mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
-    uiState . uiWorldEditor . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
+    uiState . uiWorldEditor . worldOverdraw . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
     uiState . uiWorldEditor . lastWorldEditorMessage .= Nothing
   immediatelyRedrawWorld
   return ()
@@ -69,9 +69,9 @@ handleRightClick :: B.Location -> EventM Name AppState ()
 handleRightClick mouseLoc = do
   worldEditor <- use $ uiState . uiWorldEditor
   _ <- runMaybeT $ do
-    guard $ worldEditor ^. isWorldEditorEnabled
+    guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
-    uiState . uiWorldEditor . paintedTerrain %= M.delete (mouseCoords ^. planar)
+    uiState . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
   immediatelyRedrawWorld
   return ()
 
@@ -79,12 +79,12 @@ handleRightClick mouseLoc = do
 handleMiddleClick :: B.Location -> EventM Name AppState ()
 handleMiddleClick mouseLoc = do
   worldEditor <- use $ uiState . uiWorldEditor
-  when (worldEditor ^. isWorldEditorEnabled) $ do
+  when (worldEditor ^. worldOverdraw . isWorldEditorEnabled) $ do
     w <- use $ gameState . landscape . multiWorld
     let setTerrainPaint coords = do
           let (terrain, maybeElementPaint) =
-                EU.getContentAt
-                  worldEditor
+                EU.getEditorContentAt
+                  (worldEditor ^. worldOverdraw)
                   w
                   coords
           uiState . uiWorldEditor . terrainList %= BL.listMoveToElement terrain
@@ -142,7 +142,7 @@ saveMapFile = do
   worldEditor <- use $ uiState . uiWorldEditor
   maybeBounds <- use $ uiState . uiWorldEditor . editingBounds . boundsRect
   w <- use $ gameState . landscape . multiWorld
-  let mapCellGrid = EU.getEditedMapRectangle worldEditor maybeBounds w
+  let mapCellGrid = EU.getEditedMapRectangle (worldEditor ^. worldOverdraw) maybeBounds w
 
   let fp = worldEditor ^. outputFilePath
   maybeScenarioPair <- use $ uiState . scenarioRef

--- a/src/Swarm/TUI/Editor/Model.hs
+++ b/src/Swarm/TUI/Editor/Model.hs
@@ -54,13 +54,19 @@ data MapEditingBounds = MapEditingBounds
 
 makeLenses ''MapEditingBounds
 
-data WorldEditor n = WorldEditor
+data WorldOverdraw = WorldOverdraw
   { _isWorldEditorEnabled :: Bool
-  , _terrainList :: BL.List n TerrainType
-  , _entityPaintList :: BL.List n EntityFacade
   -- ^ This field has deferred initialization; it gets populated when a game
   -- is initialized.
   , _paintedTerrain :: M.Map W.Coords (TerrainWith EntityFacade)
+  }
+
+makeLenses ''WorldOverdraw
+
+data WorldEditor n = WorldEditor
+  { _worldOverdraw :: WorldOverdraw
+  , _terrainList :: BL.List n TerrainType
+  , _entityPaintList :: BL.List n EntityFacade
   , _editingBounds :: MapEditingBounds
   , _editorFocusRing :: FocusRing n
   , _outputFilePath :: FilePath
@@ -72,10 +78,9 @@ makeLenses ''WorldEditor
 initialWorldEditor :: TimeSpec -> WorldEditor Name
 initialWorldEditor ts =
   WorldEditor
-    False
+    (WorldOverdraw False mempty)
     (BL.list TerrainList (V.fromList listEnums) 1)
     (BL.list EntityPaintList (V.fromList []) 1)
-    mempty
     bounds
     (focusRing $ map WorldEditorPanelControl listEnums)
     "mymap.yaml"

--- a/src/Swarm/TUI/Editor/Util.hs
+++ b/src/Swarm/TUI/Editor/Util.hs
@@ -5,7 +5,6 @@ module Swarm.TUI.Editor.Util where
 import Control.Applicative ((<|>))
 import Control.Lens hiding (Const, from)
 import Control.Monad (guard)
-import Data.Int (Int32)
 import Data.Map qualified as M
 import Data.Map qualified as Map
 import Data.Maybe qualified as Maybe
@@ -19,7 +18,6 @@ import Swarm.Game.Terrain (TerrainType)
 import Swarm.Game.Universe
 import Swarm.Game.World qualified as W
 import Swarm.TUI.Editor.Model
-import Swarm.TUI.Model
 import Swarm.Util.Erasable
 
 getEntitiesForList :: EntityMap -> V.Vector EntityFacade
@@ -37,12 +35,18 @@ getEditingBounds myWorld =
   a = EA.getAreaDimensions $ area myWorld
   lowerRightLoc = EA.upperLeftToBottomRight a upperLeftLoc
 
-getContentAt ::
-  WorldEditor Name ->
+getContentAt :: W.MultiWorld Int e -> Cosmic W.Coords -> (TerrainType, Maybe e)
+getContentAt w coords = (underlyingCellTerrain, underlyingCellEntity)
+ where
+  underlyingCellEntity = W.lookupCosmicEntity coords w
+  underlyingCellTerrain = W.lookupCosmicTerrain coords w
+
+getEditorContentAt ::
+  WorldOverdraw ->
   W.MultiWorld Int Entity ->
   Cosmic W.Coords ->
   (TerrainType, Maybe EntityPaint)
-getContentAt editor w coords =
+getEditorContentAt editorOverdraw w coords =
   (terrainWithOverride, entityWithOverride)
  where
   terrainWithOverride = Maybe.fromMaybe underlyingCellTerrain $ do
@@ -55,22 +59,21 @@ getContentAt editor w coords =
     Facade <$> erasableToMaybe e
 
   maybePaintedCell = do
-    guard $ editor ^. isWorldEditorEnabled
+    guard $ editorOverdraw ^. isWorldEditorEnabled
     Map.lookup (coords ^. planar) pm
 
-  pm = editor ^. paintedTerrain
+  pm = editorOverdraw ^. paintedTerrain
 
   entityWithOverride = (Ref <$> underlyingCellEntity) <|> maybeEntityOverride
-  underlyingCellEntity = W.lookupCosmicEntity coords w
-  underlyingCellTerrain = W.lookupCosmicTerrain coords w
+  (underlyingCellTerrain, underlyingCellEntity) = getContentAt w coords
 
 getTerrainAt ::
-  WorldEditor Name ->
+  WorldOverdraw ->
   W.MultiWorld Int Entity ->
   Cosmic W.Coords ->
   TerrainType
 getTerrainAt editor w coords =
-  fst $ getContentAt editor w coords
+  fst $ getEditorContentAt editor w coords
 
 isOutsideTopLeftCorner ::
   -- | top left corner coords
@@ -100,25 +103,32 @@ isOutsideRegion (tl, br) coord =
   isOutsideTopLeftCorner tl coord || isOutsideBottomRightCorner br coord
 
 getEditedMapRectangle ::
-  WorldEditor Name ->
+  WorldOverdraw ->
   Maybe (Cosmic W.BoundsRectangle) ->
   W.MultiWorld Int Entity ->
   [[CellPaintDisplay]]
 getEditedMapRectangle _ Nothing _ = []
 getEditedMapRectangle worldEditor (Just (Cosmic subworldName coords)) w =
+  getMapRectangle toFacade getContent coords
+ where
+  getContent = getEditorContentAt worldEditor w . Cosmic subworldName
+
+getMapRectangle ::
+  (d -> e) ->
+  (W.Coords -> (TerrainType, Maybe d)) ->
+  W.BoundsRectangle ->
+  [[PCell e]]
+getMapRectangle paintTransform contentFunc coords =
   map renderRow [yTop .. yBottom]
  where
   (W.Coords (yTop, xLeft), W.Coords (yBottom, xRight)) = coords
 
-  getContent = getContentAt worldEditor w . Cosmic subworldName
-
-  drawCell :: Int32 -> Int32 -> CellPaintDisplay
-  drawCell rowIndex colIndex =
+  drawCell f rowIndex colIndex =
     Cell
       terrain
-      (toFacade <$> maybeToErasable erasableEntity)
+      (f <$> maybeToErasable erasableEntity)
       []
    where
-    (terrain, erasableEntity) = getContent $ W.Coords (rowIndex, colIndex)
+    (terrain, erasableEntity) = contentFunc $ W.Coords (rowIndex, colIndex)
 
-  renderRow rowIndex = map (drawCell rowIndex) [xLeft .. xRight]
+  renderRow rowIndex = map (drawCell paintTransform rowIndex) [xLeft .. xRight]

--- a/src/Swarm/TUI/Editor/Util.hs
+++ b/src/Swarm/TUI/Editor/Util.hs
@@ -67,12 +67,12 @@ getEditorContentAt editorOverdraw w coords =
   entityWithOverride = (Ref <$> underlyingCellEntity) <|> maybeEntityOverride
   (underlyingCellTerrain, underlyingCellEntity) = getContentAt w coords
 
-getTerrainAt ::
+getEditorTerrainAt ::
   WorldOverdraw ->
   W.MultiWorld Int Entity ->
   Cosmic W.Coords ->
   TerrainType
-getTerrainAt editor w coords =
+getEditorTerrainAt editor w coords =
   fst $ getEditorContentAt editor w coords
 
 isOutsideTopLeftCorner ::

--- a/src/Swarm/TUI/Editor/View.hs
+++ b/src/Swarm/TUI/Editor/View.hs
@@ -26,7 +26,7 @@ import Swarm.Util (listEnums)
 
 drawWorldEditor :: FocusRing Name -> UIState -> Widget Name
 drawWorldEditor toplevelFocusRing uis =
-  if worldEditor ^. isWorldEditorEnabled
+  if worldEditor ^. worldOverdraw . isWorldEditorEnabled
     then
       panel
         highlightAttr

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -90,8 +90,7 @@ module Swarm.TUI.Model (
   stdEntityMap,
   stdRecipes,
   appData,
-  stdAdjList,
-  stdNameList,
+  nameParts,
 
   -- ** Utility
   logEvent,
@@ -127,15 +126,12 @@ import Control.Effect.Throw
 import Control.Lens hiding (from, (<.>))
 import Control.Monad ((>=>))
 import Control.Monad.State (MonadState)
-import Data.Array (Array, listArray)
 import Data.List (findIndex)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
-import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Sequence (Seq)
 import Data.Text (Text)
-import Data.Text qualified as T (lines)
 import Data.Vector qualified as V
 import GitHash (GitInfo)
 import Graphics.Vty (ColorMode (..))
@@ -144,7 +140,7 @@ import Swarm.Game.CESK (TickNumber (..))
 import Swarm.Game.Entity as E
 import Swarm.Game.Failure
 import Swarm.Game.Recipe (Recipe, loadRecipes)
-import Swarm.Game.ResourceLoading (readAppData)
+import Swarm.Game.ResourceLoading (NameGenerator, initNameGenerator, readAppData)
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Status
 import Swarm.Game.ScenarioInfo (ScenarioCollection, loadScenarios, _SISingle)
@@ -159,9 +155,7 @@ import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.UI
 import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Version (NewReleaseFailure (NoMainUpstreamRelease))
-import System.FilePath ((<.>))
 import Text.Fuzzy qualified as Fuzzy
-import Witch (into)
 
 ------------------------------------------------------------
 -- Custom UI label types
@@ -204,8 +198,7 @@ data RuntimeState = RuntimeState
   , _stdEntityMap :: EntityMap
   , _stdRecipes :: [Recipe Entity]
   , _appData :: Map Text Text
-  , _stdAdjList :: Array Int Text
-  , _stdNameList :: Array Int Text
+  , _nameParts :: NameGenerator
   }
 
 initRuntimeState ::
@@ -220,15 +213,7 @@ initRuntimeState = do
   worlds <- loadWorlds entities
   scenarios <- loadScenarios entities worlds
   appDataMap <- readAppData
-
-  let getDataLines f = case M.lookup f appDataMap of
-        Nothing ->
-          throwError $
-            AssetNotLoaded (Data NameGeneration) (into @FilePath f <.> ".txt") (DoesNotExist File)
-        Just content -> return . tail . T.lines $ content
-  adjs <- getDataLines "adjectives"
-  names <- getDataLines "names"
-
+  nameGen <- initNameGenerator appDataMap
   return $
     RuntimeState
       { _webPort = Nothing
@@ -239,8 +224,7 @@ initRuntimeState = do
       , _stdEntityMap = entities
       , _stdRecipes = recipes
       , _appData = appDataMap
-      , _stdAdjList = listArray (0, length adjs - 1) adjs
-      , _stdNameList = listArray (0, length names - 1) names
+      , _nameParts = nameGen
       }
 
 makeLensesNoSigs ''RuntimeState
@@ -279,11 +263,8 @@ stdRecipes :: Lens' RuntimeState [Recipe Entity]
 --   the logo, about page, tutorial story, etc.
 appData :: Lens' RuntimeState (Map Text Text)
 
--- | List of words for use in building random robot names.
-stdAdjList :: Lens' RuntimeState (Array Int Text)
-
--- | List of words for use in building random robot names.
-stdNameList :: Lens' RuntimeState (Array Int Text)
+-- | Lists of words/adjectives for use in building random robot names.
+nameParts :: Lens' RuntimeState NameGenerator
 
 --------------------------------------------------
 -- Utility
@@ -301,8 +282,7 @@ logEvent src sev who msg el =
 mkGameStateConfig :: RuntimeState -> GameStateConfig
 mkGameStateConfig rs =
   GameStateConfig
-    { initAdjList = rs ^. stdAdjList
-    , initNameList = rs ^. stdNameList
+    { initNameParts = rs ^. nameParts
     , initEntities = rs ^. stdEntityMap
     , initRecipes = rs ^. stdRecipes
     , initWorldMap = rs ^. worlds

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -79,10 +79,13 @@ import Swarm.Game.Location
 import Swarm.Game.Recipe
 import Swarm.Game.Robot
 import Swarm.Game.Scenario (
-  scenarioAuthor, scenarioCreative,
-  scenarioDescription, scenarioKnown,
+  scenarioAuthor,
+  scenarioCreative,
+  scenarioDescription,
+  scenarioKnown,
   scenarioName,
-  scenarioObjectives, scenarioSeed,
+  scenarioObjectives,
+  scenarioSeed,
  )
 import Swarm.Game.Scenario.Scoring.Best
 import Swarm.Game.Scenario.Scoring.CodeSize
@@ -250,6 +253,7 @@ drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
    where
     defaultVC = Cosmic DefaultRootSubworld origin
 
+    -- The first robot is guaranteed to be the base.
     baseRobotLoc :: Maybe (Cosmic Location)
     baseRobotLoc = do
       theBaseRobot <- listToMaybe theRobots

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -18,7 +18,7 @@ module Swarm.TUI.View (
   drawKeyCmd,
 
   -- * World
-  drawWorld,
+  drawWorldPane,
 
   -- * Robot panel
   drawRobotPanel,
@@ -61,7 +61,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.List.Split (chunksOf)
 import Data.Map qualified as M
-import Data.Maybe (catMaybes, fromMaybe, isJust, mapMaybe, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe, maybeToList)
 import Data.Semigroup (sconcat)
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set (toList)
@@ -79,10 +79,10 @@ import Swarm.Game.Location
 import Swarm.Game.Recipe
 import Swarm.Game.Robot
 import Swarm.Game.Scenario (
-  scenarioAuthor,
-  scenarioDescription,
+  scenarioAuthor, scenarioCreative,
+  scenarioDescription, scenarioKnown,
   scenarioName,
-  scenarioObjectives,
+  scenarioObjectives, scenarioSeed,
  )
 import Swarm.Game.Scenario.Scoring.Best
 import Swarm.Game.Scenario.Scoring.CodeSize
@@ -244,9 +244,34 @@ drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
   drawDescription (SISingle (s, si)) =
     vBox
       [ drawMarkdown (nonBlank (s ^. scenarioDescription))
+      , hCenter . padTop (Pad 1) . vLimit 6 $ hLimitPercent 60 worldPeek
       , padTop (Pad 1) table
       ]
    where
+    defaultVC = Cosmic DefaultRootSubworld origin
+
+    baseRobotLoc :: Maybe (Cosmic Location)
+    baseRobotLoc = do
+      theBaseRobot <- listToMaybe theRobots
+      view trobotLocation theBaseRobot
+
+    vc = fromMaybe defaultVC baseRobotLoc
+
+    worldTuples = buildWorldTuples s
+    theWorlds = genMultiWorld worldTuples $ fromMaybe 0 $ s ^. scenarioSeed
+    theRobots = genRobotTemplates s worldTuples
+
+    ri =
+      RenderingInput theWorlds $
+        getEntityIsKnown $
+          EntityKnowledgeDependencies
+            { isCreativeMode = s ^. scenarioCreative
+            , globallyKnownEntities = s ^. scenarioKnown
+            , theFocusedRobot = Nothing
+            }
+    renderCoord = renderDisplay . displayLocRaw (WorldOverdraw False mempty) ri []
+    worldPeek = worldWidget renderCoord vc
+
     firstRow =
       ( withAttr dimAttr $ txt "Author:"
       , withAttr dimAttr . txt <$> s ^. scenarioAuthor
@@ -426,7 +451,7 @@ drawGameUI s =
    where
     widg = case s ^. uiState . uiWorldCursor of
       Nothing -> str $ renderCoordsString $ s ^. gameState . viewCenter
-      Just coord -> clickable WorldPositionIndicator $ drawWorldCursorInfo (s ^. uiState . uiWorldEditor) (s ^. gameState) coord
+      Just coord -> clickable WorldPositionIndicator $ drawWorldCursorInfo (s ^. uiState . uiWorldEditor . worldOverdraw) (s ^. gameState) coord
   -- Add clock display in top right of the world view if focused robot
   -- has a clock equipped
   addClock = topLabels . rightLabel ?~ padLeftRight 1 (drawClockDisplay (s ^. uiState . lgTicksPerSecond) $ s ^. gameState)
@@ -447,7 +472,7 @@ drawGameUI s =
             & addCursorPos
             & addClock
         )
-        (drawWorld (s ^. uiState) (s ^. gameState))
+        (drawWorldPane (s ^. uiState) (s ^. gameState))
     , drawKeyMenu s
     ]
   replPanel =
@@ -474,7 +499,7 @@ renderCoordsString (Cosmic sw coords) =
     DefaultRootSubworld -> []
     SubworldName swName -> ["in", T.unpack swName]
 
-drawWorldCursorInfo :: WorldEditor Name -> GameState -> Cosmic W.Coords -> Widget Name
+drawWorldCursorInfo :: WorldOverdraw -> GameState -> Cosmic W.Coords -> Widget Name
 drawWorldCursorInfo worldEditor g cCoords =
   case getStatic g coords of
     Just s -> renderDisplay $ displayStatic s
@@ -493,8 +518,9 @@ drawWorldCursorInfo worldEditor g cCoords =
    where
     f cell preposition = [renderDisplay cell, txt preposition]
 
-  terrain = displayTerrainCell worldEditor g cCoords
-  entity = displayEntityCell worldEditor g cCoords
+  ri = RenderingInput (g ^. landscape . multiWorld) (getEntityIsKnown $ mkEntityKnowledge g)
+  terrain = displayTerrainCell worldEditor ri cCoords
+  entity = displayEntityCell worldEditor ri cCoords
   robot = displayRobotCell g cCoords
 
   merge = fmap sconcat . NE.nonEmpty . filter (not . (^. invisible))
@@ -1034,7 +1060,7 @@ data KeyHighlight = NoHighlight | Alert | PanelSpecific
 drawKeyCmd :: (KeyHighlight, Text, Text) -> Widget Name
 drawKeyCmd (h, key, cmd) =
   hBox
-    [ withAttr attr (txt $ T.concat ["[", key, "] "])
+    [ withAttr attr (txt $ brackets key)
     , txt cmd
     ]
  where
@@ -1047,22 +1073,31 @@ drawKeyCmd (h, key, cmd) =
 -- World panel
 ------------------------------------------------------------
 
+worldWidget ::
+  (Cosmic W.Coords -> Widget n) ->
+  -- | view center
+  Cosmic Location ->
+  Widget n
+worldWidget renderCoord gameViewCenter = Widget Fixed Fixed $
+  do
+    ctx <- getContext
+    let w = ctx ^. availWidthL
+        h = ctx ^. availHeightL
+        vr = viewingRegion gameViewCenter (fromIntegral w, fromIntegral h)
+        ixs = range $ vr ^. planar
+    render . vBox . map hBox . chunksOf w . map (renderCoord . Cosmic (vr ^. subworld)) $ ixs
+
 -- | Draw the current world view.
-drawWorld :: UIState -> GameState -> Widget Name
-drawWorld ui g =
+drawWorldPane :: UIState -> GameState -> Widget Name
+drawWorldPane ui g =
   center
     . cached WorldCache
     . reportExtent WorldExtent
     -- Set the clickable request after the extent to play nice with the cache
     . clickable (FocusablePanel WorldPanel)
-    . Widget Fixed Fixed
-    $ do
-      ctx <- getContext
-      let w = ctx ^. availWidthL
-          h = ctx ^. availHeightL
-          vr = viewingRegion g (fromIntegral w, fromIntegral h)
-          ixs = range $ vr ^. planar
-      render . vBox . map hBox . chunksOf w . map (drawLoc ui g . Cosmic (vr ^. subworld)) $ ixs
+    $ worldWidget renderCoord (g ^. viewCenter)
+ where
+  renderCoord = drawLoc ui g
 
 ------------------------------------------------------------
 -- Robot inventory panel

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -41,7 +41,6 @@ import Swarm.TUI.Editor.Util qualified as EU
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.UI
 import Swarm.TUI.View.Attribute.Attr
-import Swarm.Util (isAny)
 import Witch (from)
 import Witch.Encoding qualified as Encoding
 
@@ -71,7 +70,7 @@ displayTerrainCell ::
   Cosmic W.Coords ->
   Display
 displayTerrainCell worldEditor ri coords =
-  terrainMap M.! EU.getTerrainAt worldEditor (multiworldFoo ri) coords
+  terrainMap M.! EU.getEditorTerrainAt worldEditor (multiworldFoo ri) coords
 
 displayRobotCell ::
   GameState ->
@@ -98,7 +97,7 @@ data EntityKnowledgeDependencies = EntityKnowledgeDependencies
 getEntityIsKnown :: EntityKnowledgeDependencies -> EntityPaint -> Bool
 getEntityIsKnown knowledge ep = case ep of
   Facade (EntityFacade _ _) -> True
-  Ref e -> isAny reasonsToShow
+  Ref e -> or reasonsToShow
    where
     reasonsToShow =
       [ isCreativeMode knowledge

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -60,7 +60,7 @@ drawLoc ui g cCoords@(Cosmic _ coords) =
   drawCell = renderDisplay $ displayLoc showRobots we g cCoords
 
 data RenderingInput = RenderingInput
-  { multiworldFoo :: W.MultiWorld Int Entity
+  { multiworldInfo :: W.MultiWorld Int Entity
   , isKnownFunc :: EntityPaint -> Bool
   }
 
@@ -70,7 +70,7 @@ displayTerrainCell ::
   Cosmic W.Coords ->
   Display
 displayTerrainCell worldEditor ri coords =
-  terrainMap M.! EU.getEditorTerrainAt worldEditor (multiworldFoo ri) coords
+  terrainMap M.! EU.getEditorTerrainAt worldEditor (multiworldInfo ri) coords
 
 displayRobotCell ::
   GameState ->
@@ -115,7 +115,7 @@ displayEntityCell ::
 displayEntityCell worldEditor ri coords =
   maybeToList $ displayForEntity <$> maybeEntity
  where
-  (_, maybeEntity) = EU.getEditorContentAt worldEditor (multiworldFoo ri) coords
+  (_, maybeEntity) = EU.getEditorContentAt worldEditor (multiworldInfo ri) coords
 
   displayForEntity :: EntityPaint -> Display
   displayForEntity e = (if isKnownFunc ri e then id else hidden) $ getDisplay e

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -59,6 +59,7 @@ drawLoc ui g cCoords@(Cosmic _ coords) =
   we = ui ^. uiWorldEditor . worldOverdraw
   drawCell = renderDisplay $ displayLoc showRobots we g cCoords
 
+-- | Subset of the game state needed to render the world
 data RenderingInput = RenderingInput
   { multiworldInfo :: W.MultiWorld Int Entity
   , isKnownFunc :: EntityPaint -> Bool
@@ -80,6 +81,8 @@ displayRobotCell g coords =
   map (view robotDisplay) $
     robotsAtLocation (fmap W.coordsToLoc coords) g
 
+-- | Extract the relevant subset of information from the 'GameState' to be able
+-- to compute whether an entity is "known".
 mkEntityKnowledge :: GameState -> EntityKnowledgeDependencies
 mkEntityKnowledge gs =
   EntityKnowledgeDependencies
@@ -88,12 +91,17 @@ mkEntityKnowledge gs =
     , theFocusedRobot = focusedRobot gs
     }
 
+-- | The subset of information required to compute whether
+-- an entity is "known", and therefore should be rendered
+-- normally vs as a question mark.
 data EntityKnowledgeDependencies = EntityKnowledgeDependencies
   { isCreativeMode :: Bool
   , globallyKnownEntities :: [Text]
   , theFocusedRobot :: Maybe Robot
   }
 
+-- | Determines whether an entity should be rendered
+-- normally vs as a question mark.
 getEntityIsKnown :: EntityKnowledgeDependencies -> EntityPaint -> Bool
 getEntityIsKnown knowledge ep = case ep of
   Facade (EntityFacade _ _) -> True

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -15,10 +15,19 @@ import Data.Map qualified as M
 import Data.Maybe (maybeToList)
 import Data.Semigroup (sconcat)
 import Data.Tagged (unTagged)
+import Data.Text (Text)
 import Data.Word (Word32)
 import Linear.Affine ((.-.))
 import Swarm.Game.CESK (TickNumber (..))
-import Swarm.Game.Display
+import Swarm.Game.Display (
+  Attribute (AEntity),
+  Display,
+  defaultEntityDisplay,
+  displayAttr,
+  displayChar,
+  displayPriority,
+  hidden,
+ )
 import Swarm.Game.Entity
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Topography.EntityFacade
@@ -32,6 +41,7 @@ import Swarm.TUI.Editor.Util qualified as EU
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.UI
 import Swarm.TUI.View.Attribute.Attr
+import Swarm.Util (isAny)
 import Witch (from)
 import Witch.Encoding qualified as Encoding
 
@@ -47,16 +57,21 @@ drawLoc ui g cCoords@(Cosmic _ coords) =
     else drawCell
  where
   showRobots = ui ^. uiShowRobots
-  we = ui ^. uiWorldEditor
+  we = ui ^. uiWorldEditor . worldOverdraw
   drawCell = renderDisplay $ displayLoc showRobots we g cCoords
 
+data RenderingInput = RenderingInput
+  { multiworldFoo :: W.MultiWorld Int Entity
+  , isKnownFunc :: EntityPaint -> Bool
+  }
+
 displayTerrainCell ::
-  WorldEditor Name ->
-  GameState ->
+  WorldOverdraw ->
+  RenderingInput ->
   Cosmic W.Coords ->
   Display
-displayTerrainCell worldEditor g coords =
-  terrainMap M.! EU.getTerrainAt worldEditor (g ^. landscape . multiWorld) coords
+displayTerrainCell worldEditor ri coords =
+  terrainMap M.! EU.getTerrainAt worldEditor (multiworldFoo ri) coords
 
 displayRobotCell ::
   GameState ->
@@ -66,58 +81,75 @@ displayRobotCell g coords =
   map (view robotDisplay) $
     robotsAtLocation (fmap W.coordsToLoc coords) g
 
-displayEntityCell :: WorldEditor Name -> GameState -> Cosmic W.Coords -> [Display]
-displayEntityCell worldEditor g coords =
+mkEntityKnowledge :: GameState -> EntityKnowledgeDependencies
+mkEntityKnowledge gs =
+  EntityKnowledgeDependencies
+    { isCreativeMode = gs ^. creativeMode
+    , globallyKnownEntities = gs ^. discovery . knownEntities
+    , theFocusedRobot = focusedRobot gs
+    }
+
+data EntityKnowledgeDependencies = EntityKnowledgeDependencies
+  { isCreativeMode :: Bool
+  , globallyKnownEntities :: [Text]
+  , theFocusedRobot :: Maybe Robot
+  }
+
+getEntityIsKnown :: EntityKnowledgeDependencies -> EntityPaint -> Bool
+getEntityIsKnown knowledge ep = case ep of
+  Facade (EntityFacade _ _) -> True
+  Ref e -> isAny reasonsToShow
+   where
+    reasonsToShow =
+      [ isCreativeMode knowledge
+      , e `hasProperty` Known
+      , (e ^. entityName) `elem` globallyKnownEntities knowledge
+      , showBasedOnRobotKnowledge
+      ]
+    showBasedOnRobotKnowledge = maybe False (`robotKnows` e) $ theFocusedRobot knowledge
+
+displayEntityCell ::
+  WorldOverdraw ->
+  RenderingInput ->
+  Cosmic W.Coords ->
+  [Display]
+displayEntityCell worldEditor ri coords =
   maybeToList $ displayForEntity <$> maybeEntity
  where
-  (_, maybeEntity) = EU.getContentAt worldEditor (g ^. landscape . multiWorld) coords
+  (_, maybeEntity) = EU.getEditorContentAt worldEditor (multiworldFoo ri) coords
 
   displayForEntity :: EntityPaint -> Display
-  displayForEntity e = (if known e then id else hidden) $ getDisplay e
-
-  known (Facade (EntityFacade _ _)) = True
-  known (Ref e) =
-    e
-      `hasProperty` Known
-      || (e ^. entityName)
-        `elem` (g ^. discovery . knownEntities)
-      || case hidingMode g of
-        HideAllEntities -> False
-        HideNoEntity -> True
-        HideEntityUnknownTo ro -> ro `robotKnows` e
-
-data HideEntity = HideAllEntities | HideNoEntity | HideEntityUnknownTo Robot
-
-hidingMode :: GameState -> HideEntity
-hidingMode g
-  | g ^. creativeMode = HideNoEntity
-  | otherwise = maybe HideAllEntities HideEntityUnknownTo $ focusedRobot g
+  displayForEntity e = (if isKnownFunc ri e then id else hidden) $ getDisplay e
 
 -- | Get the 'Display' for a specific location, by combining the
 --   'Display's for the terrain, entity, and robots at the location, and
 --   taking into account "static" based on the distance to the robot
 --   being @view@ed.
-displayLoc :: Bool -> WorldEditor Name -> GameState -> Cosmic W.Coords -> Display
+displayLoc :: Bool -> WorldOverdraw -> GameState -> Cosmic W.Coords -> Display
 displayLoc showRobots we g cCoords@(Cosmic _ coords) =
   staticDisplay g coords
-    <> displayLocRaw showRobots we g cCoords
+    <> displayLocRaw we ri robots cCoords
+ where
+  ri = RenderingInput (g ^. landscape . multiWorld) (getEntityIsKnown $ mkEntityKnowledge g)
+  robots =
+    if showRobots
+      then displayRobotCell g cCoords
+      else []
 
 -- | Get the 'Display' for a specific location, by combining the
 --   'Display's for the terrain, entity, and robots at the location.
 displayLocRaw ::
-  Bool ->
-  WorldEditor Name ->
-  GameState ->
+  WorldOverdraw ->
+  RenderingInput ->
+  -- | Robot displays
+  [Display] ->
   Cosmic W.Coords ->
   Display
-displayLocRaw showRobots worldEditor g coords = sconcat $ terrain NE.:| entity <> robots
+displayLocRaw worldEditor ri robotDisplays coords =
+  sconcat $ terrain NE.:| entity <> robotDisplays
  where
-  terrain = displayTerrainCell worldEditor g coords
-  entity = displayEntityCell worldEditor g coords
-  robots =
-    if showRobots
-      then displayRobotCell g coords
-      else []
+  terrain = displayTerrainCell worldEditor ri coords
+  entity = displayEntityCell worldEditor ri coords
 
 -- | Random "static" based on the distance to the robot being
 --   @view@ed.

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -13,7 +13,6 @@ module Swarm.Util (
   sortPair,
   maxOn,
   maximum0,
-  isAny,
   cycleEnum,
   listEnums,
   showEnum,
@@ -89,7 +88,6 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
-import Data.Monoid (Any (..))
 import Data.Ord (comparing)
 import Data.Set (Set)
 import Data.Set qualified as S
@@ -134,9 +132,6 @@ maxOn f x y
 maximum0 :: (Num a, Ord a) => [a] -> a
 maximum0 [] = 0
 maximum0 xs = maximum xs
-
-isAny :: [Bool] -> Bool
-isAny = getAny . mconcat . map Any
 
 -- | Take the successor of an 'Enum' type, wrapping around when it
 --   reaches the end.

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -13,6 +13,7 @@ module Swarm.Util (
   sortPair,
   maxOn,
   maximum0,
+  isAny,
   cycleEnum,
   listEnums,
   showEnum,
@@ -88,6 +89,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
+import Data.Monoid (Any (..))
 import Data.Ord (comparing)
 import Data.Set (Set)
 import Data.Set qualified as S
@@ -132,6 +134,9 @@ maxOn f x y
 maximum0 :: (Num a, Ord a) => [a] -> a
 maximum0 [] = 0
 maximum0 xs = maximum xs
+
+isAny :: [Bool] -> Bool
+isAny = getAny . mconcat . map Any
 
 -- | Take the successor of an 'Enum' type, wrapping around when it
 --   reaches the end.

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -159,6 +159,7 @@ library
                       Swarm.Game.World.Interpret
                       Swarm.Game.World.Load
                       Swarm.Game.World.Parse
+                      Swarm.Game.World.Render
                       Swarm.Game.World.Syntax
                       Swarm.Game.World.Typecheck
                       Swarm.Language.Capability


### PR DESCRIPTION
Closes #353

Also adds a new top-level command to render a scenario map to the console.

Most of the work for this feature entailed identifying the subset of `GameState` that is actually needed for rendering the world, so that the required information can be retrieved from just the `Scenario` rather than having to instantiate an entire `GameState`.

# Potential follow-ups

- [ ] There is some noticeable lag when using the up/down arrow to navigate to any of the largely "procedurally generated" scenarios, e.g. `classic` or `creative`.  May want to do caching of some kind.  The other "challenge scenarios" render without perceptible delay.
- [ ] The heuristic for choosing the view center could be improved, possibly by defining new "hints" as part of the scenario schema.
- [ ] Rendering to the console could be augmented with color.
- [ ] Could render to other image formats like PNG or SVG
- [ ] account for a user-selected seed in the scenario launch parameters dialog

# Demos
## Scenario selection preview
![image](https://github.com/swarm-game/swarm/assets/261693/7c54c6bb-fb02-461f-98a1-06eccbbfc450)

## Command-line map rendering
```
~/github/swarm$ scripts/play.sh map data/scenarios/Challenges/ice-cream.yaml
              
              
              
              
           OO 
▒▒▒ ▒▒▒▒  OOOO
┌─┐▒┌──┐  MMMM
│B   V6│  \ZZ/
└──────┘   \/ 
```

and
```
stack run -- map data/scenarios/Challenges/hackman.yaml
▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
▒••••••••••▒••••••••••▒
▒o▒▒▒•▒▒▒▒•▒•▒▒▒▒•▒▒▒o▒
▒•▒▒▒•▒▒▒▒•▒•▒▒▒▒•▒▒▒•▒
▒•••••••••••••••••••••▒
▒•▒▒▒•▒•▒▒▒▒▒▒▒•▒•▒▒▒•▒
▒•••••▒••••▒••••▒•••••▒
▒▒▒▒▒•▒▒▒▒ ▒ ▒▒▒▒•▒▒▒▒▒
    ▒•▒         ▒•▒    
▒▒▒▒▒•▒ ┌──=──┐ ▒•▒▒▒▒▒
     •  │     │  •     
▒▒▒▒▒•▒ └─────┘ ▒•▒▒▒▒▒
    ▒•▒         ▒•▒    
▒▒▒▒▒•▒ ▒▒▒▒▒▒▒ ▒•▒▒▒▒▒
▒••••••••••▒••••••••••▒
▒•▒▒▒•▒▒▒▒•▒•▒▒▒▒•▒▒▒•▒
▒o••▒•••••••••••••▒••o▒
▒▒▒•▒•▒•▒▒▒▒▒▒▒•▒•▒•▒▒▒
▒•••••▒••••▒••••▒•••••▒
▒•▒▒▒▒▒▒▒▒•▒•▒▒▒▒▒▒▒▒•▒
▒•••••••••••••••••••••▒
▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒

```
