### PR TITLE
Account for symlink when applying JSON schemas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "yaml.schemas": {
         "data/schema/scenario.json": [
-            "data/scenarios/**/*.yaml"
+            "data/scenarios/**/*.yaml",
+            "scenarios/**/*.yaml"
         ],
         "data/schema/entities.json": [
             "data/entities.yaml"


### PR DESCRIPTION
This allows the validation to work in VS Code if one happens to open the symlinked version of a scenario file, which is easy to do accidentally via CTRL+P.