### PR TITLE
Use type family for robot CESK machine field

### DIFF
--- a/app/doc/Swarm/Doc/Gen.hs
+++ b/app/doc/Swarm/Doc/Gen.hs
@@ -136,7 +136,7 @@ generateSpecialKeyNames =
 generateRecipe :: IO String
 generateRecipe = simpleErrorHandle $ do
   (classic, (worlds, entities, recipes)) <- loadStandaloneScenario "data/scenarios/classic.yaml"
-  baseRobot <- getBaseRobot classic
+  baseRobot <- instantiateBaseRobot classic
   return . Dot.showDot $ recipesToDot baseRobot (worlds ! "classic") entities recipes
 
 recipesToDot :: Robot -> Some (TTerm '[]) -> EntityMap -> [Recipe Entity] -> Dot ()

--- a/src/Swarm/Doc/Util.hs
+++ b/src/Swarm/Doc/Util.hs
@@ -48,7 +48,7 @@ commands = filter Syntax.isCmd Syntax.allConst
 constSyntax :: Const -> Text
 constSyntax = Syntax.syntax . Syntax.constInfo
 
-getBaseRobot :: Has (Throw SystemFailure) sig m => Scenario -> m Robot
-getBaseRobot s = case listToMaybe $ view scenarioRobots s of
-  Just r -> pure $ instantiateRobot 0 r
+instantiateBaseRobot :: Has (Throw SystemFailure) sig m => Scenario -> m Robot
+instantiateBaseRobot s = case listToMaybe $ view scenarioRobots s of
+  Just r -> pure $ instantiateRobot Nothing 0 r
   Nothing -> throwError $ CustomFailure "Scenario contains no robots"

--- a/src/swarm-engine/Swarm/Game/State.hs
+++ b/src/swarm-engine/Swarm/Game/State.hs
@@ -677,8 +677,11 @@ pureScenarioToGameState scenario theSeed now toRun gsc =
 
   initialCodeToRun = getCodeToRun <$> toRun
 
+  robotListRaw =
+    zipWith (instantiateRobot Nothing) [baseID ..] robotsByBasePrecedence
+
   robotList =
-    zipWith instantiateRobot [baseID ..] robotsByBasePrecedence
+    robotListRaw
       -- If the  --run flag was used, use it to replace the CESK machine of the
       -- robot whose id is 0, i.e. the first robot listed in the scenario.
       -- Note that this *replaces* any program the base robot otherwise

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -231,10 +231,10 @@ viewCenterRule = lens getter setter
 --   First, generate a unique ID number for it.  Then, add it to the
 --   main robot map, the active robot set, and to to the index of
 --   robots by location. Return the updated robot.
-addTRobot :: (Has (State Robots) sig m) => TRobot -> m Robot
-addTRobot r = do
+addTRobot :: (Has (State Robots) sig m) => CESK -> TRobot -> m Robot
+addTRobot initialMachine r = do
   rid <- robotNaming . gensym <+= 1
-  let r' = instantiateRobot rid r
+  let r' = instantiateRobot (Just initialMachine) rid r
   addRobot r'
   return r'
 

--- a/src/swarm-engine/Swarm/Game/Step/Combustion.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Combustion.hs
@@ -97,7 +97,7 @@ addCombustionBot inputEntity combustibility ts loc = do
   let combustionProg = combustionProgram combustionDurationRand combustibility
   void
     . zoomRobots
-    . addTRobot
+    . addTRobot (initMachine combustionProg empty emptyStore)
     $ mkRobot
       ()
       Nothing
@@ -109,7 +109,7 @@ addCombustionBot inputEntity combustibility ts loc = do
           & displayAttr .~ AWorld "fire"
           & displayPriority .~ 0
       )
-      (initMachine combustionProg empty emptyStore)
+      Nothing
       []
       botInventory
       True
@@ -212,7 +212,7 @@ addIgnitionBot ::
   m ()
 addIgnitionBot ignitionDelay inputEntity ts loc =
   void $
-    addTRobot $
+    addTRobot (initMachine (ignitionProgram ignitionDelay) empty emptyStore) $
       mkRobot
         ()
         Nothing
@@ -223,7 +223,7 @@ addIgnitionBot ignitionDelay inputEntity ts loc =
         ( defaultEntityDisplay '*'
             & invisible .~ True
         )
-        (initMachine (ignitionProgram ignitionDelay) empty emptyStore)
+        Nothing
         []
         []
         True

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -1061,7 +1061,7 @@ execConst runChildProg c vs s k = do
         -- Construct the new robot and add it to the world.
         parentCtx <- use robotContext
         newRobot <-
-          zoomRobots . addTRobot . (trobotContext .~ parentCtx) $
+          zoomRobots . addTRobot (In cmd e s [FExec]) . (trobotContext .~ parentCtx) $
             mkRobot
               ()
               (Just pid)
@@ -1074,7 +1074,7 @@ execConst runChildProg c vs s k = do
               ( defaultRobotDisplay
                   & inherit displayAttr (r ^. robotDisplay)
               )
-              (In cmd e s [FExec])
+              Nothing
               []
               []
               isSystemRobot

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -375,7 +375,7 @@ addSeedBot ::
 addSeedBot e (minT, maxT) loc ts =
   void
     . zoomRobots
-    . addTRobot
+    . addTRobot (initMachine (seedProgram minT (maxT - minT) (e ^. entityName)) empty emptyStore)
     $ mkRobot
       ()
       Nothing
@@ -387,7 +387,7 @@ addSeedBot e (minT, maxT) loc ts =
           & displayAttr .~ (e ^. entityDisplay . displayAttr)
           & displayPriority .~ 0
       )
-      (initMachine (seedProgram minT (maxT - minT) (e ^. entityName)) empty emptyStore)
+      Nothing
       []
       [(1, e)]
       True


### PR DESCRIPTION
Towards #1715 and #1043.

This refactoring step is a prerequisite for #1719 to extricate references to the `CESK` module from the base `RobotR` definition.

In this PR:
* `Swarm.Game.CESK` is imported qualified to more easily track usages
* A new `RobotMachine` type family is added to parameterize the `_machine` field.
* `CESK` is a new parameter to `addTRobot`
