### PR TITLE
structure recognition enhancements

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -633,6 +633,15 @@
     A circuit is needed for constructing various "smart" devices.
   properties: [portable]
 
+- name: blueprint
+  display:
+    attr: blue
+    char: 'B'
+  description:
+  - Locate and analyze structures placed in the world.
+  properties: [portable]
+  capabilities: [structure]
+
 - name: drill bit
   display:
     attr: entity

--- a/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
+++ b/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
@@ -9,4 +9,5 @@
 1575-remove-structure.yaml
 1575-swap-structure.yaml
 1575-placement-occlusion.yaml
+1575-interior-entity-placement.yaml
 1575-floorplan-command.yaml

--- a/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
+++ b/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
@@ -9,3 +9,4 @@
 1575-remove-structure.yaml
 1575-swap-structure.yaml
 1575-placement-occlusion.yaml
+1575-floorplan-command.yaml

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-browse-structures.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-browse-structures.yaml
@@ -1,18 +1,18 @@
 version: 1
 name: Structure browser
 description: |
-  Hit F6 to view the recognizable structures.
+  Hit *F6* to view the recognizable structures.
 
   Only the subset of the structures marked with
-  "recognize: true" are browseable.
-  In particular, the "donut" structure is placed
-  in the map but not displayed in the F6 dialog.
+  *recognize: true* are browseable.
+  In particular, the `donut`{=structure} structure is placed
+  in the map but not displayed in the *F6* dialog.
 creative: false
 objectives:
   - teaser: Build structure
     goal:
       - |
-        Build a "precious" structure
+        Build a `precious`{=structure} structure
     condition: |
       foundStructure <- structure "precious" 0;
       return $ case foundStructure (\_. false) (\_. true);

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-construction-count.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-construction-count.yaml
@@ -7,7 +7,7 @@ objectives:
   - teaser: Build 12 structures
     goal:
       - |
-        Build 12 copies of the "green_jewel" structure
+        Build 12 copies of the `green_jewel`{=structure} structure
     condition: |
       foundGreen <- structure "green_jewel" 0;
       return $ case foundGreen (\_. false) (\x. fst x >= 12);

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-disjoint.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-disjoint.yaml
@@ -9,7 +9,7 @@ description: |
   should not be counted until all three are placed.
 creative: false
 objectives:
-  - teaser: Build 2 chessboards
+  - teaser: Build 2 `chessboard`{=structure}s
     prerequisite:
       not: premature_win
     goal:

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-single-recognition.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-single-recognition.yaml
@@ -6,7 +6,7 @@ description: |
   structure template.
 creative: false
 objectives:
-  - teaser: Build 2 chessboards
+  - teaser: Build 2 `chessboard`{=structure}s
     prerequisite:
       not: premature_win
     goal:

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-floorplan-command.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-floorplan-command.yaml
@@ -1,0 +1,75 @@
+version: 1
+name: Floorplan command
+description: |
+  Query the dimensions of a structure
+  template to build one.
+creative: false
+objectives:
+  - teaser: Build structure
+    goal:
+      - |
+        Build a `wooden box`{=structure} structure.
+    condition: |
+      def isRight = \x. case x (\_. false) (\_. true); end;
+      foundBox <- structure "wooden box" 0;
+      return $ isRight foundBox;
+robots:
+  - name: base
+    dir: [1, 0]
+    devices:
+      - ADT calculator
+      - blueprint
+      - branch predictor
+      - comparator
+      - dictionary
+      - grabber
+      - logger
+      - treads
+    inventory:
+      - [100, board]
+solution: |
+  def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
+
+  def mkRow = \width.
+    doN width $ (place "board"; move;);
+    turn back;
+    doN width move;
+    end;
+
+  def mkRows = \height. \width.
+    doN height $ (mkRow width; turn left; move; turn left);
+    end;
+
+  dims <- floorplan "wooden box";
+  let width = fst dims in
+  let height = snd dims in
+
+  mkRows height width;
+structures:
+  - name: wooden box
+    recognize: true
+    structure:
+      palette:
+        'b': [stone, board]
+      map: |
+       bbbbbbb
+       bbbbbbb
+       bbbbbbb
+       bbbbbbb
+       bbbbbbb
+known: [board]
+world:
+  dsl: |
+    {blank}
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+  upperleft: [0, 0]
+  map: |
+    ..........
+    .B........
+    ..........
+    ..........
+    ..........
+    ..........
+    ..........

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-handle-overlapping.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-handle-overlapping.yaml
@@ -8,7 +8,7 @@ objectives:
   - teaser: Build structure
     goal:
       - |
