### PR TITLE
path caching

### DIFF
--- a/data/scenarios/Fun/00-ORDER.txt
+++ b/data/scenarios/Fun/00-ORDER.txt
@@ -1,2 +1,3 @@
 GoL.yaml
 logo-burst.yaml
+horton.yaml

--- a/data/scenarios/Fun/horton.yaml
+++ b/data/scenarios/Fun/horton.yaml
@@ -1,0 +1,84 @@
+version: 1
+name: Horton's Field
+author: Karl Ostmo
+seed: 1
+description: |
+  Horton picks all of the flowers
+creative: false
+objectives:
+  - goal:
+      - |
+        Pluck every flower.
+    condition: |
+      as base {
+        flowerCount <- count "flower";
+        return $ flowerCount >= 399;
+      }
+robots:
+  - name: Horton
+    dir: [0, 1]
+    devices:
+      - ADT calculator
+      - branch predictor
+      - comparator
+      - compass
+      - dictionary
+      - grabber
+      - hourglass
+      - clock
+      - lambda
+      - logger
+      - net
+      - scanner
+      - strange loop
+      - treads
+      - wayfinder
+solution: |
+  def goDir = \f. \d.
+    if (d == down) {grab; f;} {turn d; move; f;}
+    end;
+
+  def followRoute =
+      nextDir <- path (inL ()) (inR "flower");
+      case nextDir return $ goDir followRoute;
+      end;
+
+  followRoute;
+entities:
+  - name: wayfinder
+    display:
+      char: 'w'
+    description:
+      - Enables `path` command
+    properties: [known, portable]
+    capabilities: [path]
+known: [water, boulder, flower]
+world:
+  dsl: |
+    let
+      cl  = perlin seed 4 0.08 0.5,
+      patch = cl > 0.0,
+      prize = cl < -0.8
+    in
+      overlay
+      [ {dirt}
+      , mask (patch) {boulder}
+      , mask (prize) {flower}
+      , mask (y < -80 || y > 80 || x < -60 || x > 60) (overlay [{water}])
+      ]
+  upperleft: [-4, 4]
+  offset: false
+  palette:
+    'B': [grass, erase, Horton]
+    '.': [grass, erase]
+    'x': [blank]
+  map: |
+    xxx...xxx
+    x.......x
+    x.......x
+    .........
+    ....B....
+    .........
+    x.......x
+    x.......x
+    xxx...xxx

--- a/data/scenarios/Fun/horton.yaml
+++ b/data/scenarios/Fun/horton.yaml
@@ -49,7 +49,18 @@ entities:
     display:
       char: 'w'
     description:
-      - Enables `path` command
+      - |
+        Enables the `path` command:
+      - |
+        `path : (unit + int) -> ((int * int) + text) -> cmd (unit + dir)`
+      - |
+        Optionally supply a distance limit as the first argument, and
+        supply either a location (`inL`) or an entity (`inR`) as the second argument.
+      - |
+        Example:
+      - |
+        `path (inL ()) (inR "tree");`
+      - If a path exists, returns the direction to proceed along.
     properties: [known, portable]
     capabilities: [path]
 known: [water, boulder, flower]

--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -42,6 +42,7 @@ Achievements
 1356-portals
 144-subworlds
 836-pathfinding
+1569-pathfinding-cache
 1341-command-count.yaml
 1355-combustion.yaml
 1379-single-world-portal-reorientation.yaml

--- a/data/scenarios/Testing/1569-pathfinding-cache/00-ORDER.txt
+++ b/data/scenarios/Testing/1569-pathfinding-cache/00-ORDER.txt
@@ -1,0 +1,3 @@
+1569-harvest-batch.yaml
+1569-cache-invalidation-modes.yaml
+1569-cache-invalidation-distance-limit.yaml

--- a/data/scenarios/Testing/1569-pathfinding-cache/1569-cache-invalidation-distance-limit.yaml
+++ b/data/scenarios/Testing/1569-pathfinding-cache/1569-cache-invalidation-distance-limit.yaml
@@ -1,0 +1,128 @@
+version: 1
+name: Pathfinding cache - changing distance limit
+description: |
+  Demonstrates various sequences of distance limit increases and decreases.
+creative: false
+objectives:
+  - goal:
+      - Make lemonade
+    condition: |
+      as base {
+        has "lemonade";
+      };
+solution: |
+  def go =
+
+    // The cache gets initially populated with an
+    // unlimited distance, so in a sequence of
+    // (1) a decreased limit followed by
+    // (2) an increased finite limit,
+    // the increase in (2) is still considered a decrease
+    // relative to the cache.
+
+    // Invocation #1: Expect RECOMPUTATION
+    path (inL ()) (inR "flower");
+
+    // Invocation #2: Expect SUCCESS
+    path (inL ()) (inR "flower");
+
+    // Invocation #3: Expect SUCCESS
+    path (inR 5) (inR "flower");
+
+    // Invocation #4: Expect SUCCESS
+    // Even though this is an increase relative to the previous invocation,
+    // it is a decrease relative to the cached limit.
+    path (inR 6) (inR "flower");
+
+    move;
+
+    // Invocation #5: Expect RECOMPUTATION
+    // We have invoked 'path' from a new location, so evict the cache.
+    path (inR 6) (inR "flower");
+
+    // Invocation #6: Expect SUCCESS
+    path (inR 4) (inR "flower");
+
+    // Invocation #7: Expect RECOMPUTATION
+    path (inR 7) (inR "flower");
+
+    // Invocation #8: Expect SUCCESS
+    path (inR 5) (inR "flower");
+
+    // Invocation #9: Expect FAILURE
+    // This failure is not cached.
+    path (inR 2) (inR "flower");
+
+    // Invocation #10: Expect SUCCESS
+    // The cache is still valid from the previous success.
+    path (inR 4) (inR "flower");
+  
+    make "lemonade";
+    end;
+
+  go;
+entities:
+  - name: wayfinder
+    display:
+      char: 'w'
+    description:
+      - Enables `path` command
+    properties: [known, portable]
+    capabilities: [path]
+  - name: monolith
+    display:
+      char: '@'
+      attr: rock
+    description:
+    - Pushable rock
+    properties: [known, unwalkable, portable]
+  - name: lemon
+    display:
+      char: 'o'
+      attr: gold
+    description:
+    - Sour fruit
+    properties: [known, portable]
+  - name: lemonade
+    display:
+      char: 'c'
+      attr: gold
+    description:
+    - Sweet drink
+    properties: [known, portable]
+recipes:
+  - in:
+      - [1, lemon]
+    out:
+      - [1, lemonade]
+robots:
+  - name: base
+    dir: [0, 1]
+    devices:
+      - ADT calculator
+      - antenna
+      - branch predictor
+      - comparator
+      - compass
+      - dictionary
+      - linotype
+      - logger
+      - grabber
+      - toolkit
+      - treads
+      - wayfinder
+      - workbench
+    inventory:
+      - [1, lemon]
+known: [flower]
+world:
+  palette:
+    'B': [grass, erase, base]
+    '.': [grass]
+    'f': [grass, flower]
+    '@': [grass, monolith]
+  upperleft: [0, 0]
+  map: |
+    ....
+    B..f
+    ....

