### PR TITLE
Decompose UIState record

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -303,7 +303,7 @@ pressAnyKey _ _ = continueWithoutRedraw
 handleMainEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleMainEvent ev = do
   s <- get
-  mt <- preuse $ uiState . uiModal . _Just . modalType
+  mt <- preuse $ uiState . uiGameplay . uiModal . _Just . modalType
   let isRunning = maybe True isRunningModal mt
   let isPaused = s ^. gameState . temporal . paused
   let isCreative = s ^. gameState . creativeMode
@@ -323,9 +323,9 @@ handleMainEvent ev = do
         _ -> toggleModal QuitModal
     VtyEvent (V.EvResize _ _) -> invalidateCache
     Key V.KEsc
-      | Just m <- s ^. uiState . uiModal -> do
+      | Just m <- s ^. uiState . uiGameplay . uiModal -> do
           safeAutoUnpause
-          uiState . uiModal .= Nothing
+          uiState . uiGameplay . uiModal .= Nothing
           -- message modal is not autopaused, so update notifications when leaving it
           case m ^. modalType of
             MessagesModal -> do
@@ -345,23 +345,23 @@ handleMainEvent ev = do
     FKey 6 | not (null $ s ^. gameState . discovery . structureRecognition . automatons . originalStructureDefinitions) -> toggleModal StructuresModal
     -- show goal
     ControlChar 'g' ->
-      if hasAnythingToShow $ s ^. uiState . uiGoal . goalsContent
+      if hasAnythingToShow $ s ^. uiState . uiGameplay . uiGoal . goalsContent
         then toggleModal GoalModal
         else continueWithoutRedraw
     -- hide robots
     MetaChar 'h' -> do
       t <- liftIO $ getTime Monotonic
-      h <- use $ uiState . uiHideRobotsUntil
+      h <- use $ uiState . uiGameplay . uiHideRobotsUntil
       if h >= t
         then -- ignore repeated keypresses
           continueWithoutRedraw
         else -- hide for two seconds
         do
-          uiState . uiHideRobotsUntil .= t + TimeSpec 2 0
+          uiState . uiGameplay . uiHideRobotsUntil .= t + TimeSpec 2 0
           invalidateCacheEntry WorldCache
     -- debug focused robot
     MetaChar 'd' | isPaused && hasDebug -> do
-      debug <- uiState . uiShowDebug Lens.<%= not
+      debug <- uiState . uiGameplay . uiShowDebug Lens.<%= not
       if debug
         then gameState . temporal . gameStep .= RobotStep SBefore
         else zoomGameState finishGameTick >> void updateUI
@@ -380,21 +380,21 @@ handleMainEvent ev = do
     MetaChar 't' -> setFocus InfoPanel
     -- pass keys on to modal event handler if a modal is open
     VtyEvent vev
-      | isJust (s ^. uiState . uiModal) -> handleModalEvent vev
+      | isJust (s ^. uiState . uiGameplay . uiModal) -> handleModalEvent vev
     -- toggle creative mode if in "cheat mode"
 
     MouseDown (TerrainListItem pos) V.BLeft _ _ ->
-      uiState . uiWorldEditor . terrainList %= BL.listMoveTo pos
+      uiState . uiGameplay . uiWorldEditor . terrainList %= BL.listMoveTo pos
     MouseDown (EntityPaintListItem pos) V.BLeft _ _ ->
-      uiState . uiWorldEditor . entityPaintList %= BL.listMoveTo pos
+      uiState . uiGameplay . uiWorldEditor . entityPaintList %= BL.listMoveTo pos
     ControlChar 'v'
       | s ^. uiState . uiCheatMode -> gameState . creativeMode %= not
     -- toggle world editor mode if in "cheat mode"
     ControlChar 'e'
       | s ^. uiState . uiCheatMode -> do
-          uiState . uiWorldEditor . worldOverdraw . isWorldEditorEnabled %= not
+          uiState . uiGameplay . uiWorldEditor . worldOverdraw . isWorldEditorEnabled %= not
           setFocus WorldEditorPanel
-    MouseDown WorldPositionIndicator _ _ _ -> uiState . uiWorldCursor .= Nothing
+    MouseDown WorldPositionIndicator _ _ _ -> uiState . uiGameplay . uiWorldCursor .= Nothing
     MouseDown (FocusablePanel WorldPanel) V.BMiddle _ mouseLoc ->
       -- Eye Dropper tool
       EC.handleMiddleClick mouseLoc
@@ -407,21 +407,21 @@ handleMainEvent ev = do
     -- toggle collapse/expand REPL
     MetaChar ',' -> do
       invalidateCacheEntry WorldCache
-      uiState . uiShowREPL %= not
+      uiState . uiGameplay . uiShowREPL %= not
     MouseDown n _ _ mouseLoc ->
       case n of
         FocusablePanel WorldPanel -> do
           mouseCoordsM <- Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
           shouldUpdateCursor <- EC.updateAreaBounds mouseCoordsM
           when shouldUpdateCursor $
-            uiState . uiWorldCursor .= mouseCoordsM
+            uiState . uiGameplay . uiWorldCursor .= mouseCoordsM
         REPLInput -> handleREPLEvent ev
         _ -> continueWithoutRedraw
     MouseUp n _ _mouseLoc -> do
       case n of
-        InventoryListItem pos -> uiState . uiInventory . traverse . _2 %= BL.listMoveTo pos
+        InventoryListItem pos -> uiState . uiGameplay . uiInventory . uiInventoryList . traverse . _2 %= BL.listMoveTo pos
         x@(WorldEditorPanelControl y) -> do
-          uiState . uiWorldEditor . editorFocusRing %= focusSetCurrent x
+          uiState . uiGameplay . uiWorldEditor . editorFocusRing %= focusSetCurrent x
           EC.activateWorldEditorFunction y
         _ -> return ()
       flip whenJust setFocus $ case n of
@@ -440,7 +440,7 @@ handleMainEvent ev = do
         _ -> return ()
     -- dispatch any other events to the focused panel handler
     _ev -> do
-      fring <- use $ uiState . uiFocusRing
+      fring <- use $ uiState . uiGameplay . uiFocusRing
       case focusGetCurrent fring of
         Just (FocusablePanel x) -> ($ ev) $ case x of
           REPLPanel -> handleREPLEvent
@@ -459,8 +459,8 @@ handleMainEvent ev = do
 safeTogglePause :: EventM Name AppState ()
 safeTogglePause = do
   curTime <- liftIO $ getTime Monotonic
-  uiState . lastFrameTime .= curTime
-  uiState . uiShowDebug .= False
+  uiState . uiGameplay . uiTiming . lastFrameTime .= curTime
+  uiState . uiGameplay . uiShowDebug .= False
   p <- gameState . temporal . runStatus Lens.<%= toggleRunStatus
   when (p == Running) $ zoomGameState finishGameTick
 
@@ -475,15 +475,15 @@ safeAutoUnpause = do
 
 toggleModal :: ModalType -> EventM Name AppState ()
 toggleModal mt = do
-  modal <- use $ uiState . uiModal
+  modal <- use $ uiState . uiGameplay . uiModal
   case modal of
     Nothing -> openModal mt
-    Just _ -> uiState . uiModal .= Nothing >> safeAutoUnpause
+    Just _ -> uiState . uiGameplay . uiModal .= Nothing >> safeAutoUnpause
 
 handleModalEvent :: V.Event -> EventM Name AppState ()
 handleModalEvent = \case
   V.EvKey V.KEnter [] -> do
-    mdialog <- preuse $ uiState . uiModal . _Just . modalDialog
+    mdialog <- preuse $ uiState . uiGameplay . uiModal . _Just . modalDialog
     toggleModal QuitModal
     case dialogSelection =<< mdialog of
       Just (Button QuitButton, _) -> quitGame
@@ -497,33 +497,33 @@ handleModalEvent = \case
         startGame siPair Nothing
       _ -> return ()
   ev -> do
-    Brick.zoom (uiState . uiModal . _Just . modalDialog) (handleDialogEvent ev)
-    modal <- preuse $ uiState . uiModal . _Just . modalType
+    Brick.zoom (uiState . uiGameplay . uiModal . _Just . modalDialog) (handleDialogEvent ev)
+    modal <- preuse $ uiState . uiGameplay . uiModal . _Just . modalType
     case modal of
       Just TerrainPaletteModal ->
-        refreshList $ uiState . uiWorldEditor . terrainList
+        refreshList $ uiState . uiGameplay . uiWorldEditor . terrainList
       Just EntityPaletteModal -> do
-        refreshList $ uiState . uiWorldEditor . entityPaintList
+        refreshList $ uiState . uiGameplay . uiWorldEditor . entityPaintList
       Just GoalModal -> case ev of
-        V.EvKey (V.KChar '\t') [] -> uiState . uiGoal . focus %= focusNext
+        V.EvKey (V.KChar '\t') [] -> uiState . uiGameplay . uiGoal . focus %= focusNext
         _ -> do
-          focused <- use $ uiState . uiGoal . focus
+          focused <- use $ uiState . uiGameplay . uiGoal . focus
           case focusGetCurrent focused of
             Just (GoalWidgets w) -> case w of
               ObjectivesList -> do
-                lw <- use $ uiState . uiGoal . listWidget
+                lw <- use $ uiState . uiGameplay . uiGoal . listWidget
                 newList <- refreshGoalList lw
-                uiState . uiGoal . listWidget .= newList
+                uiState . uiGameplay . uiGoal . listWidget .= newList
               GoalSummary -> handleInfoPanelEvent modalScroll (VtyEvent ev)
             _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
       Just StructuresModal -> case ev of