-        Build a "precious" structure
+        Build a `precious`{=structure} structure
     condition: |
       foundStructure <- structure "precious" 0;
       return $ case foundStructure (\_. false) (\_. true);

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-interior-entity-placement.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-interior-entity-placement.yaml
@@ -1,0 +1,111 @@
+version: 1
+name: Structure recognition - interior space
+description: |
+  Entities can be added and removed
+  on empty cells within the rectangular
+  boundary of an already-placed structure without
+  affecting its recognition status.
+
+  Additionally, recognition of statically-placed
+  structures at scenario initialization is also
+  unaffected by interior entities.
+
+  However, any such "contaminating" entities
+  will prevent the recognition of a structure
+  when constructed by a robot.
+creative: false
+objectives:
+  - teaser: Replace rock
+    prerequisite: grab_rock
+    goal:
+      - |
+        Place the `rock`{=entity} entity back inside the `pigpen`{=structure}.
+    condition: |
+      foundBox <- structure "pigpen" 0;
+      case foundBox (\_. return false) (\struc.
+        let structPos = snd struc in
+        j <- robotnamed "judge";
+        as j {
+          structBounds <- floorplan "pigpen";
+
+          // Move to bottom-left corner
+          teleport self structPos;
+
+          rockCount <- resonate "rock" ((0, 0), structBounds);
+          return $ rockCount > 0;
+        }
+      );
+  - teaser: Grab rock
+    id: grab_rock
+    prerequisite: prerecognized
+    goal:
+      - |
+        Grab an entity from inside a `pigpen`{=structure} structure.
+    condition: |
+      as base {
+        has "rock";
+      }
+  - teaser: Prerecognize
+    id: prerecognized
+    goal:
+      - |
+        `pigpen`{=structure} structure should be recognized upon initialization,
+        even with an extraneous entity within its bounds.
+    condition: |
+      def isRight = \x. case x (\_. false) (\_. true); end;
+      foundBox <- structure "pigpen" 0;
+      return $ isRight foundBox;
+robots:
+  - name: base
+    dir: [1, 0]
+    devices:
+      - ADT calculator
+      - blueprint
+      - grabber
+      - logger
+      - treads
+  - name: judge
+    dir: [1, 0]
+    system: true
+    display:
+      invisible: true
+solution: |
+  move; move;
+  x <- grab;
+  move;
+  place x;
+structures:
+  - name: pigpen
+    recognize: true
+    structure:
+      palette:
+        'b': [stone, board]
+      mask: '.'
+      map: |
+       bbbb
+       b..b
+       b..b
+       bbbb
+known: [board, rock]
+world:
+  dsl: |
+    {blank}
+  placements:
+    - src: pigpen
+      offset: [1, 0]
+    - src: pigpen
+      offset: [3, -6]
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+    'r': [grass, rock]
+    'j': [grass, erase, judge]
+  upperleft: [-7, 3]
+  map: |
+    j.....
+    ......
+    B.r...
+    ......
+    ......
+
+

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-nested-structure-definition.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-nested-structure-definition.yaml
@@ -10,8 +10,8 @@ objectives:
     prerequisite: grab_tree
     goal:
       - |
-        Replace tree after grabbing.
-        Structure should be recognized again.
+        Replace `tree`{=entity} after grabbing.
+        The `double ring`{=structure} structure should be recognized again.
     condition: |
       foundStructure <- structure "double ring" 0;
       return $ case foundStructure (\_. false) (\_. true);
@@ -29,7 +29,7 @@ objectives:
     id: grab_tree
     goal:
       - |
