### PR TITLE
Structure recognition with encroaching entities

### DIFF
--- a/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
+++ b/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
@@ -11,3 +11,4 @@
 1575-placement-occlusion.yaml
 1575-interior-entity-placement.yaml
 1575-floorplan-command.yaml
+1575-bounding-box-overlap.yaml

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-bounding-box-overlap.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-bounding-box-overlap.yaml
@@ -1,0 +1,83 @@
+version: 1
+name: Structure recognizer - overlapping bounding boxes
+description: |
+  Recognize non-rectangular structures even when
+  bounding boxes overlap with each other,
+  or when non-participating entities encroach within
+  the candidate bounding box.
+
+  In this scenario, there is only one possible arrangement.
+creative: false
+objectives:
+  - teaser: Build structures
+    goal:
+      - |
+        Build 3 `chevron`{=structure} structures
+    condition: |
+      foundStructure <- structure "chevron" 0;
+      return $ case foundStructure (\_. false) (\x. fst x >= 3);
+robots:
+  - name: base
+    dir: [1, 0]
+    devices:
+      - ADT calculator
+      - branch predictor
+      - comparator
+      - dictionary
+      - fast grabber
+      - lambda
+      - logger
+      - strange loop
+      - treads
+    inventory:
+      - [10, boulder]
+solution: |
+  def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
+
+  doN 2 move;
+  turn right;
+
+  doN 2 (place "boulder"; move;);
+  turn right;
+  doN 2 (place "boulder"; move;);
+  place "boulder";
+
+  turn left;
+  doN 2 move;
+
+  turn left;
+  doN 2 move;
+
+  doN 2 (place "boulder"; move;);
+  turn left;
+  doN 3 (place "boulder"; move;);
+structures:
+  - name: chevron
+    recognize: true
+    structure:
+      palette:
+        'g': [stone, boulder]
+      mask: '.'
+      map: |
+       ..g
+       ..g
+       ggg
+known: [boulder, mountain, water]
+world:
+  name: root
+  dsl: |
+    {water}
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+    'M': [grass, mountain]
+  placements:
+    - src: chevron
+      offset: [1, -1]
+  upperleft: [0, 0]
+  map: |
+    B....
+    .M...
+    .....
+    .....
+    .....

--- a/src/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -28,9 +28,10 @@ import Data.Map (Map)
 import Data.Maybe (catMaybes)
 import Data.Ord (Down (Down))
 import Data.Semigroup (Max, Min)
+import Data.Set (Set)
 import GHC.Generics (Generic)
 import Linear (V2 (..))
-import Swarm.Game.Entity (Entity)
+import Swarm.Game.Entity (Entity, EntityName)
 import Swarm.Game.Location (Location)
 import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.Cell
@@ -65,7 +66,7 @@ type SymbolSequence = [AtomicKeySymbol]
 -- It contains search automatons customized to the 2-D structures
 -- that may possibly contain the row found by the 1-D searcher.
 data StructureSearcher = StructureSearcher
-  { automaton2D :: AutomatonInfo SymbolSequence StructureRow
+  { automaton2D :: AutomatonInfo SymbolSequence StructureWithGrid
   , needleContent :: SymbolSequence
   , singleRowItems :: NE.NonEmpty SingleRowEntityOccurrences
   }
@@ -169,7 +170,8 @@ instance Semigroup InspectionOffsets where
 -- a certain subset of structure rows, that may either
 -- all be within one structure, or span multiple structures.
 data AutomatonInfo k v = AutomatonInfo
-  { _inspectionOffsets :: InspectionOffsets
+  { _participatingEntities :: Set EntityName
+  , _inspectionOffsets :: InspectionOffsets
   , _automaton :: StateMachine k v
   }
   deriving (Generic)

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -418,6 +418,7 @@ testScenarioSolutions rs ui =
             , testSolution Default "Testing/1575-structure-recognizer/1575-placement-occlusion"
             , testSolution Default "Testing/1575-structure-recognizer/1575-interior-entity-placement"
             , testSolution Default "Testing/1575-structure-recognizer/1575-floorplan-command"
+            , testSolution Default "Testing/1575-structure-recognizer/1575-bounding-box-overlap"
             ]
         ]
     , testSolution' Default "Testing/1430-built-robot-ownership" CheckForBadErrors $ \g -> do


### PR DESCRIPTION
Structure recognition already supports overlapping bounding boxes between two structures (where one of the structure templates has vacant cells).  This PR adds test coverage for this.

More importantly, this PR makes sure that structures can be recognized even with non-participating entities within their bounding box.  The same integration test (`1575-bounding-box-overlap.yaml`) covers this case as well.

A "non-participating entity" is an entity that is not an ingredient to any structures participating in structure recognition.  Such entities are "masked out" when the world cells (i.e. the "haystack") are queried to apply the Aho-Corasick matcher to.

## Example

Given a structure defined as `boulder`s (`@`) in a backwards "L" shape, it will be recognized despite a `mountain` (`A`) within its bounding box:

![image](https://github.com/swarm-game/swarm/assets/261693/1c559a50-e9bd-4f97-87a1-20d4f964cfa9)

This is because `mountain` is not a member of any recognizable structures.

## Caveats

This PR strictly increases the situations in which valid structures may be recognized.

However, it is still the case that encroaching entities that **are** members of some structure template will thwart structure recognition.  One consequence of this is that the order in which structures are completed can matter.

If some partially-built but incomplete structure lies within the bounding box of another candidate structure, the candidate structure will not be recognized as "complete" unless (1) the offending entities are removed first, or (2) the other structure is completed first.