### PR TITLE
Restore the "classic world" background for `friend` challenge

### DIFF
--- a/data/scenarios/Challenges/friend.yaml
+++ b/data/scenarios/Challenges/friend.yaml
@@ -88,6 +88,8 @@ world:
     '*': [grass, flower]
     '@': [stone, boulder]
   upperleft: [-20, 2]
+  dsl: |
+    "classic"
   map: |-
     c,..,,,,,,..,,,,...,.
     ,..,,,,,,,...........

--- a/data/scenarios/Challenges/gopher.yaml
+++ b/data/scenarios/Challenges/gopher.yaml
@@ -129,12 +129,14 @@ solution: |
    run "scenarios/Challenges/_gopher/solution.sw"
 known: []
 world:
+  dsl: |
+    "classic"
   upperleft: [-1, 1]
   offset: false
   palette:
-    'x': [dirt]
-    '.': [grass]
-    'g': [dirt, null, gopher]
+    'x': [dirt, erase]
+    '.': [grass, erase]
+    'g': [dirt, erase, gopher]
   map: |
     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     x............................x


### PR DESCRIPTION
This was broken by #1376.  Any challenge which did *not* specify a `default` field would have had the classic world as an implicit background, but in this case I failed to add the proper `dsl` field to specify it.  I don't *think* there are any other such challenge scenarios, although to be really sure we would have to identify all the scenarios did not specify a `default` field before #1376 was merged and ensure that each of them now has an appropriate `dsl` field.

Before:

![before](https://github.com/swarm-game/swarm/assets/533859/4756e889-5455-4a88-b114-ae00df79555c)


After:

![after](https://github.com/swarm-game/swarm/assets/533859/9004e108-5c39-4de9-a2fe-c60e38b63ca0)

