### PR TITLE
Web API docs improvements

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -87,6 +87,7 @@ cliParser =
       , command "keys" (info (pure SpecialKeyNames) $ progDesc "Output list of recognized special key names")
       , command "cheatsheet" (info (CheatSheet <$> address <*> cheatsheet <**> helper) $ progDesc "Output nice Wiki tables")
       , command "pedagogy" (info (pure TutorialCoverage) $ progDesc "Output tutorial coverage")
+      , command "endpoints" (info (pure WebAPIEndpoints) $ progDesc "Generate markdown Web API documentation.")
       ]
 
   editor :: Parser (Maybe EditorType)

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -61,9 +61,9 @@ import Swarm.Language.Text.Markdown as Markdown (docToMark)
 import Swarm.Language.Typecheck (inferConst)
 import Swarm.Util (both, listEnums, quote)
 import Swarm.Util.Effect (simpleErrorHandle)
+import Swarm.Web (swarmApiMarkdown)
 import Text.Dot (Dot, NodeId, (.->.))
 import Text.Dot qualified as Dot
-import Swarm.Web (swarmApiMarkdown)
 
 -- ============================================================================
 -- MAIN ENTRYPOINT TO CLI DOCUMENTATION GENERATOR

--- a/src/Swarm/Doc/Gen.hs
+++ b/src/Swarm/Doc/Gen.hs
@@ -63,6 +63,7 @@ import Swarm.Util (both, listEnums, quote)
 import Swarm.Util.Effect (simpleErrorHandle)
 import Text.Dot (Dot, NodeId, (.->.))
 import Text.Dot qualified as Dot
+import Swarm.Web (swarmApiMarkdown)
 
 -- ============================================================================
 -- MAIN ENTRYPOINT TO CLI DOCUMENTATION GENERATOR
@@ -84,6 +85,8 @@ data GenerateDocs where
   CheatSheet :: PageAddress -> Maybe SheetType -> GenerateDocs
   -- | List command introductions by tutorial
   TutorialCoverage :: GenerateDocs
