### PR TITLE
[EXPERIMENTAL] perf improvement using set

### DIFF
--- a/data/scenarios/Challenges/Sokoban/_foresight/solution.sw
+++ b/data/scenarios/Challenges/Sokoban/_foresight/solution.sw
@@ -139,7 +139,7 @@ def firstLeg =
     pushUntilBarrier;
 
     wait 4;
-    move;
+    moveUntilBlocked;
     doN 5 (turn left; moveUntilBlocked);
 
     turn right;

--- a/data/scenarios/Challenges/_combo-lock/solution.sw
+++ b/data/scenarios/Challenges/_combo-lock/solution.sw
@@ -4,7 +4,6 @@ def moveToLock =
     end;
 
 def cycleCombos = \n.
-    wait 1;
     entityNorth <- scan north;
     let hasGate = case entityNorth (\_. false) (\x. x == "gate") in
     if hasGate {

--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -46,6 +46,8 @@ Achievements
 1341-command-count.yaml
 1355-combustion.yaml
 1379-single-world-portal-reorientation.yaml
+1322-wait-with-instant.yaml
+1598-detect-entity-change.yaml
 1399-backup-command.yaml
 1430-built-robot-ownership.yaml
 1536-custom-unwalkable-entities.yaml

--- a/data/scenarios/Testing/1322-wait-with-instant.yaml
+++ b/data/scenarios/Testing/1322-wait-with-instant.yaml
@@ -1,0 +1,72 @@
+version: 1
+name: Using wait with instant
+author: Karl Ostmo
+description: |
+  Observe timing of (instant $ wait 1)
+  interspersed with other commands
+creative: false
+seed: 0
+objectives:
+  - goal:
+      - |
+        Hare must win by three cells
+    condition: |
+      h <- robotnamed "hare";
+      hareloc <- as h {whereami};
+
+      t <- robotnamed "tortoise";
+      tortoiseloc <- as t {whereami};
+
+      let xDiff = fst hareloc - fst tortoiseloc in
+
+      return $ fst hareloc == 0 && xDiff == 3;
+solution: |
+  noop;
+robots:
+  - name: base
+    dir: [1, 0]
+    display:
+      invisible: true
+    devices:
+      - hourglass
+      - logger
+  - name: tortoise
+    system: true
+    display:
+      invisible: false
+      attr: green
+    dir: [1, 0]
+    program: |
+      move; move;
+      move; move;
+      move; move;
+  - name: hare
+    system: true
+    display:
+      invisible: false
+      attr: snow
+    dir: [1, 0]
+    program: |
+      instant (
+        move; move;
+        wait 1;
+        move; move;
+        wait 1;
+        move; move;
+      );
+world:
+  dsl: |
+    {blank}
+  upperleft: [-6, 2]
+  offset: false
+  palette:
+    '.': [grass, erase]
+    'd': [dirt, erase]
+    'B': [grass, erase, base]
+    'T': [grass, erase, tortoise]
+    'H': [grass, erase, hare]
+  map: |
+    B.....d.
+    T.....d.
+    H.....d.
+    ......d.

--- a/data/scenarios/Testing/1598-detect-entity-change.yaml
+++ b/data/scenarios/Testing/1598-detect-entity-change.yaml
@@ -1,0 +1,94 @@
+version: 1
+name: Entity change detection
+author: Karl Ostmo
+description: |
+  Ensure that a change to an entity can be observed
+  by a system robot within a single tick.
+
+  In this scenario, the base will first `swap` the
+  existing `dial (R)`{=entity} with a `dial (G)`{=entity},
+  then immediately `swap` again with a `dial (B)`{=entity}.
+
+  The system robot should be able to detect the presence
+  of the `dial (G)`{=entity} before it is `swap`ped a second time.
+creative: false
+seed: 0
+objectives:
+  - goal:
+      - |
+        Turn the light green
+    condition: |
+      as base {has "flower"};
+    prerequisite:
+      not: blue_light
+  - id: blue_light
+    teaser: No blue light
+    optional: true
+    goal:
+      - |
+        Turn the light blue
+    condition: |
+      r <- robotnamed "lockbot";
+      as r {ishere "dial (B)"};
+robots:
+  - name: base
+    dir: [1, 0]
+    display:
+      invisible: true
+    devices:
+      - hourglass
+      - fast grabber
+      - logger
+      - treads
+    inventory:
+      - [1, "dial (R)"]
+      - [1, "dial (G)"]
+      - [1, "dial (B)"]
+  - name: lockbot
+    system: true
+    display:
+      invisible: true
+    dir: [1, 0]
+    program: |
+      run "scenarios/Testing/_1598-detect-entity-change/setup.sw"
+    inventory:
+      - [1, flower]
+solution: |
+  wait 2;
+  move;
+  move;
+  swap "dial (G)";
+  swap "dial (B)";
+entities:
+  - name: "dial (R)"
+    display:
+      char: '•'
+      attr: red
+    description:
+      - A red dial
+    properties: [known, pickable]
+  - name: "dial (G)"
+    display:
+      char: '•'
+      attr: green
+    description:
+      - A green dial
+    properties: [known, pickable]
+  - name: "dial (B)"
+    display:
+      char: '•'
+      attr: blue
+    description:
+      - A blue dial
+    properties: [known, pickable]
+world:
+  dsl: |
+    {blank}
+  upperleft: [-1, -1]
+  offset: false
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+    'c': [grass, dial (R), lockbot]
+  map: |
+    B.c

--- a/data/scenarios/Testing/_1598-detect-entity-change/setup.sw
+++ b/data/scenarios/Testing/_1598-detect-entity-change/setup.sw
@@ -1,0 +1,17 @@
+def doUntilCorrect =
+    herenow <- ishere "dial (G)";
+    if herenow {
+        give base "flower";
+    } {
+        watch down;
+        wait 1000;
+        doUntilCorrect;
+    }
+    end;
+    
+def go =
+    instant $
+        doUntilCorrect;
+    end;
+
+go;

--- a/scripts/benchmark-against-ancestor.sh
+++ b/scripts/benchmark-against-ancestor.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -xe
+
+# Requires that the working tree be clean.
+
+REFERENCE_COMMIT=${1:-HEAD~}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+
+if git diff --quiet --exit-code
+then
+   echo "Working tree is clean. Starting benchmarks..."
+else
+   echo "Working tree is dirty! Quitting."
+   exit 1
+fi
+
+BASELINE_OUTPUT=baseline.csv
+
+git checkout $REFERENCE_COMMIT
+
+scripts/run-benchmarks.sh "--csv $BASELINE_OUTPUT"
+
+git switch -
+scripts/run-benchmarks.sh "--baseline $BASELINE_OUTPUT --fail-if-slower 3"

--- a/scripts/benchmark-against-parent.sh
+++ b/scripts/benchmark-against-parent.sh
@@ -1,23 +1,6 @@
 #!/bin/bash -xe
 
-# Requires that the working tree be clean.
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 
-if git diff --quiet --exit-code
-then
-   echo "Working tree is clean. Starting benchmarks..."
-else
-   echo "Working tree is dirty! Quitting."
-   exit 1
-fi
-
-BASELINE_OUTPUT=baseline.csv
-
-git checkout HEAD~
-
-scripts/run-benchmarks.sh "--csv $BASELINE_OUTPUT"
-
-git switch -
-scripts/run-benchmarks.sh "--baseline $BASELINE_OUTPUT --fail-if-slower 3"
+scripts/benchmark-against-ancestor.sh HEAD~

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -314,7 +314,6 @@ wakeUpRobotsDoneSleeping time = do
 
   internalWaitingRobots .= futureMap
 
-
   internalActiveRobots %= IS.union (IS.fromList newlyAlive)
   use activeRobots
 

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -378,7 +378,7 @@ wakeWatchingRobots myID currentTick loc = do
       -- Step 4: Re-add the watching bots to be awakened ASAP:
       wakeableBotIds = map fst wakeTimes
 
-      -- It is crucial that only robots with a larger RID thatn the current robot
+      -- It is crucial that only robots with a larger RID than the current robot
       -- be scheduled for the *same* tick, since within a given tick we iterate over
       -- robots in increasing order of RID.
       -- See note in 'iterateRobots'.

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -67,7 +67,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set qualified as S
 import Data.Tuple (swap)
 import GHC.Generics (Generic)
-import Swarm.Game.CESK (CESK (Waiting), TickNumber (..))
+import Swarm.Game.CESK (CESK (Waiting))
 import Swarm.Game.Location
 import Swarm.Game.ResourceLoading (NameGenerator)
 import Swarm.Game.Robot

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -377,8 +377,12 @@ wakeWatchingRobots myID currentTick loc = do
 
       -- Step 4: Re-add the watching bots to be awakened ASAP:
       wakeableBotIds = map fst wakeTimes
-      (currTickWakeable, nextTickWakeable) = partition (> myID) wakeableBotIds
 
+      -- It is crucial that only robots with a larger RID thatn the current robot
+      -- be scheduled for the *same* tick, since within a given tick we iterate over
+      -- robots in increasing order of RID.
+      -- See note in 'iterateRobots'.
+      (currTickWakeable, nextTickWakeable) = partition (> myID) wakeableBotIds
       wakeTimeGroups =
         [ (currentTick, currTickWakeable)
         , (addTicks 1 currentTick, nextTickWakeable)

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -300,18 +300,21 @@ wakeUpRobotsDoneSleeping time = do
   let (beforeMap, maybeAt, futureMap) = M.splitLookup time waitingMap
       mrids = NE.nonEmpty $ concat $ fromMaybe [] maybeAt : M.elems beforeMap
 
-  case mrids of
-    Nothing -> return ()
+  newlyAlive <- case mrids of
+    Nothing -> return []
     Just rids -> do
       robots <- use robotMap
       let aliveRids = filter (`IM.member` robots) $ NE.toList rids
-      internalActiveRobots %= IS.union (IS.fromList aliveRids)
 
       -- These robots' wake times may have been moved "forward"
       -- by 'wakeWatchingRobots'.
       clearWatchingRobots $ NE.toList rids
 
+      return aliveRids
+
   internalWaitingRobots .= futureMap
+
+  internalActiveRobots %= IS.union (IS.fromList newlyAlive)
 
 -- | Clear the "watch" state of all of the
 -- awakened robots

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -294,23 +294,37 @@ activateRobot rid = internalActiveRobots %= IS.insert rid
 -- | Removes robots whose wake up time matches the current game ticks count
 --   from the 'waitingRobots' queue and put them back in the 'activeRobots' set
 --   if they still exist in the keys of 'robotMap'.
+--
+-- = Mutations
+--
+-- This function modifies:
+--
+-- * 'wakeLog'
+-- * 'robotsWatching' (by way of 'clearWatchingRobots')
+-- * 'internalWaitingRobots'
+-- * 'internalActiveRobots' (aka 'activeRobots')
+--
+-- = Efficiency (excluding 'wakeLog')
+--
+-- * O(log N) where N is the number of keys in 'waitingMap'
+-- * O(M) where M is the number of robots to wake
+-- * O(M + A) where A is the number of active robots
 wakeUpRobotsDoneSleeping :: (Has (State Robots) sig m) => TickNumber -> m IntSet
 wakeUpRobotsDoneSleeping time = do
   waitingMap <- use waitingRobots
+
   let (beforeMap, maybeAt, futureMap) = M.splitLookup time waitingMap
-      mrids = NE.nonEmpty $ concat $ fromMaybe [] maybeAt : M.elems beforeMap
+      currentTickMap = maybe mempty (M.singleton time) maybeAt
+      -- Note: 'union' is safe because currentTickMap and beforeMap are disjoint
+      wakeableRIDs = concat $ M.elems $ M.union currentTickMap beforeMap
 
-  newlyAlive <- case mrids of
-    Nothing -> return []
-    Just rids -> do
-      robots <- use robotMap
-      let aliveRids = filter (`IM.member` robots) $ NE.toList rids
+  -- These robots' wake times may have been moved "forward"
+  -- by 'wakeWatchingRobots'.
+  clearWatchingRobots wakeableRIDs
 
-      -- These robots' wake times may have been moved "forward"
-      -- by 'wakeWatchingRobots'.
-      clearWatchingRobots $ NE.toList rids
-
-      return aliveRids
+  robots <- use robotMap
+  -- Limit ourselves to the robots that have not expired in their sleep
+  let newlyAlive = filter (`IM.member` robots) wakeableRIDs
 
   internalWaitingRobots .= futureMap
 

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -294,7 +294,7 @@ activateRobot rid = internalActiveRobots %= IS.insert rid
 -- | Removes robots whose wake up time matches the current game ticks count
 --   from the 'waitingRobots' queue and put them back in the 'activeRobots' set
 --   if they still exist in the keys of 'robotMap'.
-wakeUpRobotsDoneSleeping :: (Has (State Robots) sig m) => TickNumber -> m ()
+wakeUpRobotsDoneSleeping :: (Has (State Robots) sig m) => TickNumber -> m IntSet
 wakeUpRobotsDoneSleeping time = do
   waitingMap <- use waitingRobots
   let (beforeMap, maybeAt, futureMap) = M.splitLookup time waitingMap
@@ -314,7 +314,9 @@ wakeUpRobotsDoneSleeping time = do
 
   internalWaitingRobots .= futureMap
 
+
   internalActiveRobots %= IS.union (IS.fromList newlyAlive)
+  use activeRobots
 
 -- | Clear the "watch" state of all of the
 -- awakened robots

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -83,7 +83,7 @@ import Prelude hiding (Applicative (..), lookup)
 --
 --   Note that the game may be in 'RobotStep' mode and not finish
 --   the tick. Use the return value to check whether a full tick happened.
-gameTick :: (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m) => m Bool
+gameTick :: HasGameStepState sig m => m Bool
 gameTick = do
   time <- use $ temporal . ticks
   active <- zoomRobots $ wakeUpRobotsDoneSleeping time
@@ -131,7 +131,7 @@ gameTick = do
 -- | Finish a game tick in progress and set the game to 'WorldTick' mode afterwards.
 --
 -- Use this function if you need to unpause the game.
-finishGameTick :: (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m) => m ()
+finishGameTick :: HasGameStepState sig m => m ()
 finishGameTick =
   use (temporal . gameStep) >>= \case
     WorldTick -> pure ()
@@ -156,6 +156,9 @@ insertBackRobot rn rob = do
           Nothing ->
             unless (isActive rob) (sleepForever rn)
 
+-- | GameState with support for IO and Time effect
+type HasGameStepState sig m = (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m)
+
 -- | Run a set of robots - this is used to run robots before/after the focused one.
 --
 -- Note that during the iteration over the supplied robot IDs, it is possible
@@ -169,15 +172,16 @@ insertBackRobot rn rob = do
 --
 -- * Every tick, every active robot shall have exactly one opportunity to run.
 -- * The sequence in which robots are chosen to run is by increasing order of 'RID'.
-runRobotIDs :: (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m) => IS.IntSet -> m ()
+runRobotIDs :: HasGameStepState sig m => IS.IntSet -> m ()
 runRobotIDs robotNames = forM_ (IS.toList robotNames) $ \rn -> do
   mr <- uses (robotInfo . robotMap) (IM.lookup rn)
   forM_ mr (stepOneRobot rn)
  where
+  stepOneRobot :: HasGameStepState sig m => RID -> Robot -> m ()
   stepOneRobot rn rob = tickRobot rob >>= insertBackRobot rn
 
 -- | This is a helper function to do one robot step or run robots before/after.
-singleStep :: (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m) => SingleStep -> RID -> IS.IntSet -> m Bool
+singleStep :: HasGameStepState sig m => SingleStep -> RID -> IS.IntSet -> m Bool
 singleStep ss focRID robotSet = do
   let (preFoc, focusedActive, postFoc) = IS.splitMember focRID robotSet
   case ss of
@@ -434,7 +438,7 @@ traceLogShow = void . traceLog Logged Info . from . show
 -- | Run a robot for one tick, which may consist of up to
 --   'robotStepsPerTick' CESK machine steps and at most one tangible
 --   command execution, whichever comes first.
-tickRobot :: (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m) => Robot -> m Robot
+tickRobot :: HasGameStepState sig m => Robot -> m Robot
 tickRobot r = do
   steps <- use $ temporal . robotStepsPerTick
   tickRobotRec (r & activityCounts . tickStepBudget .~ steps)
@@ -443,7 +447,7 @@ tickRobot r = do
 --   robot is actively running and still has steps left, and if so
 --   runs it for one step, then calls itself recursively to continue
 --   stepping the robot.
-tickRobotRec :: (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m) => Robot -> m Robot
+tickRobotRec :: HasGameStepState sig m => Robot -> m Robot
 tickRobotRec r = do
   time <- use $ temporal . ticks
   case wantsToStep time r && (r ^. runningAtomic || r ^. activityCounts . tickStepBudget > 0) of
@@ -452,7 +456,7 @@ tickRobotRec r = do
 
 -- | Single-step a robot by decrementing its 'tickStepBudget' counter and
 --   running its CESK machine for one step.
-stepRobot :: (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m) => Robot -> m Robot
+stepRobot :: HasGameStepState sig m => Robot -> m Robot
 stepRobot r = do
   (r', cesk') <- runState (r & activityCounts . tickStepBudget -~ 1) (stepCESK (r ^. machine))
   -- sendIO $ appendFile "out.txt" (prettyString cesk' ++ "\n")

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -86,10 +86,8 @@ import Prelude hiding (Applicative (..), lookup)
 gameTick :: HasGameStepState sig m => m Bool
 gameTick = do
   time <- use $ temporal . ticks
-
   void $ zoomRobots $ wakeUpRobotsDoneSleeping time
   active <- use $ robotInfo . activeRobots
-
   focusedRob <- use $ robotInfo . focusedRobotID
 
   ticked <-
@@ -168,20 +166,31 @@ type HasGameStepState sig m = (Has (State GameState) sig m, Has (Lift IO) sig m,
 -- Running a given robot _may_ cause another robot
 -- with a higher 'RID' to be inserted into the runnable set.
 --
+-- Note that the behavior we desire is described precisely by a
+-- <Monotone_priority_queue https://en.wikipedia.org/wiki/Monotone_priority_queue>.
+--
+-- A priority queue allows O(1) access to the lowest priority item. However,
+-- /splitting/ the min item from rest of the queue is still an O(log N) operation,
+-- and therefore is not any better than the 'minView' function from 'IntSet'.
+--
 -- Tail-recursive.
 iterateRobots :: HasGameStepState sig m => TickNumber -> (RID -> m ()) -> IS.IntSet -> m ()
 iterateRobots time f runnableBots =
-  unless (IS.null runnableBots) $ do
+  forM_ (IS.minView runnableBots) $ \(thisRobotId, remainingBotIDs) -> do
     f thisRobotId
 
     -- We may have awakened new robots in the current robot's iteration,
     -- so we add them to the list
     robotsToAdd <- zoomRobots $ wakeUpRobotsDoneSleeping time
-    -- let (_, robotsToAdd) = IS.split thisRobotId activeRIDsThisTick
+
+    -- NOTE: We could use 'IS.split thisRobotId activeRIDsThisTick'
+    -- to ensure that we only insert RIDs greater than 'thisRobotId'
+    -- into the queue.
+    -- However, we already ensure in 'wakeWatchingRobots' that only
+    -- robots with a larger RID are scheduled for the current tick;
+    -- robots with smaller RIDs will be scheduled for the next tick.
 
     iterateRobots time f $ IS.union robotsToAdd remainingBotIDs
- where
-  (thisRobotId, remainingBotIDs) = IS.deleteFindMin runnableBots
 
 -- | Run a set of robots - this is used to run robots before/after the focused one.
 --

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -160,6 +160,29 @@ insertBackRobot rn rob = do
 -- | GameState with support for IO and Time effect
 type HasGameStepState sig m = (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m)
 
+-- | Run a set of robots - this is used to run robots before/after the focused one.
+--
+-- Note that during the iteration over the supplied robot IDs, it is possible
+-- that a robot that may have been present in 'robotMap' at the outset
+-- of the iteration to be removed before the iteration comes upon it.
+-- This is why we must perform a 'robotMap' lookup at each iteration, rather
+-- than looking up elements from 'robotMap' in bulk up front with something like
+-- 'restrictKeys'.
+--
+-- = Invariants
+--
+-- * Every tick, every active robot shall have exactly one opportunity to run.
+-- * The sequence in which robots are chosen to run is by increasing order of 'RID'.
+runRobotIDs :: HasGameStepState sig m => IS.IntSet -> m ()
+runRobotIDs robotNames = do
+  time <- use $ temporal . ticks
+  flip (iterateRobots time) robotNames $ \rn -> do
+    mr <- uses (robotInfo . robotMap) (IM.lookup rn)
+    forM_ mr (stepOneRobot rn)
+ where
+  stepOneRobot :: HasGameStepState sig m => RID -> Robot -> m ()
+  stepOneRobot rn rob = tickRobot rob >>= insertBackRobot rn
+
 -- |
 -- Runs the given robots in increasing order of 'RID'.
 --
@@ -191,29 +214,6 @@ iterateRobots time f runnableBots =
     -- robots with smaller RIDs will be scheduled for the next tick.
 
     iterateRobots time f $ IS.union robotsToAdd remainingBotIDs
-
--- | Run a set of robots - this is used to run robots before/after the focused one.
---
--- Note that during the iteration over the supplied robot IDs, it is possible
--- that a robot that may have been present in 'robotMap' at the outset
--- of the iteration to be removed before the iteration comes upon it.
--- This is why we must perform a 'robotMap' lookup at each iteration, rather
--- than looking up elements from 'robotMap' in bulk up front with something like
--- 'restrictKeys'.
---
--- = Invariants
---
--- * Every tick, every active robot shall have exactly one opportunity to run.
--- * The sequence in which robots are chosen to run is by increasing order of 'RID'.
-runRobotIDs :: HasGameStepState sig m => IS.IntSet -> m ()
-runRobotIDs robotNames = do
-  time <- use $ temporal . ticks
-  flip (iterateRobots time) robotNames $ \rn -> do
-    mr <- uses (robotInfo . robotMap) (IM.lookup rn)
-    forM_ mr (stepOneRobot rn)
- where
-  stepOneRobot :: HasGameStepState sig m => RID -> Robot -> m ()
-  stepOneRobot rn rob = tickRobot rob >>= insertBackRobot rn
 
 -- | This is a helper function to do one robot step or run robots before/after.
 singleStep :: HasGameStepState sig m => SingleStep -> RID -> IS.IntSet -> m Bool

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -86,7 +86,10 @@ import Prelude hiding (Applicative (..), lookup)
 gameTick :: HasGameStepState sig m => m Bool
 gameTick = do
   time <- use $ temporal . ticks
-  active <- zoomRobots $ wakeUpRobotsDoneSleeping time
+
+  void $ zoomRobots $ wakeUpRobotsDoneSleeping time
+  active <- use $ robotInfo . activeRobots
+
   focusedRob <- use $ robotInfo . focusedRobotID
 
   ticked <-
@@ -173,8 +176,8 @@ iterateRobots time f runnableBots =
 
     -- We may have awakened new robots in the current robot's iteration,
     -- so we add them to the list
-    activeRIDs <- zoomRobots $ wakeUpRobotsDoneSleeping time
-    let (_, robotsToAdd) = IS.split thisRobotId activeRIDs
+    robotsToAdd <- zoomRobots $ wakeUpRobotsDoneSleeping time
+    -- let (_, robotsToAdd) = IS.split thisRobotId activeRIDsThisTick
 
     iterateRobots time f $ IS.union robotsToAdd remainingBotIDs
  where

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -166,11 +166,17 @@ type HasGameStepState sig m = (Has (State GameState) sig m, Has (Lift IO) sig m,
 -- with a higher 'RID' to be inserted into the runnable set.
 --
 -- Tail-recursive.
-iterateRobots :: HasGameStepState sig m => (RID -> m ()) -> IS.IntSet -> m ()
-iterateRobots f runnableBots =
+iterateRobots :: HasGameStepState sig m => TickNumber -> (RID -> m ()) -> IS.IntSet -> m ()
+iterateRobots time f runnableBots =
   unless (IS.null runnableBots) $ do
     f thisRobotId
-    iterateRobots f remainingBotIDs
+
+    -- We may have awakened new robots in the current robot's iteration,
+    -- so we add them to the list
+    activeRIDs <- zoomRobots $ wakeUpRobotsDoneSleeping time
+    let (_, robotsToAdd) = IS.split thisRobotId activeRIDs
+
+    iterateRobots time f $ IS.union robotsToAdd remainingBotIDs
  where
   (thisRobotId, remainingBotIDs) = IS.deleteFindMin runnableBots
 
@@ -188,9 +194,11 @@ iterateRobots f runnableBots =
 -- * Every tick, every active robot shall have exactly one opportunity to run.
 -- * The sequence in which robots are chosen to run is by increasing order of 'RID'.
 runRobotIDs :: HasGameStepState sig m => IS.IntSet -> m ()
-runRobotIDs robotNames = flip iterateRobots robotNames $ \rn -> do
-  mr <- uses (robotInfo . robotMap) (IM.lookup rn)
-  forM_ mr (stepOneRobot rn)
+runRobotIDs robotNames = do
+  time <- use $ temporal . ticks
+  flip (iterateRobots time) robotNames $ \rn -> do
+    mr <- uses (robotInfo . robotMap) (IM.lookup rn)
+    forM_ mr (stepOneRobot rn)
  where
   stepOneRobot :: HasGameStepState sig m => RID -> Robot -> m ()
   stepOneRobot rn rob = tickRobot rob >>= insertBackRobot rn

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -86,8 +86,7 @@ import Prelude hiding (Applicative (..), lookup)
 gameTick :: (Has (State GameState) sig m, Has (Lift IO) sig m, Has Effect.Time sig m) => m Bool
 gameTick = do
   time <- use $ temporal . ticks
-  zoomRobots $ wakeUpRobotsDoneSleeping time
-  active <- use $ robotInfo . activeRobots
+  active <- zoomRobots $ wakeUpRobotsDoneSleeping time
   focusedRob <- use $ robotInfo . focusedRobotID
 
   ticked <-

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -86,7 +86,7 @@ import Prelude hiding (Applicative (..), lookup)
 gameTick :: HasGameStepState sig m => m Bool
 gameTick = do
   time <- use $ temporal . ticks
-  void $ zoomRobots $ wakeUpRobotsDoneSleeping time
+  zoomRobots $ wakeUpRobotsDoneSleeping time
   active <- use $ robotInfo . activeRobots
   focusedRob <- use $ robotInfo . focusedRobotID
 
@@ -204,16 +204,22 @@ iterateRobots time f runnableBots =
 
     -- We may have awakened new robots in the current robot's iteration,
     -- so we add them to the list
-    robotsToAdd <- zoomRobots $ wakeUpRobotsDoneSleeping time
+    poolAugmentation <- do
+      -- NOTE: We could use 'IS.split thisRobotId activeRIDsThisTick'
+      -- to ensure that we only insert RIDs greater than 'thisRobotId'
+      -- into the queue.
+      -- However, we already ensure in 'wakeWatchingRobots' that only
+      -- robots with a larger RID are scheduled for the current tick;
+      -- robots with smaller RIDs will be scheduled for the next tick.
+      robotsToAdd <- use $ robotInfo . currentTickWakeableBots
+      if null robotsToAdd
+        then return id
+        else do
+          zoomRobots $ wakeUpRobotsDoneSleeping time
+          robotInfo . currentTickWakeableBots .= []
+          return $ IS.union $ IS.fromList robotsToAdd
 
-    -- NOTE: We could use 'IS.split thisRobotId activeRIDsThisTick'
-    -- to ensure that we only insert RIDs greater than 'thisRobotId'
-    -- into the queue.
-    -- However, we already ensure in 'wakeWatchingRobots' that only
-    -- robots with a larger RID are scheduled for the current tick;
-    -- robots with smaller RIDs will be scheduled for the next tick.
-
-    iterateRobots time f $ IS.union robotsToAdd remainingBotIDs
+    iterateRobots time f $ poolAugmentation remainingBotIDs
 
 -- | This is a helper function to do one robot step or run robots before/after.
 singleStep :: HasGameStepState sig m => SingleStep -> RID -> IS.IntSet -> m Bool

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -60,7 +60,7 @@ lookInDirection d = do
 
 -- | Modify the entity (if any) at a given location.
 updateEntityAt ::
-  (Has (State GameState) sig m) =>
+  (Has (State Robot) sig m, Has (State GameState) sig m) =>
   Cosmic Location ->
   (Maybe Entity -> Maybe Entity) ->
   m ()
@@ -71,7 +71,8 @@ updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
 
   forM_ (WM.getModification =<< someChange) $ \modType -> do
     currentTick <- use $ temporal . ticks
-    zoomRobots $ wakeWatchingRobots currentTick cLoc
+    myID <- use robotID
+    zoomRobots $ wakeWatchingRobots myID currentTick cLoc
     SRT.entityModified modType cLoc
 
     pcr <- use $ pathCaching . pathCachingRobots

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -20,6 +20,7 @@ import Control.Effect.Lens
 import Control.Effect.Lift
 import Control.Lens as Lens hiding (Const, distrib, from, parts, use, uses, view, (%=), (+=), (.=), (<+=), (<>=))
 import Control.Monad (forM_, unless, when)
+import Data.IntSet qualified as IS
 import Data.Map qualified as M
 import Data.Sequence qualified as Seq
 import Data.Set (Set)
@@ -88,10 +89,10 @@ purgeFarAwayWatches = do
   let isNearby = isNearbyOrExempt privileged myLoc
       f loc =
         if not $ isNearby loc
-          then S.delete rid
+          then IS.delete rid
           else id
 
-  robotInfo . robotsWatching %= M.filter (not . null) . M.mapWithKey f
+  robotInfo . robotsWatching %= M.filter (not . IS.null) . M.mapWithKey f
 
 verbedGrabbingCmd :: GrabbingCmd -> Text
 verbedGrabbingCmd = \case
@@ -267,7 +268,7 @@ addWatchedLocation ::
   m ()
 addWatchedLocation loc = do
   rid <- use robotID
-  robotInfo . robotsWatching %= M.insertWith (<>) loc (S.singleton rid)
+  robotInfo . robotsWatching %= M.insertWith (<>) loc (IS.singleton rid)
 
 -- | Give some entities from a parent robot (the robot represented by
 --   the ambient @State Robot@ effect) to a child robot (represented

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -366,7 +366,7 @@ createLogEntry source sev msg = do
 
 -- | replace some entity in the world with another entity
 updateWorld ::
-  (Has (State GameState) sig m, Has (Throw Exn) sig m) =>
+  (Has (State Robot) sig m, Has (State GameState) sig m, Has (Throw Exn) sig m) =>
   Const ->
   WorldUpdate Entity ->
   m ()

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -367,7 +367,7 @@ createLogEntry source sev msg = do
 
 -- | replace some entity in the world with another entity
 updateWorld ::
-  (Has (State Robot) sig m, Has (State GameState) sig m, Has (Throw Exn) sig m) =>
+  HasRobotStepState sig m =>
   Const ->
   WorldUpdate Entity ->
   m ()

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -226,7 +226,7 @@ testScenarioSolutions rs ui =
         ]
     , testGroup
         "Fun"
-        [ testSolution (Sec 10) "Fun/snake"
+        [ testSolution (Sec 20) "Fun/snake"
         ]
     , testGroup
         "Challenges"
@@ -234,7 +234,7 @@ testScenarioSolutions rs ui =
         , testSolution Default "Challenges/teleport"
         , testSolution Default "Challenges/maypole"
         , testSolution (Sec 5) "Challenges/2048"
-        , testSolution (Sec 3) "Challenges/word-search"
+        , testSolution (Sec 6) "Challenges/word-search"
         , testSolution (Sec 10) "Challenges/bridge-building"
         , testSolution (Sec 5) "Challenges/ice-cream"
         , testSolution (Sec 10) "Challenges/combo-lock"
@@ -261,7 +261,7 @@ testScenarioSolutions rs ui =
             "Ranching"
             [ testSolution Default "Challenges/Ranching/capture"
             , testSolution (Sec 60) "Challenges/Ranching/beekeeping"
-            , testSolution (Sec 10) "Challenges/Ranching/powerset"
+            , testSolution (Sec 20) "Challenges/Ranching/powerset"
             , testSolution (Sec 10) "Challenges/Ranching/fishing"
             , testSolution (Sec 30) "Challenges/Ranching/gated-paddock"
             ]

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -363,6 +363,8 @@ testScenarioSolutions rs ui =
         , testSolution Default "Testing/144-subworlds/subworld-located-robots"
         , testSolution Default "Testing/1355-combustion"
         , testSolution Default "Testing/1379-single-world-portal-reorientation"
+        , testSolution Default "Testing/1322-wait-with-instant"
+        , testSolution Default "Testing/1598-detect-entity-change"
         , testSolution Default "Testing/1399-backup-command"
         , testSolution Default "Testing/1536-custom-unwalkable-entities"
         , testSolution Default "Testing/1631-tags"

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -226,7 +226,7 @@ testScenarioSolutions rs ui =
         ]
     , testGroup
         "Fun"
-        [ testSolution (Sec 20) "Fun/snake"
+        [ testSolution (Sec 10) "Fun/snake"
         ]
     , testGroup
         "Challenges"
@@ -234,7 +234,7 @@ testScenarioSolutions rs ui =
         , testSolution Default "Challenges/teleport"
         , testSolution Default "Challenges/maypole"
         , testSolution (Sec 5) "Challenges/2048"
-        , testSolution (Sec 6) "Challenges/word-search"
+        , testSolution (Sec 3) "Challenges/word-search"
         , testSolution (Sec 10) "Challenges/bridge-building"
         , testSolution (Sec 5) "Challenges/ice-cream"
         , testSolution (Sec 10) "Challenges/combo-lock"
@@ -261,7 +261,7 @@ testScenarioSolutions rs ui =
             "Ranching"
             [ testSolution Default "Challenges/Ranching/capture"
             , testSolution (Sec 60) "Challenges/Ranching/beekeeping"
-            , testSolution (Sec 20) "Challenges/Ranching/powerset"
+            , testSolution (Sec 10) "Challenges/Ranching/powerset"
             , testSolution (Sec 10) "Challenges/Ranching/fishing"
             , testSolution (Sec 30) "Challenges/Ranching/gated-paddock"
             ]


### PR DESCRIPTION
Apply perf idea from #1736

## Testing

To test using GHC 9.4 (set using `ghcup`), use:

    cabal test swarm-integration --test-show-details streaming --test-options '--color always --pattern "word-search"'

This report `1.88s` for this commit and `0.56s` for the `main` branch!