### PR TITLE
Fix the stack build

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,9 +3,12 @@ extra-deps:
 - hsnoise-0.0.3@sha256:260b39175b8a3e3b1719ad3987b7d72a3fd7a0fa99be8639b91cf4dc3f1c8796,1476
 - simple-enumeration-0.2.1@sha256:8625b269c1650d3dd0e3887351c153049f4369853e0d525219e07480ea004b9f,1178
 - boolexpr-0.2@sha256:07f38a0206ad63c2c893e3c6271a2e45ea25ab4ef3a9e973edc746876f0ab9e8,853
-- brick-1.10
+- vty-6.0@sha256:3c4ee4ffd6e38720e227c45e85eb91ff611125dbff178e9f2fadc993160e1464,3661
+- vty-crossplatform-0.2.0.0@sha256:6dc6b72ba2fe63f0af582a501ab133a69f49fb75fef3ad7a870412472be077ec,3161
+- vty-unix-0.1.0.0@sha256:8d1dd971d49b4d3575ec76994a8dd5d330d7b81a30ece40344ee170d73a28ac3,2932
+- brick-2.1.1
+- brick-list-skip-0.1.1.8
 - astar-0.3.0.0
-- brick-list-skip-0.1.1.5
 # We should update to lsp-2.0 and lsp-types-2.0 but it involves some
 # breaking changes; see https://github.com/swarm-game/swarm/issues/1350
 - lsp-1.6.0.0


### PR DESCRIPTION
Closes #1624.

Note, however, that currently (until #1623) this will not work on Windows, since I explicitly added `vty-unix` as an `extra-dep` in the `stack.yaml` file.  However, I expect we will get #1623 soon and then we can remove it.