-        V.EvKey (V.KChar '\t') [] -> uiState . uiStructure . structurePanelFocus %= focusNext
+        V.EvKey (V.KChar '\t') [] -> uiState . uiGameplay . uiStructure . structurePanelFocus %= focusNext
         _ -> do
-          focused <- use $ uiState . uiStructure . structurePanelFocus
+          focused <- use $ uiState . uiGameplay . uiStructure . structurePanelFocus
           case focusGetCurrent focused of
             Just (StructureWidgets w) -> case w of
               StructuresList ->
-                refreshList $ uiState . uiStructure . structurePanelListWidget
+                refreshList $ uiState . uiGameplay . uiStructure . structurePanelListWidget
               StructureSummary -> handleInfoPanelEvent modalScroll (VtyEvent ev)
             _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
       _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
@@ -556,7 +556,7 @@ saveScenarioInfoOnFinish p = do
   let currentScenarioInfo :: Traversal' AppState ScenarioInfo
       currentScenarioInfo = runtimeState . scenarios . scenarioItemByPath p . _SISingle . _2
 
-  replHist <- use $ uiState . uiREPL . replHistory
+  replHist <- use $ uiState . uiGameplay . uiREPL . replHistory
   let determinator = CodeSizeDeterminators initialRunCode $ replHist ^. replHasExecutedManualInput
   currentScenarioInfo
     %= updateScenarioInfoOnFinish determinator t ts won
@@ -628,7 +628,7 @@ saveScenarioInfoOnQuit = do
 quitGame :: EventM Name AppState ()
 quitGame = do
   -- Write out REPL history.
-  history <- use $ uiState . uiREPL . replHistory
+  history <- use $ uiState . uiGameplay . uiREPL . replHistory
   let hist = mapMaybe getREPLEntry $ getLatestREPLHistoryItems maxBound history
   liftIO $ (`T.appendFile` T.unlines hist) =<< getSwarmHistoryPath True
 
@@ -677,12 +677,12 @@ runFrame = do
 
   -- Find out how long the previous frame took, by subtracting the
   -- previous time from the current time.
-  prevTime <- use (uiState . lastFrameTime)
+  prevTime <- use (uiState . uiGameplay . uiTiming . lastFrameTime)
   curTime <- liftIO $ getTime Monotonic
   let frameTime = diffTimeSpec curTime prevTime
 
   -- Remember now as the new previous time.
-  uiState . lastFrameTime .= curTime
+  uiState . uiGameplay . uiTiming . lastFrameTime .= curTime
 
   -- We now have some additional accumulated time to play with.  The
   -- idea is to now "catch up" by doing as many ticks as are supposed
@@ -691,43 +691,43 @@ runFrame = do
   -- deal smoothly with things like a variable frame rate, the frame
   -- rate not being a nice multiple of the desired ticks per second,
   -- etc.
-  uiState . accumulatedTime += frameTime
+  uiState . uiGameplay . uiTiming . accumulatedTime += frameTime
 
   -- Figure out how many ticks per second we're supposed to do,
   -- and compute the timestep `dt` for a single tick.
-  lgTPS <- use (uiState . lgTicksPerSecond)
+  lgTPS <- use (uiState . uiGameplay . uiTiming . lgTicksPerSecond)
   let oneSecond = 1_000_000_000 -- one second = 10^9 nanoseconds
       dt
         | lgTPS >= 0 = oneSecond `div` (1 `shiftL` lgTPS)
         | otherwise = oneSecond * (1 `shiftL` abs lgTPS)
 
   -- Update TPS/FPS counters every second
-  infoUpdateTime <- use (uiState . lastInfoTime)
+  infoUpdateTime <- use (uiState . uiGameplay . uiTiming . lastInfoTime)
   let updateTime = toNanoSecs $ diffTimeSpec curTime infoUpdateTime
   when (updateTime >= oneSecond) $ do
     -- Wait for at least one second to have elapsed
     when (infoUpdateTime /= 0) $ do
       -- set how much frame got processed per second
-      frames <- use (uiState . frameCount)
-      uiState . uiFPS .= fromIntegral (frames * fromInteger oneSecond) / fromIntegral updateTime
+      frames <- use (uiState . uiGameplay . uiTiming . frameCount)
+      uiState . uiGameplay . uiTiming . uiFPS .= fromIntegral (frames * fromInteger oneSecond) / fromIntegral updateTime
 
       -- set how much ticks got processed per frame
-      uiTicks <- use (uiState . tickCount)
-      uiState . uiTPF .= fromIntegral uiTicks / fromIntegral frames
+      uiTicks <- use (uiState . uiGameplay . uiTiming . tickCount)
+      uiState . uiGameplay . uiTiming . uiTPF .= fromIntegral uiTicks / fromIntegral frames
 
       -- ensure this frame gets drawn
       gameState . needsRedraw .= True
 
     -- Reset the counter and wait another seconds for the next update
-    uiState . tickCount .= 0
-    uiState . frameCount .= 0
-    uiState . lastInfoTime .= curTime
+    uiState . uiGameplay . uiTiming . tickCount .= 0
+    uiState . uiGameplay . uiTiming . frameCount .= 0
+    uiState . uiGameplay . uiTiming . lastInfoTime .= curTime
 
   -- Increment the frame count
-  uiState . frameCount += 1
+  uiState . uiGameplay . uiTiming . frameCount += 1
 
   -- Now do as many ticks as we need to catch up.
-  uiState . frameTickCount .= 0
+  uiState . uiGameplay . uiTiming . frameTickCount .= 0
   runFrameTicks (fromNanoSecs dt)
 
 ticksPerFrameCap :: Int
@@ -739,8 +739,8 @@ ticksPerFrameCap = 30
 --   first.
 runFrameTicks :: TimeSpec -> EventM Name AppState ()
 runFrameTicks dt = do
-  a <- use (uiState . accumulatedTime)
-  t <- use (uiState . frameTickCount)
+  a <- use (uiState . uiGameplay . uiTiming . accumulatedTime)
+  t <- use (uiState . uiGameplay . uiTiming . frameTickCount)
 
   -- Ensure there is still enough time left, and we haven't hit the
   -- tick limit for this frame.
@@ -748,9 +748,10 @@ runFrameTicks dt = do
     -- If so, do a tick, count it, subtract dt from the accumulated time,
     -- and loop!
     runGameTick
-    uiState . tickCount += 1
-    uiState . frameTickCount += 1
-    uiState . accumulatedTime -= dt
+    Brick.zoom (uiState . uiGameplay . uiTiming) $ do
+      tickCount += 1
+      frameTickCount += 1
+      accumulatedTime -= dt
     runFrameTicks dt
 
 -- | Run the game for a single tick, and update the UI.
@@ -802,14 +803,14 @@ updateUI = do
   when (g ^. needsRedraw) $ invalidateCacheEntry WorldCache
 
   -- The hash of the robot whose inventory is currently displayed (if any)
-  listRobotHash <- fmap fst <$> use (uiState . uiInventory)
+  listRobotHash <- fmap fst <$> use (uiState . uiGameplay . uiInventory . uiInventoryList)
 
   -- The hash of the focused robot (if any)
   fr <- use (gameState . to focusedRobot)
   let focusedRobotHash = view inventoryHash <$> fr
 
   -- Check if the inventory list needs to be updated.
-  shouldUpdate <- use (uiState . uiInventoryShouldUpdate)
+  shouldUpdate <- use (uiState . uiGameplay . uiInventory . uiInventoryShouldUpdate)
 
   -- Whether the focused robot is too far away to sense, & whether
   -- that has recently changed
@@ -825,8 +826,9 @@ updateUI = do
   inventoryUpdated <-
     if farChanged || (not farChanged && listRobotHash /= focusedRobotHash) || shouldUpdate
       then do
-        Brick.zoom uiState $ populateInventoryList (if tooFar then Nothing else fr)
-        (uiState . uiInventoryShouldUpdate) .= False
+        Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+          populateInventoryList $ if tooFar then Nothing else fr
+          uiInventoryShouldUpdate .= False
         pure True
       else pure False
 
@@ -845,7 +847,7 @@ updateUI = do
       itIx <- use (gameState . gameControls . replNextValueIndex)
       let itName = fromString $ "it" ++ show itIx
       let out = T.intercalate " " [itName, ":", prettyText finalType, "=", into (prettyValue v)]
-      uiState . uiREPL . replHistory %= addREPLItem (REPLOutput out)
+      uiState . uiGameplay . uiREPL . replHistory %= addREPLItem (REPLOutput out)
       invalidateCacheEntry REPLHistoryCache
       vScrollToEnd replScroll
       gameState . gameControls . replStatus .= REPLDone (Just val)
@@ -860,13 +862,13 @@ updateUI = do
   -- isn't currently on the inventory or info panels, attempt to
   -- automatically switch to the logger and scroll all the way down so
   -- the new message can be seen.
-  uiState . uiScrollToEnd .= False
+  uiState . uiGameplay . uiScrollToEnd .= False
   logUpdated <- do
     -- If the inventory or info panels are currently focused, it would
     -- be rude to update them right under the user's nose, so consider
     -- them "sticky".  They will be updated as soon as the player moves
     -- the focus away.
-    fring <- use $ uiState . uiFocusRing
+    fring <- use $ uiState . uiGameplay . uiFocusRing
     let sticky = focusGetCurrent fring `elem` map (Just . FocusablePanel) [RobotPanel, InfoPanel]
 
     -- Check if the robot log was updated and we are allowed to change
