### PR TITLE
render recognized structures in bold

### DIFF
--- a/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-disjoint.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-disjoint.yaml
@@ -65,6 +65,7 @@ structures:
        sgsg
        gsgs
        sgsg
+known: [water, gold, silver]
 world:
   name: root
   dsl: |


### PR DESCRIPTION
Visually differentiate entities in the plane when they become part of a recognized structure.

## Demo

    scripts/play.sh -i data/scenarios/Testing/1575-structure-recognizer/1575-browse-structures.yaml --autoplay --speed 2

![image](https://github.com/swarm-game/swarm/assets/261693/71d7f3cc-40b9-4ffe-88c9-7c528cc358b3)
