### PR TITLE
rename 'portable' to 'pickable'

### DIFF
--- a/app/doc/Swarm/Doc/Wiki/Cheatsheet.hs
+++ b/app/doc/Swarm/Doc/Wiki/Cheatsheet.hs
@@ -184,7 +184,7 @@ capabilityPage a em = capabilityTable a em listEnums
 -- ** Entities
 
 entityHeader :: [Text]
-entityHeader = ["?", "Name", "Capabilities", "Properties*", "Portable"]
+entityHeader = ["?", "Name", "Capabilities", "Properties*", "Pickable"]
 
 entityToList :: Entity -> [Text]
 entityToList e =
@@ -193,8 +193,8 @@ entityToList e =
     [ codeQuote . T.singleton $ e ^. entityDisplay . to displayChar
     , addLink ("#" <> linkID) $ view entityName e
     , T.intercalate ", " $ Capability.capabilityName <$> Set.toList (view E.entityCapabilities e)
-    , T.intercalate ", " . map tshow . filter (/= E.Portable) $ toList props
-    , if E.Portable `elem` props
+    , T.intercalate ", " . map tshow . filter (/= E.Pickable) $ toList props
+    , if E.Pickable `elem` props
         then ":heavy_check_mark:"
         else ":negative_squared_cross_mark:"
     ]
@@ -229,7 +229,7 @@ entitiesPage _a es =
   T.intercalate "\n\n" $
     [ "# Entities"
     , "This is a quick-overview table of entities - click the name for detailed description."
-    , "*) As a note, most entities have the Portable property, so we show it in a separate column."
+    , "*) As a note, most entities have the Pickable property, so we show it in a separate column."
     , entityTable es
     ]
       <> map entityToSection es

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -7,7 +7,7 @@
       A tall, living entity made of a tough cellular material called "wood".
       They regrow after being harvested and are an important raw ingredient used
       in making many different devices.
-  properties: [portable, growable, opaque, combustible]
+  properties: [pickable, growable, opaque, combustible]
   growth: [500, 600]
   combustion:
     ignition: 0.01
@@ -20,21 +20,21 @@
   description:
     - |
       Burned-out remnants of combustion.
-  properties: [portable]
+  properties: [pickable]
 - name: branch
   display:
     attr: wood
     char: 'y'
   description:
     - A branch cut from a tree.  It's as if the tree had to make a decision and was exploring two options.
-  properties: [portable]
+  properties: [pickable]
 - name: log
   display:
     attr: wood
     char: 'l'
   description:
     - A wooden log, obtained by harvesting a tree and cutting off its branches.
-  properties: [portable, combustible]
+  properties: [pickable, combustible]
   combustion:
     ignition: 0.05
     duration: [40, 80]
@@ -45,7 +45,7 @@
     char: 'w'
   description:
     - A wooden board, made by cutting a log into pieces.
-  properties: [portable, combustible]
+  properties: [pickable, combustible]
   combustion:
     ignition: 0.2
     duration: [20, 40]
@@ -61,7 +61,7 @@
       ```
       make "log"
       ```
-  properties: [portable]
+  properties: [pickable]
   capabilities: [make]
 - name: paper
   display:
@@ -69,7 +69,7 @@
     char: '■'
   description:
     - A flat material made of pressed and dried wood fibers, used as a surface on which to inscribe symbols.
-  properties: [portable, combustible]
+  properties: [pickable, combustible]
   combustion:
     ignition: 0.5
     duration: [10, 20]
@@ -80,21 +80,21 @@
     char: 'P'
   description:
     - Perhaps writing one of these will help gain the trust and respect of the native inhabitants.
-  properties: [portable]
+  properties: [pickable]
 - name: rock
   display:
     attr: rock
     char: 'o'
   description:
     - A medium-sized rock, picked up from the ground or created by drilling. Can be ground into sand or used to build a simple furnace, among other things.
-  properties: [portable]
+  properties: [pickable]
 - name: handle
   display:
     attr: device
     char: 'h'
   description:
     - Ergonomic affordance for manipulating objects. Also grants the "setname" capability, allowing one to assign a "handle" to robots.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [setname]
 - name: lodestone
   display:
@@ -102,7 +102,7 @@
     char: 'o'
   description:
     - A medium-sized rock... that looks a little different. It seems to react to iron and surprisingly also to naturally growing bits.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [negation]
 - name: beaglepuss
   display:
@@ -110,7 +110,7 @@
     char: 'B'
   description:
     - Iconic novelty disguise. Renders one either completely inconspicuous, or the opposite.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [appear]
 - name: boulder
   display:
@@ -141,7 +141,7 @@
   description:
     - Raw copper ore, useful for making wires, pipes, and other metal things. Patches of copper ore can be found on the surface, but are quickly exhausted.
     - Scanners seem to indicate larger quantities of copper could be found beneath some of the mountains, but those would require a drill to access and mine.
-  properties: [portable]
+  properties: [pickable]
 - name: copper mine
   display:
     attr: copper'
@@ -156,14 +156,14 @@
     char: '|'
   description:
     - Copper wire is very good at conducting electricity and useful for making various types of circuits and machines.
-  properties: [portable]
+  properties: [pickable]
 - name: strange loop
   display:
     attr: copper
     char: '8'
   description:
     - Two copper wires twisted together in a strange shape that loops back on itself. It must be useful for something...
-  properties: [portable]
+  properties: [pickable]
   capabilities: [recursion]
 - name: copper pipe
   display:
@@ -171,7 +171,7 @@
     char: 'I'
   description:
     - A pipe made out of a thin sheet of copper.  Great for transmitting water or steam.
-  properties: [portable]
+  properties: [pickable]
 - name: iron plate
   display:
     attr: iron
@@ -179,14 +179,14 @@
   description:
     - Worked iron suitable for crafting resilient tools.
     - It also possess some electro-magnetic properties.
-  properties: [portable]
+  properties: [pickable]
 - name: iron gear
   display:
     attr: iron
     char: '*'
   description:
     - An iron gear, suitable for constructing larger, more powerful machinery than a wooden gear.
-  properties: [portable]
+  properties: [pickable]
 - name: iron ore
   display:
     attr: iron
@@ -194,7 +194,7 @@
   description:
     - Raw iron ore. Used to create more resilient tools than copper.
     - It can only be mined by drilling in the mountains.
-  properties: [portable]
+  properties: [pickable]
 - name: iron mine
   display:
     attr: iron'
@@ -210,7 +210,7 @@
   description:
     - Raw quartz crystals.  Useful for creating devices like clocks, and can be processed to extract silicon.
     - It can only be mined by drilling in the mountains.
-  properties: [portable]
+  properties: [pickable]
 - name: quartz mine
   display:
     attr: quartz
@@ -225,7 +225,7 @@
     char: 'S'
   description:
     - Extracted by processing quartz at high temperatures, silicon can be used to construct integrated circuits.
-  properties: [portable]
+  properties: [pickable]
 - name: deep mine
   display:
     attr: rock
@@ -241,7 +241,7 @@
     char: '•'
   description:
     - A shiny, metallic substance, noted for its high reflectivity when polished.
-  properties: [portable]
+  properties: [pickable]
 - name: gold
   display:
     attr: gold
@@ -249,28 +249,28 @@
   description:
     - A shiny, metallic substance, with applications in specialized electronics.
     - It also seems to be highly valued by local aliens.
-  properties: [portable]
+  properties: [pickable]
 - name: mithril
   display:
     attr: silver
     char: 'M'
   description:
     - Mithril can be beaten like copper, and polished like glass.  One can also make of it a metal, light and yet harder than tempered steel. Its beauty is like to that of common silver, but the beauty of mithril does not tarnish or grow dim.
-  properties: [portable]
+  properties: [pickable]
 - name: furnace
   display:
     attr: fire
     char: '#'
   description:
     - A furnace can be used to turn metal ore into various useful products.
-  properties: [portable]
+  properties: [pickable]
 - name: big furnace
   display:
     attr: fire
     char: '#'
   description:
     - A big furnace can get even hotter than a normal furnace, and can be used to process quartz into silicon.
-  properties: [portable]
+  properties: [pickable]
 - name: small motor
   display:
     attr: entity
@@ -278,7 +278,7 @@
   description:
     - A motor is useful for making devices that can turn when electric current is applied.
     - This one is rather small, but surprisingly efficient.
-  properties: [portable]
+  properties: [pickable]
 - name: big motor
   display:
     attr: entity
@@ -286,14 +286,14 @@
   description:
     - A motor is useful for making devices that can turn when electric current is applied.
     - This one is huge and could be used to construct powerful machinery.
-  properties: [portable]
+  properties: [pickable]
 - name: flower
   display:
     attr: flower
     char: '*'
   description:
     - A beautiful flower that grows wild in local meadows.  It is not clear what it might be useful for, but it looks nice.
-  properties: [portable, growable]
+  properties: [pickable, growable]
   growth: [30, 50]
 - name: cotton
   display:
@@ -301,7 +301,7 @@
     char: 'i'
   description:
     - A plant with tufts of soft fibers that can be harvested and used to make things, including sheets of material that the local aliens like to drape over their bodies.
-  properties: [portable, growable, combustible]
+  properties: [pickable, growable, combustible]
   growth: [100, 800]
   combustion:
     ignition: 0.1
