### PR TITLE
Use type family for RobotContext field

### DIFF
--- a/src/swarm-engine/Swarm/Game/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/Robot.hs
@@ -100,69 +100,19 @@ import Swarm.Game.CESK qualified as C
 import Swarm.Game.Display (Display, curOrientation, defaultRobotDisplay, invisible)
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Location (Heading, Location, toDirection, toHeading)
+import Swarm.Game.Robot.Context
 import Swarm.Game.Universe
 import Swarm.Language.Capability (Capability)
-import Swarm.Language.Context qualified as Ctx
 import Swarm.Language.Pipeline (ProcessedTerm)
 import Swarm.Language.Pipeline.QQ (tmQ)
-import Swarm.Language.Requirement (ReqCtx)
 import Swarm.Language.Syntax (Const, Syntax)
 import Swarm.Language.Text.Markdown (Document)
-import Swarm.Language.Typed (Typed (..))
-import Swarm.Language.Types (TCtx)
 import Swarm.Language.Value as V
 import Swarm.Log
 import Swarm.Util.Lens (makeLensesExcluding, makeLensesNoSigs)
 import Swarm.Util.WindowedCounter
 import Swarm.Util.Yaml
 import System.Clock (TimeSpec)
-
--- | A record that stores the information
---   for all definitions stored in a 'Robot'
-data RobotContext = RobotContext
-  { _defTypes :: TCtx
-  -- ^ Map definition names to their types.
-  , _defReqs :: ReqCtx
-  -- ^ Map definition names to the capabilities
-  --   required to evaluate/execute them.
-  , _defVals :: Env
-  -- ^ Map definition names to their values. Note that since
-  --   definitions are delayed, the values will just consist of
-  --   'VRef's pointing into the store.
-  , _defStore :: C.Store
-  -- ^ A store containing memory cells allocated to hold
-  --   definitions.
-  }
-  deriving (Eq, Show, Generic, Ae.FromJSON, Ae.ToJSON)
-
-makeLenses ''RobotContext
-
-emptyRobotContext :: RobotContext
-emptyRobotContext = RobotContext Ctx.empty Ctx.empty Ctx.empty C.emptyStore
-
-type instance Index RobotContext = Ctx.Var
-type instance IxValue RobotContext = Typed Value
-
-instance Ixed RobotContext
-instance At RobotContext where
-  at name = lens getter setter
-   where
-    getter ctx =
-      do
-        typ <- Ctx.lookup name (ctx ^. defTypes)
-        val <- Ctx.lookup name (ctx ^. defVals)
-        req <- Ctx.lookup name (ctx ^. defReqs)
-        return $ Typed val typ req
-    setter ctx Nothing =
-      ctx
-        & defTypes %~ Ctx.delete name
-        & defVals %~ Ctx.delete name
-        & defReqs %~ Ctx.delete name
-    setter ctx (Just (Typed val typ req)) =
-      ctx
-        & defTypes %~ Ctx.addBinding name typ
-        & defVals %~ Ctx.addBinding name val
-        & defReqs %~ Ctx.addBinding name req
 
 -- | A unique identifier for a robot.
 type RID = Int

--- a/src/swarm-engine/Swarm/Game/Robot/Context.hs
+++ b/src/swarm-engine/Swarm/Game/Robot/Context.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- A data type to represent robot context.
+module Swarm.Game.Robot.Context where
+
+import Control.Lens hiding (Const, contains)
+import Data.Aeson qualified as Ae (FromJSON, ToJSON (..))
+import GHC.Generics (Generic)
+import Swarm.Game.CESK qualified as C
+import Swarm.Language.Context qualified as Ctx
+import Swarm.Language.Requirement (ReqCtx)
+import Swarm.Language.Typed (Typed (..))
+import Swarm.Language.Types (TCtx)
+import Swarm.Language.Value as V
+
+-- | A record that stores the information
+--   for all definitions stored in a 'Robot'
+data RobotContext = RobotContext
+  { _defTypes :: TCtx
+  -- ^ Map definition names to their types.
+  , _defReqs :: ReqCtx
+  -- ^ Map definition names to the capabilities
+  --   required to evaluate/execute them.
+  , _defVals :: Env
+  -- ^ Map definition names to their values. Note that since
+  --   definitions are delayed, the values will just consist of
+  --   'VRef's pointing into the store.
+  , _defStore :: C.Store
+  -- ^ A store containing memory cells allocated to hold
+  --   definitions.
+  }
+  deriving (Eq, Show, Generic, Ae.FromJSON, Ae.ToJSON)
+
+makeLenses ''RobotContext
+
+emptyRobotContext :: RobotContext
+emptyRobotContext = RobotContext Ctx.empty Ctx.empty Ctx.empty C.emptyStore
+
+type instance Index RobotContext = Ctx.Var
+type instance IxValue RobotContext = Typed Value
+
+instance Ixed RobotContext
+instance At RobotContext where
+  at name = lens getter setter
+   where
+    getter ctx =
+      do
+        typ <- Ctx.lookup name (ctx ^. defTypes)
+        val <- Ctx.lookup name (ctx ^. defVals)
+        req <- Ctx.lookup name (ctx ^. defReqs)
+        return $ Typed val typ req
+    setter ctx Nothing =
+      ctx
+        & defTypes %~ Ctx.delete name
+        & defVals %~ Ctx.delete name
+        & defReqs %~ Ctx.delete name
+    setter ctx (Just (Typed val typ req)) =
+      ctx
+        & defTypes %~ Ctx.addBinding name typ
+        & defVals %~ Ctx.addBinding name val
+        & defReqs %~ Ctx.addBinding name req

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -358,16 +358,17 @@ evalPT t = evaluateCESK (initMachine t empty emptyStore)
 --
 -- Use ID (-1) so it won't conflict with any robots currently in the robot map.
 hypotheticalRobot :: CESK -> TimeSpec -> Robot
