### PR TITLE
Refactor hierarchy of state inputs

### DIFF
--- a/app/doc/Swarm/Doc/Gen.hs
+++ b/app/doc/Swarm/Doc/Gen.hs
@@ -38,7 +38,7 @@ import Swarm.Game.Entity qualified as E
 import Swarm.Game.Land
 import Swarm.Game.Recipe (Recipe, recipeCatalysts, recipeInputs, recipeOutputs)
 import Swarm.Game.Robot (Robot, equippedDevices, robotInventory)
-import Swarm.Game.Scenario (GameStateInputs (..), loadStandaloneScenario, scenarioLandscape)
+import Swarm.Game.Scenario (GameStateInputs (..), ScenarioInputs (..), loadStandaloneScenario, scenarioLandscape)
 import Swarm.Game.World.Gen (extractEntities)
 import Swarm.Game.World.Typecheck (Some (..), TTerm)
 import Swarm.Language.Key (specialKeyNames)
@@ -136,7 +136,7 @@ generateSpecialKeyNames =
 
 generateRecipe :: IO String
 generateRecipe = simpleErrorHandle $ do
-  (classic, GameStateInputs worlds (TerrainEntityMaps _ entities) recipes) <- loadStandaloneScenario "data/scenarios/classic.yaml"
+  (classic, GameStateInputs (ScenarioInputs worlds (TerrainEntityMaps _ entities)) recipes) <- loadStandaloneScenario "data/scenarios/classic.yaml"
   baseRobot <- instantiateBaseRobot $ classic ^. scenarioLandscape
   return . Dot.showDot $ recipesToDot baseRobot (worlds ! "classic") entities recipes
 

--- a/src/Swarm/Doc/Pedagogy.hs
+++ b/src/Swarm/Doc/Pedagogy.hs
@@ -35,6 +35,7 @@ import Swarm.Game.Failure (SystemFailure)
 import Swarm.Game.Land
 import Swarm.Game.Scenario (
   Scenario,
+  ScenarioInputs (..),
   scenarioDescription,
   scenarioMetadata,
   scenarioName,
@@ -181,7 +182,7 @@ loadScenarioCollection = simpleErrorHandle $ do
   -- all the scenarios via the usual code path; we do not need to do
   -- anything with them here while simply rendering pedagogy info.
   worlds <- ignoreWarnings @(Seq SystemFailure) $ loadWorlds tem
-  ignoreWarnings @(Seq SystemFailure) $ loadScenarios tem worlds
+  ignoreWarnings @(Seq SystemFailure) $ loadScenarios $ ScenarioInputs worlds tem
 
 renderUsagesMarkdown :: CoverageInfo -> Text
 renderUsagesMarkdown (CoverageInfo (TutorialInfo (s, si) idx _sCmds dCmds) novelCmds) =

--- a/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
+++ b/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
@@ -56,12 +56,10 @@ import Data.Sequence qualified as Seq
 import Data.Text (Text)
 import Data.Yaml as Y
 import Swarm.Game.Failure
-import Swarm.Game.Land
 import Swarm.Game.ResourceLoading (getDataDirSafe, getSwarmSavePath)
 import Swarm.Game.Scenario
 import Swarm.Game.Scenario.Scoring.CodeSize
 import Swarm.Game.Scenario.Status
-import Swarm.Game.World.Typecheck (WorldMap)
 import Swarm.Util.Effect (warn, withThrow)
 import System.Directory (canonicalizePath, doesDirectoryExist, doesFileExist, listDirectory)
 import System.FilePath (pathSeparator, splitDirectories, takeBaseName, takeExtensions, (-<.>), (</>))
@@ -137,16 +135,15 @@ flatten (SICollection _ c) = concatMap flatten $ scenarioCollectionToList c
 -- | Load all the scenarios from the scenarios data directory.
 loadScenarios ::
   (Has (Accum (Seq SystemFailure)) sig m, Has (Lift IO) sig m) =>
-  TerrainEntityMaps ->
-  WorldMap ->
+  ScenarioInputs ->
   m ScenarioCollection
-loadScenarios tem worldMap = do
+loadScenarios scenarioInputs = do
   res <- runThrow @SystemFailure $ getDataDirSafe Scenarios "scenarios"
   case res of
     Left err -> do
       warn err
       return $ SC mempty mempty
-    Right dataDir -> loadScenarioDir tem worldMap dataDir
+    Right dataDir -> loadScenarioDir scenarioInputs dataDir
 
 -- | The name of the special file which indicates the order of
 --   scenarios in a folder.
@@ -161,11 +158,10 @@ readOrderFile orderFile =
 --   the 00-ORDER file (if any) giving the order for the scenarios.
 loadScenarioDir ::
   (Has (Accum (Seq SystemFailure)) sig m, Has (Lift IO) sig m) =>
-  TerrainEntityMaps ->
-  WorldMap ->
+  ScenarioInputs ->
   FilePath ->
   m ScenarioCollection
-loadScenarioDir tem worldMap dir = do
+loadScenarioDir scenarioInputs dir = do
   let orderFile = dir </> orderFileName
       dirName = takeBaseName dir
   orderExists <- sendIO $ doesFileExist orderFile
@@ -196,7 +192,7 @@ loadScenarioDir tem worldMap dir = do
   -- Only keep the files from 00-ORDER.txt that actually exist.
   let morder' = filter (`elem` itemPaths) <$> morder
       loadItem filepath = do
-        item <- loadScenarioItem tem worldMap (dir </> filepath)
+        item <- loadScenarioItem scenarioInputs (dir </> filepath)
         return (filepath, item)
   scenarios <- mapM (runThrow @SystemFailure . loadItem) itemPaths
   let (failures, successes) = partitionEithers scenarios
@@ -257,17 +253,16 @@ loadScenarioItem ::
   , Has (Accum (Seq SystemFailure)) sig m
   , Has (Lift IO) sig m
   ) =>