@@ -882,11 +884,11 @@ updateUI = do
             isLogger _ = False
             focusLogger = BL.listFindBy isLogger
 
-        uiState . uiInventory . _Just . _2 %= focusLogger
+        uiState . uiGameplay . uiInventory . uiInventoryList . _Just . _2 %= focusLogger
 
         -- Now inform the UI that it should scroll the info panel to
         -- the very end.
-        uiState . uiScrollToEnd .= True
+        uiState . uiGameplay . uiScrollToEnd .= True
         pure True
 
   goalOrWinUpdated <- doGoalUpdates
@@ -913,7 +915,7 @@ updateUI = do
 -- * shows the player more "optional" goals they can continue to pursue
 doGoalUpdates :: EventM Name AppState Bool
 doGoalUpdates = do
-  curGoal <- use (uiState . uiGoal . goalsContent)
+  curGoal <- use (uiState . uiGameplay . uiGoal . goalsContent)
   isCheating <- use (uiState . uiCheatMode)
   curWinCondition <- use (gameState . winCondition)
   announcementsSeq <- use (gameState . messageInfo . announcementQueue)
@@ -969,6 +971,7 @@ doGoalUpdates = do
         -- The "uiGoal" field is necessary at least to "persist" the data that is needed
         -- if the player chooses to later "recall" the goals dialog with CTRL+g.
         uiState
+          . uiGameplay
           . uiGoal
           .= GoalDisplay
             newGoalTracking
@@ -979,7 +982,7 @@ doGoalUpdates = do
         -- automatically popped up.
         gameState . messageInfo . announcementQueue .= mempty
 
-        hideGoals <- use $ uiState . uiHideGoals
+        hideGoals <- use $ uiState . uiGameplay . uiHideGoals
         unless hideGoals $
           openModal GoalModal
 
@@ -996,17 +999,17 @@ stripCmd pty = pty
 ------------------------------------------------------------
 
 -- | Set the REPL to the given text and REPL prompt type.
-resetREPL :: T.Text -> REPLPrompt -> UIState -> UIState
-resetREPL t r ui =
-  ui
-    & uiREPL . replPromptText .~ t
-    & uiREPL . replPromptType .~ r
+resetREPL :: T.Text -> REPLPrompt -> REPLState -> REPLState
+resetREPL t r replState =
+  replState
+    & replPromptText .~ t
+    & replPromptType .~ r
 
 -- | Handle a user input event for the REPL.
 handleREPLEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleREPLEvent x = do
   s <- get
-  let theRepl = s ^. uiState . uiREPL
+  let theRepl = s ^. uiState . uiGameplay . uiREPL
       controlMode = theRepl ^. replControlMode
       uinput = theRepl ^. replPromptText
   case x of
@@ -1014,26 +1017,27 @@ handleREPLEvent x = do
     -- base program no matter what REPL control mode we are in.
     ControlChar 'c' -> do
       gameState . baseRobot . machine %= cancel
-      uiState . uiREPL . replPromptType .= CmdPrompt []
-      uiState . uiREPL . replPromptText .= ""
+      Brick.zoom (uiState . uiGameplay . uiREPL) $ do
+        replPromptType .= CmdPrompt []
+        replPromptText .= ""
 
     -- Handle M-p and M-k, shortcuts for toggling pilot + key handler modes.
     MetaChar 'p' ->
       onlyCreative $ do
-        curMode <- use $ uiState . uiREPL . replControlMode
+        curMode <- use $ uiState . uiGameplay . uiREPL . replControlMode
         case curMode of
-          Piloting -> uiState . uiREPL . replControlMode .= Typing
+          Piloting -> uiState . uiGameplay . uiREPL . replControlMode .= Typing
           _ ->
             if T.null uinput
-              then uiState . uiREPL . replControlMode .= Piloting
+              then uiState . uiGameplay . uiREPL . replControlMode .= Piloting
               else do
                 let err = REPLError "Please clear the REPL before engaging pilot mode."
-                uiState . uiREPL . replHistory %= addREPLItem err
+                uiState . uiGameplay . uiREPL . replHistory %= addREPLItem err
                 invalidateCacheEntry REPLHistoryCache
     MetaChar 'k' -> do
       when (isJust (s ^. gameState . gameControls . inputHandler)) $ do
-        curMode <- use $ uiState . uiREPL . replControlMode
-        (uiState . uiREPL . replControlMode) .= case curMode of Handling -> Typing; _ -> Handling
+        curMode <- use $ uiState . uiGameplay . uiREPL . replControlMode
+        (uiState . uiGameplay . uiREPL . replControlMode) .= case curMode of Handling -> Typing; _ -> Handling
 
     -- Handle other events in a way appropriate to the current REPL
     -- control mode.
@@ -1089,7 +1093,7 @@ handleREPLEventPiloting x = case x of
   _ -> inputCmd "noop"
  where
   inputCmd cmdText = do
-    uiState . uiREPL %= setCmd (cmdText <> ";")
+    uiState . uiGameplay . uiREPL %= setCmd (cmdText <> ";")
     modify validateREPLForm
     handleREPLEventTyping $ Key V.KEnter
 
@@ -1107,14 +1111,14 @@ runBaseWebCode uinput = do
 
 runBaseCode :: (MonadState AppState m) => RobotContext -> T.Text -> m ()
 runBaseCode topCtx uinput = do
-  uiState . uiREPL . replHistory %= addREPLItem (REPLEntry uinput)
-  uiState %= resetREPL "" (CmdPrompt [])
+  uiState . uiGameplay . uiREPL . replHistory %= addREPLItem (REPLEntry uinput)
+  uiState . uiGameplay . uiREPL %= resetREPL "" (CmdPrompt [])
   case processTerm' (topCtx ^. defTypes) (topCtx ^. defReqs) uinput of
     Right mt -> do
-      uiState . uiREPL . replHistory . replHasExecutedManualInput .= True
+      uiState . uiGameplay . uiREPL . replHistory . replHasExecutedManualInput .= True
       runBaseTerm topCtx mt
     Left err -> do
-      uiState . uiREPL . replHistory %= addREPLItem (REPLError err)
+      uiState . uiGameplay . uiREPL . replHistory %= addREPLItem (REPLError err)
 
 runBaseTerm :: (MonadState AppState m) => RobotContext -> Maybe ProcessedTerm -> m ()
 runBaseTerm topCtx =
@@ -1157,7 +1161,7 @@ handleREPLEventTyping = \case
       Key V.KEnter -> do
         s <- get
         let topCtx = topContext s
-            theRepl = s ^. uiState . uiREPL
+            theRepl = s ^. uiState . uiGameplay . uiREPL
             uinput = theRepl ^. replPromptText
 
         if not $ s ^. gameState . gameControls . replWorking
@@ -1167,43 +1171,43 @@ handleREPLEventTyping = \case
               invalidateCacheEntry REPLHistoryCache
             SearchPrompt hist ->
               case lastEntry uinput hist of
-                Nothing -> uiState %= resetREPL "" (CmdPrompt [])
+                Nothing -> uiState . uiGameplay . uiREPL %= resetREPL "" (CmdPrompt [])
                 Just found
-                  | T.null uinput -> uiState %= resetREPL "" (CmdPrompt [])
+                  | T.null uinput -> uiState . uiGameplay . uiREPL %= resetREPL "" (CmdPrompt [])
                   | otherwise -> do
-                      uiState %= resetREPL found (CmdPrompt [])
+                      uiState . uiGameplay . uiREPL %= resetREPL found (CmdPrompt [])
                       modify validateREPLForm
           else continueWithoutRedraw
       Key V.KUp -> modify $ adjReplHistIndex Older
       Key V.KDown -> modify $ adjReplHistIndex Newer
       ControlChar 'r' -> do
         s <- get
-        let uinput = s ^. uiState . uiREPL . replPromptText
-        case s ^. uiState . uiREPL . replPromptType of
-          CmdPrompt _ -> uiState . uiREPL . replPromptType .= SearchPrompt (s ^. uiState . uiREPL . replHistory)
+        let uinput = s ^. uiState . uiGameplay . uiREPL . replPromptText
+        case s ^. uiState . uiGameplay . uiREPL . replPromptType of
+          CmdPrompt _ -> uiState . uiGameplay . uiREPL . replPromptType .= SearchPrompt (s ^. uiState . uiGameplay . uiREPL . replHistory)
           SearchPrompt rh -> case lastEntry uinput rh of
             Nothing -> pure ()
-            Just found -> uiState . uiREPL . replPromptType .= SearchPrompt (removeEntry found rh)
+            Just found -> uiState . uiGameplay . uiREPL . replPromptType .= SearchPrompt (removeEntry found rh)
       CharKey '\t' -> do
         s <- get
         let names = s ^.. gameState . baseRobot . robotContext . defTypes . to assocs . traverse . _1
-        uiState . uiREPL %= tabComplete (CompletionContext (s ^. gameState . creativeMode)) names (s ^. gameState . landscape . entityMap)
+        uiState . uiGameplay . uiREPL %= tabComplete (CompletionContext (s ^. gameState . creativeMode)) names (s ^. gameState . landscape . entityMap)
         modify validateREPLForm
       EscapeKey -> do
-        formSt <- use $ uiState . uiREPL . replPromptType
+        formSt <- use $ uiState . uiGameplay . uiREPL . replPromptType
         case formSt of
           CmdPrompt {} -> continueWithoutRedraw
           SearchPrompt _ ->
