### PR TITLE
Remove superfluous trobotContext lens

### DIFF
--- a/src/swarm-engine/Swarm/Game/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/Robot.hs
@@ -51,7 +51,6 @@ module Swarm.Game.Robot (
   robotCapabilities,
   walkabilityContext,
   robotContext,
-  trobotContext,
   robotID,
   robotParentID,
   robotHeavy,
@@ -412,10 +411,6 @@ robotInventory = robotEntity . entityInventory
 
 -- | The robot's context.
 robotContext :: Lens' Robot RobotContext
-
--- | The robot's context.
-trobotContext :: Lens' TRobot RobotContext
-trobotContext = lens _robotContext (\r c -> r {_robotContext = c})
 
 -- | The (unique) ID number of the robot.  This is only a Getter since
 --   the robot ID is immutable.

--- a/src/swarm-engine/Swarm/Game/Step/Combustion.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Combustion.hs
@@ -20,7 +20,7 @@ import Control.Applicative (Applicative (..))
 import Control.Carrier.State.Lazy
 import Control.Effect.Lens
 import Control.Lens as Lens hiding (Const, distrib, from, parts, use, uses, view, (%=), (+=), (.=), (<+=), (<>=))
-import Control.Monad (forM_, void, when)
+import Control.Monad (forM_, when)
 import Data.Text qualified as T
 import Linear (zero)
 import Swarm.Effect as Effect (Time, getNow)
@@ -95,8 +95,7 @@ addCombustionBot inputEntity combustibility ts loc = do
       return $ maybe [] (pure . (1,)) maybeE
   combustionDurationRand <- uniform durationRange
   let combustionProg = combustionProgram combustionDurationRand combustibility
-  void
-    . zoomRobots
+  zoomRobots
     . addTRobot (initMachine combustionProg empty emptyStore)
     $ mkRobot
       ()
@@ -211,22 +210,21 @@ addIgnitionBot ::
   Cosmic Location ->
   m ()
 addIgnitionBot ignitionDelay inputEntity ts loc =
-  void $
-    addTRobot (initMachine (ignitionProgram ignitionDelay) empty emptyStore) $
-      mkRobot
-        ()
-        Nothing
-        "firestarter"
-        (Markdown.fromText $ T.unwords ["Delayed ignition of", (inputEntity ^. entityName) <> "."])
-        (Just loc)
-        zero
-        ( defaultEntityDisplay '*'
-            & invisible .~ True
-        )
-        Nothing
-        []
-        []
-        True
-        False
-        mempty
-        ts
+  addTRobot (initMachine (ignitionProgram ignitionDelay) empty emptyStore) $
+    mkRobot
+      ()
+      Nothing
+      "firestarter"
+      (Markdown.fromText $ T.unwords ["Delayed ignition of", (inputEntity ^. entityName) <> "."])
+      (Just loc)
+      zero
+      ( defaultEntityDisplay '*'
+          & invisible .~ True
+      )
+      Nothing
+      []
+      []
+      True
+      False
+      mempty
+      ts

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -1061,7 +1061,7 @@ execConst runChildProg c vs s k = do
         -- Construct the new robot and add it to the world.
         parentCtx <- use robotContext
         newRobot <-
-          zoomRobots . fmap (robotContext .~ parentCtx) . addTRobot (In cmd e s [FExec]) $
+          zoomRobots . addTRobotWithContext parentCtx (In cmd e s [FExec]) $
             mkRobot
               ()
               (Just pid)

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -1061,7 +1061,7 @@ execConst runChildProg c vs s k = do
         -- Construct the new robot and add it to the world.
         parentCtx <- use robotContext
         newRobot <-
-          zoomRobots . addTRobot (In cmd e s [FExec]) . (trobotContext .~ parentCtx) $
+          zoomRobots . fmap (robotContext .~ parentCtx) . addTRobot (In cmd e s [FExec]) $
             mkRobot
               ()
               (Just pid)

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -20,7 +20,6 @@ import Control.Effect.Lens
 import Control.Effect.Lift
 import Control.Lens as Lens hiding (Const, distrib, from, parts, use, uses, view, (%=), (+=), (.=), (<+=), (<>=))
 import Control.Monad (forM_, unless)
-import Data.Functor (void)
 import Data.Map qualified as M
 import Data.Sequence qualified as Seq
 import Data.Set (Set)
@@ -373,8 +372,7 @@ addSeedBot ::
   TimeSpec ->
   m ()
 addSeedBot e (minT, maxT) loc ts =
-  void
-    . zoomRobots
+  zoomRobots
     . addTRobot (initMachine (seedProgram minT (maxT - minT) (e ^. entityName)) empty emptyStore)
     $ mkRobot
       ()

--- a/test/bench/Benchmark.hs
+++ b/test/bench/Benchmark.hs
@@ -122,7 +122,7 @@ mkGameState prog robotMaker numRobots = do
   let robots = [robotMaker (Location (fromIntegral x) 0) | x <- [0 .. numRobots - 1]]
   Right initAppState <- runExceptT classicGame0
   execStateT
-    (zoomRobots $ mapM (addTRobot $ initMachine prog Context.empty emptyStore) robots)
+    (zoomRobots $ mapM_ (addTRobot $ initMachine prog Context.empty emptyStore) robots)
     ( (initAppState ^. gameState)
         & creativeMode .~ True
         & landscape . multiWorld .~ M.singleton DefaultRootSubworld (newWorld (WF $ const (fromEnum DirtT, ENothing)))


### PR DESCRIPTION
# Motivation

Want to remove dependence of `TRobot` on the `RobotContext` record.  However, a lens `trobotContext` had been added in #817 to fix #394.

# Test

    scripts/run-tests.sh --test-arguments '--pattern "394-build-drill"'
