### PR TITLE
Use 'path' command to check goal in sheep scenario

### DIFF
--- a/data/scenarios/Challenges/Ranching/_gated-paddock/enclosure-checking.sw
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/enclosure-checking.sw
@@ -1,131 +1,11 @@
-// Algorithm:
-// ----------
-// Maintain current direction until a wall is encountered.
-// Then enter "wall-following mode".
-// This mode presumes the wall is not a loop.
-// Wall-following mode exploits recursion to keep track of how many left turns were made
-// and then unwinds them again by ensuring each is paired with a right turn.
-// Once the recursion is fully unwound, the robot proceeds along its original direction
-// (though it may now be laterally displaced).
-//
-// (If it was a loop, then an "oriented breadcrumb" would need to be left.
-// The breadcrumb is oriented in case a single-width passage is backtracked
-// along the opposite wall.)
-
-/** A "gate" is walkable, so we need to supplement the "blocked" check with this function.
-Since fences are "unwalkable", they do not need to be mentioned in this function.
-*/
-def isFenced =
-    s <- scan forward;
-    return (
-        case s
-            (\_. false)
-            (\x. x == "gate")
-    );
-    end;
-
 def isBlockedOrFenced =
     b <- blocked;
-    f <- isFenced;
-    return (b || f);
-    end;
-
-// Returns true if we've already placed two
-// breadcrumbs on a given tile, false otherwise.
-def leaveBreadcrumbs =
-    
-    let bc1 = "fresh breadcrumb" in
-    let bc2 = "treaded breadcrumb" in
-
-    wasTraversedOnce <- ishere bc1;
-    if wasTraversedOnce {
-        _crumb <- grab;
-        make bc2;
-        place bc2;
-        return false;
-    } {
-        wasTraversedTwice <- ishere bc2;
-        if wasTraversedTwice {
-            return true;
-        } {
-            // Make sure nothing's in the way before we place
-            // our breadcrumb:
-            x <- scan down;
-            case x return (\y.
-                // If we're on a water tile, get rid of
-                // it with our special "drilling" recipe
-                if (y == "water") {
-                    drill down;
-                    // Nothing will remain on the ground.
-                    // after making the "steam" via
-                    // the drilling recipe.
-                    return ();
-                } {
-                    grab;
-                    return ();
-                };
-            );
-
-            make bc1;
-            place bc1;
-            return false;
-        };
-    };
-    end;
-
-def goForwardToPatrol = \wasBlocked.
-    b <- isBlockedOrFenced;
-    if b {
-        turn left;
-        goForwardToPatrol true;
-        turn right;
-        goForwardToPatrol false;
-    } {
-        if wasBlocked {
-            isLoop <- leaveBreadcrumbs;
-            if isLoop {
-                fail "loop";
-            } {};
-        } {};
-        move;
-    };
-    end;
-
-/**
-There should only be one place in the
-code where an exception is thrown: that is,
-if a treaded breadcrumb is encountered.
-*/
-def checkIsEnclosedInner =
-    try {
-        goForwardToPatrol false;
-        // Water is the outer boundary
-        hasWater <- ishere "water";
-        if hasWater {
-            return false;
-        } {
-            checkIsEnclosedInner;
-        };
-    } {
-        return true;
-    };
+    return b;
     end;
 
 def checkIsEnclosed =
-
-    // The "evaporator" drill is used
-    // to clear water tiles.
-    let specialDrill = "evaporator" in
-    create specialDrill;
-    equip specialDrill;
-
-    // NOTE: System robots can walk on water
-    // so we only need this if we want to
-    // demo the algorithm with a player robot.
-//    create "boat";
-//    equip "boat";
-
-    checkIsEnclosedInner;
+    maybePath <- path (inL ()) (inR "water");
+    case maybePath (\_. return True) (\_. return False);
     end;
 
 def boolToInt = \b. if (b) {return 1} {return 0}; end;
@@ -215,34 +95,12 @@ def getValForSheepIndex = \predicateCmd. \i.
     }
     end;
 
