### PR TITLE
Fix reference to nonexistent `entity` type

### DIFF
--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -742,7 +742,7 @@ inferConst c = case c of
   Selfdestruct -> [tyQ| cmd unit |]
   Move -> [tyQ| cmd unit |]
   Backup -> [tyQ| cmd unit |]
-  Path -> [tyQ| (unit + int) -> ((int * int) + entity) -> cmd (unit + dir) |]
+  Path -> [tyQ| (unit + int) -> ((int * int) + text) -> cmd (unit + dir) |]
   Push -> [tyQ| cmd unit |]
   Stride -> [tyQ| int -> cmd unit |]
   Turn -> [tyQ| dir -> cmd unit |]


### PR DESCRIPTION
Toward #1547.

I decided to simply fix the error in this PR.  At #1547 there is discussion of various other means to prevent this kind of error in the future (both for developers and players), but I will leave implementing some of those ideas to a future PR.