### PR TITLE
Limit system robot activity tracking

### DIFF
--- a/src/Swarm/Game/CESK.hs
+++ b/src/Swarm/Game/CESK.hs
@@ -98,7 +98,7 @@ import Swarm.Language.Requirement (ReqCtx)
 import Swarm.Language.Syntax
 import Swarm.Language.Types
 import Swarm.Language.Value as V
-import Swarm.Util.WindowedCounter
+import Swarm.Util.WindowedCounter (Offsettable (..))
 
 -- | A newtype representing a count of ticks (typically since the
 --   start of a game).


### PR DESCRIPTION
Extension of #1484 that partially mitigates #1558.

Let's not bother to track the activity levels of system robots when we're not in creative mode, because they won't even show up in the `F2` dialog.  This mitigation can be substantial, as we generally expect there to be many more system robots than player robots.

It doesn't have quite the same "warm up" drawback as the potential mitigation described in https://github.com/swarm-game/swarm/issues/1558#issuecomment-1741794123, because player robots will always be warmed up, and system robots will have been warmed up if we've been playing in creative mode.  We wouldn't necessarily expect frequent toggling in-and-out of creative mode while trying to observe performance in the `F2` dialog.