@@ -319,7 +319,7 @@
       format : a -> text
       ```
       which can turn any value into a suitable text representation.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [format]
 - name: Elmer's glue
   display:
@@ -334,7 +334,7 @@
       can be used to concatenate two text values.  For example,
     - |
       "Number of widgets: " ++ format numWidgets
-  properties: [portable]
+  properties: [pickable]
   capabilities: [concat]
 - name: caliper
   display:
@@ -347,7 +347,7 @@
       chars : text -> int
       ```
       computes the number of characters in a `text`{=type} value.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [charcount]
 - name: wedge
   display:
@@ -361,7 +361,7 @@
       split : int -> text -> text * text
       ```
       splits a `text`{=type} value into two pieces, one before the given index and one after.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [split]
 - name: string
   display:
@@ -389,7 +389,7 @@
     - |
       `split : int -> text -> text * text` splits a `text`{=type} value into
       two pieces, one before the given index and one after.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [format, concat, charcount, split]
 - name: decoder ring
   display:
@@ -406,7 +406,7 @@
     - |
       `toChar : int -> text` creates a singleton (length-1) `text`{=type}
       value containing a character with the given numeric code.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [code]
 - name: lambda
   display:
@@ -420,7 +420,7 @@
       def thrice : cmd unit -> cmd unit = \c. c;c;c end
       ```
     - defines the function `thrice`{=snippet} which repeats a command three times.
-  properties: [portable, growable]
+  properties: [pickable, growable]
   growth: [100, 200]
   capabilities: [lambda]
 - name: curry
@@ -429,21 +429,21 @@
     char: 'C'
   description:
     - Delicious curry cooked from wild lambdas.
-  properties: [portable]
+  properties: [pickable]
 - name: water
   display:
     attr: water
     char: ' '
   description:
     - Liquid dihydrogen monoxide, which seems to be plentiful on this planet.
-  properties: [portable, infinite, liquid]
+  properties: [pickable, infinite, liquid]
 - name: wavy water
   display:
     attr: water
     char: '~'
   description:
     - A wavy section of water.  The same as normal water, but with more waves.
-  properties: [portable, infinite, liquid]
+  properties: [pickable, infinite, liquid]
   yields: water
 - name: boat
   display:
@@ -456,7 +456,7 @@
       will require them; but this doesn't work in the case of boats since floating is not
       associated with any particular command.  To manually ensure a boat is equipped on
       a robot, just add the special command `require "boat"` to the robot's program.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [float]
 - name: sand
   display:
@@ -464,21 +464,21 @@
     char: '█'
   description:
     - A substance composed mostly of tiny rocks and mineral particles that can be used in a furnace to make glass.  You can often find it near water, or make it yourself by grinding up rocks.
-  properties: [portable]
+  properties: [pickable]
 - name: glass
   display:
     attr: entity
     char: '□'
   description:
     - A pane of a brittle, clear substance, made from melting sand in a furnace.
-  properties: [portable]
+  properties: [pickable]
 - name: LaTeX
   display:
     attr: flower
     char: '$'
   description:
     - A naturally occurring substance derived from trees, useful for producing rubber and for typesetting mathematical documents.
-  properties: [portable, growable]
+  properties: [pickable, growable]
   growth: [2000, 3000]
 - name: rubber
   display:
@@ -486,14 +486,14 @@
     char: '%'
   description:
     - A flexible, durable material made from LaTeX.
-  properties: [portable]
+  properties: [pickable]
 - name: bit (0)
   display:
     attr: entity
     char: '0'
   description:
     - A bit is used to represent the smallest possible amount of information. Useful for constructing various information-processing devices, as well as drills.
-  properties: [portable, growable]
+  properties: [pickable, growable]
   growth: [200, 400]
 - name: bit (1)
   display:
@@ -501,7 +501,7 @@
     char: '1'
   description:
     - A bit is used to represent the smallest possible amount of information. Useful for constructing various information-processing devices, as well as drills.
-  properties: [portable, growable]
+  properties: [pickable, growable]
   growth: [200, 400]
 - name: pixel (R)
   display:
@@ -509,7 +509,7 @@
     char: '.'
   description:
     - A tiny picture element, used either to emit or detect red light.
-  properties: [portable, growable]
+  properties: [pickable, growable]
   growth: [1000, 1500]
 - name: pixel (G)
   display:
@@ -517,7 +517,7 @@
     char: '.'
   description:
     - A tiny picture element, used either to emit or detect green light.
-  properties: [portable, growable]
+  properties: [pickable, growable]
   growth: [1000, 1500]
 - name: pixel (B)
   display:
@@ -525,7 +525,7 @@
     char: '.'
   description:
     - A tiny picture element, used either to emit or detect blue light.
-  properties: [portable, growable]
+  properties: [pickable, growable]
   growth: [1000, 1500]
 - name: camera
   display:
@@ -533,7 +533,7 @@
     char: '@'
   description:
     - A camera is a device for capturing images.
-  properties: [portable]
+  properties: [pickable]
 - name: circuit
   display:
     attr: plant
@@ -541,7 +541,7 @@
   description:
     - |
       A circuit is needed for constructing various "smart" devices.
-  properties: [portable]
+  properties: [pickable]
 - name: blueprint
   display:
     attr: blue
@@ -554,7 +554,7 @@
     - |
       `floorplan : text -> cmd (int * int)`
     - Gets the dimensions of a structure template.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [structure]
 - name: drill bit
   display:
@@ -562,35 +562,35 @@
     char: '!'
   description:
     - A drill bit is the most important component of a drill, and must be made out of two bits of opposite parity, for strength.
-  properties: [portable]
+  properties: [pickable]
 - name: box
   display:
     attr: wood
     char: '□'
   description:
     - A wooden box.  It can hold things or be used as housing for other devices.
-  properties: [portable]
+  properties: [pickable]
 - name: wooden gear
   display:
     attr: wood
     char: '*'
   description:
     - A wooden gear.  Not quite as strong or versatile as an iron gear, but easy to produce.
-  properties: [portable]
+  properties: [pickable]
 - name: teeter-totter
   display:
     attr: wood
     char: '/'
   description:
     - A rotating board apparently popular with young aliens.  Perhaps it could also be used as a primitive balance scale.
-  properties: [portable]
+  properties: [pickable]
 - name: Linux
   display:
     attr: entity
     char: 'L'
   description:
     - A copy of the Linux operating system.
-  properties: [portable]
+  properties: [pickable]
 - name: gold coin
   display:
     char: '©'
@@ -598,7 +598,7 @@
   description:
     - A small round shaped piece of gold metal that the aliens pass between each other occasionaly.
     - Besides staying shiny it does not appear to have practical use.
-  properties: [portable]
+  properties: [pickable]
 ############################################################
 ### Utility ################################################
 ############################################################
@@ -682,7 +682,7 @@
   description:
     - A beautiful round shaped piece of metal that seems to be of great value to the aliens on this planet.
     - Just like the bit it has two sides and when you flip it, it lands perfectly randomly on one of the sides.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [random]
 - name: treads
   plural: treads
@@ -702,7 +702,7 @@
     - |
       `move; turn left; move; turn right`
   capabilities: [move, turn]
-  properties: [portable]
+  properties: [pickable]
 - name: tank treads
   plural: tank treads
   display:
@@ -711,7 +711,7 @@
   description:
     - Tank treads work like treads, but are large enough to move even heavy robots around.
   capabilities: [move, turn, moveheavy]
-  properties: [portable]
+  properties: [pickable]
 - name: tape drive
   display:
     attr: device
@@ -719,7 +719,7 @@
   description:
     - A `tape drive`{=entity} allows you to `backup`; that is, to drive in reverse.
   capabilities: [backup]
-  properties: [portable]
+  properties: [pickable]
 - name: dozer blade
   display:
     attr: silver
@@ -728,7 +728,7 @@
     - A broad, sturdy surface that can be attached to a robot and used to `push` objects.
     - |
       `push : cmd unit` will advance the robot and the entity in front of it forward by one step.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [push]
 - name: grabber
   display:
@@ -740,7 +740,7 @@
     - The `place` command takes one argument, the name of the item to place.  The item is removed from the robot's inventory and placed in the robot's current cell (which must be empty).  Raises an exception if the operation fails.
     - "The `give` command takes two arguments: the actor to give an item to (which can be at most 1 cell away), and the name of the item to give. Raises an exception if the operation fails."
   capabilities: [grab, give, place]
-  properties: [portable]
+  properties: [pickable]
 - name: fast grabber
   display:
     attr: device
@@ -751,7 +751,7 @@
     - You can use this to prevent failures where multiple robots are trying to grab, place or scan a given location.
     - In addition you retain the capability to use the `atomic` command, with which you can implement other commands that are safe when run in parallel.
   capabilities: [grab, swap, give, place, atomic]
-  properties: [portable]
+  properties: [pickable]
 - name: binoculars
   display:
     attr: device
@@ -759,7 +759,7 @@
   description:
     - Allows one to `scout` for other robots
   capabilities: [recondir]
-  properties: [portable]
+  properties: [pickable]
 - name: welder
   display:
     attr: device
@@ -775,7 +775,7 @@
       The `unequip` command takes one argument: the name of the device to unequip.
       Raises an exception if the device is not equipped.
   capabilities: [equip, unequip]
-  properties: [portable]
+  properties: [pickable]
 - name: harvester
   display:
     attr: device
@@ -784,7 +784,7 @@
     - A harvester can be used via the `harvest` command, which is almost identical to the `grab` command.  The big difference is that some entities, when harvested instead of grabbed, leave behind a seed which will eventually grow into another copy of the original entity.
     - For entities which do not grow, `harvest` behaves exactly the same as `grab`.
   capabilities: [grab, harvest, place]