-            uiState %= resetREPL "" (CmdPrompt [])
+            uiState . uiGameplay . uiREPL %= resetREPL "" (CmdPrompt [])
       ControlChar 'd' -> do
-        text <- use $ uiState . uiREPL . replPromptText
+        text <- use $ uiState . uiGameplay . uiREPL . replPromptText
         if text == T.empty
           then toggleModal QuitModal
           else continueWithoutRedraw
       -- finally if none match pass the event to the editor
       ev -> do
-        Brick.zoom (uiState . uiREPL . replPromptEditor) (handleEditorEvent ev)
-        uiState . uiREPL . replPromptType %= \case
+        Brick.zoom (uiState . uiGameplay . uiREPL . replPromptEditor) (handleEditorEvent ev)
+        uiState . uiGameplay . uiREPL . replPromptType %= \case
           CmdPrompt _ -> CmdPrompt [] -- reset completions on any event passed to editor
           SearchPrompt a -> SearchPrompt a
         modify validateREPLForm
@@ -1288,7 +1292,7 @@ validateREPLForm s =
     CmdPrompt _
       | T.null uinput ->
           let theType = s ^. gameState . gameControls . replStatus . replActiveType
-           in s & uiState . uiREPL . replType .~ theType
+           in s & uiState . uiGameplay . uiREPL . replType .~ theType
     CmdPrompt _
       | otherwise ->
           let result = processTerm' (topCtx ^. defTypes) (topCtx ^. defReqs) uinput
@@ -1296,19 +1300,19 @@ validateREPLForm s =
                 Right (Just (ProcessedTerm (Module tm _) _ _)) -> Just (tm ^. sType)
                 _ -> Nothing
            in s
-                & uiState . uiREPL . replValid .~ isRight result
-                & uiState . uiREPL . replType .~ theType
+                & uiState . uiGameplay . uiREPL . replValid .~ isRight result
+                & uiState . uiGameplay . uiREPL . replType .~ theType
     SearchPrompt _ -> s
  where
-  uinput = s ^. uiState . uiREPL . replPromptText
-  replPrompt = s ^. uiState . uiREPL . replPromptType
+  uinput = s ^. uiState . uiGameplay . uiREPL . replPromptText
+  replPrompt = s ^. uiState . uiGameplay . uiREPL . replPromptType
   topCtx = topContext s
 
 -- | Update our current position in the REPL history.
 adjReplHistIndex :: TimeDir -> AppState -> AppState
 adjReplHistIndex d s =
   s
-    & uiState . uiREPL %~ moveREPL
+    & uiState . uiGameplay . uiREPL %~ moveREPL
     & validateREPLForm
  where
   moveREPL :: REPLState -> REPLState
@@ -1352,7 +1356,7 @@ handleWorldEvent = \case
     invalidateCacheEntry WorldCache
     gameState . robotInfo . viewCenterRule .= VCRobot 0
   -- show fps
-  CharKey 'f' -> uiState . uiShowFPS %= not
+  CharKey 'f' -> uiState . uiGameplay . uiTiming . uiShowFPS %= not
   -- Fall-through case: don't do anything.
   _ -> continueWithoutRedraw
  where
@@ -1391,7 +1395,7 @@ keyToDir _ = zero
 
 -- | Adjust the ticks per second speed.
 adjustTPS :: (Int -> Int -> Int) -> AppState -> AppState
-adjustTPS (+/-) = uiState . lgTicksPerSecond %~ (+/- 1)
+adjustTPS (+/-) = uiState . uiGameplay . uiTiming . lgTicksPerSecond %~ (+/- 1)
 
 ------------------------------------------------------------
 -- Robot panel events
@@ -1400,7 +1404,7 @@ adjustTPS (+/-) = uiState . lgTicksPerSecond %~ (+/- 1)
 -- | Handle user input events in the robot panel.
 handleRobotPanelEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleRobotPanelEvent bev = do
-  search <- use (uiState . uiInventorySearch)
+  search <- use $ uiState . uiGameplay . uiInventory . uiInventorySearch
   case search of
     Just _ -> handleInventorySearchEvent bev
     Nothing -> case bev of
@@ -1408,18 +1412,22 @@ handleRobotPanelEvent bev = do
         gets focusedEntity >>= maybe continueWithoutRedraw descriptionModal
       CharKey 'm' ->
         gets focusedEntity >>= maybe continueWithoutRedraw makeEntity
-      CharKey '0' -> do
-        uiState . uiInventoryShouldUpdate .= True
-        uiState . uiShowZero %= not
-      CharKey ';' -> do
-        uiState . uiInventoryShouldUpdate .= True
-        uiState . uiInventorySort %= cycleSortOrder
-      CharKey ':' -> do
-        uiState . uiInventoryShouldUpdate .= True
-        uiState . uiInventorySort %= cycleSortDirection
-      CharKey '/' -> do
-        uiState . uiInventoryShouldUpdate .= True
-        uiState . uiInventorySearch .= Just ""
+      CharKey '0' ->
+        Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+          uiInventoryShouldUpdate .= True
+          uiShowZero %= not
+      CharKey ';' ->
+        Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+          uiInventoryShouldUpdate .= True
+          uiInventorySort %= cycleSortOrder
+      CharKey ':' ->
+        Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+          uiInventoryShouldUpdate .= True
+          uiInventorySort %= cycleSortDirection
+      CharKey '/' ->
+        Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+          uiInventoryShouldUpdate .= True
+          uiInventorySearch .= Just ""
       VtyEvent ev -> handleInventoryListEvent ev
       _ -> continueWithoutRedraw
 
@@ -1428,38 +1436,42 @@ handleInventoryListEvent :: V.Event -> EventM Name AppState ()
 handleInventoryListEvent ev = do
   -- Note, refactoring like this is tempting:
   --
-  --   Brick.zoom (uiState . uiInventory . _Just . _2) (handleListEventWithSeparators ev (is _Separator))
+  --   Brick.zoom (uiState . uiGameplay . uiInventory . uiInventoryList . _Just . _2) (handleListEventWithSeparators ev (is _Separator))
   --
   -- However, this does not work since we want to skip redrawing in the no-list case!
 
-  mList <- preuse $ uiState . uiInventory . _Just . _2
+  mList <- preuse $ uiState . uiGameplay . uiInventory . uiInventoryList . _Just . _2
   case mList of
     Nothing -> continueWithoutRedraw
     Just l -> do
       l' <- nestEventM' l (handleListEventWithSeparators ev (is _Separator))
-      uiState . uiInventory . _Just . _2 .= l'
+      uiState . uiGameplay . uiInventory . uiInventoryList . _Just . _2 .= l'
 
 -- | Handle a user input event in the robot/inventory panel, while in
 --   inventory search mode.
 handleInventorySearchEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleInventorySearchEvent = \case
   -- Escape: stop filtering and go back to regular inventory mode
-  EscapeKey -> do
-    uiState . uiInventoryShouldUpdate .= True
-    uiState . uiInventorySearch .= Nothing
+  EscapeKey ->
+    Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+      uiInventoryShouldUpdate .= True
+      uiInventorySearch .= Nothing
   -- Enter: return to regular inventory mode, and pop out the selected item
   Key V.KEnter -> do
-    uiState . uiInventoryShouldUpdate .= True
-    uiState . uiInventorySearch .= Nothing
+    Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+      uiInventoryShouldUpdate .= True
+      uiInventorySearch .= Nothing
     gets focusedEntity >>= maybe continueWithoutRedraw descriptionModal
   -- Any old character: append to the current search string
-  CharKey c -> do
-    uiState . uiInventoryShouldUpdate .= True
-    uiState . uiInventorySearch %= fmap (`snoc` c)
+  CharKey c ->
+    Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+      uiInventoryShouldUpdate .= True
+      uiInventorySearch %= fmap (`snoc` c)
   -- Backspace: chop the last character off the end of the current search string
   BackspaceKey -> do
-    uiState . uiInventoryShouldUpdate .= True
-    uiState . uiInventorySearch %= fmap (T.dropEnd 1)
+    Brick.zoom (uiState . uiGameplay . uiInventory) $ do
+      uiInventoryShouldUpdate .= True
+      uiInventorySearch %= fmap (T.dropEnd 1)
   -- Handle any other event as list navigation, so we can look through
   -- the filtered inventory using e.g. arrow keys
   VtyEvent ev -> handleInventoryListEvent ev
@@ -1487,7 +1499,7 @@ makeEntity e = do
 descriptionModal :: Entity -> EventM Name AppState ()
 descriptionModal e = do
   s <- get
-  uiState . uiModal ?= generateModal s (DescriptionModal e)
+  uiState . uiGameplay . uiModal ?= generateModal s (DescriptionModal e)
 
 ------------------------------------------------------------
 -- Info panel events

--- a/src/Swarm/TUI/Controller/Util.hs
+++ b/src/Swarm/TUI/Controller/Util.hs
@@ -46,7 +46,7 @@ openModal :: ModalType -> EventM Name AppState ()
 openModal mt = do
   newModal <- gets $ flip generateModal mt
   ensurePause
-  uiState . uiModal ?= newModal
+  uiState . uiGameplay . uiModal ?= newModal
   -- Beep
   case mt of
     ScenarioEndModal _ -> do
@@ -68,7 +68,7 @@ isRunningModal = \case
   _ -> False
 
 setFocus :: FocusablePanel -> EventM Name AppState ()
