### PR TITLE
group robot info into subrecord

### DIFF
--- a/src/Swarm/Game/Step/Util.hs
+++ b/src/Swarm/Game/Step/Util.hs
@@ -148,7 +148,7 @@ weightedChoice weight as = do
 -- | Generate a random robot name in the form @adjective_name@.
 randomName :: Has (State GameState) sig m => m Text
 randomName = do
-  NameGenerator adjs names <- use $ robotNaming . nameGenerator
+  NameGenerator adjs names <- use $ robotInfo . robotNaming . nameGenerator
   i <- uniform (bounds adjs)
   j <- uniform (bounds names)
   return $ T.concat [adjs ! i, "_", names ! j]

--- a/src/Swarm/Game/Step/Util/Inspect.hs
+++ b/src/Swarm/Game/Step/Util/Inspect.hs
@@ -24,8 +24,8 @@ getNeighborLocs loc = map (offsetBy loc . flip applyTurn north . DRelative . DPl
 
 -- | Get the robot with a given ID.
 robotWithID :: (Has (State GameState) sig m) => RID -> m (Maybe Robot)
-robotWithID rid = use (robotMap . at rid)
+robotWithID rid = use (robotInfo . robotMap . at rid)
 
 -- | Get the robot with a given name.
 robotWithName :: (Has (State GameState) sig m) => Text -> m (Maybe Robot)
-robotWithName rname = use (robotMap . to IM.elems . to (find $ \r -> r ^. robotName == rname))
+robotWithName rname = use (robotInfo . robotMap . to IM.elems . to (find $ \r -> r ^. robotName == rname))

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -1344,7 +1344,7 @@ handleWorldEvent = \case
         when (c || s) $ scrollView (.+^ (worldScrollDist *^ keyToDir k))
   CharKey 'c' -> do
     invalidateCacheEntry WorldCache
-    gameState . viewCenterRule .= VCRobot 0
+    gameState . robotInfo . viewCenterRule .= VCRobot 0
   -- show fps
   CharKey 'f' -> uiState . uiShowFPS %= not
   -- Fall-through case: don't do anything.

--- a/src/Swarm/TUI/Controller/Util.hs
+++ b/src/Swarm/TUI/Controller/Util.hs
@@ -79,7 +79,7 @@ loadVisibleRegion = do
   mext <- lookupExtent WorldExtent
   forM_ mext $ \(Extent _ _ size) -> do
     gs <- use gameState
-    let vr = viewingRegion (gs ^. viewCenter) (over both fromIntegral size)
+    let vr = viewingRegion (gs ^. robotInfo . viewCenter) (over both fromIntegral size)
     gameState . landscape . multiWorld %= M.adjust (W.loadRegion (vr ^. planar)) (vr ^. subworld)
 
 mouseLocToWorldCoords :: Brick.Location -> EventM Name GameState (Maybe (Cosmic W.Coords))
@@ -88,7 +88,7 @@ mouseLocToWorldCoords (Brick.Location mouseLoc) = do
   case mext of
     Nothing -> pure Nothing
     Just ext -> do
-      region <- gets $ flip viewingRegion (bimap fromIntegral fromIntegral (extentSize ext)) . view viewCenter
+      region <- gets $ flip viewingRegion (bimap fromIntegral fromIntegral (extentSize ext)) . view (robotInfo . viewCenter)
       let regionStart = W.unCoords (fst $ region ^. planar)
           mouseLoc' = bimap fromIntegral fromIntegral mouseLoc
           mx = snd mouseLoc' + fst regionStart

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -435,7 +435,7 @@ drawGameUI s =
   addCursorPos = bottomLabels . leftLabel ?~ padLeftRight 1 widg
    where
     widg = case s ^. uiState . uiWorldCursor of
-      Nothing -> str $ renderCoordsString $ s ^. gameState . viewCenter
+      Nothing -> str $ renderCoordsString $ s ^. gameState . robotInfo . viewCenter
       Just coord -> clickable WorldPositionIndicator $ drawWorldCursorInfo (s ^. uiState . uiWorldEditor . worldOverdraw) (s ^. gameState) coord
   -- Add clock display in top right of the world view if focused robot
   -- has a clock equipped
@@ -743,7 +743,7 @@ robotsListWidget s = hCenter table
   robots =
     filter (\robot -> debugging || (isRelevant robot && isNear robot))
       . IM.elems
-      $ g ^. robotMap
+      $ g ^. robotInfo . robotMap
   creative = g ^. creativeMode
   cheat = s ^. uiState . uiCheatMode
   debugging = creative && cheat
@@ -975,7 +975,7 @@ drawKeyMenu s =
   isReplWorking = s ^. gameState . gameControls . replWorking
   isPaused = s ^. gameState . temporal . paused
   hasDebug = fromMaybe creative $ s ^? gameState . to focusedRobot . _Just . robotCapabilities . Lens.contains CDebug
-  viewingBase = (s ^. gameState . viewCenterRule) == VCRobot 0
+  viewingBase = (s ^. gameState . robotInfo . viewCenterRule) == VCRobot 0
   creative = s ^. gameState . creativeMode
   cheat = s ^. uiState . uiCheatMode
   goal = hasAnythingToShow $ s ^. uiState . uiGoal . goalsContent
@@ -1089,7 +1089,7 @@ drawWorldPane ui g =
     . reportExtent WorldExtent
     -- Set the clickable request after the extent to play nice with the cache
     . clickable (FocusablePanel WorldPanel)
-    $ worldWidget renderCoord (g ^. viewCenter)
+    $ worldWidget renderCoord (g ^. robotInfo . viewCenter)
  where
   renderCoord = drawLoc ui g
 
@@ -1436,7 +1436,7 @@ drawREPL s =
     (Just False, _) -> renderREPLPrompt (s ^. uiState . uiFocusRing) theRepl
     _running -> padRight Max $ txt "..."
   theRepl = s ^. uiState . uiREPL
-  base = s ^. gameState . robotMap . at 0
+  base = s ^. gameState . robotInfo . robotMap . at 0
   fmt (REPLEntry e) = txt $ "> " <> e
   fmt (REPLOutput t) = txt t
   fmt (REPLError t) = txtWrapWith indent2 {preserveIndentation = True} t

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -214,7 +214,7 @@ getStatic g coords
  where
   -- Offset from the location of the view center to the location under
   -- consideration for display.
-  offset = W.coordsToLoc coords .-. (g ^. viewCenter . planar)
+  offset = W.coordsToLoc coords .-. (g ^. robotInfo . viewCenter . planar)
 
   -- Hash.
   h =

--- a/src/Swarm/Web.hs
+++ b/src/Swarm/Web.hs
@@ -164,12 +164,12 @@ mkApp state events =
 robotsHandler :: ReadableIORef AppState -> Handler [Robot]
 robotsHandler appStateRef = do
   appState <- liftIO (readIORef appStateRef)
-  pure $ IM.elems $ appState ^. gameState . robotMap
+  pure $ IM.elems $ appState ^. gameState . robotInfo . robotMap
 
 robotHandler :: ReadableIORef AppState -> RobotID -> Handler (Maybe Robot)
 robotHandler appStateRef (RobotID rid) = do
   appState <- liftIO (readIORef appStateRef)
-  pure $ IM.lookup rid (appState ^. gameState . robotMap)
+  pure $ IM.lookup rid (appState ^. gameState . robotInfo . robotMap)
 
 prereqsHandler :: ReadableIORef AppState -> Handler [PrereqSatisfaction]
 prereqsHandler appStateRef = do

--- a/test/unit/TestNotification.hs
+++ b/test/unit/TestNotification.hs
@@ -40,7 +40,7 @@ testNotification gs =
         assertNew (gs' & messageInfo . lastSeenMessageTime .~ TickNumber 0) 1 "message" messageNotifications
     , testCase "new message after log" $ do
         gs' <- goodPlay "create \"logger\"; equip \"logger\"; log \"Hello world!\""
-        let r = gs' ^?! robotMap . ix (-1)
+        let r = gs' ^?! robotInfo . robotMap . ix (-1)
         assertBool "There should be one log entry in robots log" (length (r ^. robotLog) == 1)
         assertEqual "The hypothetical robot should be in focus" (Just (r ^. robotID)) (view robotID <$> focusedRobot gs')
         assertEqual "There should be one log notification" [TickNumber 2] (view leTime <$> gs' ^. messageNotifications . notificationsContent)

--- a/test/unit/TestUtil.hs
+++ b/test/unit/TestUtil.hs
@@ -61,12 +61,12 @@ play g = either (return . (,g) . Left) playPT . processTerm1
     gs =
       g
         & execState (addRobot hr)
-        & viewCenterRule .~ VCRobot hid
+        & robotInfo . viewCenterRule .~ VCRobot hid
         & creativeMode .~ True
 
 playUntilDone :: RID -> StateT GameState IO (Either Text ())
 playUntilDone rid = do
-  w <- use robotMap
+  w <- use $ robotInfo . robotMap
   case w ^? ix rid . to isActive of
     Just True -> do
       void $ runTimeIO gameTick


### PR DESCRIPTION
Add another subrecord to `GameState` dedicated to robot fields.  This shrinks the size of `GameState` by 8 more fields.  It's getting reasonable now!

The `_viewCenter*` fields were put there too, for now, because the manually-defined `setter` of the `viewCenterRule` lens needs access to the `robotMap` field.