-  properties: [portable]
+  properties: [pickable]
 - name: toolkit
   display:
     attr: device
@@ -793,7 +793,7 @@
     - "A toolkit can be used, via the `salvage` command, to take apart old robots."
     - "`salvage` takes no arguments. It looks for an inactive robot (one which is not currently running a program) in the current cell. If an inactive robot is found, its log (if any) is downloaded and it is dismantled, transferring its knowledge, devices, and inventory to the robot running `salvage`.  If no inactive robots are found in the current cell, `salvage` does nothing."
   capabilities: [salvage]
-  properties: [portable]
+  properties: [pickable]
 - name: solar panel
   display:
     attr: device
@@ -801,7 +801,7 @@
   description:
     - An extremely efficient solar panel, capable of generating sufficient power from ambient starlight alone. A robot powered by one of these can operate any time, including on cloudy days and at night.
   capabilities: [power]
-  properties: [portable]
+  properties: [pickable]
 - name: drill
   display:
     attr: device
@@ -809,7 +809,7 @@
   description:
     - A drill allows robots to `drill` through rocks and mountains (with e.g. `drill forward`), and extract resources from mines (with `drill down`).
   capabilities: [drill]
-  properties: [portable]
+  properties: [pickable]
 - name: metal drill
   display:
     attr: iron
@@ -818,14 +818,14 @@
     - A metal drill allows robots to drill through rocks and mountains, and extract resources from mines, faster than a regular drill.
     - A metal drill is also able to drill deeper than a regular drill.  Thus, some resources are only reachable using a metal drill.
   capabilities: [drill]
-  properties: [portable]
+  properties: [pickable]
 - name: typewriter
   display:
     attr: device
     char: 'Д'
   description:
     - A typewriter is used to inscribe symbols on paper, thus reifying pure, platonic information into a physical form.
-  properties: [portable]
+  properties: [pickable]
 - name: 3D printer
   display:
     attr: device
@@ -847,7 +847,7 @@
       ```
     - |
       builds a robot and then views it.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [build]
 - name: dictionary
   display:
@@ -869,7 +869,7 @@
       let x : int = 3 in x^2 + 2*x + 1
       ```
     - The type annotations in `def`{=snippet} are optional.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [env]
 - name: branch predictor
   display:
@@ -887,7 +887,7 @@
       let x = 2 in
       if (x > 3) {move} {turn right; move}
       ```
-  properties: [portable]
+  properties: [pickable]
   capabilities: [cond]
 - name: detonator
   display:
@@ -895,7 +895,7 @@
     char: '*'
   description:
     - An explosive device which can be used to self-destruct, via the `selfdestruct` command.  Immediately vaporizes the robot and any inventory it is carrying.  Can be useful, say, if you are sending out some exploratory robots and don't want them cluttering up the world once they are done.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [selfdestruct]
 - name: life support system
   display:
@@ -903,7 +903,7 @@
     char: 'Ж'
   description:
     - A state-of-the-art life support system which maintains the particular temperature and mixture of gases you need to survive. It uses a sophisticated recirculating system and can run pretty much indefinitely.  Unfortunately, the atmosphere outside is severely toxic (why do the inhabitants of this planet need so much nitrogen!?), so you'll have to stay inside for now.
-  properties: [portable]
+  properties: [pickable]
 - name: scanner
   display:
     attr: device
@@ -912,7 +912,7 @@
     - "With a scanner device, robots can use the `scan` command to learn about their surroundings.  Simply give `scan` a direction in which to scan, and information about the scanned item (if any) will be added to the robot's inventory."
     - "A scanner also enables `blocked : cmd bool`, which returns a boolean value indicating whether the robot's path is blocked (i.e. whether executing a `move` command would fail); `ishere : text -> cmd bool` for checking whether the current cell contains a particular entity; and `isempty : cmd bool` for checking whether the current cell is empty of entities. Note that `ishere` and `isempty` do not detect robots, only entities."
     - "Finally, robots can use the `upload` command to copy their accumulated knowledge to another nearby robot; for example, `upload base`."
-  properties: [portable]
+  properties: [pickable]
   capabilities: [scan, sensefront, sensehere]
 - name: olfactometer
   display:
@@ -921,7 +921,7 @@
     - An electronic "nose" that can tell how far away something is.
     - |
       `sniff : text -> cmd int` returns the distance to the nearest specified entity.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [detectdistance]
 - name: flash memory
   display:
@@ -931,7 +931,7 @@
     - "A compact, non-volatile memory device, capable of storing up to 8 pZ of data."
     - "Flash memory can be used as a component of other devices.  In addition, a flash memory device can be used to reprogram other robots using the `reprogram` command."
     - "The robot being reprogrammed must be idle, and must possess enough capabilities to run the new command; otherwise reprogramming will fail."
-  properties: [portable]
+  properties: [pickable]
   capabilities: [reprogram]
 - name: mirror
   display:
@@ -941,7 +941,7 @@
     - "With a mirror, robots can reflect on themselves and see their own name."
     - "A mirror enables the `whoami` command, which returns the robot's name as a string."
     - "It also enables the special `self` variable, which gives a robot a reference to itself."
-  properties: [portable]
+  properties: [pickable]
   capabilities: [whoami]
 - name: logger
   display:
@@ -949,7 +949,7 @@
     char: 'l'
   description:
     - "Allows a robot to generate and store messages for later viewing, using the `log` command, which takes a string.  Log messages are also automatically generated by uncaught exceptions."
-  properties: [portable]
+  properties: [pickable]
   capabilities: [log]
 - name: hearing aid
   display:
@@ -964,7 +964,7 @@
       ```
       l <- listen; log $ "I have waited for someone to say " ++ l
       ```
-  properties: [portable]
+  properties: [pickable]
   capabilities: [listen]
 - name: counter
   display:
@@ -977,7 +977,7 @@
       in the inventory.  This is an upgraded version of the `has`
       command, which returns a bool instead of an int and does
       not require any special device.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [count]
 - name: calculator
   display:
@@ -985,7 +985,7 @@
     char: '+'
   description:
     - "A calculator allows a robot to do basic arithmetic calculations: addition, subtraction, multiplication, division, and exponentiation."
-  properties: [portable]
+  properties: [pickable]
   capabilities: [arith]
 - name: ADT calculator
   display:
@@ -1018,7 +1018,7 @@
       function `case : (a + b) -> (a -> c) -> (b -> c) -> c`.  For
       example, `case (inl 3) (\x. 2*x) (\y. 3*y) == 6`, and `case (inr
       3) (\x. 2*x) (\y. 3*y) == 9`.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [arith, sum, prod]
 - name: compass
   display:
@@ -1036,7 +1036,7 @@
       east and then restores the same heading as before:
     - |
       `d <- heading; turn east; move; turn d`
-  properties: [portable]
+  properties: [pickable]
   capabilities: [orient]
 - name: clock
   display:
@@ -1048,7 +1048,7 @@
       `time : cmd int` returns the current time, measured in game ticks since the beginning of the game.
     - |
       `wait : int -> cmd unit` causes a robot to sleep for a specified amount of time (measured in game ticks).
-  properties: [portable]
+  properties: [pickable]
   capabilities: [timeabs, timerel]
 - name: hourglass
   display:
@@ -1058,7 +1058,7 @@
     - An hourglass can measure the relative passage of time.  It enables the `wait` command.
     - |
       `wait : int -> cmd unit` causes a robot to sleep for a specified amount of time (measured in game ticks).
-  properties: [portable]
+  properties: [pickable]
   capabilities: [timerel]
 - name: rolex
   display:
@@ -1069,7 +1069,7 @@
     - |
       `watch : dir -> cmd unit` will mark an adjacent (in the specified direction) location of interest to monitor for placement or removal of items.
       A subsequent call to `wait` will be interrupted upon a change to the location.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [timerel, wakeself]
 - name: comparator
   display:
@@ -1078,7 +1078,7 @@
   description:
     - "A comparator allows comparing two values to see whether the first is less, equal, or greater than the second."
     - "Valid comparison operators are <, <=, >, >=, ==, and !=."
-  properties: [portable]
+  properties: [pickable]
   capabilities: [compare]
 - name: I/O cable
   display:
@@ -1086,7 +1086,7 @@
     char: 'Ю'
   description:
     - An I/O cable can be used to communicate with adjacent actors.
-  properties: [portable]
+  properties: [pickable]
 - name: rubber band
   display:
     attr: device
@@ -1104,7 +1104,7 @@
       ```
       atomic (b <- ishere "rock"; if b {grab; return ()} {})
       ```
-  properties: [portable]
+  properties: [pickable]
   capabilities: [atomic]
 - name: net
   display:
@@ -1117,7 +1117,7 @@
       try {move} {turn left}
       ```
     - will attempt to move, but if that fails, turn left instead.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [try]
 - name: antenna
   display:
@@ -1141,7 +1141,7 @@
       `x`{=snippet}, `y`{=snippet}, and `z`{=snippet}
       are nearby actors, then `meetAll f b0`{=snippet} is equivalent to
       `b1 <- f b0 x; b2 <- f b1 y; f b2 z`{=snippet}.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [meet]
 - name: GPS receiver
   display:
@@ -1152,7 +1152,7 @@
       A GPS receiver triangulates your current (x,y) coordinates from
       some convenient satellite signals,
       enabling the command `whereami : cmd (int * int)`.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [senseloc]
 - name: tweezers
   display:
