### PR TITLE
update to `megaparsec-9.6.1`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -77,11 +77,6 @@ jobs:
             compilerVersion: 9.0.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.7
-            compilerKind: ghc
-            compilerVersion: 8.10.7
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,6 @@ queue_rules:
           - check-success=Haskell-CI - Linux - ghc-9.4.5
           - check-success=Haskell-CI - Linux - ghc-9.2.7
           - check-success=Haskell-CI - Linux - ghc-9.0.2
-          - check-success=Haskell-CI - Linux - ghc-8.10.7
 
 pull_request_rules:
 - actions:
@@ -49,7 +48,6 @@ pull_request_rules:
       - check-success=Haskell-CI - Linux - ghc-9.4.5
       - check-success=Haskell-CI - Linux - ghc-9.2.7
       - check-success=Haskell-CI - Linux - ghc-9.0.2
-      - check-success=Haskell-CI - Linux - ghc-8.10.7
   - label=merge me
   - ! '#approved-reviews-by>=1'
   - ! '#changes-requested-reviews-by=0'

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,5 +10,6 @@ extra-deps:
 # breaking changes; see https://github.com/swarm-game/swarm/issues/1350
 - lsp-1.6.0.0
 - lsp-types-1.6.0.0
-resolver: lts-21.0
+- megaparsec-9.6.1
+resolver: lts-21.19
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -267,7 +267,7 @@ library
                       lens                          >= 4.19 && < 5.3,
                       linear                        >= 1.21.6 && < 1.23,
                       lsp                           >= 1.6 && < 1.7,
-                      megaparsec                    >= 9.0 && < 9.6,
+                      megaparsec                    >= 9.6.1 && < 9.7,
                       minimorph                     >= 0.3 && < 0.4,
                       transformers                  >= 0.5 && < 0.7,
                       mtl                           >= 2.2.2 && < 2.4,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -32,7 +32,7 @@ maintainer:         byorgey@gmail.com
 bug-reports:        https://github.com/swarm-game/swarm/issues
 copyright:          Brent Yorgey 2021
 category:           Game
-tested-with:        GHC ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.5 || ==9.6.2
+tested-with:        GHC ==9.0.2 || ==9.2.7 || ==9.4.5 || ==9.6.2
 extra-source-files: CHANGELOG.md
                     example/*.sw
                     editors/emacs/*.el


### PR DESCRIPTION
This allows us to remove any annoying workaround. Also bump stack resolver to LTS-21.19.