-        Grab a tree
+        Grab a `tree`{=entity}
     condition: |
       as base {
         has "tree";

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-overlapping-tiebreaker-by-location.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-overlapping-tiebreaker-by-location.yaml
@@ -10,7 +10,7 @@ objectives:
       not: wrong_structure
     goal:
       - |
-        Build a structure
+        Build a `topleft`{=structure} structure
     condition: |
       foundStructure <- structure "topleft" 0;
       return $ case foundStructure (\_. false) (\_. true);
@@ -19,7 +19,7 @@ objectives:
     optional: true
     goal:
       - |
-        The "bottomright" structure shouldn't be recognized.
+        The `bottomright`{=structure} structure shouldn't be recognized.
     condition: |
       foundStructure <- structure "bottomright" 0;
       return $ case foundStructure (\_. false) (\_. true);

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-placement-occlusion.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-placement-occlusion.yaml
@@ -11,7 +11,7 @@ objectives:
       not: complete_red_structure
     goal:
       - |
-        Build a "green_jewel" structure
+        Build a `green_jewel`{=structure} structure
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
 
@@ -22,7 +22,7 @@ objectives:
     teaser: Complete red structure
     goal:
       - |
-        A "red_jewel" structure should not be recognized
+        A `red_jewel`{=structure} structure should not be recognized
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
 

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-remove-structure.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-remove-structure.yaml
@@ -17,7 +17,7 @@ objectives:
     teaser: Complete structure
     goal:
       - |
-        Build a structure
+        Build a `chessboard`{=structure} structure
     condition: |
       foundStructure <- structure "chessboard" 0;
       return $ case foundStructure (\_. false) (\_. true);

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-swap-structure.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-swap-structure.yaml
@@ -9,7 +9,7 @@ objectives:
     prerequisite: complete_green_structure
     goal:
       - |
-        Build a "blue_jewel" structure
+        Build a `blue_jewel`{=structure} structure
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
 
@@ -22,7 +22,7 @@ objectives:
     prerequisite: complete_red_structure
     goal:
       - |
-        Build a "green_jewel" structure
+        Build a `green_jewel`{=structure} structure
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
 
@@ -33,7 +33,7 @@ objectives:
     teaser: Complete red structure
     goal:
       - |
-        Build a "red_jewel" structure
+        Build a `red_jewel`{=structure} structure
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
 

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -88,6 +88,7 @@
                "whereami"
                "waypoint"
                "structure"
+               "floorplan"
                "detect"
                "resonate"
                "density"

--- a/editors/vim/swarm.vim
+++ b/editors/vim/swarm.vim
@@ -1,6 +1,6 @@
 syn keyword Keyword def end let in require
 syn keyword Builtins self parent base if inl inr case fst snd force undefined fail not format chars split charat tochar key
-syn keyword Command noop wait selfdestruct move backup path push stride turn grab harvest ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami waypoint structure detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows
+syn keyword Command noop wait selfdestruct move backup path push stride turn grab harvest ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami waypoint structure floorplan detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows
 syn keyword Direction east north west south down forward left back right
 syn keyword Type int text dir bool cmd void unit actor
 

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -58,7 +58,7 @@
 				},
 				{
 				"name": "keyword.other",
-				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|backup|path|push|stride|turn|grab|harvest|ignite|place|ping|give|equip|unequip|make|has|equipped|count|drill|use|build|salvage|reprogram|say|listen|log|view|appear|create|halt|time|scout|whereami|waypoint|structure|detect|resonate|density|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|instant|installkeyhandler|teleport|as|robotnamed|robotnumbered|knows)\\b"
+				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|backup|path|push|stride|turn|grab|harvest|ignite|place|ping|give|equip|unequip|make|has|equipped|count|drill|use|build|salvage|reprogram|say|listen|log|view|appear|create|halt|time|scout|whereami|waypoint|structure|floorplan|detect|resonate|density|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|instant|installkeyhandler|teleport|as|robotnamed|robotnumbered|knows)\\b"
 				}
 			]
 			},

--- a/src/Swarm/Game/Scenario/Topography/Structure/Recognition/Precompute.hs
+++ b/src/Swarm/Game/Scenario/Topography/Structure/Recognition/Precompute.hs
@@ -159,7 +159,7 @@ mkAutomatons xs =
   grids = map extractGrid xs
 
   process g = StructureInfo g . histogram . concatMap catMaybes $ entityGrid g
-  infos = map process grids
+  infos = M.fromList $ map (name . originalDefinition &&& process) grids
 
 extractGrid :: NamedGrid (Maybe Cell) -> StructureWithGrid
 extractGrid x = StructureWithGrid x $ getEntityGrid $ structure x