@@ -1164,7 +1164,7 @@
       relays, preventing it from executing properly.  Tweezers are
       useful for removing such pests, and for inspecting robots' detailed
       inner workings.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [debug]
 - name: victrola
   display:
@@ -1183,7 +1183,7 @@
       can be projected using dot notation.  For example,
       `let r = [y="hi", x=2] in r.x` has the value `2`.  The order
       of the fields does not matter.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [record]
 - name: quantum dot
   display:
@@ -1193,14 +1193,14 @@
     - |
       A nanoscale semiconductor particle with a wide range of
       applications.
-  properties: [portable]
+  properties: [pickable]
 - name: 'key'
   display:
     attr: gold
     char: 'k'
   description:
     - A versatile item, with uses such as opening locked doors, entering input, and retrieving stored values.
-  properties: [portable]
+  properties: [pickable]
 - name: keyboard
   display:
     attr: device
@@ -1214,7 +1214,7 @@
     - |
       `key : text -> key` constructs values of type `key`{=type}, for
       example `key "Down"` or `key "C-S-x"`.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [handleinput]
 - name: halting oracle
   display:
@@ -1227,5 +1227,5 @@
       a robot as an argument and, if it is up to one cell away,
       cancels its currently running program (if any).  In creative mode,
       there is no distance limitation.
-  properties: [portable]
+  properties: [pickable]
   capabilities: [halt]

--- a/data/scenarios/Challenges/2048.yaml
+++ b/data/scenarios/Challenges/2048.yaml
@@ -25,84 +25,84 @@ entities:
       char: "#"
     description:
       - This is a one.  Maybe you can combine it with other ones somehow.
-    properties: [growable, portable, infinite]
+    properties: [growable, pickable, infinite]
   - name: "2"
     display:
       attr: gold
       char: "#"
     description:
       - This is a two.  Maybe you can combine it with other twos somehow.
-    properties: [portable]
+    properties: [pickable]
   - name: "4"
     display:
       attr: gold
       char: "#"
     description:
       - This is a four.  You get the idea.
-    properties: [portable]
+    properties: [pickable]
   - name: "8"
     display:
       attr: gold
       char: "#"
     description:
       - An eight.
-    properties: [portable]
+    properties: [pickable]
   - name: "16"
     display:
       attr: gold
       char: "#"
     description:
       - A 16.
-    properties: [portable]
+    properties: [pickable]
   - name: "32"
     display:
       attr: gold
       char: "#"
     description:
       - A 32.
-    properties: [portable]
+    properties: [pickable]
   - name: "64"
     display:
       attr: gold
       char: "#"
     description:
       - A 64.
-    properties: [portable]
+    properties: [pickable]
   - name: "128"
     display:
       attr: gold
       char: "#"
     description:
       - A 128.
-    properties: [portable]
+    properties: [pickable]
   - name: "256"
     display:
       attr: gold
       char: "#"
     description:
       - A 256.
-    properties: [portable]
+    properties: [pickable]
   - name: "512"
     display:
       attr: gold
       char: "#"
     description:
       - A 512.
-    properties: [portable]
+    properties: [pickable]
   - name: "1024"
     display:
       attr: gold
       char: "#"
     description:
       - A 1024.
-    properties: [portable]
+    properties: [pickable]
   - name: "2048"
     display:
       attr: gold
       char: "#"
     description:
       - A 2048.
-    properties: [portable]
+    properties: [pickable]
 recipes:
   - in:
       - [2, "1"]

--- a/data/scenarios/Challenges/Mazes/easy_cave_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/easy_cave_maze.yaml
@@ -63,7 +63,7 @@ entities:
       attr: device
     description:
       - The place you're trying to reach!  You win by executing `grab` on this item.
-    properties: [known, portable]
+    properties: [known, pickable]
 world:
   dsl: |
     {ice}

--- a/data/scenarios/Challenges/Mazes/easy_spiral_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/easy_spiral_maze.yaml
@@ -62,7 +62,7 @@ entities:
       attr: device
     description:
       - The place you're trying to reach!  You win by executing `grab` on this item.
-    properties: [known, portable]
+    properties: [known, pickable]
 world:
   dsl: |
     {ice}

--- a/data/scenarios/Challenges/Mazes/invisible_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/invisible_maze.yaml
@@ -58,7 +58,7 @@ entities:
       attr: device
     description:
       - The place you're trying to reach!  You win by executing `grab` on this item.
-    properties: [known, portable]
+    properties: [known, pickable]
 world:
   dsl: |
     {grass}

--- a/data/scenarios/Challenges/Mazes/loopy_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/loopy_maze.yaml
@@ -51,7 +51,7 @@ entities:
       attr: device
     description:
       - The place you're trying to reach!  You win by executing `grab` on this item.
-    properties: [known, portable]
+    properties: [known, pickable]
 world:
   dsl: |
     {grass}

--- a/data/scenarios/Challenges/Ranching/beekeeping.yaml
+++ b/data/scenarios/Challenges/Ranching/beekeeping.yaml
@@ -171,28 +171,28 @@ entities:
       char: 'k'
     description:
       - All the essentials to equip your own "worker bee"
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: reed
     display:
       attr: plant
       char: 'r'
     description:
       - Reeds, grow near water
-    properties: [known, portable, growable]
+    properties: [known, pickable, growable]
   - name: honeycomb
     display:
       char: 'x'
       attr: gold
     description:
       - Product of bees that have consumed nectar
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: proboscis
     display:
       char: 'p'
       attr: device
     description:
       - Senses direction to nectar-producing flowers
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [detectdirection, structure]
   - name: honey
     display:
@@ -200,26 +200,26 @@ entities:
       attr: gold
     description:
       - Pure liquid honey
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: mead
     display:
       char: 'm'
     description:
       - Honey-based alcoholic beverage
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: honey extractor
     display:
       char: 'e'
       attr: device
     description:
       - Device for extracting honey from the comb
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: buzz
     display:
       char: 'z'
     description:
       - Result of discarding surplus honeycomb
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: wax gland
     display:
       char: 'g'
@@ -232,35 +232,35 @@ entities:
       attr: gold
     description:
       - Obtained from wildflowers
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: honey frame
     display:
       char: '-'
       attr: iceblue
     description:
       - Internal component of a beehive
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: stave
     display:
       char: 'l'
       attr: wood
     description:
       - Wooden plank comprising the sides of a cask
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: cask
     display:
       char: 'c'
       attr: wood
     description:
       - Wooden barrel for liquids
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: water cask
     display:
       char: 'c'
       attr: water_cask
     description:
       - Water-filled cask
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: lakewater
     display:
       attr: water
@@ -274,14 +274,14 @@ entities:
       attr: device
     description:
       - Used to fill a cask with water
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: steel hoop
     display:
       char: 'o'
       attr: iron
     description:
       - Binds staves into a cask
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: wall
     display:
       char: 'w'
@@ -295,7 +295,7 @@ entities:
       attr: wood
     description:
       - A segment of banquet table
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: hearth
     display:
       char: 'h'
@@ -309,14 +309,14 @@ entities:
       attr: rock
     description:
       - Grand entrance
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: stone tile
     display:
       char: '.'
       attr: rock
     description:
       - Refined flooring
-    properties: [known, portable]
+    properties: [known, pickable]
 recipes:
   - in:
       - [1, botkit]

--- a/data/scenarios/Challenges/Ranching/capture.yaml
+++ b/data/scenarios/Challenges/Ranching/capture.yaml
@@ -129,7 +129,7 @@ entities:
       char: '@'
     description:
       - Pushable rock
-    properties: [known, unwalkable, portable]
+    properties: [known, unwalkable, pickable]
     capabilities: [push]
   - name: bacon
     display:

--- a/data/scenarios/Challenges/Ranching/gated-paddock.yaml
+++ b/data/scenarios/Challenges/Ranching/gated-paddock.yaml
@@ -234,7 +234,7 @@ entities:
       char: '#'
     description:
       - Keeps sheep in. And some other things out.
-    properties: [known, portable, unwalkable]
+    properties: [known, pickable, unwalkable]
   - name: post puller
     display:
       char: 'P'
@@ -242,27 +242,27 @@ entities:
     capabilities: [drill]
     description:
       - Good for dismantling fences.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: scrap wood
     display:
       char: '\'
     description:
       - Scrap wood. Can be reconditioned into boards.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: sweater
     display:
       attr: gold
       char: 'S'
     description:
       - A warm wool sweater. Just in time for winter!
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: clover
     display:
       attr: flower
       char: '%'
     description:
       - A tasty stack for fluffy ruminants.
-    properties: [portable, growable]
+    properties: [pickable, growable]
     growth: [80, 100]
   - name: gate
     display:
@@ -277,7 +277,7 @@ entities:
       attr: rock
     description:
       - Facilitates swinging action.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: cabin
     display:
       char: Π
@@ -297,19 +297,19 @@ entities:
       char: '.'
     description:
       - A marker that can be put down and found again. Used only by judge robot.
-    properties: [portable]
+    properties: [pickable]
   - name: treaded breadcrumb
     display:
       char: 'x'
     description:
       - A marker that can be put down and found again (for a second time). Used only by judge robot.
-    properties: [portable]
+    properties: [pickable]
   - name: evaporator
     display:
       char: 'E'
     description:
       - A tool that allows clearing a water tile. Used only by judge robot.
-    properties: [portable]
+    properties: [pickable]
     capabilities: [drill]
   - name: wool
     display:
@@ -317,13 +317,13 @@ entities:
       attr: gold
     description:
       - A bundle of raw animal fiber.
-    properties: [portable]
+    properties: [pickable]
   - name: steam
     display:
       char: 'Z'
     description:
       - What's left after evaporating water. Used only by judge robot.
-    properties: [portable]
+    properties: [pickable]
 recipes:
   - in:
       - [2, board]

--- a/data/scenarios/Challenges/Ranching/powerset.yaml
+++ b/data/scenarios/Challenges/Ranching/powerset.yaml
@@ -98,7 +98,7 @@ entities:
       char: 's'
     description:
       - Allows one to `stride` across multiple cells
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [movemultiple]
   - name: bell
     display:
@@ -106,7 +106,7 @@ entities:
       attr: gold
     description:
       - A bell for Bill
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: fruit picker
     display:
       char: 'P'
@@ -127,7 +127,7 @@ entities:
       attr: fruit0
     description:
       - Dragonfruits
-    properties: [known, growable, portable]
+    properties: [known, growable, pickable]
     growth: [10, 10]
   - name: grape
     display:
@@ -136,7 +136,7 @@ entities:
     description:
       - Grapes
     growth: [10, 10]
-    properties: [known, growable, portable]
+    properties: [known, growable, pickable]
   - name: lemon
     display:
       char: 'Y'
@@ -144,7 +144,7 @@ entities:
     description:
       - Lemons
     growth: [10, 10]
-    properties: [known, growable, portable]
+    properties: [known, growable, pickable]
   - name: apple
     display:
       char: 'Y'
@@ -152,7 +152,7 @@ entities:
     description:
       - Apple
     growth: [10, 10]
-    properties: [known, growable, portable]
+    properties: [known, growable, pickable]
   - name: blueberry
     display:
       char: 'Y'
@@ -160,7 +160,7 @@ entities:
     description:
       - Blueberries
     growth: [10, 10]
-    properties: [known, growable, portable]
+    properties: [known, growable, pickable]
   - name: watermelon
     display:
       char: 'Y'
@@ -168,7 +168,7 @@ entities:
     description:
       - Watermelons
     growth: [10, 10]
-    properties: [known, growable, portable]
+    properties: [known, growable, pickable]
   - name: orange
     display:
       char: 'Y'
@@ -176,7 +176,7 @@ entities:
     description:
       - Oranges
     growth: [10, 10]
-    properties: [known, growable, portable]
+    properties: [known, growable, pickable]
 known: [sand]
 world:
   dsl: |

--- a/data/scenarios/Challenges/Sliding Puzzles/3x3.yaml
+++ b/data/scenarios/Challenges/Sliding Puzzles/3x3.yaml
@@ -185,7 +185,7 @@ entities:
       char: '/'
     description:
       - Facilitates pushing
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [push]
   - name: sliding-tile
     display:
@@ -199,175 +199,175 @@ entities:
       attr: oddtile
     description:
       - One
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: b-tile
     display:
       char: 'b'
       attr: eventile
     description:
       - Two
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: c-tile
     display:
       char: 'c'
       attr: oddtile
     description:
       - Three
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: d-tile
     display:
       char: 'd'
       attr: eventile
     description:
       - Four
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: e-tile
     display:
       char: 'e'
       attr: oddtile
     description:
       - Five
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: f-tile
     display:
       char: 'f'
       attr: eventile
     description:
       - Six
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: g-tile
     display:
       char: 'g'
       attr: oddtile
     description:
       - Seven
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: h-tile
     display:
       char: 'h'
       attr: eventile
     description:
       - Eight
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: i-tile
     display:
       char: 'i'
       attr: oddtile
     description:
       - Nine
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: j-tile
     display:
       char: 'j'
       attr: eventile
     description:
       - Ten
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: k-tile
     display:
       char: 'k'
       attr: oddtile
     description:
       - Eleven
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: l-tile
     display:
       char: 'l'
       attr: eventile
     description:
       - Twelve
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: m-tile
     display:
       char: 'm'
       attr: oddtile
     description:
       - Thirteen
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: n-tile
     display:
       char: 'n'
       attr: eventile
     description:
       - Fourteen
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: o-tile
     display:
       char: 'o'
       attr: oddtile
     description:
       - Fifteen
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: p-tile
     display:
       char: 'p'
       attr: eventile
     description:
       - Sixteen
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: q-tile
     display:
       char: 'q'
       attr: oddtile
     description:
       - Seventeen
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: r-tile
     display:
       char: 'r'
       attr: eventile
     description:
       - Eighteen
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: s-tile
     display:
       char: 's'
       attr: oddtile
     description:
       - Nineteen
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: t-tile
     display:
       char: 't'
       attr: eventile
     description:
       - Twenty
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: u-tile
     display:
       char: 'u'
       attr: oddtile
     description:
       - Twenty-one
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: v-tile
     display:
       char: 'v'
       attr: eventile
     description:
       - Twenty-two
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: w-tile
     display:
       char: 'w'
       attr: oddtile
     description:
       - Twenty-three
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: x-tile
     display:
       char: 'x'
       attr: eventile
     description:
       - Twenty-four
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: y-tile
     display:
       char: 'y'
       attr: oddtile
     description:
       - Twenty-five
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: a-tile-ordinal
     display:
       char: 'a'

--- a/data/scenarios/Challenges/Sokoban/Gadgets/no-reverse.yaml
+++ b/data/scenarios/Challenges/Sokoban/Gadgets/no-reverse.yaml
@@ -63,7 +63,7 @@ entities:
       char: '@'
     description:
       - Pushable rock
-    properties: [known, unwalkable, portable]
+    properties: [known, unwalkable, pickable]
 known: [mountain, water, flower]
 world:
   dsl: |

--- a/data/scenarios/Challenges/Sokoban/Gadgets/one-way.yaml
+++ b/data/scenarios/Challenges/Sokoban/Gadgets/one-way.yaml
@@ -46,7 +46,7 @@ entities:
       char: '@'
     description:
       - Pushable rock
-    properties: [known, unwalkable, portable]
+    properties: [known, unwalkable, pickable]
 known: [mountain, water, flower]
 world:
   dsl: |

--- a/data/scenarios/Challenges/Sokoban/Simple/trapdoor.yaml
+++ b/data/scenarios/Challenges/Sokoban/Simple/trapdoor.yaml
@@ -98,7 +98,7 @@ entities:
       char: '@'
     description:
       - Pushable rock
-    properties: [known, unwalkable, portable]
+    properties: [known, unwalkable, pickable]
 known: [mountain, water, flower]
 world:
   dsl: |

--- a/data/scenarios/Challenges/Sokoban/foresight.yaml
+++ b/data/scenarios/Challenges/Sokoban/foresight.yaml
@@ -78,14 +78,14 @@ entities:
       attr: gold
     description:
       - Pushable rock
-    properties: [known, unwalkable, portable]
+    properties: [known, unwalkable, pickable]
   - name: crate
     display:
       attr: wood
       char: '▪'
     description:
       - Pushable crate
-    properties: [known, portable, unwalkable]
+    properties: [known, pickable, unwalkable]
   - name: wall
     display:
       attr: barrier

--- a/data/scenarios/Challenges/arbitrage.yaml
+++ b/data/scenarios/Challenges/arbitrage.yaml
@@ -87,95 +87,95 @@ entities:
     description:
       - An ubiquitous office accoutrement.
       - Practically worthless as a single unit.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: pinwheel
     display:
       char: 'P'
       attr: gold
     description:
       - Watch it spin. Wheee!
-    properties: [portable]
+    properties: [pickable]
   - name: stapler
     display:
       char: 'S'
       attr: red
     description:
       - A shiny red stapler
-    properties: [portable]
+    properties: [pickable]
   - name: toothbrush
     display:
       char: 'b'
       attr: blue
     description:
       - Brushy brushy
-    properties: [portable]
+    properties: [pickable]
   - name: Pez dispenser
     display:
       char: 'P'
     description:
       - Classic collectible toy. Absent its chalky candy.
-    properties: [portable]
+    properties: [pickable]
   - name: shoehorn
     display:
       char: 'h'
     description:
       - Handheld apparatus for donning snug footwear
-    properties: [portable]
+    properties: [pickable]
   - name: trivet
     display:
       char: 'v'
     description:
       - Protective silicone mat for hot cookware
-    properties: [portable]
+    properties: [pickable]
   - name: coffee mug
     display:
       char: 'c'
     description:
       - Caffeine conveyance
-    properties: [portable]
+    properties: [pickable]
   - name: toaster
     display:
       char: 'A'
     description:
       - Bread warmer-upper
-    properties: [portable]
+    properties: [pickable]
   - name: blender
     display:
       char: 'B'
     description:
       - Essential for smoothie preparation
-    properties: [portable]
+    properties: [pickable]
   - name: electric can opener
     display:
       char: 'B'
     description:
       - |
         For when you can't be bothered to manually open a can
-    properties: [portable]
+    properties: [pickable]
   - name: wok
     display:
       char: 'w'
     description:
       - One must wok before one can run.
-    properties: [portable]
+    properties: [pickable]
   - name: sous vide cooker
     display:
       char: 's'
     description:
       - trendy gourmet cooking appliance
-    properties: [portable]
+    properties: [pickable]
   - name: french press
     display:
       char: 'f'
     description:
       - plunger-based coffee maker
-    properties: [portable]
+    properties: [pickable]
   - name: stand mixer
     display:
       char: 'm'
     description:
       - whips, kneads, and mixes
