### PR TITLE
[EXPERIMENTAL] benchmark comparison with GHC 9.6.3

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -10,11 +10,12 @@ extra-deps:
 - brick-2.1.1
 - brick-list-skip-0.1.1.8
 - astar-0.3.0.0
+- unification-fd-0.11.2@sha256:b2e11811b703b63682076ae326bd856fd47caf7db881e9e5b896a6342bceb51f,3736
 # We should update to lsp-2.0 and lsp-types-2.0 but it involves some
 # breaking changes; see https://github.com/swarm-game/swarm/issues/1350
 - lsp-1.6.0.0
 - lsp-types-1.6.0.0
 - megaparsec-9.6.1
 - AhoCorasick-0.0.4
-resolver: lts-21.25
+resolver: lts-22.6
 


### PR DESCRIPTION
Since the integration tests for #1736 pass on GHC 9.6 but not GHC 9.4, it would be interesting to compare benchmarks using the script:

    scripts/benchmark-against-parent.sh

# Results:
```
  run 1000 game ticks
    idlers         
      10: OK (0.20s)
        2.64 ms ± 240 μs, 22% less than baseline
      20: OK (0.38s)
        2.68 ms ± 128 μs, 22% less than baseline
      30: OK (0.38s)
        2.72 ms ± 174 μs, 21% less than baseline
      40: OK (0.21s)
        2.71 ms ± 198 μs, 22% less than baseline
    trees          
      10: OK (0.38s)
        2.65 ms ± 121 μs, 22% less than baseline
      20: OK (0.38s)
        2.69 ms ± 189 μs, 21% less than baseline
      30: OK (0.38s)
        2.70 ms ± 134 μs, 22% less than baseline
      40: OK (0.21s)
        2.72 ms ± 199 μs, 21% less than baseline
    circlers       
      10: FAIL (0.88s)
        290  ms ± 5.2 ms, 18% more than baseline
        Use -p '/circlers.10/' to rerun this test only.
      20: FAIL (1.73s)
        574  ms ±  12 ms, 23% more than baseline
        Use -p '/circlers.20/' to rerun this test only.
      30: FAIL (2.56s)
        851  ms ± 5.5 ms, 25% more than baseline
        Use -p '/circlers.30/' to rerun this test only.
      40: FAIL (3.43s)
        1.140 s ±  29 ms, 27% more than baseline
        Use -p '/circlers.40/' to rerun this test only.
    movers         
      10: FAIL (1.44s)
        478  ms ± 5.1 ms, 20% more than baseline
        Use -p '/movers.10/' to rerun this test only.
      20: FAIL (2.82s)
        936  ms ±  27 ms, 24% more than baseline
        Use -p '/movers.20/' to rerun this test only.
      30: FAIL (4.18s)
        1.393 s ± 4.9 ms, 26% more than baseline
        Use -p '/movers.30/' to rerun this test only.
      40: FAIL (5.58s)
        1.857 s ±  36 ms, 26% more than baseline
        Use -p '/movers.40/' to rerun this test only.
    wavesInlined   
      10: OK (0.76s)
        248  ms ± 3.6 ms,  2% more than baseline
      20: FAIL (1.49s)
        493  ms ±  12 ms,  7% more than baseline
        Use -p '/wavesInlined.20/' to rerun this test only.
      30: FAIL (2.19s)
        727  ms ±  19 ms, 11% more than baseline
        Use -p '/wavesInlined.30/' to rerun this test only.
      40: FAIL (2.93s)
        975  ms ±  23 ms, 15% more than baseline
        Use -p '/wavesInlined.40/' to rerun this test only.
    wavesWithDef   
      10: FAIL (2.15s)
        713  ms ±  24 ms, 2.87x, 10% more than baseline
        Use -p '/wavesWithDef.10/' to rerun this test only.
      20: FAIL (4.24s)
        1.410 s ±  66 ms, 2.86x, 13% more than baseline
        Use -p '/wavesWithDef.20/' to rerun this test only.
      30: FAIL (6.31s)
        2.104 s ±  63 ms, 2.90x, 16% more than baseline
        Use -p '/wavesWithDef.30/' to rerun this test only.
      40: FAIL (8.37s)
        2.794 s ±  49 ms, 2.87x, 18% more than baseline
        Use -p '/wavesWithDef.40/' to rerun this test only.
                   
15 out of 24 tests failed (53.56s)
```