-  TerrainEntityMaps ->
-  WorldMap ->
+  ScenarioInputs ->
   FilePath ->
   m ScenarioItem
-loadScenarioItem tem worldMap path = do
+loadScenarioItem scenarioInputs path = do
   isDir <- sendIO $ doesDirectoryExist path
   let collectionName = into @Text . dropWhile isSpace . takeBaseName $ path
   case isDir of
-    True -> SICollection collectionName <$> loadScenarioDir tem worldMap path
+    True -> SICollection collectionName <$> loadScenarioDir scenarioInputs path
     False -> do
-      s <- loadScenarioFile tem worldMap path
+      s <- loadScenarioFile scenarioInputs path
       eitherSi <- runThrow @SystemFailure (loadScenarioInfo path)
       case eitherSi of
         Right si -> return $ SISingle (s, si)

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -207,7 +207,7 @@ initRobots gsc =
     , _robotsWatching = mempty
     , _robotNaming =
         RobotNaming
-          { _nameGenerator = initNameParts gsc
+          { _nameGenerator = nameParts gsc
           , _gensym = 0
           }
     , _viewCenterRule = VCRobot 0

--- a/src/swarm-engine/Swarm/Game/State/Substate.hs
+++ b/src/swarm-engine/Swarm/Game/State/Substate.hs
@@ -448,4 +448,4 @@ initRecipeMaps gsc =
     , _recipesCat = catRecipeMap recipeList
     }
  where
-  recipeList = initRecipes $ initState gsc
+  recipeList = gsiRecipes $ initState gsc

--- a/src/swarm-scenario/Swarm/Game/State/Config.hs
+++ b/src/swarm-scenario/Swarm/Game/State/Config.hs
@@ -5,12 +5,16 @@
 -- 'Swarm.Game.State.GameState' record and its subrecords.
 module Swarm.Game.State.Config where
 
+import Data.Map (Map)
+import Data.Text (Text)
 import Swarm.Game.ResourceLoading (NameGenerator)
 import Swarm.Game.Scenario (GameStateInputs)
 
 -- | Record to pass information needed to create an initial
 --   'GameState' record when starting a scenario.
 data GameStateConfig = GameStateConfig