-    properties: [portable]
+    properties: [pickable]
   - name: shopA
     display:
       char: 'A'

--- a/data/scenarios/Challenges/blender.yaml
+++ b/data/scenarios/Challenges/blender.yaml
@@ -151,7 +151,7 @@ entities:
       attr: gold
     description:
       - used to unlock a door
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [drill]
   - name: bind gt
     display:
@@ -173,7 +173,7 @@ entities:
       attr: snow
     description:
       - The figurative jewel of category theory
-    properties: [known, portable]
+    properties: [known, pickable]
 recipes:
   - in:
       - [1, locked door]

--- a/data/scenarios/Challenges/bridge-building.yaml
+++ b/data/scenarios/Challenges/bridge-building.yaml
@@ -190,21 +190,21 @@ entities:
       attr: 'magenta'
     description:
       - The map describes local points of interest, relative to your cabin.
-    properties: [portable, known]
+    properties: [pickable, known]
   - name: peat furnace
     display:
       char: 'F'
       attr: tan
     description:
       - Fueled by peat.
-    properties: [portable, known]
+    properties: [pickable, known]
   - name: clay
     display:
       char: 'c'
       attr: tan
     description:
       - Can be fired in a peat furnace into a vessel.
-    properties: [portable, known]
+    properties: [pickable, known]
   - name: lava
     display:
       char: 'w'
@@ -218,21 +218,21 @@ entities:
       attr: tan
     description:
       - A tiny, inconsequential rock.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: machete
     display:
       char: '/'
       attr: cyan
     description:
       - Easily cuts through jungle overgrowth.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: painted plate
     display:
       char: 'o'
       attr: obsidian
     description:
       - Limited edition 1978 collectible Helix the Cat ornamental hand-painted dinner plate.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: oven mitts
     display:
       char: 'm'
@@ -272,7 +272,7 @@ entities:
       attr: silver
     description:
       - Can break hard objects
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: granite mountain
     display:
       char: 'A'
@@ -298,35 +298,35 @@ entities:
       char: 'L'
     description:
       - Can be used to traverse down a cliff.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: hemp
     display:
       char: 'h'
       attr: plant
     description:
       - Can be used to make rope
-    properties: [known, portable, growable]
+    properties: [known, pickable, growable]
   - name: flimsy board
     display:
       char: 'b'
       attr: wood
     description:
       - Board made from a soft log. Has poor rigidity.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: soft log
     display:
       char: 'l'
       attr: wood
     description:
       - Log made from a palm tree. A bit flexible.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: coconut
     display:
       char: 'c'
       attr: wood
     description:
       - Spherical, buoyant husk
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: floating boardwalk
     display:
       char: '▒'
@@ -340,7 +340,7 @@ entities:
       attr: wood
     description:
       - Burnable plant material
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: peat bog
     display:
       char: 'b'
@@ -374,14 +374,14 @@ entities:
       char: 'c'
     description:
       - An empty crucible. Can carry lava.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: lava-filled crucible
     display:
       char: 'C'
       attr: lavaBG
     description:
       - Crucible filled with lava
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: quarry
     display:
       char: 'Q'
@@ -436,13 +436,13 @@ entities:
       char: 'r'
     description:
       - An empty container for rubble.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: rubble-filled skip
     display:
       char: 'R'
     description:
       - An full container of rubble. Can be dumped in the water as fill to form a causeway.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: causeway
     display:
       char: '▒'
@@ -454,14 +454,14 @@ entities:
       char: 'k'
     description:
       - Tank with nothing in it
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: water-filled tank
     display:
       char: 'K'
       attr: blueBG
     description:
       - Tank filled with water
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: obsidian path
     display:
       char: '`'
@@ -475,14 +475,14 @@ entities:
       attr: obsidian
     description:
       - Dislodged fragment of obsidian
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: palm tree
     display:
       char: 'P'
       attr: beach
     description:
       - Palm tree.
-    properties: [known, portable, growable]
+    properties: [known, pickable, growable]
 recipes:
   - in:
       - [8, clay]

--- a/data/scenarios/Challenges/bucket-brigade.yaml
+++ b/data/scenarios/Challenges/bucket-brigade.yaml
@@ -84,7 +84,7 @@ entities:
       char: 'x'
     description:
       - A powerful machine designed to remove overburden in mining operations.
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [drill]
   - name: lignite mine
     display:
@@ -98,31 +98,31 @@ entities:
       char: 'c'
     description:
       - Primitive, sooty fuel.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: coal briquette
     display:
       char: 'q'
     description:
       - A compressed, convenient form of coal for consumption and transport.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: briquette press
     display:
       char: 'P'
     description:
       - A device to compress coal lumps into briquettes.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: energy
     display:
       char: 'E'
     description:
       - The result of burning a coal briquettte.
-    properties: [portable]
+    properties: [pickable]
   - name: repro kit
     display:
       char: 'k'
     description:
       - Kit that can be unpacked into everything a robot needs to reproduce.
-    properties: [known, portable]
+    properties: [known, pickable]
 recipes:
   - in:
       - [1, repro kit]

--- a/data/scenarios/Challenges/dimsum.yaml
+++ b/data/scenarios/Challenges/dimsum.yaml
@@ -85,19 +85,19 @@ entities:
       char: 's'
     description:
       - Serving utensil for the cart
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: fork
     display:
       char: 'k'
     description:
       - Eating utensil for patron
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: food
     display:
       char: 'f'
     description:
       - Food from the cart
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: empty cart
     display:
       attr: copper

--- a/data/scenarios/Challenges/friend.yaml
+++ b/data/scenarios/Challenges/friend.yaml
@@ -72,7 +72,7 @@ entities:
       char: 'f'
     description:
       - A smelly fish. Rather unappetizing to a robot.
-    properties: [known, portable]
+    properties: [known, pickable]
 known: [fish]
 seed: 0
 world:

--- a/data/scenarios/Challenges/gopher.yaml
+++ b/data/scenarios/Challenges/gopher.yaml
@@ -110,14 +110,14 @@ entities:
     capabilities: [turn]
     description:
       - Allows a robot to "turn" but not "move".
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: uranium
     display:
       char: 'U'
       attr: silver
     description:
       - Unearthed by industrious gophers.
-    properties: [known, portable]
+    properties: [known, pickable]
 recipes:
   - in:
       - [1, mound]

--- a/data/scenarios/Challenges/hackman.yaml
+++ b/data/scenarios/Challenges/hackman.yaml
@@ -211,7 +211,7 @@ entities:
     description:
       - A caffeine pellet.
       - Helps Hackman produce more code.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: donut
     display:
       char: 'o'
@@ -219,14 +219,14 @@ entities:
     description:
       - Breakfast of champions.
       - Fancied by ghosts. Will you share?
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: den key
     display:
       char: 'k'
       attr: gold
     description:
       - Opens a gate
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: strawberry
     display:
       char: 'v'
@@ -234,7 +234,7 @@ entities:
     description:
       - A tart berry
       - Possessing this fruit gives you great satisfaction.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: gate
     display:
       char: '='

--- a/data/scenarios/Challenges/hanoi.yaml
+++ b/data/scenarios/Challenges/hanoi.yaml
@@ -101,21 +101,21 @@ entities:
       attr: gold
     description:
       - A disk of radius 3.
-    properties: [portable]
+    properties: [pickable]
   - name: two
     display:
       char: '2'
       attr: gold
     description:
       - A disk of radius 2.
-    properties: [portable]
+    properties: [pickable]
   - name: one
     display:
       char: '1'
       attr: gold
     description:
       - A disk of radius 1.
-    properties: [portable]
+    properties: [pickable]
   - name: blocked one
     display:
       char: '1'

--- a/data/scenarios/Challenges/ice-cream.yaml
+++ b/data/scenarios/Challenges/ice-cream.yaml
@@ -77,19 +77,19 @@ entities:
       char: '@'
     description:
       - A single scoop of vanilla ice cream
-    properties: [portable]
+    properties: [pickable]
   - name: cherry
     display:
       char: '6'
       attr: 'red'
-    properties: [portable]
+    properties: [pickable]
     description:
       - A traditional ice cream garnish
   - name: Counter
     display:
       char: '▒'
       attr: 'sand'
-    properties: [portable, known]
+    properties: [pickable, known]
     capabilities: [count]
     description:
       - Where customers are served.
@@ -98,42 +98,42 @@ entities:
     display:
       char: 'V'
       attr: 'sand'
-    properties: [portable]
+    properties: [pickable]
     description:
       - A conical, edible container for ice cream
   - name: egg
     display:
       char: 'e'
       attr: 'gold'
-    properties: [portable]
+    properties: [pickable]
     description:
       - Organic from local, free-range, meticulously pampered chickens.
   - name: milk
     display:
       char: 'm'
       attr: 'silver'
-    properties: [portable]
+    properties: [pickable]
     description:
       - Pasteurized, homogenized, commoditized, metabolized.
   - name: ice
     display:
       char: 'i'
       attr: 'snow'
-    properties: [portable]
+    properties: [pickable]
     description:
       - Ice cream is better cold, don't you think?
   - name: sugar
     display:
       char: 's'
       attr: 'snow'
-    properties: [portable]
+    properties: [pickable]
     description:
       - Basis of most desserts
   - name: vanilla
     display:
       char: 'v'
       attr: 'wood'
-    properties: [portable]
+    properties: [pickable]
     description:
       - Traditional ice cream flavoring
   - name: briefcase
@@ -141,7 +141,7 @@ entities:
       char: 'B'
       attr: rubber
     capabilities: [sum, prod]
