### PR TITLE
Inventory requirements for child robots of system robots

### DIFF
--- a/data/scenarios/Testing/201-require/00-ORDER.txt
+++ b/data/scenarios/Testing/201-require/00-ORDER.txt
@@ -5,3 +5,4 @@
 201-require-entities-def.yaml
 533-reprogram-simple.yaml
 533-reprogram.yaml
+1664-require-system-robot-children.yaml

--- a/data/scenarios/Testing/201-require/1664-require-system-robot-children.yaml
+++ b/data/scenarios/Testing/201-require/1664-require-system-robot-children.yaml
@@ -1,0 +1,51 @@
+version: 1
+name: Requirements of system-robot children
+description: |
+  Normally, system robots are not required to possess devices in order to use any particular command.
+  However, a robot built by a system robot becomes subject to the requirement.
+  This is a bug.
+
+  In this scenario, the child robot cannot be built because the
+  parent robot ("queenbee") does not possess a "beaglepuss" in its inventory.
+objectives:
+  - condition: |
+      try {
+        robotnamed "childbot";
+        return true;
+      } {
+        return false;
+      }
+solution: |
+  noop;
+robots:
+  - name: base
+    dir: [1, 0]
+  - name: queenbee
+    dir: [1, 0]
+    system: true
+    display:
+      invisible: false
+      char: 'Q'
+    inventory:
+      - [1, solar panel]
+      - [0, beaglepuss]
+    program: |
+      def createWorker =
+          build {
+              setname "childbot";
+              appear "B";
+          };
+          end;
+
+      createWorker;
+known: [water]
+world:
+  palette:
+    '.': [grass]
+    'B': [grass, null, base]
+    'Q': [grass, null, queenbee]
+  upperleft: [-1, 1]
+  map: |
+    B..Q
+    ....
+    ....

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -480,6 +480,7 @@ test-suite swarm-integration
 
     build-depends:    tasty                         >= 0.10 && < 1.6,
                       tasty-hunit                   >= 0.10 && < 0.11,
+                      tasty-expected-failure        >= 0.12 && < 0.13,
                       -- Imports shared with the library don't need bounds
                       base,
                       containers,

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -84,6 +84,7 @@ import Swarm.Util.Yaml (decodeFileEitherE)
 import System.FilePath.Posix (splitDirectories)
 import System.Timeout (timeout)
 import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.ExpectedFailure (expectFailBecause)
 import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 import Witch (into)
 
@@ -300,6 +301,7 @@ testScenarioSolutions rs ui =
             , testSolution Default "Testing/201-require/201-require-entities-def"
             , testSolution Default "Testing/201-require/533-reprogram-simple"
             , testSolution Default "Testing/201-require/533-reprogram"
+            , expectFailBecause "Fix #1664" $ testSolution Default "Testing/201-require/1664-require-system-robot-children"
             ]
         , testSolution Default "Testing/479-atomic-race"
         , testSolution (Sec 5) "Testing/479-atomic"


### PR DESCRIPTION
Towards #1664.

This PR adds a failing unit test.