-  { initNameParts :: NameGenerator
+  { initAppDataMap :: Map Text Text
+  , nameParts :: NameGenerator
+  -- ^ Lists of words/adjectives for use in building random robot names.
   , initState :: GameStateInputs
   }

--- a/src/swarm-scenario/Swarm/Game/State/Landscape.hs
+++ b/src/swarm-scenario/Swarm/Game/State/Landscape.hs
@@ -83,7 +83,7 @@ initLandscape gsc =
   Landscape
     { _worldNavigation = Navigation mempty mempty
     , _multiWorld = mempty
-    , _terrainAndEntities = initEntityTerrain $ initState gsc
+    , _terrainAndEntities = initEntityTerrain $ gsiScenarioInputs $ initState gsc
     , _worldScrollable = True
     }
 

--- a/test/bench/Benchmark.hs
+++ b/test/bench/Benchmark.hs
@@ -6,7 +6,7 @@
 module Main where
 
 import Control.Carrier.Accum.FixedStrict (runAccum)
-import Control.Lens ((&), (.~))
+import Control.Lens (view, (&), (.~))
 import Control.Monad (replicateM_)
 import Control.Monad.State (evalStateT, execStateT)
 import Data.Map qualified as M
@@ -24,7 +24,7 @@ import Swarm.Game.Scenario (loadStandaloneScenario)
 import Swarm.Game.State (GameState, creativeMode, landscape, pureScenarioToGameState, zoomRobots)
 import Swarm.Game.State.Landscape (multiWorld)
 import Swarm.Game.State.Robot (addTRobot)
-import Swarm.Game.State.Runtime (initRuntimeState, mkGameStateConfig)
+import Swarm.Game.State.Runtime (initRuntimeState, stdGameConfigInputs)
 import Swarm.Game.Step (gameTick)
 import Swarm.Game.Terrain (blankTerrainIndex)
 import Swarm.Game.Universe (Cosmic (..), SubworldName (DefaultRootSubworld))
@@ -146,7 +146,7 @@ mkGameState prog robotMaker numRobots = do
   gs <- simpleErrorHandle $ do
     (_ :: Seq SystemFailure, initRS) <- runAccum mempty initRuntimeState
     (scenario, _) <- loadStandaloneScenario "classic"
-    return $ pureScenarioToGameState scenario 0 0 Nothing $ mkGameStateConfig initRS
+    return $ pureScenarioToGameState scenario 0 0 Nothing $ view stdGameConfigInputs initRS
 
   execStateT
     (zoomRobots $ mapM_ (addTRobot $ initMachine prog Context.empty emptyStore) robots)

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -13,6 +13,8 @@ import Control.Monad.Except (runExceptT)
 import Data.List (subsequences)
 import Data.Set (Set)
 import Data.Set qualified as S
+import Swarm.Game.State.Runtime (stdGameConfigInputs)
+import Swarm.Game.State.Substate (initState)
 import Swarm.TUI.Model (AppState, gameState, runtimeState)
 import Swarm.TUI.Model.StateUpdate (classicGame0)
 import Swarm.Util (removeSupersets, smallHittingSet)
@@ -56,7 +58,7 @@ tests s =
     , testPrettyConst
     , testBoolExpr
     , testCommands
-    , testDeviceRecipeCoverage (s ^. runtimeState)
+    , testDeviceRecipeCoverage (initState $ s ^. runtimeState . stdGameConfigInputs)
     , testHighScores
     , testEval (s ^. gameState)
     , testModel

--- a/test/unit/TestRecipeCoverage.hs
+++ b/test/unit/TestRecipeCoverage.hs
@@ -14,14 +14,14 @@ import Data.Text qualified as T
 import Swarm.Game.Entity (EntityMap (entitiesByCap), entityName)
 import Swarm.Game.Land
 import Swarm.Game.Recipe (recipeOutputs)
-import Swarm.Game.State.Runtime (RuntimeState, stdEntityTerrainMap, stdRecipes)
+import Swarm.Game.Scenario (GameStateInputs (..), initEntityTerrain)
 import Swarm.Util (commaList, quote)
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (expectFailBecause)
 import Test.Tasty.HUnit
 
-testDeviceRecipeCoverage :: RuntimeState -> TestTree
-testDeviceRecipeCoverage rs =
+testDeviceRecipeCoverage :: GameStateInputs -> TestTree
+testDeviceRecipeCoverage gsi =
   testGroup
     "Recipe coverage"
     [ expectFailBecause "Need to come up with more recipes" checkCoverage
@@ -44,8 +44,8 @@ testDeviceRecipeCoverage rs =
     -- Only include entities that grant a capability:
     entityNames =
       Set.fromList . map (^. entityName) . concat . M.elems . entitiesByCap $
-        rs ^. stdEntityTerrainMap . entityMap
+        initEntityTerrain (gsiScenarioInputs gsi) ^. entityMap
 
     getOutputsForRecipe r = map ((^. entityName) . snd) $ r ^. recipeOutputs
-    recipeOutputEntities = Set.fromList . concatMap getOutputsForRecipe $ rs ^. stdRecipes
+    recipeOutputEntities = Set.fromList . concatMap getOutputsForRecipe $ gsiRecipes gsi
     nonCoveredEntities = Set.difference entityNames recipeOutputEntities


### PR DESCRIPTION
Towards #1797

Combines `TerrainEntityMaps` and `WorldMap` into a single record, `ScenarioInputs`.

Establishes a Matroska-style arrangement of records to represent various scopes of state, eliminating several redundant fields.