### PR TITLE
Decouple robot log message colors from entity colors

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -51,3 +51,4 @@ Achievements
 1536-custom-unwalkable-entities.yaml
 1535-ping
 1575-structure-recognizer
+1634-message-colors.yaml

--- a/data/scenarios/Testing/1634-message-colors.yaml
+++ b/data/scenarios/Testing/1634-message-colors.yaml
@@ -1,0 +1,41 @@
+version: 1
+name: Robot message log coloring
+description: |
+  Demo color selection for robot log messages
+robots:
+  - name: base
+    devices:
+      - logger
+      - hearing aid
+  - name: saybot
+    system: true
+    display:
+      invisible: false
+      attr: blue
+    program: |
+      loc <- whereami;
+      let idx = -(snd loc) in
+      wait $ idx + 1;
+      say $ "Hello saybot" ++ format idx;
+world:
+  palette:
+    '.': [grass]
+    'B': [grass, null, base]
+    's': [grass, null, saybot]
+  upperleft: [0, 0]
+  map: |
+    B.s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    ..s
+    

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -926,7 +926,7 @@ colorLogs e = case e ^. leSource of
     RobotError -> colorSeverity (e ^. leSeverity)
  where
   -- color each robot message with different color of the world
-  robotColor = indexWrapNonEmpty worldAttributeNames
+  robotColor = indexWrapNonEmpty messageAttributeNames
 
 colorSeverity :: Severity -> AttrName
 colorSeverity = \case

--- a/src/Swarm/TUI/View/Attribute/Attr.hs
+++ b/src/Swarm/TUI/View/Attribute/Attr.hs
@@ -16,6 +16,7 @@ module Swarm.TUI.View.Attribute.Attr (
   worldAttributeNames,
   worldPrefix,
   meterAttributeNames,
+  messageAttributeNames,
   toAttrName,
 
   -- ** Terrain attributes
@@ -79,6 +80,7 @@ swarmAttrMap =
   attrMap
     V.defAttr
     $ NE.toList activityMeterAttributes
+      <> NE.toList robotMessageAttributes
       <> NE.toList (NE.map (first getWorldAttrName) worldAttributes)
       <> [(waterAttr, V.white `on` V.blue)]
       <> terrainAttr
@@ -162,6 +164,19 @@ worldAttributes =
 
 worldAttributeNames :: NonEmpty AttrName
 worldAttributeNames = NE.map (getWorldAttrName . fst) worldAttributes
+
+robotMessagePrefix :: AttrName
+robotMessagePrefix = attrName "robotMessage"
+
+robotMessageAttributes :: NonEmpty (AttrName, V.Attr)
+robotMessageAttributes =
+  NE.zip indices $ fromMaybe (pure $ fg V.white) $ NE.nonEmpty brewers
+ where
+  indices = NE.map ((robotMessagePrefix <>) . attrName . show) $ (0 :: Int) :| [1 ..]
+  brewers = map (fg . kolorToAttrColor) $ brewerSet Set3 12
+
+messageAttributeNames :: NonEmpty AttrName
+messageAttributeNames = NE.map fst robotMessageAttributes
 
 activityMeterPrefix :: AttrName
 activityMeterPrefix = attrName "activityMeter"


### PR DESCRIPTION
This is code cleanup towards #1415, which will require some refactoring of `Attr.hs`.

## Demo

    scripts/play.sh -i data/scenarios/Testing/9999-message-colors.yaml --autoplay --speed 2

![Screenshot from 2023-11-16 17-25-14](https://github.com/swarm-game/swarm/assets/261693/1fdfa852-1acc-4ff4-93d5-7818ae858f86)
