### PR TITLE
Allow blaze-html-0.9.2

### DIFF
--- a/swarm.cabal
+++ b/swarm.cabal
@@ -710,7 +710,7 @@ executable swarm
   build-depends:
     -- Imports shared with the library don't need bounds
     base,
-    blaze-html >=0.9.1 && <0.9.2,
+    blaze-html >=0.9.1 && <0.10,
     brick,
     fused-effects,
     githash >=0.1.6 && <0.2,


### PR DESCRIPTION
Not sure why we had such a restrictive set of bounds on `blaze-html`.  It used to be `< 0.9.2`; I changed it to `< 0.10` which should be fine according to the PVP, and it seems to build fine with version `0.9.2.0`.