### PR TITLE
custom unwalkable entities

### DIFF
--- a/data/scenarios/Challenges/Ranching/_gated-paddock/enclosure-checking.sw
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/enclosure-checking.sw
@@ -1,131 +1,11 @@
-// Algorithm:
-// ----------
-// Maintain current direction until a wall is encountered.
-// Then enter "wall-following mode".
-// This mode presumes the wall is not a loop.
-// Wall-following mode exploits recursion to keep track of how many left turns were made
-// and then unwinds them again by ensuring each is paired with a right turn.
-// Once the recursion is fully unwound, the robot proceeds along its original direction
-// (though it may now be laterally displaced).
-//
-// (If it was a loop, then an "oriented breadcrumb" would need to be left.
-// The breadcrumb is oriented in case a single-width passage is backtracked
-// along the opposite wall.)
-
-/** A "gate" is walkable, so we need to supplement the "blocked" check with this function.
-Since fences are "unwalkable", they do not need to be mentioned in this function.
-*/
-def isFenced =
-    s <- scan forward;
-    return (
-        case s
-            (\_. false)
-            (\x. x == "gate")
-    );
-    end;
-
 def isBlockedOrFenced =
     b <- blocked;
-    f <- isFenced;
-    return (b || f);
-    end;
-
-// Returns true if we've already placed two
-// breadcrumbs on a given tile, false otherwise.
-def leaveBreadcrumbs =
-    
-    let bc1 = "fresh breadcrumb" in
-    let bc2 = "treaded breadcrumb" in
-
-    wasTraversedOnce <- ishere bc1;
-    if wasTraversedOnce {
-        _crumb <- grab;
-        make bc2;
-        place bc2;
-        return false;
-    } {
-        wasTraversedTwice <- ishere bc2;
-        if wasTraversedTwice {
-            return true;
-        } {
-            // Make sure nothing's in the way before we place
-            // our breadcrumb:
-            x <- scan down;
-            case x return (\y.
-                // If we're on a water tile, get rid of
-                // it with our special "drilling" recipe
-                if (y == "water") {
-                    drill down;
-                    // Nothing will remain on the ground.
-                    // after making the "steam" via
-                    // the drilling recipe.
-                    return ();
-                } {
-                    grab;
-                    return ();
-                };
-            );
-
-            make bc1;
-            place bc1;
-            return false;
-        };
-    };
-    end;
-
-def goForwardToPatrol = \wasBlocked.
-    b <- isBlockedOrFenced;
-    if b {
-        turn left;
-        goForwardToPatrol true;
-        turn right;
-        goForwardToPatrol false;
-    } {
-        if wasBlocked {
-            isLoop <- leaveBreadcrumbs;
-            if isLoop {
-                fail "loop";
-            } {};
-        } {};
-        move;
-    };
-    end;
-
-/**
-There should only be one place in the
-code where an exception is thrown: that is,
-if a treaded breadcrumb is encountered.
-*/
-def checkIsEnclosedInner =
-    try {
-        goForwardToPatrol false;
-        // Water is the outer boundary
-        hasWater <- ishere "water";
-        if hasWater {
-            return false;
-        } {
-            checkIsEnclosedInner;
-        };
-    } {
-        return true;
-    };
+    return b;
     end;
 
 def checkIsEnclosed =
-
-    // The "evaporator" drill is used
-    // to clear water tiles.
-    let specialDrill = "evaporator" in
-    create specialDrill;
-    equip specialDrill;
-
-    // NOTE: System robots can walk on water
-    // so we only need this if we want to
-    // demo the algorithm with a player robot.
-//    create "boat";
-//    equip "boat";
-
-    checkIsEnclosedInner;
+    maybePath <- path (inL ()) (inR "water");
+    case maybePath (\_. return True) (\_. return False);
     end;
 
 def boolToInt = \b. if (b) {return 1} {return 0}; end;
@@ -215,34 +95,12 @@ def getValForSheepIndex = \predicateCmd. \i.
     }
     end;
 
-/**
-There are 3 sheep.
-They have indices 1, 2, 3.
-(The base has index 0).
-
-THIS DOES NOT WORK!
-*/
-def countSheepWithRecursive = \predicateCmd. \i.
-
-    if (i > 0) {
-        val <- getValForSheepIndex predicateCmd i;
-        recursiveCount <- countSheepWithRecursive predicateCmd $ i - 1;
-        return $ val + recursiveCount;
-    } {
-        return 0;
-    }
-    end;
-
-
 def countSheepWith = \predicateCmd.