-setFocus name = uiState . uiFocusRing %= focusSetCurrent (FocusablePanel name)
+setFocus name = uiState . uiGameplay . uiFocusRing %= focusSetCurrent (FocusablePanel name)
 
 immediatelyRedrawWorld :: EventM Name AppState ()
 immediatelyRedrawWorld = do

--- a/src/Swarm/TUI/Editor/Controller.hs
+++ b/src/Swarm/TUI/Editor/Controller.hs
@@ -40,20 +40,20 @@ activateWorldEditorFunction :: WorldEditorFocusable -> EventM Name AppState ()
 activateWorldEditorFunction BrushSelector = openModal TerrainPaletteModal
 activateWorldEditorFunction EntitySelector = openModal EntityPaletteModal
 activateWorldEditorFunction AreaSelector = do
-  selectorStage <- use $ uiState . uiWorldEditor . editingBounds . boundsSelectionStep
+  selectorStage <- use $ uiState . uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep
   case selectorStage of
-    SelectionComplete -> uiState . uiWorldEditor . editingBounds . boundsSelectionStep .= UpperLeftPending
+    SelectionComplete -> uiState . uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep .= UpperLeftPending
     _ -> return ()
 activateWorldEditorFunction OutputPathSelector =
   -- TODO: #1371
   liftIO $ putStrLn "File selection"
 activateWorldEditorFunction MapSaveButton = saveMapFile
 activateWorldEditorFunction ClearEntityButton =
-  uiState . uiWorldEditor . entityPaintList . BL.listSelectedL .= Nothing
+  uiState . uiGameplay . uiWorldEditor . entityPaintList . BL.listSelectedL .= Nothing
 
 handleCtrlLeftClick :: B.Location -> EventM Name AppState ()
 handleCtrlLeftClick mouseLoc = do
-  worldEditor <- use $ uiState . uiWorldEditor
+  worldEditor <- use $ uiState . uiGameplay . uiWorldEditor
   _ <- runMaybeT $ do
     guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     let getSelected x = snd <$> BL.listSelectedElement x
@@ -61,25 +61,26 @@ handleCtrlLeftClick mouseLoc = do
         maybeEntityPaint = getSelected $ worldEditor ^. entityPaintList
     terrain <- hoistMaybe maybeTerrainType
     mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
-    uiState . uiWorldEditor . worldOverdraw . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
-    uiState . uiWorldEditor . lastWorldEditorMessage .= Nothing
+    Brick.zoom (uiState . uiGameplay . uiWorldEditor) $ do
+      worldOverdraw . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
+      lastWorldEditorMessage .= Nothing
   immediatelyRedrawWorld
   return ()
 
 handleRightClick :: B.Location -> EventM Name AppState ()
 handleRightClick mouseLoc = do
-  worldEditor <- use $ uiState . uiWorldEditor
+  worldEditor <- use $ uiState . uiGameplay . uiWorldEditor
   _ <- runMaybeT $ do
     guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
-    uiState . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
+    uiState . uiGameplay . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
   immediatelyRedrawWorld
   return ()
 
 -- | "Eye Dropper" tool:
 handleMiddleClick :: B.Location -> EventM Name AppState ()
 handleMiddleClick mouseLoc = do
-  worldEditor <- use $ uiState . uiWorldEditor
+  worldEditor <- use $ uiState . uiGameplay . uiWorldEditor
   when (worldEditor ^. worldOverdraw . isWorldEditorEnabled) $ do
     w <- use $ gameState . landscape . multiWorld
     let setTerrainPaint coords = do
@@ -88,12 +89,12 @@ handleMiddleClick mouseLoc = do
                   (worldEditor ^. worldOverdraw)
                   w
                   coords
-          uiState . uiWorldEditor . terrainList %= BL.listMoveToElement terrain
+          uiState . uiGameplay . uiWorldEditor . terrainList %= BL.listMoveToElement terrain
           forM_ maybeElementPaint $ \elementPaint ->
             let p = case elementPaint of
                   Facade efd -> efd
                   Ref r -> mkFacade r
-             in uiState . uiWorldEditor . entityPaintList %= BL.listMoveToElement p
+             in uiState . uiGameplay . uiWorldEditor . entityPaintList %= BL.listMoveToElement p
 
     mouseCoordsM <- Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
     whenJust mouseCoordsM setTerrainPaint
@@ -101,15 +102,15 @@ handleMiddleClick mouseLoc = do
 -- | Handle user input events in the robot panel.
 handleWorldEditorPanelEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleWorldEditorPanelEvent = \case
-  Key V.KEsc -> uiState . uiWorldEditor . editingBounds . boundsSelectionStep .= SelectionComplete
+  Key V.KEsc -> uiState . uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep .= SelectionComplete
   Key V.KEnter -> do
-    fring <- use $ uiState . uiWorldEditor . editorFocusRing
+    fring <- use $ uiState . uiGameplay . uiWorldEditor . editorFocusRing
     case focusGetCurrent fring of
       Just (WorldEditorPanelControl x) -> activateWorldEditorFunction x
       _ -> return ()
   ControlChar 's' -> saveMapFile
-  CharKey '\t' -> uiState . uiWorldEditor . editorFocusRing %= focusNext
-  Key V.KBackTab -> uiState . uiWorldEditor . editorFocusRing %= focusPrev
+  CharKey '\t' -> uiState . uiGameplay . uiWorldEditor . editorFocusRing %= focusNext
+  Key V.KBackTab -> uiState . uiGameplay . uiWorldEditor . editorFocusRing %= focusPrev
   _ -> return ()
 
 -- | Return value: whether the cursor position should be updated
@@ -117,36 +118,34 @@ updateAreaBounds :: Maybe (Cosmic W.Coords) -> EventM Name AppState Bool
 updateAreaBounds = \case
   Nothing -> return True
   Just mouseCoords -> do
-    selectorStage <- use $ uiState . uiWorldEditor . editingBounds . boundsSelectionStep
+    selectorStage <- use $ uiState . uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep
     case selectorStage of
       UpperLeftPending -> do
