### PR TITLE
Fix REPL type display

### DIFF
--- a/src/Swarm/TUI/Panel.hs
+++ b/src/Swarm/TUI/Panel.hs
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 {-# LANGUAGE TemplateHaskell #-}
 
 -- |
@@ -9,7 +7,8 @@
 -- a border around some content, with the color of the border
 -- depending on whether the panel is currently focused.  Panels exist
 -- within a 'FocusRing' such that the user can cycle between the
--- panels (using /e.g./ the @Tab@ key).
+-- panels (using /e.g./ the @Tab@ key).  Panels can also have labels
+-- at up to 6 locations (top\/bottom, left\/center\/right).
 module Swarm.TUI.Panel (
   panel,
 ) where

--- a/src/Swarm/TUI/View/Util.hs
+++ b/src/Swarm/TUI/View/Util.hs
@@ -21,7 +21,7 @@ import Swarm.Game.Scenario (scenarioName)
 import Swarm.Game.ScenarioInfo (scenarioItemName)
 import Swarm.Game.State
 import Swarm.Game.Terrain
-import Swarm.Language.Pretty (prettyText)
+import Swarm.Language.Pretty (prettyTextLine)
 import Swarm.Language.Syntax (Syntax)
 import Swarm.Language.Text.Markdown qualified as Markdown
 import Swarm.Language.Types (Polytype)
@@ -114,7 +114,7 @@ generateModal s mt = Modal mt (dialog (Just $ str title) buttons (maxModalWindow
 
 -- | Render the type of the current REPL input to be shown to the user.
 drawType :: Polytype -> Widget Name
-drawType = withAttr infoAttr . padLeftRight 1 . txt . prettyText
+drawType = withAttr infoAttr . padLeftRight 1 . txt . prettyTextLine
 
 -- | Draw markdown document with simple code/bold/italic attributes.
 --

--- a/src/Swarm/TUI/View/Util.hs
+++ b/src/Swarm/TUI/View/Util.hs
@@ -114,7 +114,14 @@ generateModal s mt = Modal mt (dialog (Just $ str title) buttons (maxModalWindow
 
 -- | Render the type of the current REPL input to be shown to the user.
 drawType :: Polytype -> Widget Name
-drawType = withAttr infoAttr . padLeftRight 1 . txt . prettyTextLine
+drawType ty = Widget Fixed Fixed $ do
+  ctx <- getContext
+  let w = ctx ^. availWidthL
+      renderedTy = prettyTextLine ty
+      displayedTy
+        | T.length renderedTy <= w `div` 2 - 2 = renderedTy
+        | otherwise = T.take (w `div` 2 - 2 - 3) renderedTy <> "..."
+  render . withAttr infoAttr . padLeftRight 1 . txt $ displayedTy
 
 -- | Draw markdown document with simple code/bold/italic attributes.
 --


### PR DESCRIPTION
Make sure it again prints the type on one line, by using `prettyTextLine` instead of `prettyText` to format the type.

Fixes #1597.