--- a/data/scenarios/Testing/1569-pathfinding-cache/1569-cache-invalidation-modes.yaml
+++ b/data/scenarios/Testing/1569-pathfinding-cache/1569-cache-invalidation-modes.yaml
@@ -1,0 +1,176 @@
+version: 1
+name: Pathfinding cache - invalidation modes
+description: |
+  The following sequence is performed:
+
+  1. An unwalkable entity is added to the path.
+  2. An unwalkable entity is removed from the path.
+  3. The target entity is added somewhere outside of the path
+  4. The target entity is added somewhere on the path
+
+  These events are recorded in the caching log and inspected in the
+  integration test.
+creative: false
+objectives:
+  - goal:
+      - Make lemonade
+    condition: |
+      as base {
+        has "lemonade";
+      };
+solution: |
+  def queryFlowerPath =
+    p <- path (inL ()) (inR "flower");
+    log $ format p;
+    end;
+  
+  def waitUntilSalvaged =
+    salvage;
+    gotPanel <- has "solar panel";
+    if gotPanel {} {waitUntilSalvaged};
+    end;
+
+  def forceBlockageInvalidation =
+    build {
+      require 1 "monolith";
+      move;
+      place "monolith";
+      turn back;
+      move;
+    };
+
+    waitUntilSalvaged;
+    end;
+
+  def forceRemovedUnwalkableInvalidation =
+    build {
+      turn back;
+      push;
+      turn back;
+      move;
+    };
+
+    waitUntilSalvaged;
+    end;
+
+  def forceCompetingTargetInvalidation =
+    build {
+      require 1 "flower";
+      turn right;
+      move;
+      place "flower";
+      turn back;
+      move;
+    };
+
+    waitUntilSalvaged;
+    end;
+
+  def go =
+    // Invocation #1: Expect RECOMPUTATION
+    queryFlowerPath;
+    forceBlockageInvalidation;
+
+    // Invocation #2: Expect RECOMPUTATION
+    queryFlowerPath;
+
+    turn right;
+    move;
+    turn left;
+    move; move;
+    turn left;
+    move;
+    turn right;
+
+    // Invocation #3: Expect SUCCESS
+    queryFlowerPath;
+    forceRemovedUnwalkableInvalidation;
+
+    // Invocation #4: Expect RECOMPUTATION
+    queryFlowerPath;
+
+    forceCompetingTargetInvalidation;
+
+    // Invocation #5: Expect RECOMPUTATION
+    queryFlowerPath;
+
+    place "flower";
+
+    // Invocation #6: Expect SUCCESS
+    queryFlowerPath;
+
+    make "lemonade";
+    end;
+
+  go;
+entities:
+  - name: wayfinder
+    display:
+      char: 'w'
+    description:
+      - Enables `path` command
+    properties: [known, portable]
+    capabilities: [path]
+  - name: monolith
+    display:
+      char: '@'
+      attr: rock
+    description:
+    - Pushable rock
+    properties: [known, unwalkable, portable]
+  - name: lemon
+    display:
+      char: 'o'
+      attr: gold
+    description:
+    - Sour fruit
+    properties: [known, portable]
+  - name: lemonade
+    display:
+      char: 'c'
+      attr: gold
+    description:
+    - Sweet drink
+    properties: [known, portable]
+recipes:
+  - in:
+      - [1, lemon]
+    out:
+      - [1, lemonade]
+robots:
+  - name: base
+    dir: [1,0]
+    devices:
+      - 3D printer
+      - ADT calculator
+      - antenna
+      - branch predictor
+      - comparator
+      - compass
+      - dictionary
+      - linotype
+      - logger
+      - grabber
+      - toolkit
+      - treads
+      - wayfinder
+      - workbench
+    inventory:
+      - [1, solar panel]
+      - [1, treads]
+      - [1, dozer blade]
+      - [1, grabber]
+      - [1, monolith]
+      - [2, flower]
+      - [1, lemon]
+known: [flower]
+world:
+  palette:
+    'B': [grass, erase, base]
+    '.': [grass]
+    'f': [grass, flower]
+  upperleft: [0, 0]
+  map: |
+    .....
+    B...f
+    .....