-hypotheticalRobot c =
+hypotheticalRobot m =
   mkRobot
     (-1)
+    emptyRobotContext
     Nothing
     "hypothesis"
     mempty
     defaultCosmicLocation
     zero
     defaultRobotDisplay
-    c
+    m
     []
     []
     True

--- a/src/swarm-engine/Swarm/Game/Step/Combustion.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Combustion.hs
@@ -99,6 +99,7 @@ addCombustionBot inputEntity combustibility ts loc = do
     . addTRobot (initMachine combustionProg empty emptyStore)
     $ mkRobot
       ()
+      ()
       Nothing
       "fire"
       (Markdown.fromText $ T.unwords ["A burning", (inputEntity ^. entityName) <> "."])
@@ -212,6 +213,7 @@ addIgnitionBot ::
 addIgnitionBot ignitionDelay inputEntity ts loc =
   addTRobot (initMachine (ignitionProgram ignitionDelay) empty emptyStore) $
     mkRobot
+      ()
       ()
       Nothing
       "firestarter"

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -1064,6 +1064,7 @@ execConst runChildProg c vs s k = do
           zoomRobots . addTRobotWithContext parentCtx (In cmd e s [FExec]) $
             mkRobot
               ()
+              ()
               (Just pid)
               displayName
               (Markdown.fromText $ "A robot built by the robot named " <> (r ^. robotName) <> ".")

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -376,6 +376,7 @@ addSeedBot e (minT, maxT) loc ts =
     . addTRobot (initMachine (seedProgram minT (maxT - minT) (e ^. entityName)) empty emptyStore)
     $ mkRobot
       ()
+      ()
       Nothing
       "seed"
       (Markdown.fromText $ T.unwords ["A growing", e ^. entityName, "seed."])

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -175,6 +175,7 @@ library swarm-engine
                       Swarm.Game.Recipe
                       Swarm.Game.ResourceLoading
                       Swarm.Game.Robot
+                      Swarm.Game.Robot.Context
                       Swarm.Game.Scenario
                       Swarm.Game.Universe
                       Swarm.Game.Scenario.Objective
@@ -440,6 +441,7 @@ library
                       , Swarm.Game.Recipe
                       , Swarm.Game.ResourceLoading
                       , Swarm.Game.Robot
+                      , Swarm.Game.Robot.Context
                       , Swarm.Game.Scenario
                       , Swarm.Game.Universe
                       , Swarm.Game.Scenario.Objective

--- a/test/bench/Benchmark.hs
+++ b/test/bench/Benchmark.hs
@@ -113,7 +113,23 @@ waveProgram manualInline =
 
 -- | Initializes a robot with program prog at location loc facing north.
 initRobot :: ProcessedTerm -> Location -> TRobot
-initRobot prog loc = mkRobot () Nothing "" mempty (Just $ Cosmic DefaultRootSubworld loc) north defaultRobotDisplay (Just prog) [] [] False False mempty 0
+initRobot prog loc =
+  mkRobot
+    ()
+    ()
+    Nothing
+    ""
+    mempty
+    (Just $ Cosmic DefaultRootSubworld loc)
+    north
+    defaultRobotDisplay
+    (Just prog)
+    []
+    []
+    False
+    False
+    mempty
+    0
 
 -- | Creates a GameState with numRobot copies of robot on a blank map, aligned
 --   in a row starting at (0,0) and spreading east.


### PR DESCRIPTION
Continuation of #1731.

Towards #1715 and #1043.

This refactoring step is a prerequisite for #1719 to extricate references to the `CESK` module from the base `RobotR` definition.

# In this PR:

* Extracts the `RobotContext` type to a new module
* Introduces a type family for the `RobotContext` field