+  -- | Web API endpoints
+  WebAPIEndpoints :: GenerateDocs
   deriving (Eq, Show)
 
 -- | An enumeration of the editors supported by Swarm (currently,
@@ -136,6 +139,7 @@ generateDocs = \case
         recipes <- loadRecipes entities
         sendIO $ T.putStrLn $ recipePage address recipes
   TutorialCoverage -> renderTutorialProgression >>= putStrLn . T.unpack
+  WebAPIEndpoints -> putStrLn swarmApiMarkdown
 
 -- ----------------------------------------------------------------------------
 -- GENERATE KEYWORDS: LIST OF WORDS TO BE HIGHLIGHTED

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -112,6 +112,7 @@ import Swarm.Util.Lens (makeLensesExcluding, makeLensesNoSigs)
 import Swarm.Util.WindowedCounter
 import Swarm.Util.Yaml
 import System.Clock (TimeSpec)
+import Swarm.Language.Pipeline.QQ (tmQ)
 
 -- | A record that stores the information
 --   for all definitions stored in a 'Robot'
@@ -294,7 +295,24 @@ type TRobot = RobotR 'TemplateRobot
 type Robot = RobotR 'ConcreteRobot
 
 instance ToSample Robot where
-  toSamples _ = SD.noSamples
+  toSamples _ = SD.singleSample sampleBase
+    where
+      sampleBase :: Robot
+      sampleBase =
+        mkRobot
+          0
+          Nothing
+          "base"
+          "The starting robot."
+          defaultCosmicLocation
+          zero
+          defaultRobotDisplay
+          (initMachine [tmQ| move |] mempty emptyStore)
+          []
+          []
+          False
+          False
+          0
 
 -- In theory we could make all these lenses over (RobotR phase), but
 -- that leads to lots of type ambiguity problems later.  In practice

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -97,7 +97,6 @@ import Servant.Docs qualified as SD
 import Swarm.Game.CESK
 import Swarm.Game.Display (Display, curOrientation, defaultRobotDisplay, invisible)
 import Swarm.Game.Entity hiding (empty)
-import Swarm.Game.Entity qualified as Inventory (empty)
 import Swarm.Game.Location (Heading, Location, toDirection)
 import Swarm.Game.Universe
 import Swarm.Language.Capability (Capability)

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -322,6 +322,7 @@ instance ToSample Robot where
         []
         False
         False
+        mempty
         0
 
 -- In theory we could make all these lenses over (RobotR phase), but

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -607,8 +607,8 @@ instance Ae.ToJSON Robot where
     , "dir" .=? (r ^. robotEntity . entityOrientation) $ zero
     , "display" .=? (r ^. robotDisplay) $ (defaultRobotDisplay & invisible .~ sys)
     , "program" .== (r ^. machine)
-    , "devices" .=? (r ^. equippedDevices) $ Inventory.empty
-    , "inventory" .=? (r ^. robotInventory) $ Inventory.empty
+    , "devices" .=? (map (^. _2 . entityName) . elems $ r ^. equippedDevices) $ []
+    , "inventory" .=? (map (_2 %~ view entityName) . elems $ r ^. robotInventory) $ []
     , "system" .=? sys $ False
     , "heavy" .=? (r ^. robotHeavy) $ False
     , "log" .=? (r ^. robotLog) $ mempty

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -290,7 +290,10 @@ data WinCondition
 makePrisms ''WinCondition
 
 instance ToSample WinCondition where
-  toSamples _ = SD.noSamples
+  toSamples _ = SD.samples
+    [ NoWinCondition
+    -- TODO: add simple objective sample
+    ]
 
 -- | A data type to keep track of the pause mode.
 data RunStatus

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -293,7 +293,7 @@ instance ToSample WinCondition where
   toSamples _ =
     SD.samples
       [ NoWinCondition
-      -- TODO: add simple objective sample
+      -- TODO: #1552 add simple objective sample
       ]
 
 -- | A data type to keep track of the pause mode.

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -290,10 +290,11 @@ data WinCondition
 makePrisms ''WinCondition
 
 instance ToSample WinCondition where
-  toSamples _ = SD.samples
-    [ NoWinCondition
-    -- TODO: add simple objective sample
-    ]
+  toSamples _ =
+    SD.samples
+      [ NoWinCondition
+      -- TODO: add simple objective sample
+      ]
 
 -- | A data type to keep track of the pause mode.
 data RunStatus

--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -52,6 +52,10 @@ docToText = RT.renderStrict . layoutPretty defaultLayoutOptions
 prettyText :: (PrettyPrec a) => a -> Text
 prettyText = docToText . ppr
 
+-- | Pretty-print something and render it as (preferably) one line @Text@.
+prettyTextLine :: (PrettyPrec a) => a -> Text
+prettyTextLine = RT.renderStrict . layoutPretty (LayoutOptions Unbounded) . group . ppr
+
 -- | Render a pretty-printed document as a @String@.
 docToString :: Doc a -> String
 docToString = RS.renderString . layoutPretty defaultLayoutOptions

--- a/src/Swarm/Language/Text/Markdown.hs
+++ b/src/Swarm/Language/Text/Markdown.hs
@@ -52,11 +52,9 @@ import Data.Tuple.Extra (both, first)
 import Data.Vector (toList)
 import Data.Yaml
 import GHC.Exts qualified (IsList (..), IsString (..))
-import Prettyprinter (LayoutOptions (..), PageWidth (..), group, layoutPretty)
-import Prettyprinter.Render.Text qualified as RT
 import Swarm.Language.Parse (readTerm)
 import Swarm.Language.Pipeline (processParsedTerm)
-import Swarm.Language.Pretty (PrettyPrec (..), ppr, prettyText, prettyTypeErrText)
+import Swarm.Language.Pretty (PrettyPrec (..), prettyText, prettyTypeErrText, prettyTextLine)
 import Swarm.Language.Syntax (Syntax)
 
 -- | The top-level markdown document.
@@ -312,11 +310,9 @@ class ToStream a where
 instance PrettyPrec a => ToStream (Node a) where
   toStream = \case
     LeafText a t -> [TextNode a t]
-    LeafCode t -> [CodeNode (pprOneLine t)]
+    LeafCode t -> [CodeNode (prettyTextLine t)]
     LeafRaw s t -> [RawNode s t]
     LeafCodeBlock _i t -> [CodeNode (prettyText t)]
-   where
-    pprOneLine = RT.renderStrict . layoutPretty (LayoutOptions Unbounded) . group . ppr
 
 instance PrettyPrec a => ToStream (Paragraph a) where
   toStream = concatMap toStream . nodes

--- a/src/Swarm/Language/Text/Markdown.hs
+++ b/src/Swarm/Language/Text/Markdown.hs
@@ -54,7 +54,7 @@ import Data.Yaml
 import GHC.Exts qualified (IsList (..), IsString (..))
 import Swarm.Language.Parse (readTerm)
 import Swarm.Language.Pipeline (processParsedTerm)
-import Swarm.Language.Pretty (PrettyPrec (..), prettyText, prettyTypeErrText, prettyTextLine)
+import Swarm.Language.Pretty (PrettyPrec (..), prettyText, prettyTextLine, prettyTypeErrText)
 import Swarm.Language.Syntax (Syntax)
 
 -- | The top-level markdown document.

--- a/src/Swarm/TUI/Model/Goal.hs
+++ b/src/Swarm/TUI/Model/Goal.hs
@@ -72,7 +72,7 @@ instance ToSample GoalTracking where
   toSamples _ =
     SD.samples
       [ GoalTracking mempty mempty
-      -- TODO: add simple objective sample
+      -- TODO: #1552 add simple objective sample
       ]
 
 data GoalDisplay = GoalDisplay

--- a/src/Swarm/TUI/Model/Goal.hs
+++ b/src/Swarm/TUI/Model/Goal.hs
@@ -69,10 +69,11 @@ data GoalTracking = GoalTracking
   deriving (Generic, ToJSON)
 
 instance ToSample GoalTracking where
-  toSamples _ = SD.samples
-    [ GoalTracking mempty mempty
-    -- TODO: add simple objective sample
-    ]
+  toSamples _ =
+    SD.samples
+      [ GoalTracking mempty mempty
+      -- TODO: add simple objective sample
+      ]
 
 data GoalDisplay = GoalDisplay
   { _goalsContent :: GoalTracking

--- a/src/Swarm/TUI/Model/Goal.hs
+++ b/src/Swarm/TUI/Model/Goal.hs
@@ -69,7 +69,10 @@ data GoalTracking = GoalTracking
   deriving (Generic, ToJSON)
 
 instance ToSample GoalTracking where
-  toSamples _ = SD.noSamples
+  toSamples _ = SD.samples
+    [ GoalTracking mempty mempty
+    -- TODO: add simple objective sample
+    ]
 
 data GoalDisplay = GoalDisplay
   { _goalsContent :: GoalTracking

--- a/src/Swarm/TUI/Model/Repl.hs
+++ b/src/Swarm/TUI/Model/Repl.hs
@@ -83,12 +83,13 @@ data REPLHistItem
   deriving (Eq, Ord, Show, Read)
 
 instance ToSample REPLHistItem where
-  toSamples _ = SD.samples
-    [ REPLEntry "grab"
-    , REPLOutput "it0 : text = \"tree\""
-    , REPLEntry "place tree"
-    , REPLError "1:7: Unbound variable tree"
-    ]
+  toSamples _ =
+    SD.samples
+      [ REPLEntry "grab"
+      , REPLOutput "it0 : text = \"tree\""
+      , REPLEntry "place tree"
+      , REPLError "1:7: Unbound variable tree"
+      ]
 
 instance ToJSON REPLHistItem where
   toJSON e = case e of

--- a/src/Swarm/TUI/Model/Repl.hs
+++ b/src/Swarm/TUI/Model/Repl.hs
@@ -83,7 +83,12 @@ data REPLHistItem
   deriving (Eq, Ord, Show, Read)
 
 instance ToSample REPLHistItem where
-  toSamples _ = SD.noSamples
+  toSamples _ = SD.samples
+    [ REPLEntry "grab"
+    , REPLOutput "it0 : text = \"tree\""
+    , REPLEntry "place tree"
+    , REPLError "1:7: Unbound variable tree"
+    ]
 
 instance ToJSON REPLHistItem where
   toJSON e = case e of

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -24,10 +24,12 @@
 module Swarm.Web (
   startWebThread,
   defaultPort,
+
   -- ** Docs
   SwarmAPI,
   swarmApiHtml,
   swarmApiMarkdown,
+
   -- ** Development
   webMain,
 ) where
@@ -110,11 +112,11 @@ swarmApiHtml =
 swarmApiMarkdown :: String
 swarmApiMarkdown =
   SD.markdownWith
-      ( SD.defRenderingOptions
-          & SD.requestExamples .~ SD.FirstContentType
-          & SD.responseExamples .~ SD.FirstContentType
-          & SD.renderCurlBasePath ?~ "http://localhost:" <> show defaultPort
-      )
+    ( SD.defRenderingOptions
+        & SD.requestExamples .~ SD.FirstContentType
+        & SD.responseExamples .~ SD.FirstContentType
+        & SD.renderCurlBasePath ?~ "http://localhost:" <> show defaultPort
+    )
     $ SD.docsWithIntros [intro] swarmApi
  where
   intro = SD.DocIntro "Swarm Web API" ["All of the valid endpoints are documented below."]

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -64,7 +64,7 @@ import Swarm.Game.Scenario.Objective.WinCheck
 import Swarm.Game.State
 import Swarm.Language.Module
 import Swarm.Language.Pipeline
-import Swarm.Language.Pretty (prettyString)
+import Swarm.Language.Pretty (prettyTextLine)
 import Swarm.Language.Syntax
 import Swarm.ReadableIORef
 import Swarm.TUI.Model
@@ -185,7 +185,7 @@ codeRenderHandler :: Text -> Handler Text
 codeRenderHandler contents = do
   return $ case processTermEither contents of
     Right (ProcessedTerm (Module stx@(Syntax' _srcLoc _term _) _) _ _) ->
-      into @Text . drawTree . fmap prettyString . para Node $ stx
+      into @Text . drawTree . fmap (T.unpack . prettyTextLine) . para Node $ stx
     Left x -> x
 
 codeRunHandler :: BChan AppEvent -> Text -> Handler Text


### PR DESCRIPTION
* generate Web API endpoint docs in CLI - `swarm generate endpoints`
* use default port in API docs using `renderCurlBasePath`
* fix code rendering in Web API so that the tree nodes try to fit one line
* try adding some API samples
* hand craft `ToJSON Robot` instance to match `FromJSONE` more closely
  * default values are skipped
  * inventory and devices are shortened to names and counts