### PR TITLE
saybot demo

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -49,3 +49,4 @@ Achievements
 1430-built-robot-ownership.yaml
 1536-custom-unwalkable-entities.yaml
 1535-ping
+1592-shared-template-robot-say-logs.yaml

--- a/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
+++ b/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
@@ -1,0 +1,30 @@
+version: 1
+name: Logs from same-template robots
+description: |
+  Logs from different robots generated from the same template.
+robots:
+  - name: base
+    devices:
+      - logger
+      - hearing aid
+  - name: saybot
+    system: true
+    display:
+      invisible: false
+      attr: blue
+    program: |
+      loc <- whereami;
+      wait $ snd loc;
+      say "Hello";
+world:
+  palette:
+    '.': [grass]
+    'B': [grass, null, base]
+    's': [grass, null, saybot]
+    
+  upperleft: [0, 4]
+  map: |
+    ....s
+    ...ss
+    B...s
+    


### PR DESCRIPTION
Towards #1592

In the demo, if two system robots are placed in the same row (so that they `say` simultaneously), one of the log messages is missing.

![image](https://github.com/swarm-game/swarm/assets/261693/2d548a48-fdfa-4fbd-907d-252423667348)