-/**
-There are 3 sheep.
-They have indices 1, 2, 3.
-(The base has index 0).
-
-THIS DOES NOT WORK!
-*/
-def countSheepWithRecursive = \predicateCmd. \i.
-
-    if (i > 0) {
-        val <- getValForSheepIndex predicateCmd i;
-        recursiveCount <- countSheepWithRecursive predicateCmd $ i - 1;
-        return $ val + recursiveCount;
-    } {
-        return 0;
-    }
-    end;
-
-
 def countSheepWith = \predicateCmd.
-
     val1 <- getValForSheepIndex predicateCmd 1;
     val2 <- getValForSheepIndex predicateCmd 2;
     val3 <- getValForSheepIndex predicateCmd 3;
     return $ val1 + val2 + val3;
-
     end;
-
 
 justFilledGap <- as base {
     isStandingOnBridge;

--- a/data/scenarios/Challenges/Ranching/_gated-paddock/meandering-sheep.sw
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/meandering-sheep.sw
@@ -1,25 +1,6 @@
 // A "sheep" that wanders around randomly.
 
-/** A "gate" is walkable, so we need to supplement the "blocked" check with this function.
-Since fences are "unwalkable", they do not need to be mentioned in this function.
-*/
-def isFenced =
-    s <- scan forward;
-    return (
-        case s
-            (\_. false)
-            (\x. x == "gate")
-    );
-    end;
-
-def isBlockedOrFenced =
-    b <- blocked;
-    f <- isFenced;
-    return (b || f);
-    end;
-
 def elif = \p.\t.\e. {if p t e} end;
-
 
 def turnToClover = \direction.
 
@@ -95,7 +76,7 @@ forever (
   dist <- random 3;
   repeat dist (
 
-    b <- isBlockedOrFenced;
+    b <- blocked;
     if b {} {
       move;
     };

--- a/data/scenarios/Challenges/Ranching/_gated-paddock/update-and-test.sh
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/update-and-test.sh
@@ -7,4 +7,5 @@ SCENARIO_FILE=$PARENT_DIR/gated-paddock.yaml
 
 PROGRAM=$(cat $SCRIPT_DIR/enclosure-checking.sw | sed -e 's/[[:blank:]]\+$//') yq -i '.objectives[0].condition = strenv(PROGRAM) | .objectives[].condition style="literal"' $SCENARIO_FILE
 
-stack run -- --scenario $SCENARIO_FILE --run $SCRIPT_DIR/fence-construction.sw --cheat
+stack build --fast
+stack exec swarm -- --scenario $SCENARIO_FILE --run $SCRIPT_DIR/fence-construction.sw --cheat

--- a/data/scenarios/Challenges/Ranching/gated-paddock.yaml
+++ b/data/scenarios/Challenges/Ranching/gated-paddock.yaml
@@ -21,134 +21,14 @@ objectives:
         Note that you can use the `drill` command (by way of the `post puller`{=entity} tool)
         to demolish a `fence`{=entity} that has been `place`d.
     condition: |-
-      // Algorithm:
-      // ----------
-      // Maintain current direction until a wall is encountered.
-      // Then enter "wall-following mode".
-      // This mode presumes the wall is not a loop.
-      // Wall-following mode exploits recursion to keep track of how many left turns were made
-      // and then unwinds them again by ensuring each is paired with a right turn.
-      // Once the recursion is fully unwound, the robot proceeds along its original direction
-      // (though it may now be laterally displaced).
-      //
-      // (If it was a loop, then an "oriented breadcrumb" would need to be left.
-      // The breadcrumb is oriented in case a single-width passage is backtracked
-      // along the opposite wall.)
-
-      /** A "gate" is walkable, so we need to supplement the "blocked" check with this function.
-      Since fences are "unwalkable", they do not need to be mentioned in this function.
-      */
-      def isFenced =
-          s <- scan forward;
-          return (
-              case s
-                  (\_. false)
-                  (\x. x == "gate")
-          );
-          end;
-
       def isBlockedOrFenced =
           b <- blocked;
-          f <- isFenced;
-          return (b || f);
-          end;
-
-      // Returns true if we've already placed two
-      // breadcrumbs on a given tile, false otherwise.
-      def leaveBreadcrumbs =
-
-          let bc1 = "fresh breadcrumb" in
-          let bc2 = "treaded breadcrumb" in
-
-          wasTraversedOnce <- ishere bc1;
-          if wasTraversedOnce {
-              _crumb <- grab;
-              make bc2;
-              place bc2;
-              return false;
-          } {
-              wasTraversedTwice <- ishere bc2;
-              if wasTraversedTwice {
-                  return true;
-              } {
-                  // Make sure nothing's in the way before we place
-                  // our breadcrumb:
-                  x <- scan down;
-                  case x return (\y.
-                      // If we're on a water tile, get rid of
-                      // it with our special "drilling" recipe
-                      if (y == "water") {
-                          drill down;
-                          // Nothing will remain on the ground.
-                          // after making the "steam" via
-                          // the drilling recipe.
-                          return ();
-                      } {
-                          grab;
-                          return ();
-                      };
-                  );
-
-                  make bc1;
-                  place bc1;
-                  return false;
-              };
-          };
-          end;
-
-      def goForwardToPatrol = \wasBlocked.
-          b <- isBlockedOrFenced;
-          if b {
-              turn left;
-              goForwardToPatrol true;
-              turn right;
-              goForwardToPatrol false;
-          } {
-              if wasBlocked {
-                  isLoop <- leaveBreadcrumbs;
-                  if isLoop {
-                      fail "loop";
-                  } {};
-              } {};
-              move;
-          };
-          end;
-
-      /**
-      There should only be one place in the
-      code where an exception is thrown: that is,
-      if a treaded breadcrumb is encountered.
-      */
-      def checkIsEnclosedInner =
-          try {
-              goForwardToPatrol false;
-              // Water is the outer boundary
-              hasWater <- ishere "water";
-              if hasWater {
-                  return false;
-              } {
-                  checkIsEnclosedInner;
-              };
-          } {
-              return true;
-          };
+          return b;
           end;
 
       def checkIsEnclosed =
-
-          // The "evaporator" drill is used
-          // to clear water tiles.
-          let specialDrill = "evaporator" in
-          create specialDrill;
-          equip specialDrill;
-
-          // **NOTE:** System robots can walk on water
-          // so we only need this if we want to
-          // demo the algorithm with a player robot.
-      //    create "boat";
-      //    equip "boat";
-
-          checkIsEnclosedInner;
+          maybePath <- path (inL ()) (inR "water");
+          case maybePath (\_. return True) (\_. return False);
           end;
 
       def boolToInt = \b. if (b) {return 1} {return 0}; end;
@@ -238,34 +118,12 @@ objectives:
           }
           end;
 
-      /**
-      There are 3 sheep.
-      They have indices 1, 2, 3.
-      (The base has index 0).
-
-      THIS DOES NOT WORK!
-      */
-      def countSheepWithRecursive = \predicateCmd. \i.
-
-          if (i > 0) {
-              val <- getValForSheepIndex predicateCmd i;
-              recursiveCount <- countSheepWithRecursive predicateCmd $ i - 1;
-              return $ val + recursiveCount;
-          } {
-              return 0;
-          }
-          end;
-
-
       def countSheepWith = \predicateCmd.
-
           val1 <- getValForSheepIndex predicateCmd 1;
           val2 <- getValForSheepIndex predicateCmd 2;
           val3 <- getValForSheepIndex predicateCmd 3;
           return $ val1 + val2 + val3;
-
           end;
-
 
       justFilledGap <- as base {
           isStandingOnBridge;
@@ -366,6 +224,8 @@ robots:
     dir: [0, 1]
     inventory:
       - [4, wool]
+    unwalkable:
+      - gate
     program: |
       run "scenarios/Challenges/Ranching/_gated-paddock/meandering-sheep.sw";
 entities:


### PR DESCRIPTION
Builds upon #1536 (merge that one first)

| Before | After |
| --- | --- |
| 3.58s | 3.11s |

The goal-checking had already been pretty well optimized by only performing pathfinding when the player has just placed a fence between two others.  But at least the code is significantly simplified.