-    properties: [portable]
+    properties: [pickable]
     description:
       - Standard business accoutrement.
       - Particularly useful for `meet`-ings.

--- a/data/scenarios/Challenges/maypole.yaml
+++ b/data/scenarios/Challenges/maypole.yaml
@@ -63,7 +63,7 @@ entities:
       char: '@'
     description:
       - A disorienting vestibular affliction
-    properties: [portable]
+    properties: [pickable]
   - name: maypole
     display:
       char: 'M'

--- a/data/scenarios/Challenges/pack-tetrominoes.yaml
+++ b/data/scenarios/Challenges/pack-tetrominoes.yaml
@@ -50,35 +50,35 @@ entities:
       attr: q-tile
     description:
       - q-tile
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: j-tile
     display:
       char: 'j'
       attr: j-tile
     description:
       - j-tile
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: i-tile
     display:
       char: 'i'
       attr: i-tile
     description:
       - i-tile
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: t-tile
     display:
       char: 't'
       attr: t-tile
     description:
       - t-tile
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: z-tile
     display:
       char: 'z'
       attr: z-tile
     description:
       - z-tile
-    properties: [known, portable]
+    properties: [known, pickable]
 solution: |
   run "scenarios/Challenges/_pack-tetrominoes/solution.sw"
 structures:

--- a/data/scenarios/Challenges/wolf-goat-cabbage.yaml
+++ b/data/scenarios/Challenges/wolf-goat-cabbage.yaml
@@ -80,21 +80,21 @@ entities:
       attr: silver
     description:
       - A wolf. Likes to eat goats.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: goat
     display:
       char: 'g'
       attr: sand
     description:
       - A goat. Likes to eat cabbage.
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: cabbage
     display:
       char: 'c'
       attr: green
     description:
       - A cabbage.
-    properties: [known, portable]
+    properties: [known, pickable]
 known: [water, boulder]
 seed: 0
 world:

--- a/data/scenarios/Challenges/word-search.yaml
+++ b/data/scenarios/Challenges/word-search.yaml
@@ -293,14 +293,14 @@ entities:
     capabilities: [drill]
     description:
       - Instrument for marking found words
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: ink
     display:
       char: 'K'
       attr: gold
     description:
       - Ink for marking found words
-    properties: [known, portable]
+    properties: [known, pickable]
 recipes:
   - in:
       - [1, capital C]

--- a/data/scenarios/Fun/horton.yaml
+++ b/data/scenarios/Fun/horton.yaml
@@ -62,7 +62,7 @@ entities:
       - |
         `path (inL ()) (inR "tree");`
       - If a path exists, returns the direction to proceed along.
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
 known: [water, boulder, flower]
 world:

--- a/data/scenarios/Fun/snake.yaml
+++ b/data/scenarios/Fun/snake.yaml
@@ -65,7 +65,7 @@ entities:
     description:
       - |
         Enables the `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
   - name: apple
     display:
@@ -74,7 +74,7 @@ entities:
     description:
       - |
         Tasty snack
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: apple core
     display:
       char: 'I'
@@ -82,7 +82,7 @@ entities:
     description:
       - |
         Remains of an eaten apple
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: rattle
     display:
       char: 'r'

--- a/data/scenarios/Testing/1007-use-command.yaml
+++ b/data/scenarios/Testing/1007-use-command.yaml
@@ -41,7 +41,7 @@ entities:
       char: 'k'
     description:
       - Can open a closed gate
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: closed gate
     display:
       attr: wood

--- a/data/scenarios/Testing/1157-drill-return-value.yaml
+++ b/data/scenarios/Testing/1157-drill-return-value.yaml
@@ -46,7 +46,7 @@ entities:
       char: 'o'
     description:
       - Dispensed from a gumball machine
-    properties: [portable]
+    properties: [pickable]
 recipes:
   - in:
       - [1, gumball machine]

--- a/data/scenarios/Testing/1218-stride-command.yaml
+++ b/data/scenarios/Testing/1218-stride-command.yaml
@@ -74,7 +74,7 @@ entities:
       char: 't'
     description:
       - Allows one to "stride" across multiple cells
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [movemultiple]
 known: [tree, flower, boulder, water]
 world:

--- a/data/scenarios/Testing/1234-push-command.yaml
+++ b/data/scenarios/Testing/1234-push-command.yaml
@@ -48,7 +48,7 @@ entities:
       char: '▪'
     description:
       - Pushable crate
-    properties: [known, portable, unwalkable]
+    properties: [known, pickable, unwalkable]
 known: [tree, flower, boulder, water]
 world:
   palette:

--- a/data/scenarios/Testing/1355-combustion.yaml
+++ b/data/scenarios/Testing/1355-combustion.yaml
@@ -62,7 +62,7 @@ entities:
       char: 't'
     description:
       - Can set things on fire
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [ignite]
   - name: fuse
     display:
@@ -74,7 +74,7 @@ entities:
       ignition: 1
       duration: [8, 8]
       product: null
-    properties: [known, portable, combustible]
+    properties: [known, pickable, combustible]
   - name: dynamite
     display:
       attr: red
@@ -85,7 +85,7 @@ entities:
       ignition: 1
       duration: [2, 2]
       product: crater
-    properties: [known, portable, combustible]
+    properties: [known, pickable, combustible]
   - name: crater
     display:
       attr: rock

--- a/data/scenarios/Testing/1535-ping/1535-in-range.yaml
+++ b/data/scenarios/Testing/1535-ping/1535-in-range.yaml
@@ -22,14 +22,14 @@ entities:
       char: 'x'
     description:
       - Enables `ping` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [ping]
   - name: map piece
     display:
       char: 'm'
     description:
       - Half of a treasure map
-    properties: [known, portable]
+    properties: [known, pickable]
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1535-ping/1535-out-of-range.yaml
+++ b/data/scenarios/Testing/1535-ping/1535-out-of-range.yaml
@@ -21,7 +21,7 @@ entities:
       char: 'x'
     description:
       - Enables `ping` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [ping]
 robots:
   - name: base

--- a/data/scenarios/Testing/1569-pathfinding-cache/1569-cache-invalidation-distance-limit.yaml
+++ b/data/scenarios/Testing/1569-pathfinding-cache/1569-cache-invalidation-distance-limit.yaml
@@ -67,7 +67,7 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
   - name: monolith
     display:
@@ -75,21 +75,21 @@ entities:
       attr: rock
     description:
       - Pushable rock
-    properties: [known, unwalkable, portable]
+    properties: [known, unwalkable, pickable]
   - name: lemon
     display:
       char: 'o'
       attr: gold
     description:
       - Sour fruit
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: lemonade
     display:
       char: 'c'
       attr: gold
     description:
       - Sweet drink
-    properties: [known, portable]
+    properties: [known, pickable]
 recipes:
   - in:
       - [1, lemon]

--- a/data/scenarios/Testing/1569-pathfinding-cache/1569-cache-invalidation-modes.yaml
+++ b/data/scenarios/Testing/1569-pathfinding-cache/1569-cache-invalidation-modes.yaml
@@ -109,7 +109,7 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
   - name: monolith
     display:
@@ -117,21 +117,21 @@ entities:
       attr: rock
     description:
       - Pushable rock
-    properties: [known, unwalkable, portable]
+    properties: [known, unwalkable, pickable]
   - name: lemon
     display:
       char: 'o'
       attr: gold
     description:
       - Sour fruit
-    properties: [known, portable]
+    properties: [known, pickable]
   - name: lemonade
     display:
       char: 'c'
       attr: gold
     description:
       - Sweet drink
-    properties: [known, portable]
+    properties: [known, pickable]
 recipes:
   - in:
       - [1, lemon]

--- a/data/scenarios/Testing/1569-pathfinding-cache/1569-harvest-batch.yaml
+++ b/data/scenarios/Testing/1569-pathfinding-cache/1569-harvest-batch.yaml
@@ -32,7 +32,7 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
 robots:
   - name: base

--- a/data/scenarios/Testing/1631-tags.yaml
+++ b/data/scenarios/Testing/1631-tags.yaml
@@ -79,7 +79,7 @@ entities:
       char: 'S'
     description:
       - Reads the 'tag' of an item
-    properties: [portable]
+    properties: [pickable]
     capabilities: [hastag, tagmembers]
   - name: canteloupe
     display:
@@ -87,20 +87,20 @@ entities:
     description:
       - Melon
     tags: [edible, fruit]
-    properties: [portable]
+    properties: [pickable]
   - name: mushroom
     display:
       char: 'm'
     description:
       - Nature's tiny umbrella.
     tags: [edible, fungus]
-    properties: [portable]
+    properties: [pickable]
   - name: gravel
     display:
       char: 'g'
     description:
       - Crushed rock
-    properties: [portable]
+    properties: [pickable]
   - name: strawberry
     display:
       char: 's'
@@ -113,7 +113,7 @@ entities:
     description:
       - Just ripe
     tags: [edible, fruit]
-    properties: [portable]
+    properties: [pickable]
 world:
   palette:
     '.': [grass]

--- a/data/scenarios/Testing/201-require/201-require-device-creative1.yaml
+++ b/data/scenarios/Testing/201-require/201-require-device-creative1.yaml
@@ -47,6 +47,6 @@ entities:
       char: ' '
     description:
       - An infinite ocean of water.
-    properties: [known, portable, growable, liquid]
+    properties: [known, pickable, growable, liquid]
     growth: [0, 0]
     yields: water

--- a/data/scenarios/Testing/479-atomic-race.yaml
+++ b/data/scenarios/Testing/479-atomic-race.yaml
@@ -67,7 +67,7 @@ entities:
       char: 'W'
     description:
       - A fast-growing weed.
-    properties: [known, portable, growable]
+    properties: [known, pickable, growable]
     growth: [1, 2]
   - name: Win
     display:
@@ -75,7 +75,7 @@ entities:
       char: 'W'
     description:
       - You win!
-    properties: [known, portable]
+    properties: [known, pickable]
 world:
   palette:
     '.': [grass]

--- a/data/scenarios/Testing/479-atomic.yaml
+++ b/data/scenarios/Testing/479-atomic.yaml
@@ -56,7 +56,7 @@ entities:
       char: 'W'
     description:
       - A fast-growing weed.
-    properties: [known, portable, growable]
+    properties: [known, pickable, growable]
     growth: [1, 2]
 world:
   palette:

--- a/data/scenarios/Testing/508-capability-subset.yaml
+++ b/data/scenarios/Testing/508-capability-subset.yaml
@@ -60,7 +60,7 @@ entities:
       char: 'G'
     description:
       - A satellite navigation device.
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [senseloc]
   - name: Tardis
     display:
@@ -68,5 +68,5 @@ entities:
       char: '█'
     description:
       - Bigger on the inside.
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [senseloc, teleport]

--- a/data/scenarios/Testing/836-pathfinding/836-automatic-waypoint-navigation.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-automatic-waypoint-navigation.yaml
@@ -23,14 +23,14 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
   - name: atlas
     display:
       char: 'a'
     description:
       - Enables `waypoint` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [waypoint]
   - name: kudzu
     display:
@@ -46,7 +46,7 @@ entities:
       attr: easter_egg
     description:
       - A colorful egg laid by the rabbit
-    properties: [known, portable]
+    properties: [known, pickable]
     growth: [5, 10]
 robots:
   - name: base

--- a/data/scenarios/Testing/836-pathfinding/836-no-path-exists1.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-no-path-exists1.yaml
@@ -20,7 +20,7 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
 robots:
   - name: base

--- a/data/scenarios/Testing/836-pathfinding/836-no-path-exists2.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-no-path-exists2.yaml
@@ -26,7 +26,7 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
 robots:
   - name: base

--- a/data/scenarios/Testing/836-pathfinding/836-path-exists-find-entity-unwalkable.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-path-exists-find-entity-unwalkable.yaml
@@ -19,7 +19,7 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
 robots:
   - name: base

--- a/data/scenarios/Testing/836-pathfinding/836-path-exists-find-entity.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-path-exists-find-entity.yaml
@@ -16,7 +16,7 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
 robots:
   - name: base

--- a/data/scenarios/Testing/836-pathfinding/836-path-exists-find-location.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-path-exists-find-location.yaml
@@ -16,7 +16,7 @@ entities:
       char: 'w'
     description:
       - Enables `path` command
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [path]
 robots:
   - name: base

--- a/data/scenarios/Testing/958-isempty.yaml
+++ b/data/scenarios/Testing/958-isempty.yaml
@@ -37,7 +37,7 @@ entities:
       char: 'Y'
     description:
       - A thing that everyone needs!
-    properties: [portable]
+    properties: [pickable]
 world:
   palette:
     '.': [grass]

--- a/data/scenarios/Testing/961-custom-capabilities.yaml
+++ b/data/scenarios/Testing/961-custom-capabilities.yaml
@@ -20,7 +20,7 @@ entities:
       char: 'o'
     description:
       - A non-traditional means of locomotion.
-    properties: [known, portable]
+    properties: [known, pickable]
     capabilities: [move]
 robots:
   - name: base

--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -35,7 +35,7 @@ entities:
         ```
       - |
         To open the full goal text again, you can hit **Ctrl+G**.
