### PR TITLE
Refine unit test dependencies

### DIFF
--- a/scripts/gen/render-sublibrary-dependencies.sh
+++ b/scripts/gen/render-sublibrary-dependencies.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR/../..
 # Note that "rm -f dist-newstyle/cache/plan.json" is insufficient;
 # we need remove the whole cache:
 rm -r dist-newstyle/cache
-cabal build
+cabal build --dry-run
 
 cabal-plan --hide-global --hide-builtin dot --tred --root swarm | twopi -Tsvg -o docs/image/sublibrary-graph.svg

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -800,12 +800,12 @@ test-suite swarm-unit
     TestInventory
     TestLSP
     TestLanguagePipeline
-    TestModel
     TestNotification
     TestOrdering
     TestPedagogy
     TestPretty
     TestRecipeCoverage
+    TestRepl
     TestScoring
     TestUtil
 
@@ -820,7 +820,6 @@ test-suite swarm-unit
     hashable,
     lens,
     mtl,
-    swarm,
     tasty >=0.10 && <1.6,
     tasty-expected-failure >=0.12 && <0.13,
     tasty-hunit >=0.10 && <0.11,
@@ -829,6 +828,13 @@ test-suite swarm-unit
     time,
     vty,
     witch,
+
+  build-depends:
+    swarm,
+    swarm:swarm-engine,
+    swarm:swarm-lang,
+    swarm:swarm-scenario,
+    swarm:swarm-util,
 
   hs-source-dirs: test/unit
   default-language: Haskell2010

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -34,12 +34,12 @@ import TestEval (testEval)
 import TestInventory (testInventory)
 import TestLSP (testLSP)
 import TestLanguagePipeline (testLanguagePipeline)
-import TestModel (testModel)
 import TestNotification (testNotification)
 import TestOrdering (testOrdering)
 import TestPedagogy (testPedagogy)
 import TestPretty (testPrettyConst)
 import TestRecipeCoverage (testDeviceRecipeCoverage)
+import TestRepl (testRepl)
 import TestScoring (testHighScores)
 import Witch (from)
 
@@ -61,7 +61,7 @@ tests s =
     , testDeviceRecipeCoverage (initState $ s ^. runtimeState . stdGameConfigInputs)
     , testHighScores
     , testEval (s ^. gameState)
-    , testModel
+    , testRepl
     , testPedagogy (s ^. runtimeState)
     , testInventory
     , testNotification (s ^. gameState)

--- a/test/unit/TestRepl.hs
+++ b/test/unit/TestRepl.hs
@@ -3,19 +3,19 @@
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Swarm unit tests
-module TestModel where
+-- Swarm REPL unit tests
+module TestRepl where
 
 import Data.String (fromString)
 import Data.Text (Text)
-import Swarm.TUI.Model
+import Swarm.TUI.Model.Repl
 import Test.Tasty
 import Test.Tasty.HUnit
 
-testModel :: TestTree
-testModel =
+testRepl :: TestTree
+testRepl =
   testGroup
-    "TUI Model"
+    "TUI REPL"
     [ testCase
         "latest repl lines at start"
         ( assertEqual


### PR DESCRIPTION
This is a random refactoring that does two things:

* Improves speed of `scripts/gen/render-sublibrary-dependencies.sh` script
* Refine imports of the `TestModel.hs` (renamed to `TestRepl.hs`) unit test

It appears that the only reason that the `swarm-unit` test suite imports the entire `swarm` sublibrary (hence the `brick` package), is due to `TestRepl`, which (now) imports `Swarm.TUI.Model.Repl`.  Perhaps it would make sense to separate these at some point?