--- a/src/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -33,6 +33,7 @@ import Swarm.Game.Entity (Entity)
 import Swarm.Game.Location (Location)
 import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.Cell
+import Swarm.Game.Scenario.Topography.Placement (StructureName)
 import Swarm.Game.Scenario.Topography.Structure (NamedGrid)
 import Swarm.Game.Universe (Cosmic, offsetBy)
 import Text.AhoCorasick (StateMachine)
@@ -177,7 +178,7 @@ makeLenses ''AutomatonInfo
 -- | The complete set of data needed to identify applicable
 -- structures, based on a just-placed entity.
 data RecognizerAutomatons = RecognizerAutomatons
-  { _definitions :: [StructureInfo]
+  { _definitions :: Map StructureName StructureInfo
   -- ^ all of the structures that shall participate in automatic recognition.
   -- This list is used only by the UI.
   , _automatonsByEntity :: Map Entity (AutomatonInfo AtomicKeySymbol StructureSearcher)

--- a/src/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -25,6 +25,7 @@ import Data.Function (on)
 import Data.Int (Int32)
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
+import Data.Maybe (catMaybes)
 import Data.Ord (Down (Down))
 import Data.Semigroup (Max, Min)
 import GHC.Generics (Generic)
@@ -211,8 +212,12 @@ instance Ord FoundStructure where
     f1 = computeArea . getAreaDimensions . entityGrid . structureWithGrid
     f2 = Down . upperLeftCorner
 
+-- | Yields coordinates that are occupied by an entity of a placed structure.
+-- Cells within the rectangular bounds of the structure that are unoccupied
+-- are not included.
 genOccupiedCoords :: FoundStructure -> [Cosmic Location]
 genOccupiedCoords (FoundStructure swg loc) =
-  [loc `offsetBy` V2 x (negate y) | x <- [0 .. w - 1], y <- [0 .. h - 1]]
+  catMaybes . concat . zipWith mkRow [0 ..] $ entityGrid swg
  where
-  AreaDimensions w h = getAreaDimensions $ entityGrid swg
+  mkCol y x ent = loc `offsetBy` V2 x (negate y) <$ ent
+  mkRow rowIdx = zipWith (mkCol rowIdx) [0 ..]

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -1321,10 +1321,12 @@ ensureStructureIntact (FoundStructure (StructureWithGrid _ grid) upperLeft) =
   allM outer $ zip [0 ..] grid
  where
   outer (y, row) = allM (inner y) $ zip [0 ..] row
-  inner y (x, cell) =
-    fmap (== cell) $
-      entityAt $
-        upperLeft `offsetBy` V2 x (negate y)
+  inner y (x, maybeTemplateEntity) = case maybeTemplateEntity of
+    Nothing -> return True
+    Just _ ->
+      fmap (== maybeTemplateEntity) $
+        entityAt $
+          upperLeft `offsetBy` V2 x (negate y)
 
 mkRecognizer ::
   (Has (State GameState) sig m) =>

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -1182,7 +1182,7 @@ initGameState gsc =
           , -- This does not need to be initialized with anything,
             -- since the master list of achievements is stored in UIState
             _gameAchievements = mempty
-          , _structureRecognition = StructureRecognizer (RecognizerAutomatons [] mempty) emptyFoundStructures []
+          , _structureRecognition = StructureRecognizer (RecognizerAutomatons mempty mempty) emptyFoundStructures []
           }
     , _activeRobots = IS.empty
     , _waitingRobots = M.empty

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1410,9 +1410,14 @@ execConst c vs s k = do
       [VText name, VInt idx] -> do
         registry <- use $ discovery . structureRecognition . foundStructures
         let maybeFoundStructures = M.lookup (StructureName name) $ foundByName registry
-            mkOutput mapNE = (NE.length xs, indexWrapNonEmpty xs idx ^. planar)
+            mkOutput mapNE = (NE.length xs, bottomLeftCorner)
              where
-              xs = NEM.keys mapNE
+              xs = NEM.toList mapNE
+              (pos, struc) = indexWrapNonEmpty xs idx
+              topLeftCorner = pos ^. planar
+              offsetHeight = V2 0 $ -fromIntegral (length (entityGrid struc) - 1)
+              bottomLeftCorner :: Location
+              bottomLeftCorner = topLeftCorner .+^ offsetHeight
         return $ mkReturn $ mkOutput <$> maybeFoundStructures
       _ -> badConst
     Floorplan -> case vs of

--- a/src/Swarm/Game/Value.hs
+++ b/src/Swarm/Game/Value.hs
@@ -15,6 +15,7 @@ import Linear (V2 (..))
 import Swarm.Game.Entity
 import Swarm.Game.Location
 import Swarm.Game.Robot
+import Swarm.Game.Scenario.Topography.Area (AreaDimensions (..))
 import Swarm.Language.Direction
 import Swarm.Language.Value
 
@@ -77,3 +78,6 @@ instance (Valuable a) => Valuable (Maybe a) where
 instance (Valuable a, Valuable b) => Valuable (Either a b) where
   asValue (Left x) = VInj False $ asValue x
   asValue (Right x) = VInj True $ asValue x
+
+instance Valuable AreaDimensions where
+  asValue (AreaDimensions w h) = asValue (w, h)

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -80,7 +80,7 @@ data Capability
     CDrill
   | -- | Execute the 'Waypoint' command
     CWaypoint
-  | -- | Execute the 'Structure' command
+  | -- | Execute the 'Structure' and 'Floorplan' commands
     CStructure
   | -- | Execute the 'Whereami' command
     CSenseloc
@@ -264,6 +264,7 @@ constCaps = \case
   Whereami -> Just CSenseloc
   Waypoint -> Just CWaypoint
   Structure -> Just CStructure
+  Floorplan -> Just CStructure
   Detect -> Just CDetectloc
   Resonate -> Just CDetectcount
   Density -> Just CDetectcount

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -224,7 +224,7 @@ data Const
     Whereami
   | -- | Get the x, y coordinates of a named waypoint, by index
     Waypoint
-  | -- | Get the x, y coordinates of a constructed structure, by index
+  | -- | Get the x, y coordinates of southwest corner of a constructed structure, by index
     Structure
   | -- | Get the width and height of a structure template
     Floorplan
@@ -648,7 +648,7 @@ constInfo c = case c of
       , "A robot can use the count to know whether they have iterated over the full waypoint circuit."
       ]
   Structure ->
