### PR TITLE
Update to support running on Windows

### DIFF
--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -111,18 +111,18 @@ appMain opts = do
             handleEvent e
 
       -- Setup virtual terminal
-      let mkVty =
+      let buildVty =
             case colorMode opts of
               Nothing    -> VS.mkVty V.defaultConfig
               Just cMode -> do
-                    platformSettings <- VS.defaultSettings
-                    VS.mkVtyWithSettings V.defaultConfig $ platformSettings { VS.settingColorMode = cMode }
-      vty <- mkVty
+                platformSettings <- VS.defaultSettings
+                VS.mkVtyWithSettings V.defaultConfig $ platformSettings {VS.settingColorMode = cMode}
+      vty <- buildVty
 
       V.setMode (V.outputIface vty) V.Mouse True
 
       -- Run the app.
-      void $ customMain vty mkVty (Just chan) (app eventHandler) s'
+      void $ customMain vty buildVty (Just chan) (app eventHandler) s'
 
 -- | A demo program to run the web service directly, without the terminal application.
 --   This is useful to live update the code using @ghcid -W --test "Swarm.App.demoWeb"@.

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -113,7 +113,7 @@ appMain opts = do
       -- Setup virtual terminal
       let buildVty =
             case colorMode opts of
-              Nothing    -> VS.mkVty V.defaultConfig
+              Nothing -> VS.mkVty V.defaultConfig
               Just cMode -> do
                 platformSettings <- VS.defaultSettings
                 VS.mkVtyWithSettings V.defaultConfig $ platformSettings {VS.settingColorMode = cMode}

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
@@ -18,6 +19,13 @@ import Data.IORef (newIORef, writeIORef)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Graphics.Vty qualified as V
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+import Graphics.Vty.Platform.Windows.Settings qualified as VS
+import Graphics.Vty.Platform.Windows qualified as VS
+#else
+import Graphics.Vty.Platform.Unix.Settings qualified as VS
+import Graphics.Vty.Platform.Unix qualified as VS
+#endif
 import Swarm.Game.Failure (SystemFailure)
 import Swarm.Language.Pretty (prettyText)
 import Swarm.Log (LogSource (SystemLog), Severity (..))
@@ -103,12 +111,18 @@ appMain opts = do
             handleEvent e
 
       -- Setup virtual terminal
-      let buildVty = V.mkVty $ V.defaultConfig {V.colorMode = colorMode opts}
-      initialVty <- buildVty
-      V.setMode (V.outputIface initialVty) V.Mouse True
+      let mkVty =
+            case colorMode opts of
+              Nothing    -> VS.mkVty V.defaultConfig
+              Just cMode -> do
+                    platformSettings <- VS.defaultSettings
+                    VS.mkVtyWithSettings V.defaultConfig $ platformSettings { VS.settingColorMode = cMode }
+      vty <- mkVty
+
+      V.setMode (V.outputIface vty) V.Mouse True
 
       -- Run the app.
-      void $ customMain initialVty buildVty (Just chan) (app eventHandler) s'
+      void $ customMain vty mkVty (Just chan) (app eventHandler) s'
 
 -- | A demo program to run the web service directly, without the terminal application.
 --   This is useful to live update the code using @ghcid -W --test "Swarm.App.demoWeb"@.

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -254,7 +254,7 @@ library
                       astar                         >= 0.3 && < 0.3.1,
                       blaze-html                    >= 0.9.1 && < 0.9.2,
                       boolexpr                      >= 0.2 && < 0.3,
-                      brick                         >= 1.10 && < 1.11,
+                      brick                         >= 2.1.1 && < 3.0,
                       bytestring                    >= 0.10 && < 0.12,
                       clock                         >= 0.8.2 && < 0.9,
                       colour                        >= 2.3.6 && < 2.4,
@@ -310,13 +310,18 @@ library
                       unification-fd                >= 0.11  && < 0.12,
                       unordered-containers          >= 0.2.14 && < 0.3,
                       vector                        >= 0.12 && < 0.14,
-                      vty                           >= 5.33 && < 5.39,
+                      vty                           >= 6.0 && < 7.0,
+                      vty-crossplatform             >= 0.2.0.0 && < 1.0,
                       wai                           >= 3.2 && < 3.3,
                       warp                          >= 3.2 && < 3.4,
                       witch                         >= 1.1.1.0 && < 1.3,
                       witherable                    >= 0.4 && < 0.5,
                       word-wrap                     >= 0.5 && < 0.6,
-                      yaml                          >= 0.11 && < 0.11.12.0,
+                      yaml                          >= 0.11 && < 0.11.12.0
+    if os(windows)
+      build-depends:  vty-windows                   >= 0.1.0.3 && < 1.0
+    else
+      build-depends:  vty-unix                      >= 0.1.0.0 && < 1.0
     hs-source-dirs:   src
     default-language: Haskell2010
     default-extensions:

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -254,7 +254,7 @@ library
                       astar                         >= 0.3 && < 0.3.1,
                       blaze-html                    >= 0.9.1 && < 0.9.2,
                       boolexpr                      >= 0.2 && < 0.3,
-                      brick                         >= 2.1.1 && < 3.0,
+                      brick                         >= 2.1.1 && < 2.2,
                       bytestring                    >= 0.10 && < 0.12,
                       clock                         >= 0.8.2 && < 0.9,
                       colour                        >= 2.3.6 && < 2.4,
@@ -310,8 +310,8 @@ library
                       unification-fd                >= 0.11  && < 0.12,
                       unordered-containers          >= 0.2.14 && < 0.3,
                       vector                        >= 0.12 && < 0.14,
-                      vty                           >= 6.0 && < 7.0,
-                      vty-crossplatform             >= 0.2.0.0 && < 1.0,
+                      vty                           >= 6.0 && < 6.1,
+                      vty-crossplatform             >= 0.2.0.0 && < 0.3,
                       wai                           >= 3.2 && < 3.3,
                       warp                          >= 3.2 && < 3.4,
                       witch                         >= 1.1.1.0 && < 1.3,
@@ -319,9 +319,9 @@ library
                       word-wrap                     >= 0.5 && < 0.6,
                       yaml                          >= 0.11 && < 0.11.12.0
     if os(windows)
-      build-depends:  vty-windows                   >= 0.1.0.3 && < 1.0
+      build-depends:  vty-windows                   >= 0.1.0.3 && < 0.2
     else
-      build-depends:  vty-unix                      >= 0.1.0.0 && < 1.0
+      build-depends:  vty-unix                      >= 0.1.0.0 && < 0.2
     hs-source-dirs:   src
     default-language: Haskell2010
     default-extensions:


### PR DESCRIPTION
Added support for running on Windows, in command line or Powershell terminals.

Currently terminal emulators such as mintty, ConEmu, alacritty, etc are not supported.

Addresses issues #1607 and #53.