-    properties: [known, portable]
+    properties: [known, pickable]
 robots:
   - name: base
     system: true

--- a/data/scenarios/Tutorials/bind2.yaml
+++ b/data/scenarios/Tutorials/bind2.yaml
@@ -80,7 +80,7 @@ entities:
       char: 'H'
     description:
       - The Unspeakable One
-    properties: [portable]
+    properties: [pickable]
 robots:
   - name: base
     dir: north

--- a/data/scenarios/Tutorials/conditionals.yaml
+++ b/data/scenarios/Tutorials/conditionals.yaml
@@ -96,7 +96,7 @@ entities:
       invisible: true
     description:
       - A small rock.  It is so small, it is practically invisible.
-    properties: [portable]
+    properties: [pickable]
 world:
   palette:
     'Ω': [grass, null, base]

--- a/data/scenarios/Tutorials/crash.yaml
+++ b/data/scenarios/Tutorials/crash.yaml
@@ -34,7 +34,7 @@ entities:
       char: 'W'
     description:
       - If you have this, you win!
-    properties: [known, portable]
+    properties: [known, pickable]
 solution: |
   crasher <- build {
       turn east; move; move; move; log "bye"; move

--- a/data/scenarios/Tutorials/place.yaml
+++ b/data/scenarios/Tutorials/place.yaml
@@ -45,7 +45,7 @@ entities:
         in making many different devices.
       - |
         This one seems to grow a little faster.
-    properties: [portable, growable]
+    properties: [pickable, growable]
     growth: [100, 120]
 solution: |
   def t = move; place "spruce"; harvest; end;

--- a/data/scenarios/Tutorials/require.yaml
+++ b/data/scenarios/Tutorials/require.yaml
@@ -19,7 +19,7 @@ entities:
       char: '*'
     description:
       - A flower.
-    properties: [known, infinite, portable]
+    properties: [known, infinite, pickable]
 solution: |
   def m5 = move; move; move; move; move end;
   build {

--- a/data/scenarios/Tutorials/type-errors.yaml
+++ b/data/scenarios/Tutorials/type-errors.yaml
@@ -30,7 +30,7 @@ entities:
       char: 'W'
     description:
       - Do `place "Win"` once you are done with this challenge.
-    properties: [known, portable]
+    properties: [known, pickable]
 solution: |
   place "Win"
 robots:

--- a/data/scenarios/Tutorials/types.yaml
+++ b/data/scenarios/Tutorials/types.yaml
@@ -34,7 +34,7 @@ entities:
       char: 'W'
     description:
       - Do `place "Win"` once you are done with this challenge.
-    properties: [known, portable]
+    properties: [known, pickable]
 solution: |
   place "Win"
 robots:

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -1194,8 +1194,8 @@ displayProperties = displayList . mapMaybe showProperty
   showProperty Liquid = Just "liquid"
   showProperty Unwalkable = Just "blocking"
   showProperty Opaque = Just "opaque"
-  -- Most things are portable so we don't show that.
-  showProperty Portable = Nothing
+  -- Most things are pickable so we don't show that.
+  showProperty Pickable = Nothing
   -- 'Known' is just a technical detail of how we handle some entities
   -- in challenge scenarios and not really something the player needs
   -- to know.

--- a/src/swarm-engine/Swarm/Game/Entity.hs
+++ b/src/swarm-engine/Swarm/Game/Entity.hs
@@ -141,7 +141,7 @@ data EntityProperty
   = -- | Robots can't move onto a cell containing this entity.
     Unwalkable
   | -- | Robots can pick this up (via 'Swarm.Language.Syntax.Grab' or 'Swarm.Language.Syntax.Harvest').
-    Portable
+    Pickable
   | -- | Robots can 'Swarm.Language.Syntax.Push' this
     Pushable
   | -- | Obstructs the view of robots that attempt to "scout"

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -188,7 +188,7 @@ execConst runChildProg c vs s k = do
           let verbed = verbedGrabbingCmd Push'
           -- Ensure it can be pushed.
           omni <- isPrivilegedBot
-          (omni || e `hasProperty` Pushable || e `hasProperty` Portable && not (e `hasProperty` Liquid))
+          (omni || e `hasProperty` Pushable || e `hasProperty` Pickable && not (e `hasProperty` Liquid))
             `holdsOrFail` ["The", e ^. entityName, "here can't be", verbed <> "."]
 
           -- Place the entity and remove it from previous loc
@@ -1238,7 +1238,7 @@ execConst runChildProg c vs s k = do
       chosenRecipe
         `isJustOrFail` ["You don't have the ingredients to", verbPhrase, indefinite (nextE ^. entityName) <> "."]
 
-    let (out, down) = L.partition ((`hasProperty` Portable) . snd) outs
+    let (out, down) = L.partition ((`hasProperty` Pickable) . snd) outs
         learn = map (LearnEntity . snd) down
         gain = map (uncurry AddEntity) out
 
@@ -1659,7 +1659,7 @@ execConst runChildProg c vs s k = do
 
     -- Ensure it can be picked up.
     omni <- isPrivilegedBot
-    (omni || e `hasProperty` Portable)
+    (omni || e `hasProperty` Pickable)
       `holdsOrFail` ["The", e ^. entityName, "here can't be", verbed <> "."]
 
     -- Remove the entity from the world.


### PR DESCRIPTION
Closes #1695.

Updating occurrences was pretty easy:

    yq --inplace '(.[].properties[] | select(. == "portable")) |= "pickable"' data/entities.yaml

and

    find data/scenarios -type f -name '*.yaml' -print0 | xargs --max-args 1 --null yq --inplace '(select(has("entities")) | .entities[] | select(has("properties")) | .properties[] | select(. == "portable")) |= "pickable"'