### PR TITLE
serve static index page

### DIFF
--- a/swarm.cabal
+++ b/swarm.cabal
@@ -305,6 +305,7 @@ library
                       prettyprinter                 >= 1.7.0 && < 1.8,
                       random                        >= 1.2.0 && < 1.3,
                       scientific                    >= 0.3.6 && < 0.3.8,
+                      wai-app-static                >= 3.1.8 && < 3.1.9,
                       servant                       >= 0.19 && < 0.21,
                       servant-docs                  >= 0.12 && < 0.14,
                       servant-server                >= 0.19 && < 0.21,

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Swarm server</title>
+  </head>
+  <body>
+    <h1>Hello Swarm player!</h1>
+    <p>Looking for the <a href="api">Web API docs</a>?</p>
+  </body>
+</html>


### PR DESCRIPTION
API docs are moved under `api/`, and the landing page for http://localhost:5357/ is now a static `index.html` page.

This paves the way for a JS-enabled web frontend demo.