-        uiState . uiWorldEditor . editingBounds . boundsSelectionStep .= LowerRightPending mouseCoords
+        uiState . uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep .= LowerRightPending mouseCoords
         return False
       -- TODO (#1152): Validate that the lower-right click is below and to the right of
       -- the top-left coord and that they are within the same subworld
       LowerRightPending upperLeftMouseCoords -> do
-        uiState
-          . uiWorldEditor
-          . editingBounds
-          . boundsRect
-          .= Just (fmap (,view planar mouseCoords) upperLeftMouseCoords)
-        uiState . uiWorldEditor . lastWorldEditorMessage .= Nothing
-        uiState . uiWorldEditor . editingBounds . boundsSelectionStep .= SelectionComplete
         t <- liftIO $ getTime Monotonic
-        uiState . uiWorldEditor . editingBounds . boundsPersistDisplayUntil .= t + TimeSpec 2 0
+        Brick.zoom (uiState . uiGameplay . uiWorldEditor) $ do
+          lastWorldEditorMessage .= Nothing
+          Brick.zoom editingBounds $ do
+            boundsRect .= Just (fmap (,view planar mouseCoords) upperLeftMouseCoords)
+            boundsSelectionStep .= SelectionComplete
+            boundsPersistDisplayUntil .= t + TimeSpec 2 0
         setFocus WorldEditorPanel
         return False
       SelectionComplete -> return True
 
 saveMapFile :: EventM Name AppState ()
 saveMapFile = do
-  worldEditor <- use $ uiState . uiWorldEditor
-  maybeBounds <- use $ uiState . uiWorldEditor . editingBounds . boundsRect
+  worldEditor <- use $ uiState . uiGameplay . uiWorldEditor
+  maybeBounds <- use $ uiState . uiGameplay . uiWorldEditor . editingBounds . boundsRect
   w <- use $ gameState . landscape . multiWorld
   let mapCellGrid = EU.getEditedMapRectangle (worldEditor ^. worldOverdraw) maybeBounds w
 
   let fp = worldEditor ^. outputFilePath
-  maybeScenarioPair <- use $ uiState . scenarioRef
+  maybeScenarioPair <- use $ uiState . uiGameplay . scenarioRef
   liftIO $ Y.encodeFile fp $ constructScenario (fst <$> maybeScenarioPair) mapCellGrid
 
-  uiState . uiWorldEditor . lastWorldEditorMessage .= Just "Saved."
+  uiState . uiGameplay . uiWorldEditor . lastWorldEditorMessage .= Just "Saved."

--- a/src/Swarm/TUI/Editor/Masking.hs
+++ b/src/Swarm/TUI/Editor/Masking.hs
@@ -10,12 +10,12 @@ import Swarm.TUI.Editor.Model
 import Swarm.TUI.Editor.Util qualified as EU
 import Swarm.TUI.Model.UI
 
-shouldHideWorldCell :: UIState -> W.Coords -> Bool
+shouldHideWorldCell :: UIGameplay -> W.Coords -> Bool
 shouldHideWorldCell ui coords =
   isOutsideSingleSelectedCorner || isOutsideMapSaveBounds
  where
   we = ui ^. uiWorldEditor
-  withinTimeout = ui ^. lastFrameTime < we ^. editingBounds . boundsPersistDisplayUntil
+  withinTimeout = ui ^. uiTiming . lastFrameTime < we ^. editingBounds . boundsPersistDisplayUntil
 
   isOutsideMapSaveBounds =
     withinTimeout

--- a/src/Swarm/TUI/Editor/View.hs
+++ b/src/Swarm/TUI/Editor/View.hs
@@ -56,7 +56,7 @@ drawWorldEditor toplevelFocusRing uis =
       hLimit 30 $
         controlsBox <=> statusBox
 
-  worldEditor = uis ^. uiWorldEditor
+  worldEditor = uis ^. uiGameplay . uiWorldEditor
   maybeAreaBounds = worldEditor ^. editingBounds . boundsRect
 
   -- TODO (#1150): Use withFocusRing?
@@ -143,7 +143,7 @@ drawTerrainSelector s =
     . hCenter
     . vLimit (length (listEnums :: [TerrainType]))
     . BL.renderListWithIndex listDrawTerrainElement True
-    $ s ^. uiState . uiWorldEditor . terrainList
+    $ s ^. uiState . uiGameplay . uiWorldEditor . terrainList
 
 listDrawTerrainElement :: Int -> Bool -> TerrainType -> Widget Name
 listDrawTerrainElement pos _isSelected a =
@@ -155,7 +155,7 @@ drawEntityPaintSelector s =
     . hCenter
     . vLimit 10
     . BL.renderListWithIndex listDrawEntityPaintElement True
-    $ s ^. uiState . uiWorldEditor . entityPaintList
+    $ s ^. uiState . uiGameplay . uiWorldEditor . entityPaintList
 
 listDrawEntityPaintElement :: Int -> Bool -> EntityFacade -> Widget Name
 listDrawEntityPaintElement pos _isSelected a =

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -213,7 +213,7 @@ runtimeState :: Lens' AppState RuntimeState
 --   info panel (if any).
 focusedItem :: AppState -> Maybe InventoryListEntry
 focusedItem s = do
-  list <- s ^? uiState . uiInventory . _Just . _2
+  list <- s ^? uiState . uiGameplay . uiInventory . uiInventoryList . _Just . _2
   (_, entry) <- BL.listSelectedElement list
   return entry
 
@@ -233,10 +233,10 @@ focusedEntity =
 
 -- | Given the focused robot, populate the UI inventory list in the info
 --   panel with information about its inventory.
-populateInventoryList :: (MonadState UIState m) => Maybe Robot -> m ()
-populateInventoryList Nothing = uiInventory .= Nothing
+populateInventoryList :: (MonadState UIInventory m) => Maybe Robot -> m ()
+populateInventoryList Nothing = uiInventoryList .= Nothing
 populateInventoryList (Just r) = do
-  mList <- preuse (uiInventory . _Just . _2)
+  mList <- preuse $ uiInventoryList . _Just . _2
   showZero <- use uiShowZero
   sortOptions <- use uiInventorySort
   search <- use uiInventorySearch
@@ -285,7 +285,7 @@ populateInventoryList (Just r) = do
 
   -- Finally, populate the newly created list in the UI, and remember
   -- the hash of the current robot.
-  uiInventory .= Just (r ^. inventoryHash, lst)
+  uiInventoryList .= Just (r ^. inventoryHash, lst)
 
 ------------------------------------------------------------
 -- App state (= UI state + game state) initialization

--- a/src/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/Swarm/TUI/Model/StateUpdate.hs
@@ -132,7 +132,7 @@ constructAppState ::
 constructAppState rs ui opts@(AppOpts {..}) = do
   let gs = initGameState (mkGameStateConfig rs)
   case skipMenu opts of
-    False -> return $ AppState gs (ui & lgTicksPerSecond .~ defaultInitLgTicksPerSecond) rs
+    False -> return $ AppState gs (ui & uiGameplay . uiTiming . lgTicksPerSecond .~ defaultInitLgTicksPerSecond) rs
     True -> do
       (scenario, path) <- loadScenario (fromMaybe "classic" userScenario) (gs ^. landscape . entityMap) (rs ^. worlds)
       maybeRunScript <- traverse parseCodeFile scriptToRun
@@ -253,22 +253,22 @@ scenarioToUIState isAutoplaying siPair@(scenario, _) gs u = do
   return $
     u
       & uiPlaying .~ True
-      & uiGoal .~ emptyGoalDisplay
+      & uiGameplay . uiGoal .~ emptyGoalDisplay
       & uiCheatMode ||~ isAutoplaying
-      & uiHideGoals .~ (isAutoplaying && not (u ^. uiCheatMode))
-      & uiFocusRing .~ initFocusRing
-      & uiInventory .~ Nothing
-      & uiInventorySort .~ defaultSortOptions
-      & uiShowFPS .~ False
-      & uiShowZero .~ True
-      & uiREPL .~ initREPLState (u ^. uiREPL . replHistory)
-      & uiREPL . replHistory %~ restartREPLHistory
+      & uiGameplay . uiHideGoals .~ (isAutoplaying && not (u ^. uiCheatMode))
+      & uiGameplay . uiFocusRing .~ initFocusRing
+      & uiGameplay . uiInventory . uiInventoryList .~ Nothing
+      & uiGameplay . uiInventory . uiInventorySort .~ defaultSortOptions
+      & uiGameplay . uiInventory . uiShowZero .~ True
+      & uiGameplay . uiTiming . uiShowFPS .~ False
+      & uiGameplay . uiREPL .~ initREPLState (u ^. uiGameplay . uiREPL . replHistory)
+      & uiGameplay . uiREPL . replHistory %~ restartREPLHistory
       & uiAttrMap .~ applyAttrMappings (map (first getWorldAttrName . toAttrPair) $ fst siPair ^. scenarioAttrs) swarmAttrMap
-      & scenarioRef ?~ siPair
-      & lastFrameTime .~ curTime
-      & uiWorldEditor . EM.entityPaintList %~ BL.listReplace entityList Nothing
-      & uiWorldEditor . EM.editingBounds . EM.boundsRect %~ setNewBounds
-      & uiStructure
+      & uiGameplay . scenarioRef ?~ siPair
+      & uiGameplay . uiTiming . lastFrameTime .~ curTime
+      & uiGameplay . uiWorldEditor . EM.entityPaintList %~ BL.listReplace entityList Nothing
+      & uiGameplay . uiWorldEditor . EM.editingBounds . EM.boundsRect %~ setNewBounds
+      & uiGameplay . uiStructure
         .~ StructureDisplay
           (SR.makeListWidget . M.elems $ gs ^. discovery . structureRecognition . automatons . originalStructureDefinitions)
           (focusSetCurrent (StructureWidgets StructuresList) $ focusRing $ map StructureWidgets listEnums)

--- a/src/Swarm/TUI/Model/UI.hs
+++ b/src/Swarm/TUI/Model/UI.hs
@@ -8,7 +8,13 @@
 -- SPDX-License-Identifier: BSD-3-Clause
 module Swarm.TUI.Model.UI (
   UIState (..),
+  UIGameplay (..),
+  UITiming (..),
+  UIInventory (..),
   GoalDisplay (..),
+  uiGameplay,
+  uiTiming,
+  uiInventory,
   uiMenu,
   uiPlaying,
   uiCheatMode,
@@ -17,7 +23,7 @@ module Swarm.TUI.Model.UI (
   uiWorldCursor,
   uiWorldEditor,
   uiREPL,
-  uiInventory,
+  uiInventoryList,
   uiInventorySort,
   uiInventorySearch,
   uiScrollToEnd,
@@ -85,39 +91,11 @@ import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.Structure
 import Swarm.TUI.View.Attribute.Attr (swarmAttrMap)
 import Swarm.Util
-import Swarm.Util.Lens (makeLensesExcluding)
+import Swarm.Util.Lens (makeLensesExcluding, makeLensesNoSigs)
 import System.Clock
 
-------------------------------------------------------------
--- UI state
-------------------------------------------------------------
-
--- | The main record holding the UI state.  For access to the fields,
--- see the lenses below.
-data UIState = UIState
-  { _uiMenu :: Menu
-  , _uiPlaying :: Bool
-  , _uiCheatMode :: Bool
-  , _uiFocusRing :: FocusRing Name
-  , _uiLaunchConfig :: LaunchOptions
-  , _uiWorldCursor :: Maybe (Cosmic W.Coords)
-  , _uiWorldEditor :: WorldEditor Name
-  , _uiREPL :: REPLState
-  , _uiInventory :: Maybe (Int, BL.List Name InventoryListEntry)
-  , _uiInventorySort :: InventorySortOptions
-  , _uiInventorySearch :: Maybe Text
-  , _uiScrollToEnd :: Bool
-  , _uiModal :: Maybe Modal
-  , _uiGoal :: GoalDisplay
-  , _uiStructure :: StructureDisplay
-  , _uiHideGoals :: Bool
-  , _uiAchievements :: Map CategorizedAchievement Attainment
-  , _uiShowFPS :: Bool
-  , _uiShowREPL :: Bool
-  , _uiShowZero :: Bool
-  , _uiShowDebug :: Bool
-  , _uiHideRobotsUntil :: TimeSpec
-  , _uiInventoryShouldUpdate :: Bool
+data UITiming = UITiming
+  { _uiShowFPS :: Bool
   , _uiTPF :: Double
   , _uiFPS :: Double
   , _lgTicksPerSecond :: Int
@@ -127,14 +105,186 @@ data UIState = UIState
   , _lastFrameTime :: TimeSpec
   , _accumulatedTime :: TimeSpec
   , _lastInfoTime :: TimeSpec
-  , _uiAttrMap :: AttrMap
+  }
+
+-- * Lenses for UITiming
+
+makeLensesExcluding ['_lgTicksPerSecond] ''UITiming
+
+-- | A toggle to show the FPS by pressing @f@
+uiShowFPS :: Lens' UITiming Bool
+
+-- | Computed ticks per milliseconds
+uiTPF :: Lens' UITiming Double
+
+-- | Computed frames per milliseconds
+uiFPS :: Lens' UITiming Double
+
+-- | The base-2 logarithm of the current game speed in ticks/second.
+--   Note that we cap this value to the range of +/- log2 INTMAX.
+lgTicksPerSecond :: Lens' UITiming Int
+lgTicksPerSecond = lens _lgTicksPerSecond safeSetLgTicks
+ where
+  maxLog = finiteBitSize (maxBound :: Int)
+  maxTicks = maxLog - 2
+  minTicks = 2 - maxLog
+  safeSetLgTicks ui lTicks
+    | lTicks < minTicks = setLgTicks ui minTicks
+    | lTicks > maxTicks = setLgTicks ui maxTicks
+    | otherwise = setLgTicks ui lTicks
+  setLgTicks ui lTicks = ui {_lgTicksPerSecond = lTicks}
+
+-- | A counter used to track how many ticks have happened since the
+--   last time we updated the ticks/frame statistics.
+tickCount :: Lens' UITiming Int
+
+-- | A counter used to track how many frames have been rendered since the
+--   last time we updated the ticks/frame statistics.
+frameCount :: Lens' UITiming Int
+
+-- | A counter used to track how many ticks have happened in the
+--   current frame, so we can stop when we get to the tick cap.
+frameTickCount :: Lens' UITiming Int
+
+-- | The time of the last info widget update
+lastInfoTime :: Lens' UITiming TimeSpec
+
+-- | The time of the last 'Swarm.TUI.Model.Frame' event.
+lastFrameTime :: Lens' UITiming TimeSpec
+
+-- | The amount of accumulated real time.  Every time we get a 'Swarm.TUI.Model.Frame'
+--   event, we accumulate the amount of real time that happened since
+--   the last frame, then attempt to take an appropriate number of
+--   ticks to "catch up", based on the target tick rate.
+--
+--   See https://gafferongames.com/post/fix_your_timestep/ .
+accumulatedTime :: Lens' UITiming TimeSpec
+
+data UIInventory = UIInventory
+  { _uiInventoryList :: Maybe (Int, BL.List Name InventoryListEntry)
+  , _uiInventorySort :: InventorySortOptions
+  , _uiInventorySearch :: Maybe Text
+  , _uiShowZero :: Bool
+  , _uiInventoryShouldUpdate :: Bool
+  }
+
+-- * Lenses for UIInventory
+
+makeLensesNoSigs ''UIInventory
+
+-- | The order and direction of sorting inventory list.
+uiInventorySort :: Lens' UIInventory InventorySortOptions
+
+-- | The current search string used to narrow the inventory view.
+uiInventorySearch :: Lens' UIInventory (Maybe Text)
+
+-- | The hash value of the focused robot entity (so we can tell if its
+--   inventory changed) along with a list of the items in the
+--   focused robot's inventory.
+uiInventoryList :: Lens' UIInventory (Maybe (Int, BL.List Name InventoryListEntry))
+
+-- | A toggle to show or hide inventory items with count 0 by pressing @0@
+uiShowZero :: Lens' UIInventory Bool
+
+-- | Whether the Inventory ui panel should update
+uiInventoryShouldUpdate :: Lens' UIInventory Bool
+
+-- | The main record holding the gameplay UI state.  For access to the fields,
+-- see the lenses below.
+data UIGameplay = UIGameplay
+  { _uiFocusRing :: FocusRing Name
+  , _uiWorldCursor :: Maybe (Cosmic W.Coords)
+  , _uiWorldEditor :: WorldEditor Name
+  , _uiREPL :: REPLState
+  , _uiInventory :: UIInventory
+  , _uiScrollToEnd :: Bool
+  , _uiModal :: Maybe Modal
+  , _uiGoal :: GoalDisplay
+  , _uiStructure :: StructureDisplay
+  , _uiHideGoals :: Bool
+  , _uiShowREPL :: Bool
+  , _uiShowDebug :: Bool
+  , _uiHideRobotsUntil :: TimeSpec
+  , _uiTiming :: UITiming
   , _scenarioRef :: Maybe ScenarioInfoPair
   }
 
---------------------------------------------------
--- Lenses for UIState
+-- * Lenses for UIGameplay
 
-makeLensesExcluding ['_lgTicksPerSecond] ''UIState
+makeLensesNoSigs ''UIGameplay
+
+-- | Temporal information for gameplay UI
+uiTiming :: Lens' UIGameplay UITiming
+
+-- | Inventory information for gameplay UI
+uiInventory :: Lens' UIGameplay UIInventory
+
+-- | The focus ring is the set of UI panels we can cycle among using
+--   the @Tab@ key.
+uiFocusRing :: Lens' UIGameplay (FocusRing Name)
+
+-- | The last clicked position on the world view.
+uiWorldCursor :: Lens' UIGameplay (Maybe (Cosmic W.Coords))
+
+-- | State of all World Editor widgets
+uiWorldEditor :: Lens' UIGameplay (WorldEditor Name)
+
+-- | The state of REPL panel.
+uiREPL :: Lens' UIGameplay REPLState
+
+-- | A flag telling the UI to scroll the info panel to the very end
+--   (used when a new log message is appended).
+uiScrollToEnd :: Lens' UIGameplay Bool
+
+-- | When this is 'Just', it represents a modal to be displayed on
+--   top of the UI, e.g. for the Help screen.
+uiModal :: Lens' UIGameplay (Maybe Modal)
+
+-- | Status of the scenario goal: whether there is one, and whether it
+--   has been displayed to the user initially.
+uiGoal :: Lens' UIGameplay GoalDisplay
+
+-- | Definition and status of a recognizable structure
+uiStructure :: Lens' UIGameplay StructureDisplay
+
+-- | When running with @--autoplay@, suppress the goal dialogs.
+--
+-- For development, the @--cheat@ flag shows goals again.
+uiHideGoals :: Lens' UIGameplay Bool
+
+-- | A toggle to expand or collapse the REPL by pressing @Ctrl-k@
+uiShowREPL :: Lens' UIGameplay Bool
+
+-- | A toggle to show debug.
+--
+-- TODO: #1112 use record for selection of debug features?
+uiShowDebug :: Lens' UIGameplay Bool
+
+-- | Hide robots on the world map.
+uiHideRobotsUntil :: Lens' UIGameplay TimeSpec
+
+-- | Whether to show or hide robots on the world map.
+uiShowRobots :: Getter UIGameplay Bool
+uiShowRobots = to (\ui -> ui ^. uiTiming . lastFrameTime > ui ^. uiHideRobotsUntil)
+
+-- | The currently active Scenario description, useful for starting over.
+scenarioRef :: Lens' UIGameplay (Maybe ScenarioInfoPair)
+
+-- * Toplevel UIState definition
+
+data UIState = UIState
+  { _uiMenu :: Menu
+  , _uiPlaying :: Bool
+  , _uiCheatMode :: Bool
+  , _uiLaunchConfig :: LaunchOptions
+  , _uiAchievements :: Map CategorizedAchievement Attainment
+  , _uiAttrMap :: AttrMap
+  , _uiGameplay :: UIGameplay
+  }
+
+-- * Lenses for UIState
+
+makeLensesNoSigs ''UIState
 
 -- | The current menu state.
 uiMenu :: Lens' UIState Menu
@@ -153,131 +303,16 @@ uiCheatMode :: Lens' UIState Bool
 -- | Configuration modal when launching a scenario
 uiLaunchConfig :: Lens' UIState LaunchOptions
 
--- | The focus ring is the set of UI panels we can cycle among using
---   the @Tab@ key.
-uiFocusRing :: Lens' UIState (FocusRing Name)
-
--- | The last clicked position on the world view.
-uiWorldCursor :: Lens' UIState (Maybe (Cosmic W.Coords))
-
--- | State of all World Editor widgets
-uiWorldEditor :: Lens' UIState (WorldEditor Name)
-
--- | The state of REPL panel.
-uiREPL :: Lens' UIState REPLState
-
--- | The order and direction of sorting inventory list.
-uiInventorySort :: Lens' UIState InventorySortOptions
-
--- | The current search string used to narrow the inventory view.
-uiInventorySearch :: Lens' UIState (Maybe Text)
-
--- | The hash value of the focused robot entity (so we can tell if its
---   inventory changed) along with a list of the items in the
---   focused robot's inventory.
-uiInventory :: Lens' UIState (Maybe (Int, BL.List Name InventoryListEntry))
-
--- | A flag telling the UI to scroll the info panel to the very end
---   (used when a new log message is appended).
-uiScrollToEnd :: Lens' UIState Bool
-
--- | When this is 'Just', it represents a modal to be displayed on
---   top of the UI, e.g. for the Help screen.
-uiModal :: Lens' UIState (Maybe Modal)
-
--- | Status of the scenario goal: whether there is one, and whether it
---   has been displayed to the user initially.
-uiGoal :: Lens' UIState GoalDisplay
-
--- | Definition and status of a recognizable structure
-uiStructure :: Lens' UIState StructureDisplay
-
--- | When running with @--autoplay@, suppress the goal dialogs.
---
--- For development, the @--cheat@ flag shows goals again.
-uiHideGoals :: Lens' UIState Bool
-
 -- | Map of achievements that were attained
 uiAchievements :: Lens' UIState (Map CategorizedAchievement Attainment)
-
--- | A toggle to show the FPS by pressing @f@
-uiShowFPS :: Lens' UIState Bool
-
--- | A toggle to expand or collapse the REPL by pressing @Ctrl-k@
-uiShowREPL :: Lens' UIState Bool
-
--- | A toggle to show or hide inventory items with count 0 by pressing @0@
-uiShowZero :: Lens' UIState Bool
-
--- | A toggle to show debug.
---
--- TODO: #1112 use record for selection of debug features?
-uiShowDebug :: Lens' UIState Bool
-
--- | Hide robots on the world map.
-uiHideRobotsUntil :: Lens' UIState TimeSpec
-
--- | Whether to show or hide robots on the world map.
-uiShowRobots :: Getter UIState Bool
-uiShowRobots = to (\ui -> ui ^. lastFrameTime > ui ^. uiHideRobotsUntil)
-
--- | Whether the Inventory ui panel should update
-uiInventoryShouldUpdate :: Lens' UIState Bool
-
--- | Computed ticks per milliseconds
-uiTPF :: Lens' UIState Double
-
--- | Computed frames per milliseconds
-uiFPS :: Lens' UIState Double
 
 -- | Attribute map
 uiAttrMap :: Lens' UIState AttrMap
 
--- | The currently active Scenario description, useful for starting over.
-scenarioRef :: Lens' UIState (Maybe ScenarioInfoPair)
+-- | UI active during live gameplay
+uiGameplay :: Lens' UIState UIGameplay
 
--- | The base-2 logarithm of the current game speed in ticks/second.
---   Note that we cap this value to the range of +/- log2 INTMAX.
-lgTicksPerSecond :: Lens' UIState Int
-lgTicksPerSecond = lens _lgTicksPerSecond safeSetLgTicks
- where
-  maxLog = finiteBitSize (maxBound :: Int)
-  maxTicks = maxLog - 2
-  minTicks = 2 - maxLog
-  safeSetLgTicks ui lTicks
-    | lTicks < minTicks = setLgTicks ui minTicks
-    | lTicks > maxTicks = setLgTicks ui maxTicks
-    | otherwise = setLgTicks ui lTicks
-  setLgTicks ui lTicks = ui {_lgTicksPerSecond = lTicks}
-
--- | A counter used to track how many ticks have happened since the
---   last time we updated the ticks/frame statistics.
-tickCount :: Lens' UIState Int
-
--- | A counter used to track how many frames have been rendered since the
---   last time we updated the ticks/frame statistics.
-frameCount :: Lens' UIState Int
-
--- | A counter used to track how many ticks have happened in the
---   current frame, so we can stop when we get to the tick cap.
-frameTickCount :: Lens' UIState Int
-
--- | The time of the last info widget update
-lastInfoTime :: Lens' UIState TimeSpec
-
--- | The time of the last 'Swarm.TUI.Model.Frame' event.
-lastFrameTime :: Lens' UIState TimeSpec
-
--- | The amount of accumulated real time.  Every time we get a 'Swarm.TUI.Model.Frame'
---   event, we accumulate the amount of real time that happened since
---   the last frame, then attempt to take an appropriate number of
---   ticks to "catch up", based on the target tick rate.
---
---   See https://gafferongames.com/post/fix_your_timestep/ .
-accumulatedTime :: Lens' UIState TimeSpec
-
---------------------------------------------------
--- UIState initialization
+-- * UIState initialization
 
 -- | The initial state of the focus ring.
 -- NOTE: Normally, the Tab key might cycle through the members of the
@@ -315,35 +350,44 @@ initUIState speedFactor showMainMenu cheatMode = do
           , _uiPlaying = not showMainMenu
           , _uiCheatMode = cheatMode
           , _uiLaunchConfig = launchConfigPanel
-          , _uiFocusRing = initFocusRing
-          , _uiWorldCursor = Nothing
-          , _uiWorldEditor = initialWorldEditor startTime
-          , _uiREPL = initREPLState $ newREPLHistory history
-          , _uiInventory = Nothing
-          , _uiInventorySort = defaultSortOptions
-          , _uiInventorySearch = Nothing
-          , _uiScrollToEnd = False
-          , _uiModal = Nothing
-          , _uiGoal = emptyGoalDisplay
-          , _uiStructure = emptyStructureDisplay
-          , _uiHideGoals = False
           , _uiAchievements = M.fromList $ map (view achievement &&& id) achievements
-          , _uiShowFPS = False
-          , _uiShowREPL = True
-          , _uiShowZero = True
-          , _uiShowDebug = False
-          , _uiHideRobotsUntil = startTime - 1
-          , _uiInventoryShouldUpdate = False
-          , _uiTPF = 0
-          , _uiFPS = 0
-          , _lgTicksPerSecond = speedFactor
-          , _lastFrameTime = startTime
-          , _accumulatedTime = 0
-          , _lastInfoTime = 0
-          , _tickCount = 0
-          , _frameCount = 0
-          , _frameTickCount = 0
           , _uiAttrMap = swarmAttrMap
-          , _scenarioRef = Nothing
+          , _uiGameplay =
+              UIGameplay
+                { _uiFocusRing = initFocusRing
+                , _uiWorldCursor = Nothing
+                , _uiWorldEditor = initialWorldEditor startTime
+                , _uiREPL = initREPLState $ newREPLHistory history
+                , _uiInventory =
+                    UIInventory
+                      { _uiInventoryList = Nothing
+                      , _uiInventorySort = defaultSortOptions
+                      , _uiInventorySearch = Nothing
+                      , _uiShowZero = True
+                      , _uiInventoryShouldUpdate = False
+                      }
+                , _uiScrollToEnd = False
+                , _uiModal = Nothing
+                , _uiGoal = emptyGoalDisplay
+                , _uiStructure = emptyStructureDisplay
+                , _uiHideGoals = False
+                , _uiTiming =
+                    UITiming
+                      { _uiShowFPS = False
+                      , _uiTPF = 0
+                      , _uiFPS = 0
+                      , _lgTicksPerSecond = speedFactor
+                      , _lastFrameTime = startTime
+                      , _accumulatedTime = 0
+                      , _lastInfoTime = 0
+                      , _tickCount = 0
+                      , _frameCount = 0
+                      , _frameTickCount = 0
+                      }
+                , _uiShowREPL = True
+                , _uiShowDebug = False
+                , _uiHideRobotsUntil = startTime - 1
+                , _scenarioRef = Nothing
+                }
           }
   return out

--- a/src/Swarm/TUI/View/CellDisplay.hs
+++ b/src/Swarm/TUI/View/CellDisplay.hs
@@ -57,7 +57,7 @@ renderDisplay :: Display -> Widget n
 renderDisplay disp = withAttr (disp ^. displayAttr . to toAttrName) $ str [displayChar disp]
 
 -- | Render the 'Display' for a specific location.
-drawLoc :: UIState -> GameState -> Cosmic W.Coords -> Widget Name
+drawLoc :: UIGameplay -> GameState -> Cosmic W.Coords -> Widget Name
 drawLoc ui g cCoords@(Cosmic _ coords) =
   if shouldHideWorldCell ui coords
     then str " "

--- a/src/Swarm/TUI/View/Util.hs
+++ b/src/Swarm/TUI/View/Util.hs
@@ -37,7 +37,7 @@ import Witch (from, into)
 generateModal :: AppState -> ModalType -> Modal
 generateModal s mt = Modal mt (dialog (Just $ str title) buttons (maxModalWindowWidth `min` requiredWidth))
  where
-  currentScenario = s ^. uiState . scenarioRef
+  currentScenario = s ^. uiState . uiGameplay . scenarioRef
   currentSeed = s ^. gameState . randomness . seed
   haltingMessage = case s ^. uiState . uiMenu of
     NoMenu -> Just "Quit"

--- a/src/swarm-web/Swarm/Web.hs
+++ b/src/swarm-web/Swarm/Web.hs
@@ -204,7 +204,7 @@ goalsGraphHandler appStateRef = do
 uiGoalHandler :: ReadableIORef AppState -> Handler GoalTracking
 uiGoalHandler appStateRef = do
   appState <- liftIO (readIORef appStateRef)
-  return $ appState ^. uiState . uiGoal . goalsContent
+  return $ appState ^. uiState . uiGameplay . uiGoal . goalsContent
 
 goalsHandler :: ReadableIORef AppState -> Handler WinCondition
 goalsHandler appStateRef = do
@@ -250,14 +250,14 @@ cmdMatrixHandler _ = pure getCatalog
 replHandler :: ReadableIORef AppState -> Handler [REPLHistItem]
 replHandler appStateRef = do
   appState <- liftIO (readIORef appStateRef)
-  let replHistorySeq = appState ^. uiState . uiREPL . replHistory . replSeq
+  let replHistorySeq = appState ^. uiState . uiGameplay . uiREPL . replHistory . replSeq
       items = toList replHistorySeq
   pure items
 
 mapViewHandler :: ReadableIORef AppState -> AreaDimensions -> Handler GridResponse
 mapViewHandler appStateRef areaSize = do
   appState <- liftIO (readIORef appStateRef)
-  let maybeScenario = fst <$> appState ^. uiState . scenarioRef
+  let maybeScenario = fst <$> appState ^. uiState . uiGameplay . scenarioRef
   pure $ case maybeScenario of
     Just s ->
       GridResponse True


### PR DESCRIPTION
Introduced 3 new sub-records in `UI.hs`:
* `UIGameplay`
* `UITiming`
* `UIInventory`

This allows some functions (e.g. `populateInventoryList`) to operate on a narrower scope of state.

Also uses `Brick.zoom` in a few more places to mitigate the longer lens chains.