-
     val1 <- getValForSheepIndex predicateCmd 1;
     val2 <- getValForSheepIndex predicateCmd 2;
     val3 <- getValForSheepIndex predicateCmd 3;
     return $ val1 + val2 + val3;
-
     end;
-
 
 justFilledGap <- as base {
     isStandingOnBridge;

--- a/data/scenarios/Challenges/Ranching/_gated-paddock/meandering-sheep.sw
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/meandering-sheep.sw
@@ -1,25 +1,6 @@
 // A "sheep" that wanders around randomly.
 
-/** A "gate" is walkable, so we need to supplement the "blocked" check with this function.
-Since fences are "unwalkable", they do not need to be mentioned in this function.
-*/
-def isFenced =
-    s <- scan forward;
-    return (
-        case s
-            (\_. false)
-            (\x. x == "gate")
-    );
-    end;
-
-def isBlockedOrFenced =
-    b <- blocked;
-    f <- isFenced;
-    return (b || f);
-    end;
-
 def elif = \p.\t.\e. {if p t e} end;
-
 
 def turnToClover = \direction.
 
@@ -95,7 +76,7 @@ forever (
   dist <- random 3;
   repeat dist (
 
-    b <- isBlockedOrFenced;
+    b <- blocked;
     if b {} {
       move;
     };

--- a/data/scenarios/Challenges/Ranching/_gated-paddock/update-and-test.sh
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/update-and-test.sh
@@ -7,4 +7,5 @@ SCENARIO_FILE=$PARENT_DIR/gated-paddock.yaml
 
 PROGRAM=$(cat $SCRIPT_DIR/enclosure-checking.sw | sed -e 's/[[:blank:]]\+$//') yq -i '.objectives[0].condition = strenv(PROGRAM) | .objectives[].condition style="literal"' $SCENARIO_FILE
 
-stack run -- --scenario $SCENARIO_FILE --run $SCRIPT_DIR/fence-construction.sw --cheat
+stack build --fast
+stack exec swarm -- --scenario $SCENARIO_FILE --run $SCRIPT_DIR/fence-construction.sw --cheat

--- a/data/scenarios/Challenges/Ranching/gated-paddock.yaml
+++ b/data/scenarios/Challenges/Ranching/gated-paddock.yaml
@@ -21,134 +21,14 @@ objectives:
         Note that you can use the `drill` command (by way of the `post puller`{=entity} tool)
         to demolish a `fence`{=entity} that has been `place`d.
     condition: |-
-      // Algorithm:
-      // ----------
-      // Maintain current direction until a wall is encountered.
-      // Then enter "wall-following mode".
-      // This mode presumes the wall is not a loop.
-      // Wall-following mode exploits recursion to keep track of how many left turns were made
-      // and then unwinds them again by ensuring each is paired with a right turn.
-      // Once the recursion is fully unwound, the robot proceeds along its original direction
-      // (though it may now be laterally displaced).
-      //
-      // (If it was a loop, then an "oriented breadcrumb" would need to be left.
-      // The breadcrumb is oriented in case a single-width passage is backtracked
-      // along the opposite wall.)
-
-      /** A "gate" is walkable, so we need to supplement the "blocked" check with this function.
-      Since fences are "unwalkable", they do not need to be mentioned in this function.
-      */
-      def isFenced =
-          s <- scan forward;
-          return (
-              case s
-                  (\_. false)
-                  (\x. x == "gate")
-          );
-          end;
-
       def isBlockedOrFenced =
           b <- blocked;
-          f <- isFenced;
-          return (b || f);
-          end;
-
-      // Returns true if we've already placed two
-      // breadcrumbs on a given tile, false otherwise.
-      def leaveBreadcrumbs =
-
-          let bc1 = "fresh breadcrumb" in
-          let bc2 = "treaded breadcrumb" in
-
-          wasTraversedOnce <- ishere bc1;
-          if wasTraversedOnce {
-              _crumb <- grab;
-              make bc2;
-              place bc2;
-              return false;
-          } {
-              wasTraversedTwice <- ishere bc2;
-              if wasTraversedTwice {
-                  return true;
-              } {
-                  // Make sure nothing's in the way before we place
-                  // our breadcrumb:
-                  x <- scan down;
-                  case x return (\y.
-                      // If we're on a water tile, get rid of
-                      // it with our special "drilling" recipe
-                      if (y == "water") {
-                          drill down;
-                          // Nothing will remain on the ground.
-                          // after making the "steam" via
-                          // the drilling recipe.
-                          return ();
-                      } {
-                          grab;
-                          return ();
-                      };
-                  );
-
-                  make bc1;
-                  place bc1;
-                  return false;
-              };
-          };
-          end;
-
-      def goForwardToPatrol = \wasBlocked.
-          b <- isBlockedOrFenced;
-          if b {
-              turn left;
-              goForwardToPatrol true;
-              turn right;
-              goForwardToPatrol false;
-          } {
-              if wasBlocked {
-                  isLoop <- leaveBreadcrumbs;
-                  if isLoop {
-                      fail "loop";
-                  } {};
-              } {};
-              move;
-          };
-          end;
-
-      /**
-      There should only be one place in the
-      code where an exception is thrown: that is,
-      if a treaded breadcrumb is encountered.
-      */
-      def checkIsEnclosedInner =
-          try {
-              goForwardToPatrol false;
-              // Water is the outer boundary
-              hasWater <- ishere "water";
-              if hasWater {
-                  return false;
-              } {
-                  checkIsEnclosedInner;
-              };
-          } {
-              return true;
-          };
+          return b;
           end;
 
       def checkIsEnclosed =
-
-          // The "evaporator" drill is used
-          // to clear water tiles.
-          let specialDrill = "evaporator" in
-          create specialDrill;
-          equip specialDrill;
-
-          // **NOTE:** System robots can walk on water
-          // so we only need this if we want to
-          // demo the algorithm with a player robot.
-      //    create "boat";
-      //    equip "boat";
-
-          checkIsEnclosedInner;
+          maybePath <- path (inL ()) (inR "water");
+          case maybePath (\_. return True) (\_. return False);
           end;
 
       def boolToInt = \b. if (b) {return 1} {return 0}; end;
@@ -238,34 +118,12 @@ objectives:
           }
           end;
 
-      /**
-      There are 3 sheep.
-      They have indices 1, 2, 3.
-      (The base has index 0).
-
-      THIS DOES NOT WORK!
-      */
-      def countSheepWithRecursive = \predicateCmd. \i.
-
-          if (i > 0) {
-              val <- getValForSheepIndex predicateCmd i;
-              recursiveCount <- countSheepWithRecursive predicateCmd $ i - 1;
-              return $ val + recursiveCount;
-          } {
-              return 0;
-          }
-          end;
-
-
       def countSheepWith = \predicateCmd.
-
           val1 <- getValForSheepIndex predicateCmd 1;
           val2 <- getValForSheepIndex predicateCmd 2;
           val3 <- getValForSheepIndex predicateCmd 3;
           return $ val1 + val2 + val3;
-
           end;
-
 
       justFilledGap <- as base {
           isStandingOnBridge;
@@ -366,6 +224,8 @@ robots:
     dir: [0, 1]
     inventory:
       - [4, wool]
+    unwalkable:
+      - gate
     program: |
       run "scenarios/Challenges/Ranching/_gated-paddock/meandering-sheep.sw";
 entities:

--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -47,3 +47,4 @@ Achievements
 1379-single-world-portal-reorientation.yaml
 1399-backup-command.yaml
 1430-built-robot-ownership.yaml
+1536-custom-unwalkable-entities.yaml

--- a/data/scenarios/Testing/1536-custom-unwalkable-entities.yaml
+++ b/data/scenarios/Testing/1536-custom-unwalkable-entities.yaml
@@ -1,0 +1,50 @@
+version: 1
+name: Custom unwalkability
+description: The base robot cannot walk through trees.
+  The scenario shall be failed if the robot
+  manages to walk through the tree by moving
+  three cells to the east.
+objectives:
+  - goal:
+      - Get the flower
+    condition: |
+      as base {has "flower"};
+    prerequisite:
+      not: has_bitcoin
+  - id: has_bitcoin
+    optional: true
+    goal:
+      - Do not get the bitcoin
+    condition: |
+      as base {has "bitcoin"};
+solution: |
+  def tryMove = try {move} {}; end;
+  tryMove;
+  tryMove;
+  tryMove;
+  grab;
+robots:
+  - name: base
+    dir: [1, 0]
+    display:
+      attr: robot
+    devices:
+      - logger
+      - grabber
+      - treads
+      - dictionary
+      - net
+    unwalkable:
+       - tree
+known: [tree, flower, bitcoin]
+world:
+  palette:
+    'B': [grass, null, base]
+    '.': [grass]
+    'T': [grass, tree]
+    'b': [grass, bitcoin]
+    'f': [grass, flower]
+  upperleft: [0, 0]
+  map: |
+    BfTb
+    

--- a/data/schema/robot.json
+++ b/data/schema/robot.json
@@ -68,6 +68,14 @@
             "default": false,
             "type": "boolean",
             "description": "Whether the robot is heavy. Heavy robots require tank treads to move (rather than just treads for other robots)."
+        },
+        "unwalkable": {
+            "default": [],
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "A list of entities that this robot cannot walk across."
         }
     },
     "required": [

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -393,6 +393,7 @@ hypotheticalRobot c =
     []
     True
     False
+    mempty
 
 evaluateCESK ::
   (Has (Lift IO) sig m, Has (Throw Exn) sig m, Has (State GameState) sig m) =>
@@ -996,6 +997,7 @@ addSeedBot e (minT, maxT) loc ts =
         [(1, e)]
         True
         False
+        mempty
         ts
 
 -- | Interpret the execution (or evaluation) of a constant application
@@ -1900,6 +1902,7 @@ execConst c vs s k = do
               []
               isSystemRobot
               False
+              mempty
               createdAt
 
         -- Provision the new robot with the necessary devices and inventory.

--- a/src/Swarm/Game/Step/Combustion.hs
+++ b/src/Swarm/Game/Step/Combustion.hs
@@ -109,6 +109,7 @@ addCombustionBot inputEntity combustibility ts loc = do
         botInventory
         True
         False
+        mempty
         ts
   return combustionDurationRand
  where
@@ -222,4 +223,5 @@ addIgnitionBot ignitionDelay inputEntity ts loc =
         []
         True
         False
+        mempty
         ts

--- a/src/Swarm/Game/Step/Util.hs
+++ b/src/Swarm/Game/Step/Util.hs
@@ -200,13 +200,14 @@ checkMoveFailureUnprivileged :: HasRobotStepState sig m => Cosmic Location -> m 
 checkMoveFailureUnprivileged nextLoc = do
   me <- entityAt nextLoc
   caps <- use robotCapabilities
+  unwalkables <- use unwalkableEntities
   return $ do
     e <- me
-    go caps e
+    go caps unwalkables e
  where
-  go caps e
+  go caps unwalkables e
     -- robots can not walk through walls
-    | e `hasProperty` Unwalkable = Just $ MoveFailureDetails e PathBlocked
+    | e `hasProperty` Unwalkable || (e ^. entityName) `S.member` unwalkables = Just $ MoveFailureDetails e PathBlocked
     -- robots drown if they walk over liquid without boat
     | e `hasProperty` Liquid && CFloat `S.notMember` caps =
         Just $ MoveFailureDetails e PathLiquid

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -333,6 +333,7 @@ testScenarioSolutions rs ui =
         , testSolution Default "Testing/1355-combustion"
         , testSolution Default "Testing/1379-single-world-portal-reorientation"
         , testSolution Default "Testing/1399-backup-command"
+        , testSolution Default "Testing/1536-custom-unwalkable-entities"
         , testGroup
             -- Note that the description of the classic world in
             -- data/worlds/classic.yaml (automatically tested to some


### PR DESCRIPTION
Builds upon #1523 (merge that one first)

Allows specifying certain entities as unwalkable on a per-robot basis.

## Motivation

For #835, custom pathfinding logic was implemented entirely in swarm-lang.  This logic used the `blocked` command to test for fence enclosure, while also special-casing an entity called `"gate"`.  The `"gate"` entity is defined as walkable, but the `sheep` robot program is hard-coded not to be able to walk through a `"gate"`.

This new robot property will facilitate use of the new `path` command while differentiating 