### PR TITLE
Split structure assembly into separate module

### DIFF
--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -33,46 +33,11 @@ module Swarm.TUI.Model (
 
   -- * UI state
 
-  -- ** REPL
-  REPLHistItem (..),
-  replItemText,
-  isREPLEntry,
-  getREPLEntry,
-  REPLHistory,
-  replIndex,
-  replLength,
-  replSeq,
-  newREPLHistory,
-  addREPLItem,
-  restartREPLHistory,
-  getLatestREPLHistoryItems,
-  moveReplHistIndex,
-  getCurrentItemText,
-  replIndexIsAtInput,
-  TimeDir (..),
-
-  -- ** Prompt utils
-  REPLPrompt (..),
-  removeEntry,
-
   -- ** Inventory
   InventoryListEntry (..),
   _Separator,
   _InventoryEntry,
   _EquippedEntry,
-
-  -- *** REPL Panel Model
-  REPLState,
-  ReplControlMode (..),
-  replPromptType,
-  replPromptEditor,
-  replPromptText,
-  replValid,
-  replLast,
-  replType,
-  replControlMode,
-  replHistory,
-  newREPLEditor,
 
   -- ** Updating
   populateInventoryList,
@@ -132,7 +97,6 @@ import Swarm.Log
 import Swarm.TUI.Inventory.Sorting
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
-import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.UI
 import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Version (NewReleaseFailure)

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -132,7 +132,7 @@ import Swarm.TUI.Launch.Model
 import Swarm.TUI.Launch.View
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Goal (goalsContent, hasAnythingToShow)
-import Swarm.TUI.Model.Repl (getSessionREPLHistoryItems, lastEntry)
+import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.UI
 import Swarm.TUI.Panel
 import Swarm.TUI.View.Achievement

--- a/src/swarm-scenario/Swarm/Game/Scenario.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario.hs
@@ -99,6 +99,7 @@ import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.Navigation.Portal
 import Swarm.Game.Scenario.Topography.Navigation.Waypoint (Parentage (..))
 import Swarm.Game.Scenario.Topography.Structure qualified as Structure
+import Swarm.Game.Scenario.Topography.Structure.Assembly qualified as Assembly
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Symmetry
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type (SymmetryAnnotatedGrid (..))
 import Swarm.Game.Scenario.Topography.WorldDescription
@@ -333,7 +334,7 @@ instance FromJSONE ScenarioInputs Scenario where
       mergedStructures <-
         either (fail . T.unpack) return $
           mapM
-            (sequenceA . (id &&& (Structure.mergeStructures mempty Root . Structure.structure)))
+            (sequenceA . (id &&& (Assembly.mergeStructures mempty Root . Structure.structure)))
             rootLevelSharedStructures
 
       let namedGrids = map (\(ns, Structure.MergedStructure s _ _) -> Grid s <$ ns) mergedStructures

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Placement.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Placement.hs
@@ -67,16 +67,23 @@ applyOrientationTransform (Orientation upDir shouldFlip) =
     DEast -> transpose . flipV
     DWest -> flipV . transpose
 
+data Pose = Pose
+  { offset :: Location
+  , orient :: Orientation
+  }
+  deriving (Eq, Show)
+
 data Placement = Placement
   { src :: StructureName
-  , offset :: Location
-  , orient :: Orientation
+  , structurePose :: Pose
   }
   deriving (Eq, Show)
 
 instance FromJSON Placement where
   parseJSON = withObject "structure placement" $ \v -> do
     sName <- v .: "src"
-    Placement sName
-      <$> v .:? "offset" .!= origin
-      <*> v .:? "orient" .!= defaultOrientation
+    p <-
+      Pose
+        <$> v .:? "offset" .!= origin
+        <*> v .:? "orient" .!= defaultOrientation
+    return $ Placement sName p

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure.hs
@@ -7,18 +7,10 @@
 -- as well as logic for combining them.
 module Swarm.Game.Scenario.Topography.Structure where
 
-import Control.Applicative ((<|>))
-import Control.Arrow (left, (&&&))
-import Control.Monad (when)
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
-import Data.Coerce
-import Data.Either.Extra (maybeToEither)
-import Data.Foldable (foldrM)
-import Data.Map qualified as M
 import Data.Maybe (catMaybes)
 import Data.Set (Set)
-import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Yaml as Y
@@ -30,8 +22,8 @@ import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.Navigation.Waypoint
 import Swarm.Game.Scenario.Topography.Placement
 import Swarm.Game.Scenario.Topography.WorldPalette
-import Swarm.Language.Direction (AbsoluteDir, directionJsonModifier)
-import Swarm.Util (commaList, failT, quote, showT)
+import Swarm.Language.Direction (AbsoluteDir)
+import Swarm.Util (failT, showT)
 import Swarm.Util.Yaml
 import Witch (into)
 
@@ -93,123 +85,6 @@ instance HasLocation LocatedStructure where
     LocatedStructure x y $ f originalLoc
 
 data MergedStructure c = MergedStructure [[c]] [LocatedStructure] [Originated Waypoint]
-
--- | Destructively overlays one direct child structure
--- upon the input structure.
--- However, the child structure is assembled recursively.
-overlaySingleStructure ::
-  M.Map StructureName (NamedStructure (Maybe a)) ->
-  Placed (Maybe a) ->
-  MergedStructure (Maybe a) ->
-  Either Text (MergedStructure (Maybe a))
-overlaySingleStructure
-  inheritedStrucDefs
-  (Placed p@(Placement _ loc@(Location colOffset rowOffset) orientation) ns)
-  (MergedStructure inputArea inputPlacements inputWaypoints) = do
-    MergedStructure overlayArea overlayPlacements overlayWaypoints <-
-      mergeStructures inheritedStrucDefs (WithParent p) $ structure ns
-
-    let mergedWaypoints = inputWaypoints <> map (fmap $ placeOnArea overlayArea) overlayWaypoints
-        mergedPlacements = inputPlacements <> map (placeOnArea overlayArea) overlayPlacements
-        mergedArea = zipWithPad mergeSingleRow inputArea $ paddedOverlayRows overlayArea
-
-    return $ MergedStructure mergedArea mergedPlacements mergedWaypoints
-   where
-    placeOnArea overArea =
-      offsetLoc (coerce loc)
-        . modifyLoc (reorientLandmark orientation $ getAreaDimensions overArea)
-
-    zipWithPad f a b = zipWith f a $ b <> repeat Nothing
-
-    affineTransformedOverlay = applyOrientationTransform orientation
-
-    mergeSingleRow inputRow maybeOverlayRow =
-      zipWithPad (flip (<|>)) inputRow paddedSingleOverlayRow
-     where
-      paddedSingleOverlayRow = maybe [] (applyOffset colOffset) maybeOverlayRow
-
-    paddedOverlayRows = applyOffset (negate rowOffset) . map Just . affineTransformedOverlay
-    applyOffset offsetNum = modifyFront
-     where
-      integralOffset = fromIntegral offsetNum
-      modifyFront =
-        if integralOffset >= 0
-          then (replicate integralOffset Nothing <>)
-          else drop $ abs integralOffset
-
-elaboratePlacement :: Parentage Placement -> Either Text a -> Either Text a
-elaboratePlacement p = left (elaboration <>)
- where
-  pTxt = case p of
-    Root -> "root placement"
-    WithParent (Placement (StructureName sn) loc _) ->
-      T.unwords
-        [ "placement of"
-        , quote sn
-        , "at"
-        , showT loc
-        ]
-  elaboration =
-    T.unwords
-      [ "Within"
-      , pTxt <> ":"
-      , ""
-      ]
-
--- | Overlays all of the "child placements", such that the children encountered earlier
--- in the YAML file supersede the later ones (due to use of 'foldr' instead of 'foldl').
-mergeStructures ::
-  M.Map StructureName (NamedStructure (Maybe a)) ->
-  Parentage Placement ->
-  PStructure (Maybe a) ->
-  Either Text (MergedStructure (Maybe a))
-mergeStructures inheritedStrucDefs parentPlacement (Structure origArea subStructures subPlacements subWaypoints) = do
-  overlays <- elaboratePlacement parentPlacement $ mapM g subPlacements
-  let wrapPlacement (Placed z ns) = LocatedStructure (name ns) (up $ orient z) $ offset z
-      wrappedOverlays = map wrapPlacement $ filter (\(Placed _ ns) -> isRecognizable ns) overlays
-  foldrM
-    (overlaySingleStructure structureMap)
-    (MergedStructure origArea wrappedOverlays originatedWaypoints)
-    overlays
- where
-  originatedWaypoints = map (Originated parentPlacement) subWaypoints
-
-  -- deeper definitions override the outer (toplevel) ones
-  structureMap = M.union (M.fromList $ map (name &&& id) subStructures) inheritedStrucDefs
-
-  g placement@(Placement sName@(StructureName n) _ orientation) = do
-    t@(_, ns) <-
-      maybeToEither
-        (T.unwords ["Could not look up structure", quote n])
-        $ sequenceA (placement, M.lookup sName structureMap)
-    let placementDirection = up orientation
-        recognizedOrientations = recognize ns
-    when (isRecognizable ns) $ do
-      when (flipped orientation) $
-        Left $
-          T.unwords
-            [ "Placing recognizable structure"
-            , quote n
-            , "with flipped orientation is not supported."
-            ]
-
-      -- Redundant orientations by rotational symmetry are accounted
-      -- for at scenario parse time
-      when (Set.notMember placementDirection recognizedOrientations) $
-        Left $
-          T.unwords
-            [ "Placing recognizable structure"
-            , quote n
-            , "with"
-            , renderDir placementDirection
-            , "orientation is not supported."
-            , "Try"
-            , commaList $ map renderDir $ Set.toList recognizedOrientations
-            , "instead."
-            ]
-    return $ uncurry Placed t
-   where
-    renderDir = quote . T.pack . directionJsonModifier . show
 
 instance FromJSONE (TerrainEntityMaps, RobotMap) (PStructure (Maybe Cell)) where
   parseJSONE = withObjectE "structure definition" $ \v -> do

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure/Assembly.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure/Assembly.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Definitions of "structures" for use within a map
+-- as well as logic for combining them.
+module Swarm.Game.Scenario.Topography.Structure.Assembly where
+
+import Control.Applicative ((<|>))
+import Control.Arrow (left, (&&&))
+import Control.Monad (when)
+import Data.Coerce
+import Data.Either.Extra (maybeToEither)
+import Data.Foldable (foldrM)
+import Data.Map qualified as M
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Swarm.Game.Location
+import Swarm.Game.Scenario.Topography.Area
+import Swarm.Game.Scenario.Topography.Navigation.Waypoint
+import Swarm.Game.Scenario.Topography.Placement
+import Swarm.Game.Scenario.Topography.Structure
+import Swarm.Language.Direction (directionJsonModifier)
+import Swarm.Util (commaList, quote, showT)
+
+-- | Destructively overlays one direct child structure
+-- upon the input structure.
+-- However, the child structure is assembled recursively.
+overlaySingleStructure ::
+  M.Map StructureName (NamedStructure (Maybe a)) ->
+  Placed (Maybe a) ->
+  MergedStructure (Maybe a) ->
+  Either Text (MergedStructure (Maybe a))
+overlaySingleStructure
+  inheritedStrucDefs
+  (Placed p@(Placement _ loc@(Location colOffset rowOffset) orientation) ns)
+  (MergedStructure inputArea inputPlacements inputWaypoints) = do
+    MergedStructure overlayArea overlayPlacements overlayWaypoints <-
+      mergeStructures inheritedStrucDefs (WithParent p) $ structure ns
+
+    let mergedWaypoints = inputWaypoints <> map (fmap $ placeOnArea overlayArea) overlayWaypoints
+        mergedPlacements = inputPlacements <> map (placeOnArea overlayArea) overlayPlacements
+        mergedArea = zipWithPad mergeSingleRow inputArea $ paddedOverlayRows overlayArea
+
+    return $ MergedStructure mergedArea mergedPlacements mergedWaypoints
+   where
+    placeOnArea overArea =
+      offsetLoc (coerce loc)
+        . modifyLoc (reorientLandmark orientation $ getAreaDimensions overArea)
+
+    zipWithPad f a b = zipWith f a $ b <> repeat Nothing
+
+    affineTransformedOverlay = applyOrientationTransform orientation
+
+    mergeSingleRow inputRow maybeOverlayRow =
+      zipWithPad (flip (<|>)) inputRow paddedSingleOverlayRow
+     where
+      paddedSingleOverlayRow = maybe [] (applyOffset colOffset) maybeOverlayRow
+
+    paddedOverlayRows = applyOffset (negate rowOffset) . map Just . affineTransformedOverlay
+    applyOffset offsetNum = modifyFront
+     where
+      integralOffset = fromIntegral offsetNum
+      modifyFront =
+        if integralOffset >= 0
+          then (replicate integralOffset Nothing <>)
+          else drop $ abs integralOffset
+
+elaboratePlacement :: Parentage Placement -> Either Text a -> Either Text a
+elaboratePlacement p = left (elaboration <>)
+ where
+  pTxt = case p of
+    Root -> "root placement"
+    WithParent (Placement (StructureName sn) loc _) ->
+      T.unwords
+        [ "placement of"
+        , quote sn
+        , "at"
+        , showT loc
+        ]
+  elaboration =
+    T.unwords
+      [ "Within"
+      , pTxt <> ":"
+      , ""
+      ]
+
+-- | Overlays all of the "child placements", such that the children encountered earlier
+-- in the YAML file supersede the later ones (due to use of 'foldr' instead of 'foldl').
+mergeStructures ::
+  M.Map StructureName (NamedStructure (Maybe a)) ->
+  Parentage Placement ->
+  PStructure (Maybe a) ->
+  Either Text (MergedStructure (Maybe a))
+mergeStructures inheritedStrucDefs parentPlacement (Structure origArea subStructures subPlacements subWaypoints) = do
+  overlays <- elaboratePlacement parentPlacement $ mapM g subPlacements
+  let wrapPlacement (Placed z ns) = LocatedStructure (name ns) (up $ orient z) $ offset z
+      wrappedOverlays = map wrapPlacement $ filter (\(Placed _ ns) -> isRecognizable ns) overlays
+  foldrM
+    (overlaySingleStructure structureMap)
+    (MergedStructure origArea wrappedOverlays originatedWaypoints)
+    overlays
+ where
+  originatedWaypoints = map (Originated parentPlacement) subWaypoints
+
+  -- deeper definitions override the outer (toplevel) ones
+  structureMap = M.union (M.fromList $ map (name &&& id) subStructures) inheritedStrucDefs
+
+  g placement@(Placement sName@(StructureName n) _ orientation) = do
+    t@(_, ns) <-
+      maybeToEither
+        (T.unwords ["Could not look up structure", quote n])
+        $ sequenceA (placement, M.lookup sName structureMap)
+    let placementDirection = up orientation
+        recognizedOrientations = recognize ns
+    when (isRecognizable ns) $ do
+      when (flipped orientation) $
+        Left $
+          T.unwords
+            [ "Placing recognizable structure"
+            , quote n
+            , "with flipped orientation is not supported."
+            ]
+
+      -- Redundant orientations by rotational symmetry are accounted
+      -- for at scenario parse time
+      when (Set.notMember placementDirection recognizedOrientations) $
+        Left $
+          T.unwords
+            [ "Placing recognizable structure"
+            , quote n
+            , "with"
+            , renderDir placementDirection
+            , "orientation is not supported."
+            , "Try"
+            , commaList $ map renderDir $ Set.toList recognizedOrientations
+            , "instead."
+            ]
+    return $ uncurry Placed t
+   where
+    renderDir = quote . T.pack . directionJsonModifier . show

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure/Assembly.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure/Assembly.hs
@@ -5,7 +5,10 @@
 --
 -- Definitions of "structures" for use within a map
 -- as well as logic for combining them.
-module Swarm.Game.Scenario.Topography.Structure.Assembly where
+module Swarm.Game.Scenario.Topography.Structure.Assembly (
+  mergeStructures,
+)
+where
 
 import Control.Applicative ((<|>))
 import Control.Arrow (left, (&&&))
@@ -25,6 +28,32 @@ import Swarm.Game.Scenario.Topography.Structure
 import Swarm.Language.Direction (directionJsonModifier)
 import Swarm.Util (commaList, quote, showT)
 
+overlayGrid ::
+  [[Maybe a]] ->
+  Pose ->
+  [[Maybe a]] ->
+  [[Maybe a]]
+overlayGrid inputArea (Pose (Location colOffset rowOffset) orientation) overlayArea =
+  zipWithPad mergeSingleRow inputArea $ paddedOverlayRows overlayArea
+ where
+  zipWithPad f a b = zipWith f a $ b <> repeat Nothing
+
+  mergeSingleRow inputRow maybeOverlayRow =
+    zipWithPad (flip (<|>)) inputRow paddedSingleOverlayRow
+   where
+    paddedSingleOverlayRow = maybe [] (applyOffset colOffset) maybeOverlayRow
+
+  affineTransformedOverlay = applyOrientationTransform orientation
+
+  paddedOverlayRows = applyOffset (negate rowOffset) . map Just . affineTransformedOverlay
+  applyOffset offsetNum = modifyFront
+   where
+    integralOffset = fromIntegral offsetNum
+    modifyFront =
+      if integralOffset >= 0
+        then (replicate integralOffset Nothing <>)
+        else drop $ abs integralOffset
+
 -- | Destructively overlays one direct child structure
 -- upon the input structure.
 -- However, the child structure is assembled recursively.
@@ -35,14 +64,14 @@ overlaySingleStructure ::
   Either Text (MergedStructure (Maybe a))
 overlaySingleStructure
   inheritedStrucDefs
-  (Placed p@(Placement _ loc@(Location colOffset rowOffset) orientation) ns)
+  (Placed p@(Placement _ pose@(Pose loc orientation)) ns)
   (MergedStructure inputArea inputPlacements inputWaypoints) = do
     MergedStructure overlayArea overlayPlacements overlayWaypoints <-
       mergeStructures inheritedStrucDefs (WithParent p) $ structure ns
 
     let mergedWaypoints = inputWaypoints <> map (fmap $ placeOnArea overlayArea) overlayWaypoints
         mergedPlacements = inputPlacements <> map (placeOnArea overlayArea) overlayPlacements
-        mergedArea = zipWithPad mergeSingleRow inputArea $ paddedOverlayRows overlayArea
+        mergedArea = overlayGrid inputArea pose overlayArea
 
     return $ MergedStructure mergedArea mergedPlacements mergedWaypoints
    where
@@ -50,30 +79,12 @@ overlaySingleStructure
       offsetLoc (coerce loc)
         . modifyLoc (reorientLandmark orientation $ getAreaDimensions overArea)
 
-    zipWithPad f a b = zipWith f a $ b <> repeat Nothing
-
-    affineTransformedOverlay = applyOrientationTransform orientation
-
-    mergeSingleRow inputRow maybeOverlayRow =
-      zipWithPad (flip (<|>)) inputRow paddedSingleOverlayRow
-     where
-      paddedSingleOverlayRow = maybe [] (applyOffset colOffset) maybeOverlayRow
-
-    paddedOverlayRows = applyOffset (negate rowOffset) . map Just . affineTransformedOverlay
-    applyOffset offsetNum = modifyFront
-     where
-      integralOffset = fromIntegral offsetNum
-      modifyFront =
-        if integralOffset >= 0
-          then (replicate integralOffset Nothing <>)
-          else drop $ abs integralOffset
-
 elaboratePlacement :: Parentage Placement -> Either Text a -> Either Text a
 elaboratePlacement p = left (elaboration <>)
  where
   pTxt = case p of
     Root -> "root placement"
-    WithParent (Placement (StructureName sn) loc _) ->
+    WithParent (Placement (StructureName sn) (Pose loc _)) ->
       T.unwords
         [ "placement of"
         , quote sn
@@ -96,7 +107,9 @@ mergeStructures ::
   Either Text (MergedStructure (Maybe a))
 mergeStructures inheritedStrucDefs parentPlacement (Structure origArea subStructures subPlacements subWaypoints) = do
   overlays <- elaboratePlacement parentPlacement $ mapM g subPlacements
-  let wrapPlacement (Placed z ns) = LocatedStructure (name ns) (up $ orient z) $ offset z
+  let wrapPlacement (Placed z ns) = LocatedStructure (name ns) (up $ orient structPose) $ offset structPose
+       where
+        structPose = structurePose z
       wrappedOverlays = map wrapPlacement $ filter (\(Placed _ ns) -> isRecognizable ns) overlays
   foldrM
     (overlaySingleStructure structureMap)
@@ -108,7 +121,7 @@ mergeStructures inheritedStrucDefs parentPlacement (Structure origArea subStruct
   -- deeper definitions override the outer (toplevel) ones
   structureMap = M.union (M.fromList $ map (name &&& id) subStructures) inheritedStrucDefs
 
-  g placement@(Placement sName@(StructureName n) _ orientation) = do
+  g placement@(Placement sName@(StructureName n) (Pose _ orientation)) = do
     t@(_, ns) <-
       maybeToEither
         (T.unwords ["Could not look up structure", quote n])

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldDescription.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldDescription.hs
@@ -32,6 +32,7 @@ import Swarm.Game.Scenario.Topography.Structure (
   PStructure (Structure),
  )
 import Swarm.Game.Scenario.Topography.Structure qualified as Structure
+import Swarm.Game.Scenario.Topography.Structure.Assembly qualified as Assembly
 import Swarm.Game.Scenario.Topography.WorldPalette
 import Swarm.Game.Universe
 import Swarm.Game.World.Parse ()
@@ -91,7 +92,7 @@ instance FromJSONE WorldParseDependencies WorldDescription where
 
     MergedStructure mergedArea staticStructurePlacements unmergedWaypoints <-
       either (fail . T.unpack) return $
-        Structure.mergeStructures mempty Root struc
+        Assembly.mergeStructures mempty Root struc
 
     let absoluteStructurePlacements =
           map (offsetLoc $ coerce upperLeft) staticStructurePlacements

--- a/src/swarm-web/Swarm/Web.hs
+++ b/src/swarm-web/Swarm/Web.hs
@@ -82,6 +82,7 @@ import Swarm.Language.Pretty (prettyTextLine)
 import Swarm.Language.Syntax
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Goal
+import Swarm.TUI.Model.Repl (REPLHistItem, replHistory, replSeq)
 import Swarm.TUI.Model.UI
 import Swarm.Util.ReadableIORef
 import Swarm.Util.RingBuffer

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -64,7 +64,6 @@ flag ci
 common common
   if flag(ci)
     ghc-options: -Werror
-
   ghc-options:
     -Wall
     -Wcompat
@@ -90,26 +89,26 @@ common ghc2021-extensions
   default-extensions:
     -- Note we warn on prequalified
     -- Not GHC2021, but until we get \cases we use \case a lot
-    MultiParamTypeClasses
-    RankNTypes
-    ScopedTypeVariables
+    BangPatterns
+    DeriveAnyClass
+    DeriveDataTypeable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ExplicitForAll
     FlexibleContexts
     FlexibleInstances
-    BangPatterns
-    StandaloneDeriving
-    TypeOperators
     GADTSyntax
-    DeriveDataTypeable
-    DeriveGeneric
-    TupleSections
-    LambdaCase
-    ExplicitForAll
-    DeriveFunctor
-    DeriveTraversable
-    DeriveAnyClass
-    TypeApplications
-    NumericUnderscores
     ImportQualifiedPost
+    LambdaCase
+    MultiParamTypeClasses
+    NumericUnderscores
+    RankNTypes
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+    TypeOperators
 
 library swarm-lang
   import: stan-config, common, ghc2021-extensions

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -64,6 +64,7 @@ flag ci
 common common
   if flag(ci)
     ghc-options: -Werror
+
   ghc-options:
     -Wall
     -Wcompat
@@ -89,26 +90,26 @@ common ghc2021-extensions
   default-extensions:
     -- Note we warn on prequalified
     -- Not GHC2021, but until we get \cases we use \case a lot
-    BangPatterns
-    DeriveAnyClass
-    DeriveDataTypeable
-    DeriveFunctor
-    DeriveGeneric
-    DeriveTraversable
-    ExplicitForAll
-    FlexibleContexts
-    FlexibleInstances
-    GADTSyntax
-    ImportQualifiedPost
-    LambdaCase
     MultiParamTypeClasses
-    NumericUnderscores
     RankNTypes
     ScopedTypeVariables
+    FlexibleContexts
+    FlexibleInstances
+    BangPatterns
     StandaloneDeriving
-    TupleSections
-    TypeApplications
     TypeOperators
+    GADTSyntax
+    DeriveDataTypeable
+    DeriveGeneric
+    TupleSections
+    LambdaCase
+    ExplicitForAll
+    DeriveFunctor
+    DeriveTraversable
+    DeriveAnyClass
+    TypeApplications
+    NumericUnderscores
+    ImportQualifiedPost
 
 library swarm-lang
   import: stan-config, common, ghc2021-extensions
@@ -215,6 +216,7 @@ library swarm-scenario
     Swarm.Game.Scenario.Topography.Navigation.Waypoint
     Swarm.Game.Scenario.Topography.Placement
     Swarm.Game.Scenario.Topography.Structure
+    Swarm.Game.Scenario.Topography.Structure.Assembly
     Swarm.Game.Scenario.Topography.Structure.Recognition
     Swarm.Game.Scenario.Topography.Structure.Recognition.Log
     Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute


### PR DESCRIPTION
Split the `Structure.hs` module in preparation for #1780.  This refactoring entails no functional change.

# Also included
* follow-up to #1804 to remove REPL re-exports
* reformat `swarm.cabal` for the latest version of `cabal-gild`