-    command 2 Intangible . doc "Get the x, y coordinates of a constructed structure, by name and index" $
+    command 2 Intangible . doc "Get the x, y coordinates of the southwest corner of a constructed structure, by name and index" $
       [ "The outermost type of the return value indicates whether any structure of such name exists."
       , "Since structures can have multiple occurrences, returns a tuple of (count, (x, y))."
       , "The supplied index will be wrapped automatically, modulo the structure count."

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -226,6 +226,8 @@ data Const
     Waypoint
   | -- | Get the x, y coordinates of a constructed structure, by index
     Structure
+  | -- | Get the width and height of a structure template
+    Floorplan
   | -- | Locate the closest instance of a given entity within the rectangle
     -- specified by opposite corners, relative to the current location.
     Detect
@@ -651,6 +653,11 @@ constInfo c = case c of
       , "Since structures can have multiple occurrences, returns a tuple of (count, (x, y))."
       , "The supplied index will be wrapped automatically, modulo the structure count."
       , "A robot can use the count to know whether they have iterated over the full structure list."
+      ]
+  Floorplan ->
+    command 1 Intangible . doc "Get the dimensions of a structure template" $
+      [ "Returns a tuple of (width, height) for the structure of the requested name."
+      , "Yields an error if the supplied string is not the name of a structure."
       ]
   Detect ->
     command 2 Intangible . doc "Detect an entity within a rectangle." $

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -775,6 +775,7 @@ inferConst c = case c of
   Whereami -> [tyQ| cmd (int * int) |]
   Waypoint -> [tyQ| text -> int -> cmd (int * (int * int)) |]
   Structure -> [tyQ| text -> int -> cmd (unit + (int * (int * int))) |]
+  Floorplan -> [tyQ| text -> cmd (int * int) |]
   Detect -> [tyQ| text -> ((int * int) * (int * int)) -> cmd (unit + (int * int)) |]
   Resonate -> [tyQ| text -> ((int * int) * (int * int)) -> cmd int |]
   Density -> [tyQ| ((int * int) * (int * int)) -> cmd int |]

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -266,7 +266,7 @@ scenarioToUIState isAutoplaying siPair@(scenario, _) gs u = do
       & uiWorldEditor . EM.editingBounds . EM.boundsRect %~ setNewBounds
       & uiStructure
         .~ StructureDisplay
