### PR TITLE
Specifically build `swarm:swarm` component in `play.sh` script

### DIFF
--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -7,4 +7,4 @@ cd $SCRIPT_DIR/..
 # It's been observed in certain versions of GHC that compiling with optimizations
 # results in the swarm UI freezing for a potentially long time upon starting a scenario.
 # See https://github.com/swarm-game/swarm/issues/1000#issuecomment-1378632269
-stack build --fast && stack exec swarm -- "$@"
+stack build --fast swarm:swarm && stack exec swarm -- "$@"


### PR DESCRIPTION
This seems to help with rebuild times, since we are specifically requesting to only build the `swarm` executable and not, say, the `swarm-docs` executable.