### PR TITLE
Add syntax highlighting and LSP configuration for Vim/Neovim

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -34,5 +34,20 @@ To configure YAML editor tabs for schema validation, install the [YAML plugin](h
 
 ## Vim and Neovim
 
-Currently there is neither highlighting nor LSP support for Vim,
-but we would be happy to [accept a contribution](../CONTRIBUTING.md).
+Add the following lines to your Vim/Neovim configuration file for files with the `.sw` extension to be recognized as `swarm` programs:
+
+
+`init.vim`:
+
+`au BufRead,BufNewFile *.sw setfiletype swarm`
+
+
+`init.lua`:
+
+`vim.cmd[[au BufRead,BufNewFile *.sw setfiletype swarm]]`
+
+
+Basic syntax highlighting is available for both Vim and Neovim. To make use of this capability, copy [swarm.vim](vim/swarm.vim) to the `syntax` directory in your Vim or Neovim configuration directory.
+
+
+An LSP configuration leveraging Neovim's native LSP client is also available. It only works with Neovim. To enable it, copy [swarm.lua](vim/swarm.lua) to `after/ftplugin` in your Neovim configuration directory.

--- a/editors/vim/swarm.lua
+++ b/editors/vim/swarm.lua
@@ -1,0 +1,8 @@
+if vim.fn.executable('swarm') == 1 then
+    vim.lsp.start({
+        name = 'Swarm Language Server',
+        cmd = { 'swarm', 'lsp' },
+    })
+end
+
+

--- a/editors/vim/swarm.vim
+++ b/editors/vim/swarm.vim
@@ -1,6 +1,7 @@
 syn keyword Keyword def end let in require
 syn keyword Builtins self parent base if inl inr case fst snd force undefined fail not format chars split charat tochar key
-syn keyword Command noop wait selfdestruct move backup push stride turn grab harvest ignite place give equip unequip make has equipped count drill use build salvage reporgram say listen log view appear create halt time scout whereami waypoint detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows east north west south down forward left back right.
+syn keyword Command noop wait selfdestruct move backup push stride turn grab harvest ignite place give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami waypoint detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows
+syn keyword Direction east north west south down forward left back right
 syn keyword Type int text dir bool cmd void unit actor
 
 
@@ -14,6 +15,7 @@ syn match Number "\<[-]\=\d\+\>"
 hi def link Keyword Statement
 hi def link Builtins Keyword
 hi def link Command Function
+hi def link Direction Function
 hi def link Comment Comment
 hi def link MultilineComment Comment
 hi def link Brackets Keyword

--- a/editors/vim/swarm.vim
+++ b/editors/vim/swarm.vim
@@ -1,0 +1,22 @@
+syn keyword Keyword def end let in require
+syn keyword Builtins self parent base if inl inr case fst snd force undefined fail not format chars split charat tochar key
+syn keyword Command noop wait selfdestruct move backup push stride turn grab harvest ignite place give equip unequip make has equipped count drill use build salvage reporgram say listen log view appear create halt time scout whereami waypoint detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows east north west south down forward left back right.
+syn keyword Type int text dir bool cmd void unit actor
+
+
+syn match Comment "//.*$"
+syn region MultilineComment start="/\*" end="\*/"
+syn match Brackets "[\[\]\(\)\{\}]"
+syn match Colon ":"
+syn match String "\".*\""
+syn match Number "\<[-]\=\d\+\>"
+
+hi def link Keyword Statement
+hi def link Builtins Keyword
+hi def link Command Function
+hi def link Comment Comment
+hi def link MultilineComment Comment
+hi def link Brackets Keyword
+hi def link Colon Keyword
+hi def link String String 
+hi def link Number Number

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -89,7 +89,7 @@ data GenerateDocs where
 
 -- | An enumeration of the editors supported by Swarm (currently,
 --   Emacs and VS Code).
-data EditorType = Emacs | VSCode
+data EditorType = Emacs | VSCode | Vim
   deriving (Eq, Show, Enum, Bounded)
 
 -- | An enumeration of the kinds of cheat sheets we can produce.
@@ -160,6 +160,13 @@ generateEditorKeywords = \case
     T.putStrLn $ keywordsDirections VSCode
     putStrLn "\nOperators:"
     T.putStrLn operatorNames
+  Vim -> do
+    putStr "syn keyword Builtins "
+    T.putStr $ builtinFunctionList Vim
+    putStr "\nsyn keyword Command "
+    T.putStr $ keywordsCommands Vim
+    putStr "\nsyn keyword Direction "
+    T.putStrLn $ keywordsDirections Vim
 
 commands :: [Const]
 commands = filter Syntax.isCmd Syntax.allConst
@@ -177,6 +184,7 @@ editorList :: EditorType -> [Text] -> Text
 editorList = \case
   Emacs -> T.unlines . map (("  " <>) . quote)
   VSCode -> T.intercalate "|"
+  Vim -> T.intercalate " "
 
 constSyntax :: Const -> Text
 constSyntax = Syntax.syntax . Syntax.constInfo

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -38,6 +38,7 @@ extra-source-files: CHANGELOG.md
                     editors/emacs/*.el
                     editors/vscode/syntaxes/*.json
                     editors/vim/*.vim
+                    editors/vim/*.lua
 data-dir:           data/
 data-files:         *.yaml, worlds/*.world, scenarios/**/*.yaml, scenarios/**/*.txt, scenarios/**/*.sw, *.txt, test/language-snippets/**/*.sw
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -37,6 +37,7 @@ extra-source-files: CHANGELOG.md
                     example/*.sw
                     editors/emacs/*.el
                     editors/vscode/syntaxes/*.json
+                    editors/vim/*.vim
 data-dir:           data/
 data-files:         *.yaml, worlds/*.world, scenarios/**/*.yaml, scenarios/**/*.txt, scenarios/**/*.sw, *.txt, test/language-snippets/**/*.sw
 

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -441,10 +441,17 @@ testEditorFiles =
         , testTextInEmacs "commands" DocGen.keywordsCommands
         , testTextInEmacs "directions" DocGen.keywordsDirections
         ]
+    , testGroup
+        "Vim"
+        [ testTextInVim "builtin" DocGen.builtinFunctionList
+        , testTextInVim "commands" DocGen.keywordsCommands
+        , testTextInVim "directions" DocGen.keywordsDirections
+        ]
     ]
  where
   testTextInVSCode name tf = testTextInFile False name (tf VSCode) "editors/vscode/syntaxes/swarm.tmLanguage.json"
   testTextInEmacs name tf = testTextInFile True name (tf Emacs) "editors/emacs/swarm-mode.el"
+  testTextInVim name tf = testTextInFile True name (tf Vim) "editors/vim/swarm.vim"
   testTextInFile :: Bool -> String -> Text -> FilePath -> TestTree
   testTextInFile whitespace name t fp = testCase name $ do
     let removeLW' = T.unlines . map (T.dropWhile isSpace) . T.lines


### PR DESCRIPTION
This adds two files. The first is the syntax file responsible for basic highlighting. The highlight categories are based roughly on those seen in the Emacs file ([swarm-mode.el](https://github.com/swarm-game/swarm/blob/main/editors/emacs/swarm-mode.el)). The second is the file for configuring the language server. Since it is based on Neovim's native LSP client, it only works with Neovim and not Vim.

`README.md` in the `editor` folder has also been updated to include instructions for setting these up.
