### PR TITLE
preview rendered world with inotify

### DIFF
--- a/app/scene/Main.hs
+++ b/app/scene/Main.hs
@@ -6,7 +6,7 @@ module Main where
 
 import Options.Applicative
 import Swarm.Game.Scenario.Topography.Area (AreaDimensions (..))
-import Swarm.Game.World.Render (OuputFormat (..), RenderOpts (..), doRenderCmd)
+import Swarm.Game.World.Render (FailureMode (..), OuputFormat (..), RenderOpts (..), doRenderCmd)
 
 data CLI
   = RenderMap FilePath RenderOpts
@@ -26,6 +26,7 @@ cliParser =
       <*> flag ConsoleText PngImage (long "png" <> help "Render to PNG")
       <*> option str (long "dest" <> short 'd' <> value "output.png" <> help "Output filepath")
       <*> optional sizeOpts
+      <*> flag Terminate RenderBlankImage (long "fail-blank" <> short 'b' <> help "Render blank image upon failure")
 
   seed :: Parser (Maybe Int)
   seed = optional $ option auto (long "seed" <> short 's' <> metavar "INT" <> help "Seed to use for world generation")

--- a/scripts/preview-world-vscode.sh
+++ b/scripts/preview-world-vscode.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -xe
+
+# Opens a live-reloading preview of the world
+#
+# Prerequisites:
+# --------------
+# Install inotify-wait:
+#
+#    sudo apt install inotify-tools
+#
+# Usage:
+# --------------
+# Once the VS Code editor tabs are opened, one can press
+# CTRL+\ (backslash) with the image selected to split the
+# editor pane horizontally.
+# One may then navigate to the left-pane's copy of the image
+# preview with CTRL+PageUp, and then
+# CTRL+w will close the redundant image preview.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+
+
+SCENARIO_PATH=${1?"Usage: $0 SCENARIO_PATH"}
+
+IMG_WIDTH=200
+IMG_HEIGHT=150
+
+IMG_OUTPUT_PATH=output.png
+RENDER_IMG_COMMAND="stack exec swarm-scene -- $SCENARIO_PATH --fail-blank --dest $IMG_OUTPUT_PATH --png --width $IMG_WIDTH --height $IMG_HEIGHT"
+
+stack build --fast swarm:swarm-scene
+
+$RENDER_IMG_COMMAND
+code --reuse-window $SCENARIO_PATH && code --reuse-window $IMG_OUTPUT_PATH 
+
+while inotifywait -e close_write $SCENARIO_PATH; do $RENDER_IMG_COMMAND; done

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Area.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Area.hs
@@ -28,6 +28,9 @@ data AreaDimensions = AreaDimensions
   , rectHeight :: Int32
   }
 
+asTuple :: AreaDimensions -> (Int32, Int32)
+asTuple (AreaDimensions x y) = (x, y)
+
 renderRectDimensions :: AreaDimensions -> String
 renderRectDimensions (AreaDimensions w h) =
   L.intercalate "x" $ map show [w, h]


### PR DESCRIPTION
Opens a live-reloading preview of the world in VS Code.

The renderer has been modified to optionally render a blank image instead of crashing upon invalid YAML.

## Prerequisites:
Install inotify tools:

    sudo apt install inotify-tools

## Usage:

    scripts/preview-world-vscode.sh data/scenarios/Fun/horton.yaml

Once the VS Code editor tabs are opened, one can press <kbd>CTRL</kbd> + <kbd>\\</kbd> (backslash) with the image selected to split the editor pane horizontally.
One may then navigate to the left-pane's copy of the image preview with <kbd>CTRL</kbd> + <kbd>PageUp</kbd>, and then <kbd>CTRL</kbd> + <kbd>w</kbd> will close the redundant image preview.

## Screenshot

![Screenshot from 2024-01-29 18-53-55](https://github.com/swarm-game/swarm/assets/261693/63a4728c-0ccb-4c08-8cde-61d65e8322b4)