--- a/data/scenarios/Testing/1569-pathfinding-cache/1569-harvest-batch.yaml
+++ b/data/scenarios/Testing/1569-pathfinding-cache/1569-harvest-batch.yaml
@@ -1,0 +1,59 @@
+version: 1
+name: Pathfinding cache - harvest entity batches
+description: |
+  Demonstrates repeated application of `path` command to
+  harvest a cluster of entities. Upon each harvest,
+  the path cache shall be invalidated since the destination
+  entity has been removed.
+creative: false
+objectives:
+  - goal:
+      - Get 4 flowers.
+    condition: |
+      as base {
+        fCount <- count "flower";
+        return $ fCount >= 4;
+      };
+solution: |
+  def goDir = \f. \d.
+    if (d == down) {grab; f;} {turn d; move; f;}
+    end;
+
+  def followRoute =
+      nextDir <- path (inL ()) (inR "flower");
+      case nextDir return $ goDir followRoute;
+      end;
+
+  followRoute;
+entities:
+  - name: wayfinder
+    display:
+      char: 'w'
+    description:
+      - Enables `path` command
+    properties: [known, portable]
+    capabilities: [path]
+robots:
+  - name: base
+    dir: [1,0]
+    devices:
+      - ADT calculator
+      - branch predictor
+      - comparator
+      - compass
+      - dictionary
+      - logger
+      - grabber
+      - treads
+      - wayfinder
+known: [flower]
+world:
+  palette:
+    'B': [grass, erase, base]
+    '.': [grass]
+    'f': [grass, flower]
+  upperleft: [0, 0]
+  map: |
+    B...
+    ..ff
+    ..ff

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -56,6 +56,7 @@ module Swarm.Game.State (
   gameControls,
   discovery,
   landscape,
+  pathCaching,
 
   -- ** GameState subrecords
 
@@ -224,6 +225,7 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.ScenarioInfo
+import Swarm.Game.Step.Path.Type
 import Swarm.Game.Terrain (TerrainType (..))
 import Swarm.Game.Universe as U
 import Swarm.Game.World (Coords (..), WorldFun (..), locToCoords, worldFunFromArray)
@@ -602,6 +604,7 @@ data GameState = GameState
     -- that we do not have to iterate over all "waiting" robots,
     -- since there may be many.
     _robotsWatching :: Map (Cosmic Location) (S.Set RID)
+  , _pathCaching :: PathCaching
   , _discovery :: Discovery
   , _seed :: Seed
   , _randGen :: StdGen
@@ -670,6 +673,9 @@ robotsAtLocation loc gs =
 
 -- | Get a list of all the robots that are \"watching\" by location.
 robotsWatching :: Lens' GameState (Map (Cosmic Location) (S.Set RID))
+
+-- | Registry for caching output of the @path@ command
+pathCaching :: Lens' GameState PathCaching
 
 -- | Get all the robots within a given Manhattan distance from a
 --   location.
@@ -1173,6 +1179,7 @@ initGameState gsc =
     , _robotMap = IM.empty
     , _robotsByLocation = M.empty
     , _robotsWatching = mempty
+    , _pathCaching = emptyPathCache
     , _discovery =
         Discovery
           { _availableRecipes = mempty

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -83,8 +83,10 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (foundByNam
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.State
 import Swarm.Game.Step.Combustion qualified as Combustion
+import Swarm.Game.Step.Path.Finding
+import Swarm.Game.Step.Path.Type
 import Swarm.Game.Step.Path.Walkability
-import Swarm.Game.Step.Pathfinding
+import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Step.Util
 import Swarm.Game.Step.Util.Inspect
 import Swarm.Game.Universe
@@ -1077,7 +1079,7 @@ execConst c vs s k = do
                     Location (fromIntegral x) (fromIntegral y)
               _ -> badConst
         robotLoc <- use robotLocation
-        result <- pathCommand maybeLimit robotLoc goal
+        result <- pathCommand $ PathfindingParameters maybeLimit robotLoc goal
         return $ mkReturn result
       _ -> badConst
     Push -> do

--- a/src/Swarm/Game/Step/Combustion.hs
+++ b/src/Swarm/Game/Step/Combustion.hs
@@ -31,6 +31,7 @@ import Swarm.Game.Entity qualified as E
 import Swarm.Game.Location
 import Swarm.Game.Robot
 import Swarm.Game.State
+import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Step.Util
 import Swarm.Game.Step.Util.Inspect
 import Swarm.Game.Universe

--- a/src/Swarm/Game/Step/Path/Cache.hs
+++ b/src/Swarm/Game/Step/Path/Cache.hs
@@ -63,9 +63,7 @@ retrieveCachedPath currentWalkabilityContext newParms = do
   rid <- use robotID
   let eitherCachedPath = guardFailures rid pcr
       myEntry :: CacheRetrievalAttempt
-      myEntry = case eitherCachedPath of
-        Left reason -> RecomputationRequired reason
-        Right _ -> Success
+      myEntry = either RecomputationRequired (const Success) eitherCachedPath
 
   pathCaching . pathCachingLog
     %= RB.insert (CacheLogEntry rid $ RetrievalAttempt myEntry)

--- a/src/Swarm/Game/Step/Path/Cache.hs
+++ b/src/Swarm/Game/Step/Path/Cache.hs
@@ -1,0 +1,225 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Pathfinding cache invalidation logic
+--
+-- Each time the 'Path' command is invoked, the computed
+-- shortest-path is placed in in a cache specific to the invoking robot.
+-- If the 'Path' command is invoked again by that robot
+-- with identical arguments and from the same position, or a position lying
+-- on the previously computed path, then the shortest path shall
+-- be retrieved from the cache instead of being recomputed.
+--
+-- If the 'Path' command is re-invoked with different arguments
+-- or from a novel position, then the shortest-path shall be
+-- recomputed and the cache overwritten with this new result.
+--
+-- Asynchronous to the event of invoking the 'Path' command,
+-- there are a variety of events that may invalidate
+-- a previously-computed shortest path between some
+-- location and a destination, including adding or removing
+-- particular entities at certain locations.
+--
+-- Certain events allow for partial re-use of the previously
+-- computed path.
+module Swarm.Game.Step.Path.Cache (
+  retrieveCachedPath,
+  revalidatePathCache,
+  recordCache,
+) where
+
+import Control.Arrow (left, (&&&))
+import Control.Carrier.State.Lazy
+import Control.Effect.Lens
+import Control.Monad (unless)
+import Data.Either.Extra (maybeToEither)
+import Data.IntMap qualified as IM
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as M
+import Swarm.Game.Entity
+import Swarm.Game.Location
+import Swarm.Game.Robot
+import Swarm.Game.State
+import Swarm.Game.Step.Path.Cache.DistanceLimit
+import Swarm.Game.Step.Path.Type
+import Swarm.Game.Step.Path.Walkability (checkUnwalkable)
+import Swarm.Game.Step.RobotStepState
+import Swarm.Game.Step.Util.Inspect (robotWithID)
+import Swarm.Game.Universe (Cosmic (..), SubworldName)
+import Swarm.Game.World.Modify
+import Swarm.Util (prependList, tails1)
+import Swarm.Util.RingBuffer qualified as RB
+
+-- | Fetch the previously computed shortest path from the cache.
+-- Log success or the reason it failed.
+retrieveCachedPath ::
+  HasRobotStepState sig m =>
+  WalkabilityContext ->
+  PathfindingParameters (Cosmic Location) ->
+  m (Either CacheRetreivalInapplicability [Location])
+retrieveCachedPath currentWalkabilityContext newParms = do
+  pcr <- use $ pathCaching . pathCachingRobots
+  rid <- use robotID
+  let eitherCachedPath = guardFailures rid pcr
+      myEntry :: CacheRetrievalAttempt
+      myEntry = case eitherCachedPath of
+        Left reason -> RecomputationRequired reason
+        Right _ -> Success
+
+  pathCaching . pathCachingLog
+    %= RB.insert (CacheLogEntry rid $ RetrievalAttempt myEntry)
+
+  return eitherCachedPath
+ where
+  PathfindingParameters currentDistanceLimit (Cosmic currentSubworld currentRobotLoc) target = newParms
+
+  guardFailures rid pcr = do
+    -- Checks whether this robot has a cached path
+    cached <- maybeToEither NotCached $ IM.lookup rid pcr
+
+    let PathfindingCache prevParms prevWalkabilityContext _targetLoc pathCells (TailMap ps) = cached
+        PathfindingParameters prevDistLimit previousSubworldName t = prevParms
+
+    -- Subworlds must match
+    unless (previousSubworldName == currentSubworld) $
+      Left $
+        DifferentArg NewSubworld
+
+    -- Pathfinding target type must match
+    unless (t == target) $
+      Left $
+        DifferentArg NewTargetType
+
+    -- Walkability context must match
+    unless (currentWalkabilityContext == prevWalkabilityContext) $
+      Left $
+        DifferentArg NewWalkabilityContext
+
+    left (DifferentArg . NewDistanceLimit) $
+      getDistanceLimitInvalidation currentRobotLoc pathCells currentDistanceLimit prevDistLimit
+
+    -- Checks whether invoked from the same position or a position lying
+    -- on the previously computed path
+    maybeToEither PositionOutsidePath $ M.lookup currentRobotLoc ps
+
+-- | Store a newly computed shortest path in the cache.
+recordCache ::
+  HasRobotStepState sig m =>
+  PathfindingParameters SubworldName ->
+  WalkabilityContext ->
+  -- | includes robot starting position
+  NonEmpty Location ->
+  m ()
+recordCache parms wc pathLocs = do
+  rid <- use robotID
+  pathCaching . pathCachingRobots %= IM.insert rid newCache
+ where
+  newCache = PathfindingCache parms wc (NE.last pathLocs) pathLocs $ mkTailMap pathLocs
+
+-- | For every non-empty suffix of the path, place its tail in a map keyed
+-- by its head.
+mkTailMap :: NonEmpty Location -> TailMap
+mkTailMap pathLocs = TailMap locsMap
+ where
+  locsMap = M.fromList . NE.toList . NE.map (NE.head &&& NE.tail) $ tails1 pathLocs
+
+-- |
+-- Cache is affected by modification of:
+--
+-- * "unwalkable" entities (an entity is placed or removed that is "unwalkable" with respect to the invoking robot)
+-- * "target" entities (if the `path` command had been invoked with the modified entity as a target)
+--
+-- === Removed entity
+--
+-- * If an __unwalkable__ entity is removed from the map, the computed path shall be invalidated.
+-- * If a __target__ entity is removed...
+--
+--     * ...that is the destination of the computed path, invalidate the cache
+--     * ...that is /not/ the destination of the computed path, the cache is unaffected
+--
+-- === Added entity
+--
+-- * If an __unwalkable__ entity is added to the map, the computed path shall only be invalidated /if the new entity lies on the path/.
+-- * If a __target__ entity is added...
+--
+--     * ...that lies on the computed path, the computed path is truncated to that entity's location
+--     * ...that does /not/ lie on the computed path, invalidate the cache
+perhapsInvalidateForRobot ::
+  WalkabilityContext ->
+  -- | location of modified cell
+  Cosmic Location ->
+  -- | nature of entity modification
+  CellModification Entity ->
+  PathfindingCache ->
+  Either InvalidationReason (Maybe PathfindingCache)
+perhapsInvalidateForRobot
+  walkInfo
+  (Cosmic swn entityLoc)
+  entityModification
+  oldCache@(PathfindingCache (PathfindingParameters _distLimit pathSubworld tgt) _previousWalkabilityInfo destLoc origPath (TailMap locmap))
+    | swn /= pathSubworld = Right Nothing
+    | otherwise = case entityModification of
+        Swap oldEntity newEntity ->
+          handleRemovedEntity oldEntity >> handleNewEntity newEntity
+        Remove oldEntity -> handleRemovedEntity oldEntity
+        Add newEntity -> handleNewEntity newEntity
+   where
+    isUnwalkable = not . null . checkUnwalkable walkInfo
+    isOnPath = entityLoc `M.member` locmap
+
+    handleRemovedEntity oldEntity
+      | destLoc == entityLoc = Left TargetEntityRemoved
+      | isUnwalkable oldEntity = Left UnwalkableRemoved
+      | otherwise = Right Nothing
+
+    handleNewEntity newEntity
+      | isUnwalkable newEntity && isOnPath = Left UnwalkableOntoPath
+      | otherwise = case tgt of
+          LocationTarget _locTarget -> Right Nothing
+          EntityTarget targetEntityName -> handleNewEntityWithEntityTarget newEntity targetEntityName
+
+    handleNewEntityWithEntityTarget newEntity targetEntityName
+      | view entityName newEntity /= targetEntityName = Right Nothing
+      -- If the newly-added target entity lies on the existing path,
+      -- truncate the path to set it as the goal.
+      | isOnPath =
+          let truncPath = prependList truncPathExcludingEntityLoc $ pure entityLoc
+              truncPathExcludingEntityLoc = fst $ NE.break (/= entityLoc) origPath
+           in Right $
+                Just
+                  oldCache
+                    { originalPath = truncPath
+                    , locations = mkTailMap truncPath
+                    }
+      | otherwise = Left TargetEntityAddedOutsidePath
+
+-- | Given an event that entails the modification of some cell,
+-- check whether a shortest-path previously computed for a
+-- given robot is still valid or can be updated.
+revalidatePathCache ::
+  (Has (State GameState) sig m) =>
+  Cosmic Location ->
+  CellModification Entity ->
+  (RID, PathfindingCache) ->
+  m ()
+revalidatePathCache entityLoc entityModification (rid, pc) = do
+  maybeRobot <- robotWithID rid
+  let (logEntry, updateFunc) = getCacheUpdate $ checkPath maybeRobot
+  pathCaching . pathCachingRobots %= updateFunc
+  pathCaching . pathCachingLog %= RB.insert (CacheLogEntry rid logEntry)
+ where
+  checkPath = \case
+    Nothing -> Left NonexistentRobot
+    Just bot ->
+      perhapsInvalidateForRobot
+        (view walkabilityContext bot)
+        entityLoc
+        entityModification
+        pc
+
+  getCacheUpdate = \case
+    Left reason -> (Invalidate reason, IM.delete rid)
+    Right maybeReplacement -> case maybeReplacement of
+      Nothing -> (Preserve Unmodified, id)
+      Just newCache -> (Preserve PathTruncated, IM.insert rid newCache)

--- a/src/Swarm/Game/Step/Path/Cache/DistanceLimit.hs
+++ b/src/Swarm/Game/Step/Path/Cache/DistanceLimit.hs
@@ -1,0 +1,69 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Handles cache invalidation if the distance
+-- limit is modified between invocations of
+-- the 'Path' command.
+module Swarm.Game.Step.Path.Cache.DistanceLimit (
+  getDistanceLimitInvalidation,
+  withinDistance,
+) where
+
+import Control.Monad (unless)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Swarm.Game.Location
+import Swarm.Game.Step.Path.Type
+
+-- |
+-- A greater distance limit might yield a shorter path
+-- if there was an better route that just needed to venture outside
+-- of the allowed radius.
+--
+-- On the other hand, a smaller distance limit /will not/ invalidate
+-- the cache so long as all cells on the path are within the new limit.
+getDistanceLimitInvalidation ::
+  -- | current robot location
+  Location ->
+  -- | original path
+  NonEmpty Location ->
+  -- | current limit
+  Maybe Integer ->
+  -- | previous limit
+  Maybe Integer ->
+  Either DistanceLimitChange ()
+-- Limit unchanged:
+getDistanceLimitInvalidation _ _ Nothing Nothing = return ()
+-- Limit was increased to infinity:
+getDistanceLimitInvalidation _ _ Nothing (Just _) = Left LimitIncreased
+-- Limit was decreased from infinity:
+getDistanceLimitInvalidation robotLoc pathCells (Just currLimit) Nothing =
+  handleLimitDecreased robotLoc pathCells currLimit
+getDistanceLimitInvalidation robotLoc pathCells (Just currLimit) (Just prevLimit)
+  | currLimit < prevLimit = handleLimitDecreased robotLoc pathCells currLimit
+  | currLimit > prevLimit = Left LimitIncreased
+  | otherwise = return () -- Limit unchanged
+
+handleLimitDecreased ::
+  Location ->
+  NonEmpty Location ->
+  Integer ->
+  Either DistanceLimitChange ()
+handleLimitDecreased robotLoc pathCells currLimit =
+  unless (all (withinDistance currLimit robotLoc) $ NE.tail pathCells) $
+    Left PathExceededLimit
+
+-- * Utility functions
+
+-- | This function is shared between path computation logic
+-- and patch cache invalidation logic to ensure that
+-- the inequality operator is consistent (e.g. @<@ vs. @<=@).
+withinDistance ::
+  -- | distance limit
+  Integer ->
+  -- | current robot location
+  Location ->
+  -- | target location
+  Location ->
+  Bool
+withinDistance distLimit robotLoc = (<= distLimit) . fromIntegral . manhattan robotLoc

--- a/src/Swarm/Game/Step/Path/Cache/DistanceLimit.hs
+++ b/src/Swarm/Game/Step/Path/Cache/DistanceLimit.hs
@@ -17,7 +17,7 @@ import Swarm.Game.Step.Path.Type
 
 -- |
 -- A greater distance limit might yield a shorter path
--- if there was an better route that just needed to venture outside
+-- if there was a better route that just needed to venture outside
 -- of the allowed radius.
 --
 -- On the other hand, a smaller distance limit /will not/ invalidate
@@ -57,7 +57,7 @@ handleLimitDecreased robotLoc pathCells currLimit =
 
 -- | This function is shared between path computation logic
 -- and patch cache invalidation logic to ensure that
--- the inequality operator is consistent (e.g. @<@ vs. @<=@).
+-- the choice of inequality operator is consistent (e.g. @<@ vs. @<=@).
 withinDistance ::
   -- | distance limit
   Integer ->

--- a/src/Swarm/Game/Step/Path/Finding.hs
+++ b/src/Swarm/Game/Step/Path/Finding.hs
@@ -1,16 +1,17 @@
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Implementation of the @path@ command for robots.
+-- Implementation of the 'Swarm.Language.Syntax.Path' command for robots.
 --
 -- = Design considerations
 -- One possible design of the @path@ command entailed storing a computed
--- shortest path and providing a mechanism to retrieve parts of it later
--- without recomputing the whole thing.
--- However, in general the playfield can be dynamic and obstructions may
+-- shortest path and providing an interface to incrementally retrieve
+-- segments parts of it without recomputing the whole thing.
+-- However, in general the playfield can be dynamic, and obstructions may
 -- appear that invalidate a given computed shortest path.
--- Therefore, there can be limited value in caching a computed path for use
--- across ticks.
+-- Therefore, there can be only limited value in storing a computed path,
+-- either on the client side (i.e. in a swarm-lang program) or internally
+-- for use across ticks.
 --
 -- Instead, in the current implementation a complete path is computed
 -- internally upon invoking the @path@ command, and just the direction of the
@@ -20,10 +21,11 @@
 --
 -- We allow the caller to supply a max distance, but also impose an internal maximum
 -- distance to prevent programming errors from irrecoverably freezing the game.
-module Swarm.Game.Step.Pathfinding where
+module Swarm.Game.Step.Path.Finding where
 
 import Control.Carrier.State.Lazy
 import Control.Effect.Lens
+import Control.Lens ((^.))
 import Control.Monad (filterM, guard)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
@@ -31,54 +33,61 @@ import Data.Graph.AStar (aStarM)
 import Data.HashSet (HashSet)
 import Data.HashSet qualified as HashSet
 import Data.Int (Int32)
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import Swarm.Game.Entity
 import Swarm.Game.Location
+import Swarm.Game.Robot
 import Swarm.Game.State
+import Swarm.Game.Step.Path.Cache
+import Swarm.Game.Step.Path.Cache.DistanceLimit (withinDistance)
+import Swarm.Game.Step.Path.Type
+import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Step.Util
 import Swarm.Game.Step.Util.Inspect
 import Swarm.Game.Universe
 import Swarm.Language.Syntax
 import Swarm.Util (hoistMaybe)
 
--- | Shortest paths can either be computed to the nearest entity of
--- a given type or to a specific location.
-data PathfindingTarget
-  = LocationTarget Location
-  | -- | Note: navigation to entities does not benefit from the
-    -- distance heuristic optimization of the A* algorithm.
-    EntityTarget EntityName
-
--- | swarm command arguments are converted to idiomatic Haskell
+-- | Swarm command arguments are converted to idiomatic Haskell
 -- types before invoking this function, and conversely the callsite
 -- is also responsible for translating the output type to a swarm value.
 --
 -- The cost function is uniformly @1@ between adjacent cells.
 --
 -- Viable paths are determined by walkability.
--- If the goal type is an Entity, than it is permissible for that
+-- If the goal type is an 'Entity', then it is permissible for that
 -- entity to be 'Unwalkable'.
+--
+-- See "Swarm.Game.Step.Path.Cache" for caching details.
 pathCommand ::
-  (HasRobotStepState sig m, Has (State GameState) sig m) =>
-  -- | Distance limit
-  Maybe Integer ->
-  -- | Starting location
-  Cosmic Location ->
-  -- | Search goal
-  PathfindingTarget ->
+  HasRobotStepState sig m =>
+  PathfindingParameters (Cosmic Location) ->
   m (Maybe Direction)
-pathCommand maybeLimit (Cosmic currentSubworld robotLoc) target = do
-  -- This is a short-circuiting optimization; if the goal itself
-  -- is not a walkable cell, then no amount of searching will reach it.
-  isGoalLocWalkable <- case target of
-    LocationTarget loc -> null <$> checkMoveFailure (Cosmic currentSubworld loc)
-    EntityTarget _ -> return True
+pathCommand parms = do
+  currentWalkabilityContext <- use walkabilityContext
 
-  runMaybeT $ do
-    guard isGoalLocWalkable
-    maybeFoundPath <- lift computePath
-    foundPath <- hoistMaybe maybeFoundPath
-    return $ nextDir foundPath
+  -- First, check if the pathfinding target has a cached path.
+  eitherCachedPath <- retrieveCachedPath currentWalkabilityContext parms
+
+  case eitherCachedPath of
+    Right cachedPath -> return $ Just $ nextDir cachedPath
+    Left _ -> do
+      -- This is a short-circuiting optimization; if the goal location itself
+      -- is not a walkable cell, then no amount of searching will reach it.
+      isGoalLocWalkable <- case target of
+        LocationTarget loc -> null <$> checkMoveFailure (Cosmic currentSubworld loc)
+        EntityTarget _ -> return True
+
+      runMaybeT $ do
+        guard isGoalLocWalkable
+        maybeFoundPath <- lift computePath
+        foundPath <- hoistMaybe maybeFoundPath
+        -- NOTE: This will not cache the fact that a path was not found.
+        lift $ recordCache (fmap (^. subworld) parms) currentWalkabilityContext $ robotLoc :| foundPath
+        return $ nextDir foundPath
  where
+  PathfindingParameters maybeDistanceLimit (Cosmic currentSubworld robotLoc) target = parms
+
   computePath =
     aStarM
       (neighborFunc withinDistanceLimit . Cosmic currentSubworld)
@@ -88,14 +97,17 @@ pathCommand maybeLimit (Cosmic currentSubworld robotLoc) target = do
       (return robotLoc)
 
   withinDistanceLimit :: Location -> Bool
-  withinDistanceLimit = (<= distanceLimit) . fromIntegral . manhattan robotLoc
+  withinDistanceLimit = withinDistance distLimit robotLoc
+
+  directionTo :: Location -> Direction
+  directionTo nextLoc = DAbsolute $ nearestDirection $ nextLoc .-. robotLoc
 
   -- Extracts the head of the found path to determine
   -- the next direction for the robot to proceed along
   nextDir :: [Location] -> Direction
   nextDir pathLocs = case pathLocs of
     [] -> DRelative DDown
-    (nextLoc : _) -> DAbsolute $ nearestDirection $ nextLoc .-. robotLoc
+    (nextLoc : _) -> directionTo nextLoc
 
   neighborFunc ::
     HasRobotStepState sig m =>
@@ -135,4 +147,4 @@ pathCommand maybeLimit (Cosmic currentSubworld robotLoc) target = do
 
   -- A failsafe limit is hardcoded to prevent the game from freezing
   --  if an error exists in some .sw code.
-  distanceLimit = maybe maxPathRange (min maxPathRange) maybeLimit
+  distLimit = maybe maxPathRange (min maxPathRange) maybeDistanceLimit

--- a/src/Swarm/Game/Step/Path/Finding.hs
+++ b/src/Swarm/Game/Step/Path/Finding.hs
@@ -6,7 +6,7 @@
 -- = Design considerations
 -- One possible design of the @path@ command entailed storing a computed
 -- shortest path and providing an interface to incrementally retrieve
--- segments parts of it without recomputing the whole thing.
+-- segments of it without recomputing the whole thing.
 -- However, in general the playfield can be dynamic, and obstructions may
 -- appear that invalidate a given computed shortest path.
 -- Therefore, there can be only limited value in storing a computed path,

--- a/src/Swarm/Game/Step/Path/Type.hs
+++ b/src/Swarm/Game/Step/Path/Type.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Types for shortest-path-finding and logging
+-- path-cache invalidation events.
+--
+-- By convention, a @[Location]@ /does not/ include the
+-- starting location, whereas a @NonEmpty Location@ does.
+--
+-- Consequentially, an empty @[Location]@ implies that
+-- the robot's current location is already at the goal location.
+--
+-- A gratuitous number of sum types are defined here
+-- to facilitate explainability of caching behavior via logs.
+module Swarm.Game.Step.Path.Type where
+
+import Control.Lens
+import Data.Aeson (Options (..), SumEncoding (ObjectWithSingleField), ToJSON (..), defaultOptions, genericToJSON)
+import Data.IntMap.Strict (IntMap)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
+import Data.Map qualified as M
+import GHC.Generics (Generic)
+import Swarm.Game.Entity
+import Swarm.Game.Location
+import Swarm.Game.Robot (RID, WalkabilityContext)
+import Swarm.Game.Universe (SubworldName)
+import Swarm.Util.Lens (makeLensesNoSigs)
+import Swarm.Util.RingBuffer
+
+maxLogEntries :: Int
+maxLogEntries = 32
+
+-- | This is parameterized on the starting location,
+-- as we may either want to:
+--
+-- 1. provide the planar start location (when first /computing/ the path), or
+-- 2. suppress it and only propagate the subworld name
+--    (when /retrieving/ from cache), which precludes the downstream possibility
+--    of accidentally mixing up the planar location of the /target/
+--    with the current /robot location/.
+data PathfindingParameters a = PathfindingParameters
+  { distanceLimit :: Maybe Integer
+  -- ^ Manhattan distance limit on cells to explore
+  -- (NOTE: this is not a "path length" limit)
+  , startingLoc :: a
+  -- ^ Starting location
+  , searchGoal :: PathfindingTarget
+  -- ^ Search goal
+  }
+  deriving (Generic, Eq, Show, ToJSON, Functor)
+
+-- | It is possible for the cache to be unaffected
+-- by certain events, or the cache may modified without
+-- fully recomputing the shortest path.
+data CachePreservationMode
+  = Unmodified
+  | PathTruncated
+  deriving (Show, Eq, Generic, ToJSON)
+
+data CacheLogEntry = CacheLogEntry
+  { robot :: RID
+  , event :: CacheEvent
+  }
+  deriving (Show, Eq, Generic, ToJSON)
+
+objectSingleFieldEncoding :: Options
+objectSingleFieldEncoding =
+  defaultOptions
+    { sumEncoding = ObjectWithSingleField
+    }
+
+data CacheRetrievalAttempt
+  = Success
+  | RecomputationRequired CacheRetreivalInapplicability
+  deriving (Show, Eq, Generic)
+
+instance ToJSON CacheRetrievalAttempt where
+  toJSON = genericToJSON objectSingleFieldEncoding
+
+-- | Certain events can obligate the cache to be
+-- completely invalidated, or partially or fully preserved.
+data CacheEvent
+  = Invalidate InvalidationReason
+  | Preserve CachePreservationMode
+  | RetrievalAttempt CacheRetrievalAttempt
+  deriving (Show, Eq, Generic)
+
+instance ToJSON CacheEvent where
+  toJSON = genericToJSON objectSingleFieldEncoding
+
+data DistanceLimitChange
+  = LimitIncreased
+  | PathExceededLimit
+  deriving (Show, Eq, Generic, ToJSON)
+
+data DifferentArgument
+  = NewSubworld
+  | NewTargetType
+  | NewWalkabilityContext
+  | NewDistanceLimit DistanceLimitChange
+  deriving (Show, Eq, Generic, ToJSON)
+
+-- | Reasons why we cannot re-use a precomputed path
+-- from the cache upon re-invoking the 'Path' command
+data CacheRetreivalInapplicability
+  = NotCached
+  | DifferentArg DifferentArgument
+  | PositionOutsidePath
+  deriving (Show, Eq, Generic)
+
+instance ToJSON CacheRetreivalInapplicability where
+  toJSON = genericToJSON objectSingleFieldEncoding
+
+-- | Reasons for cache being invalidated
+data InvalidationReason
+  = TargetEntityAddedOutsidePath
+  | TargetEntityRemoved
+  | UnwalkableRemoved
+  | UnwalkableOntoPath
+  | NonexistentRobot
+  deriving (Show, Eq, Generic, ToJSON)
+
+emptyPathCache :: PathCaching
+emptyPathCache = PathCaching mempty $ mkRingBuffer $ Finite maxLogEntries
+
+-- | Shortest paths can either be computed to the nearest entity of
+-- a given type or to a specific location.
+data PathfindingTarget
+  = LocationTarget Location
+  | -- | Note: navigation to entities does not benefit from the
+    -- distance heuristic optimization of the A* algorithm
+    -- (but see #1568)
+    EntityTarget EntityName
+  deriving (Generic, Eq, Show, ToJSON)
+
+-- | Facilitates lookup of any shortest path to a particular
+-- goal cell, given a location that already lies on a
+-- shortest path.
+newtype TailMap = TailMap (Map Location [Location])
+  deriving (Generic, Eq, Show)
+
+instance ToJSON TailMap where
+  toJSON (TailMap x) = toJSON $ M.toList x
+
+-- | A per-robot cache for the @path@ command.
+data PathfindingCache = PathfindingCache
+  { invocationParms :: PathfindingParameters SubworldName
+  , walkabilityInfo :: WalkabilityContext
+  , targetLoc :: Location
+  , originalPath :: NonEmpty Location
+  , locations :: TailMap
+  -- ^ Fast lookup map of path suffix by
+  -- current location
+  }
+  deriving (Generic, Eq, Show, ToJSON)
+
+data PathCaching = PathCaching
+  { _pathCachingRobots :: IntMap PathfindingCache
+  -- ^ Keyed by RID
+  , _pathCachingLog :: RingBuffer CacheLogEntry
+  -- ^ For diagnostics/testing/debugging
+  }
+makeLensesNoSigs ''PathCaching
+
+-- | All the RIDs of robots that are storing a cached path that
+-- may require invalidation.
+pathCachingRobots :: Lens' PathCaching (IntMap PathfindingCache)
+
+-- | Event log for cache invalidation
+pathCachingLog :: Lens' PathCaching (RingBuffer CacheLogEntry)

--- a/src/Swarm/Game/Step/Path/Type.hs
+++ b/src/Swarm/Game/Step/Path/Type.hs
@@ -145,15 +145,20 @@ newtype TailMap = TailMap (Map Location [Location])
 instance ToJSON TailMap where
   toJSON (TailMap x) = toJSON $ M.toList x
 
+data CachedPath = CachedPath
+  { originalPath :: NonEmpty Location
+  , locations :: TailMap
+  -- ^ Fast lookup map of path suffix by
+  -- current location
+  }
+  deriving (Generic, Eq, Show, ToJSON)
+
 -- | A per-robot cache for the @path@ command.
 data PathfindingCache = PathfindingCache
   { invocationParms :: PathfindingParameters SubworldName
   , walkabilityInfo :: WalkabilityContext
   , targetLoc :: Location
-  , originalPath :: NonEmpty Location
-  , locations :: TailMap
-  -- ^ Fast lookup map of path suffix by
-  -- current location
+  , cachedPath :: CachedPath
   }
   deriving (Generic, Eq, Show, ToJSON)
 

--- a/src/Swarm/Game/Step/RobotStepState.hs
+++ b/src/Swarm/Game/Step/RobotStepState.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- This exists in its own module so that it can be
+-- used by both "Swarm.Game.Step.Path.Cache" and
+-- "Swarm.Game.Step.Util" without introducing an
+-- import cycle.
+module Swarm.Game.Step.RobotStepState where
+
+import Control.Carrier.State.Lazy
+import Control.Effect.Error
+import Swarm.Game.Exception
+import Swarm.Game.Robot
+import Swarm.Game.State
+
+-- | All functions that are used for robot step can access 'GameState' and the current 'Robot'.
+--
+-- They can also throw exception of our custom type, which is handled elsewhere.
+-- Because of that the constraint is only 'Throw', but not 'Catch'/'Error'.
+type HasRobotStepState sig m = (Has (State GameState) sig m, Has (State Robot) sig m, Has (Throw Exn) sig m)

--- a/src/Swarm/Game/Step/Util.hs
+++ b/src/Swarm/Game/Step/Util.hs
@@ -5,6 +5,8 @@
 
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Utilities for implementing robot commands.
 module Swarm.Game.Step.Util where
 
 import Control.Applicative (Applicative (..))
@@ -16,6 +18,7 @@ import Control.Monad (forM_, guard, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Data.Array (bounds, (!))
+import Data.IntMap qualified as IM
 import Data.Set qualified as S
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -27,7 +30,10 @@ import Swarm.Game.ResourceLoading (NameGenerator (..))
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Tracking qualified as SRT
 import Swarm.Game.State
+import Swarm.Game.Step.Path.Cache
+import Swarm.Game.Step.Path.Type
 import Swarm.Game.Step.Path.Walkability
+import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Universe
 import Swarm.Game.World qualified as W
 import Swarm.Game.World.Modify qualified as WM
@@ -39,12 +45,6 @@ import System.Clock (TimeSpec)
 import System.Clock qualified
 import System.Random (UniformRange, uniformR)
 import Prelude hiding (Applicative (..), lookup)
-
--- | All functions that are used for robot step can access 'GameState' and the current 'Robot'.
---
--- They can also throw exception of our custom type, which is handled elsewhere.
--- Because of that the constraint is only 'Throw', but not 'Catch'/'Error'.
-type HasRobotStepState sig m = (Has (State GameState) sig m, Has (State Robot) sig m, Has (Throw Exn) sig m)
 
 deriveHeading :: HasRobotStepState sig m => Direction -> m Heading
 deriveHeading d = do
@@ -73,6 +73,9 @@ updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
   forM_ (WM.getModification =<< someChange) $ \modType -> do
     wakeWatchingRobots cLoc
     SRT.entityModified modType cLoc
+
+    pcr <- use $ pathCaching . pathCachingRobots
+    mapM_ (revalidatePathCache cLoc modType) $ IM.toList pcr
 
 -- * Capabilities
 

--- a/src/Swarm/Game/Step/Util/Inspect.hs
+++ b/src/Swarm/Game/Step/Util/Inspect.hs
@@ -1,5 +1,7 @@
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Utilities for querying robots and their neighbors
 module Swarm.Game.Step.Util.Inspect where
 
 import Control.Carrier.State.Lazy

--- a/src/Swarm/Game/World/Modify.hs
+++ b/src/Swarm/Game/World/Modify.hs
@@ -21,6 +21,7 @@ getModification (Modified x) = Just x
 
 data CellModification e
   = -- | Fields represent what existed in the cell "before" and "after", in that order.
+    -- The values are guaranteed to be different.
     Swap e e
   | Remove e
   | Add e

--- a/src/Swarm/Util/RingBuffer.hs
+++ b/src/Swarm/Util/RingBuffer.hs
@@ -1,0 +1,47 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- A rolling window of items for the purpose of maintaining
+-- a bounded-size debugging log of recent events.
+module Swarm.Util.RingBuffer (
+  RingBuffer,
+  BufferSize (..),
+  getValues,
+  insert,
+  mkRingBuffer,
+) where
+
+import Data.Aeson
+import Data.Sequence as S
+import Servant.Docs (ToSample)
+import Servant.Docs qualified as SD
+
+-- | Isomorphic to the 'Maybe' type
+data BufferSize = Infinite | Finite Int
+
+mkRingBuffer :: BufferSize -> RingBuffer a
+mkRingBuffer = RingBuffer mempty
+
+data RingBuffer a = RingBuffer (Seq a) BufferSize
+
+instance (ToJSON a) => ToJSON (RingBuffer a) where
+  toJSON (RingBuffer xs _) = toJSON xs
+
+instance ToSample (RingBuffer a) where
+  toSamples _ = SD.noSamples
+
+getValues :: RingBuffer a -> Seq a
+getValues (RingBuffer xs _) = xs
+
+insert :: a -> RingBuffer a -> RingBuffer a
+insert x (RingBuffer xs lim) = RingBuffer inserted lim
+ where
+  inserted = popped :|> x
+  popped = case lim of
+    Infinite -> xs
+    Finite maxSize -> case xs of
+      Empty -> xs
+      _ :<| back ->
+        if S.length xs < maxSize
+          then xs
+          else back

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -70,6 +70,7 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Log
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry
 import Swarm.Game.State
+import Swarm.Game.Step.Path.Type
 import Swarm.Language.Module
 import Swarm.Language.Pipeline
 import Swarm.Language.Pretty (prettyTextLine)
@@ -78,6 +79,7 @@ import Swarm.ReadableIORef
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Goal
 import Swarm.TUI.Model.UI
+import Swarm.Util.RingBuffer
 import System.Timeout (timeout)
 import Text.Read (readEither)
 import Witch (into)
@@ -100,6 +102,7 @@ type SwarmAPI =
     :<|> "recognize" :> "found" :> Get '[JSON] [StructureLocation]
     :<|> "code" :> "render" :> ReqBody '[PlainText] T.Text :> Post '[PlainText] T.Text
     :<|> "code" :> "run" :> ReqBody '[PlainText] T.Text :> Post '[PlainText] T.Text
+    :<|> "paths" :> "log" :> Get '[JSON] (RingBuffer CacheLogEntry)
     :<|> "repl" :> "history" :> "full" :> Get '[JSON] [REPLHistItem]
 
 swarmApi :: Proxy SwarmAPI
@@ -150,6 +153,7 @@ mkApp state events =
     :<|> recogFoundHandler state
     :<|> codeRenderHandler
     :<|> codeRunHandler events
+    :<|> pathsLogHandler state
     :<|> replHandler state
 
 robotsHandler :: ReadableIORef AppState -> Handler [Robot]
@@ -220,6 +224,11 @@ codeRunHandler :: BChan AppEvent -> Text -> Handler Text
 codeRunHandler chan contents = do
   liftIO . writeBChan chan . Web $ RunWebCode contents
   return $ T.pack "Sent\n"
+
+pathsLogHandler :: ReadableIORef AppState -> Handler (RingBuffer CacheLogEntry)
+pathsLogHandler appStateRef = do
+  appState <- liftIO (readIORef appStateRef)
+  pure $ appState ^. gameState . pathCaching . pathCachingLog
 
 replHandler :: ReadableIORef AppState -> Handler [REPLHistItem]
 replHandler appStateRef = do

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -160,8 +160,12 @@ library
                       Swarm.Game.State
                       Swarm.Game.Step
                       Swarm.Game.Step.Combustion
-                      Swarm.Game.Step.Pathfinding
+                      Swarm.Game.Step.Path.Cache
+                      Swarm.Game.Step.Path.Cache.DistanceLimit
+                      Swarm.Game.Step.Path.Finding
+                      Swarm.Game.Step.Path.Type
                       Swarm.Game.Step.Path.Walkability
+                      Swarm.Game.Step.RobotStepState
                       Swarm.Game.Step.Util
                       Swarm.Game.Step.Util.Inspect
                       Swarm.Game.Terrain
@@ -238,6 +242,7 @@ library
                       Swarm.Util.Erasable
                       Swarm.Util.Lens
                       Swarm.Util.Parse
+                      Swarm.Util.RingBuffer
                       Swarm.Util.UnitInterval
                       Swarm.Util.WindowedCounter
                       Swarm.Util.Yaml

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -45,6 +45,7 @@ import Swarm.Game.State (
   messageInfo,
   messageQueue,
   notificationsContent,
+  pathCaching,
   robotMap,
   temporal,
   ticks,
@@ -53,6 +54,7 @@ import Swarm.Game.State (
   winSolution,
  )
 import Swarm.Game.Step (gameTick)
+import Swarm.Game.Step.Path.Type
 import Swarm.Game.World.Typecheck (WorldMap)
 import Swarm.Language.Context qualified as Ctx
 import Swarm.Language.Pipeline (ProcessedTerm (..), processTerm)
@@ -71,6 +73,7 @@ import Swarm.TUI.Model (
 import Swarm.TUI.Model.StateUpdate (constructAppState, initPersistentState)
 import Swarm.TUI.Model.UI (UIState)
 import Swarm.Util (acquireAllWithExt)
+import Swarm.Util.RingBuffer qualified as RB
 import Swarm.Util.Yaml (decodeFileEitherE)
 import System.FilePath.Posix (splitDirectories)
 import System.Timeout (timeout)
@@ -357,6 +360,42 @@ testScenarioSolutions rs ui =
             , testSolution Default "Testing/836-pathfinding/836-no-path-exists1"
             , testSolution (Sec 10) "Testing/836-pathfinding/836-no-path-exists2"
             , testSolution (Sec 3) "Testing/836-pathfinding/836-automatic-waypoint-navigation"
+            ]
+        , testGroup
+            "Pathfinding cache (#1569)"
+            [ testSolution Default "Testing/1569-pathfinding-cache/1569-harvest-batch"
+            , testTutorialSolution' Default "Testing/1569-pathfinding-cache/1569-cache-invalidation-modes" CheckForBadErrors $ \g -> do
+                let cachingLog = g ^. pathCaching . pathCachingLog
+                    actualEntries = map (\(CacheLogEntry _ x) -> x) $ toList $ RB.getValues cachingLog
+                    expectedEntries =
+                      [ RetrievalAttempt (RecomputationRequired NotCached)
+                      , Invalidate UnwalkableOntoPath
+                      , RetrievalAttempt (RecomputationRequired NotCached)
+                      , RetrievalAttempt Success
+                      , Invalidate UnwalkableRemoved
+                      , RetrievalAttempt (RecomputationRequired NotCached)
+                      , Invalidate TargetEntityAddedOutsidePath
+                      , RetrievalAttempt (RecomputationRequired NotCached)
+                      , Preserve PathTruncated
+                      , RetrievalAttempt Success
+                      ]
+                assertEqual "Incorrect sequence of invalidations!" expectedEntries actualEntries
+            , testTutorialSolution' Default "Testing/1569-pathfinding-cache/1569-cache-invalidation-distance-limit" CheckForBadErrors $ \g -> do
+                let cachingLog = g ^. pathCaching . pathCachingLog
+                    actualEntries = map (\(CacheLogEntry _ x) -> x) $ toList $ RB.getValues cachingLog
+                    expectedEntries =
+                      [ RetrievalAttempt (RecomputationRequired NotCached)
+                      , RetrievalAttempt Success
+                      , RetrievalAttempt Success
+                      , RetrievalAttempt Success
+                      , RetrievalAttempt (RecomputationRequired PositionOutsidePath)
+                      , RetrievalAttempt Success
+                      , RetrievalAttempt (RecomputationRequired (DifferentArg (NewDistanceLimit LimitIncreased)))
+                      , RetrievalAttempt Success
+                      , RetrievalAttempt (RecomputationRequired (DifferentArg (NewDistanceLimit PathExceededLimit)))
+                      , RetrievalAttempt Success
+                      ]
+                assertEqual "Incorrect sequence of invalidations!" expectedEntries actualEntries
             ]
         , testGroup
             "Ping (#1535)"


### PR DESCRIPTION
Closes #1569

## Performance

Path cache invalidation upon world modifications (i.e. entities inserted or removed) entails iterating over all of the previously-cached paths [here](https://github.com/swarm-game/swarm/pull/1595/files#r1390158411).  For efficiency's sake, we avoid iterating over "all existing robots".

Any scenario that does not use the `path` command is entirely unaffected by this change.

## Demo

Previously, this demo was virtually unplayable, since when moving between widely-spaced "clusters" of flowers, an expensive A-star search was invoked at almost every tick.  Now, the vast majority of moves utilize the cache, and the demo exhibits minimal stuttering (e.g. when a single A-star search is performed when moving between distant clusters).

    scripts/play.sh -i scenarios/Fun/horton.yaml --autoplay --speed 7

### Event log

An event log specific to the path cache is maintained with its own ring buffer:

    scripts/play.sh -i scenarios/Testing/1569-pathfinding-cache/1569-harvest-batch.yaml --autoplay

 and view http://localhost:5357/paths/log