-          (SR.makeListWidget $ gs ^. discovery . structureRecognition . automatons . definitions)
+          (SR.makeListWidget . M.elems $ gs ^. discovery . structureRecognition . automatons . definitions)
           (focusSetCurrent (StructureWidgets StructuresList) $ focusRing $ map StructureWidgets listEnums)
  where
   entityList = EU.getEntitiesForList $ gs ^. landscape . entityMap

--- a/src/Swarm/TUI/View/Structure.hs
+++ b/src/Swarm/TUI/View/Structure.hs
@@ -3,7 +3,7 @@
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Display logic for Objectives.
+-- Display logic for Structures.
 module Swarm.TUI.View.Structure (
   renderStructuresDisplay,
   makeListWidget,
@@ -33,6 +33,8 @@ import Swarm.TUI.View.Attribute.Attr
 import Swarm.TUI.View.CellDisplay
 import Swarm.TUI.View.Util
 
+-- | Render a two-pane widget with structure selection on the left
+-- and single-structure details on the right.
 structureWidget :: GameState -> StructureInfo -> Widget n
 structureWidget gs s =
   vBox
@@ -73,7 +75,7 @@ structureWidget gs s =
 
   ingredientsBox =
     vBox
-      [ padBottom (Pad 1) $ withAttr boldAttr $ txt "Ingredients:"
+      [ padBottom (Pad 1) $ withAttr boldAttr $ txt "Materials:"
       , ingredientLines
       ]
   ingredientLines = vBox . map showCount . M.toList $ entityCounts s

--- a/src/Swarm/TUI/View/Util.hs
+++ b/src/Swarm/TUI/View/Util.hs
@@ -137,6 +137,7 @@ drawMarkdown d = do
     Markdown.Emphasis -> italicAttr
   rawAttr = \case
     "entity" -> greenAttr
+    "structure" -> redAttr
     "type" -> magentaAttr
     _snippet -> highlightAttr -- same as plain code
 

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -356,7 +356,7 @@ testScenarioSolutions rs ui =
             , testSolution Default "Testing/836-pathfinding/836-path-exists-distance-limit-unreachable"
             , testSolution Default "Testing/836-pathfinding/836-no-path-exists1"
             , testSolution (Sec 10) "Testing/836-pathfinding/836-no-path-exists2"
-            , testSolution (Sec 3) "Testing/836-pathfinding/836-automatic-waypoint-navigation.yaml"
+            , testSolution (Sec 3) "Testing/836-pathfinding/836-automatic-waypoint-navigation"
             ]
         , testGroup
             "Ping (#1535)"
@@ -376,6 +376,7 @@ testScenarioSolutions rs ui =
             , testSolution Default "Testing/1575-structure-recognizer/1575-remove-structure"
             , testSolution Default "Testing/1575-structure-recognizer/1575-swap-structure"
             , testSolution Default "Testing/1575-structure-recognizer/1575-placement-occlusion"
+            , testSolution Default "Testing/1575-structure-recognizer/1575-floorplan-command"
             ]
         ]
     , testSolution' Default "Testing/1430-built-robot-ownership" CheckForBadErrors $ \g -> do

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -376,6 +376,7 @@ testScenarioSolutions rs ui =
             , testSolution Default "Testing/1575-structure-recognizer/1575-remove-structure"
             , testSolution Default "Testing/1575-structure-recognizer/1575-swap-structure"
             , testSolution Default "Testing/1575-structure-recognizer/1575-placement-occlusion"
+            , testSolution Default "Testing/1575-structure-recognizer/1575-interior-entity-placement"
             , testSolution Default "Testing/1575-structure-recognizer/1575-floorplan-command"
             ]
         ]


### PR DESCRIPTION
* Highlight occurrences of structures in markdown in red
* Add a new `blueprint` entity to provide `floorplan` and `structure` commands
* new `floorplan` command to get the dimensions of a structure
* structure location is southwest instead of northwest corner
* handle structures with "holes"  for statically-recognized structures and when modifying interior cells post-recognition

Each of these is its own commit for reviewability's sake.