### PR TITLE
Inherit parent robot display

### DIFF
--- a/src/Swarm/Game/Step/Const.hs
+++ b/src/Swarm/Game/Step/Const.hs
@@ -1047,7 +1047,7 @@ execConst runChildProg c vs s k = do
               ( ((r ^. robotOrientation) >>= \dir -> guard (dir /= zero) >> return dir)
                   ? north
               )
-              defaultRobotDisplay
+              ((r ^. robotDisplay) & invisible .~ False)
               (In cmd e s [FExec])
               []
               []


### PR DESCRIPTION
Closes #1663.

The status quo is that built-children of system robots are visible, even if the system robot is invisible.  So we preserve that behavior for now, with the potential to override it at some future point.  We don't yet have a definite need to make children of system robots invisible, but this PR does at least provide a mechanism to set the foreground and background of child robots (as a stopgap until #1230).

Tested with:

    scripts/play.sh -i scenarios/Challenges/Ranching/beekeeping.yaml --autoplay

| Before | After |
| --- | --- |
| ![Screenshot from 2023-12-01 17-31-00](https://github.com/swarm-game/swarm/assets/261693/9a9a49cb-fee5-424d-a748-9cb3c65ffe8f) | ![Screenshot from 2023-12-01 17-35-19](https://github.com/swarm-game/swarm/assets/261693/4da17e20-8f1a-46fc-ac9c-6154ccb7d4c7) |