### PR TITLE
spreadable plant growth 

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -64,3 +64,5 @@ Achievements
 1775-custom-terrain.yaml
 1642-biomes.yaml
 1780-structure-merge-expansion
+1533-sow-command.yaml
+1533-sow-seed-maturation.yaml

--- a/data/scenarios/Testing/1533-sow-command.yaml
+++ b/data/scenarios/Testing/1533-sow-command.yaml
@@ -1,0 +1,195 @@
+version: 1
+name: Sow command and spread
+seed: 0
+description: |
+  Demonstrate `sow` command and spreading growth with biome restrictions.
+
+  Illustrates different rates of spread for different crops.
+creative: false
+attrs:
+  - name: clay
+    fg: "#444444"
+    bg: "#c2b280"
+  - name: wheat
+    fg: "#444444"
+    bg: "#F5DEB3"
+  - name: barley
+    fg: "#444444"
+    bg: "#F6E9B1"
+  - name: maize
+    fg: "#444444"
+    bg: "#FBEC5D"
+  - name: mint
+    bg: "#3EB489"
+terrains:
+  - name: clay
+    attr: clay
+    description: |
+      Sandy soil
+objectives:
+  - goal:
+      - |
+        Observe `kudzu`{=entity} spread
+    condition: |
+      r <- robotnamed "kudzubot";
+      as r {
+        kCount <- resonate "kudzu" ((0, 0), (10, 4));
+        return $ kCount >= 45;
+      }
+solution: |
+  def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
+
+  doN 6 move;
+  harvest;
+
+  doN 13 move;
+  turn right;
+  harvest;
+  doN 6 move;
+
+  sow "mint";
+  turn right;
+  doN 13 move;
+
+  sow "barley";
+  turn left;
+  doN 7 move;
+  sow "barley";
+  turn left;
+
+  doN 13 move;
+  sow "kudzu";
+  doN 6 move;
+robots:
+  - name: base
+    dir: east
+    devices:
+      - branch predictor
+      - calculator
+      - comparator
+      - dictionary
+      - harvester
+      - logger
+      - seed spreader
+      - treads
+    inventory:
+      - [2, barley]
+      - [1, kudzu]
+      - [1, mint]
+  - name: kudzubot
+    dir: east
+    system: true
+entities:
+  - name: wheat
+    display:
+      char: 'w'
+      attr: wheat
+    description:
+      - Grain
+    properties: [known, pickable, growable]
+    growth:
+      duration: [20, 30]
+      spread:
+        radius: 2
+        density: 0.3
+    biomes: [dirt, clay]
+  - name: barley
+    display:
+      char: 'b'
+      attr: barley
+    description:
+      - Grain
+    properties: [known, pickable, growable]
+    growth:
+      duration: [30, 50]
+      spread:
+        radius: 2
+        density: 0.3
+    biomes: [dirt, clay]
+  - name: corn
+    display:
+      char: 'c'
+      attr: maize
+    description:
+      - Animal feed
+    properties: [known, pickable, growable]
+    growth:
+      duration: [30, 60]
+      spread:
+        radius: 3
+        density: 0.1
+    biomes: [dirt, clay]
+  - name: kudzu
+    display:
+      char: 'k'
+      attr: plant
+    description:
+      - Dense, impassable plant.
+    properties: [known, unwalkable, growable]
+    growth:
+      duration: [30, 50]
+      spread:
+        radius: 1
+        density: 3
+    biomes: [dirt, clay]
+  - name: mint
+    display:
+      char: 'm'
+      attr: mint
+    description:
+      - Invasive
+    properties: [known, pickable, growable]
+    growth:
+      duration: [10, 50]
+      spread:
+        radius: 2
+        density: 0.6
+    biomes: [dirt, clay]
+  - name: seed spreader
+    display:
+      char: 's'
+    description:
+      - A handheld pouch with a manual crank to broadcast seeds evenly within a small radius
+    properties: [known]
+    capabilities: [sow]
+known: [flower]
+world:
+  default: [blank]
+  palette:
+    '.': [grass]
+    'B': [grass, null, base]
+    'd': [dirt]
+    'c': [clay]
+    'K': [clay, null, kudzubot]
+    'C': [dirt, corn]
+    'W': [clay, wheat]
+  upperleft: [-1, 1]
+  map: |
+    ..........................
+    .ddddddddddd..ccccccccccc.
+    .ddddddddddd..ccccccccccc.
+    BdddddCddddd..cccccWccccc.
+    .ddddddddddd..ccccccccccc.
+    .ddddddddddd..ccccccccccc.
+    ..........................
+    .ccccccccccc..ddddddddddd.
+    .ccccccccccc..ddddddddddd.
+    .ccccccccccc..ddddddddddd.
+    .ccccccccccc..ddddddddddd.
+    .ccccccccccc..ddddddddddd.
+    ..........................
+    ..........................
+    .ddddddddddd..ccccccccccc.
+    .ddddddddddd..ccccccccccc.
+    .ddddddddddd..ccccccccccc.
+    .ddddddddddd..ccccccccccc.
+    .ddddddddddd..Kcccccccccc.
+    ..........................
+    ..........................
+    ..........................
+    .ccccccccccc..ddddddddddd.
+    .ccccccccccc..ddddddddddd.
+    .ccccccccccc..ddddddddddd.
+    .ccccccccccc..ddddddddddd.
+    .ccccccccccc..ddddddddddd.
+    ..........................

--- a/data/scenarios/Testing/1533-sow-seed-maturation.yaml
+++ b/data/scenarios/Testing/1533-sow-seed-maturation.yaml
@@ -69,7 +69,7 @@ entities:
       char: 'a'
     description:
       - Seed of an `oak`{=entity}
-    properties: [known, growable]
+    properties: [known, pickable, growable]
     growth:
       duration: [200, 300]
       mature: oak

--- a/data/scenarios/Testing/1533-sow-seed-maturation.yaml
+++ b/data/scenarios/Testing/1533-sow-seed-maturation.yaml
@@ -1,0 +1,101 @@
+version: 1
+name: Seed maturation
+description: |
+  A seed grows into a different entity, which again
+  yields the original seed when harvested.
+
+  The 'mature' sub-property of the 'growth' property
+  facilitates the distinction between seeds and the
+  entities those seeds produce. For example, it doesn't make much sense
+  to plant an `acorn`{=entity} and call the resulting,
+  fully-grown plant also an `acorn`{=entity}.
+
+  In combination with 'yields', it
+  effectively precludes the grown entity (as it exists in the world)
+  from entering into the player's inventory.
+creative: false
+objectives:
+  - id: plant_acorn
+    goal:
+      - |
+        Plant an `acorn`{=entity}
+    condition: |
+      as base {
+        x <- has "acorn";
+        return $ not x;
+      }
+  - goal:
+      - |
+        Go to the `oak`{=entity}
+    condition: |
+      as base {
+        ishere "oak";
+      }
+  - goal:
+      - |
+        Pick another `acorn`{=entity}
+    prerequisite: plant_acorn
+    condition: |
+      as base {
+        has "acorn";
+      }
+solution: |
+  sow "acorn";
+  move;
+  watch back;
+  turn back;
+  wait 1000;
+  move;
+  harvest;
+robots:
+  - name: base
+    dir: east
+    devices:
+      - branch predictor
+      - calculator
+      - comparator
+      - dictionary
+      - harvester
+      - logger
+      - rolex
+      - scanner
+      - seed spreader
+      - treads
+    inventory:
+      - [1, acorn]
+entities:
+  - name: acorn
+    display:
+      char: 'a'
+    description:
+      - Seed of an `oak`{=entity}
+    properties: [known, growable]
+    growth:
+      duration: [200, 300]
+      mature: oak
+  - name: oak
+    display:
+      char: 'k'
+    description:
+      - Grows from an `acorn`{=entity}
+    properties: [known, pickable, growable]
+    growth:
+      duration: [200, 300]
+    yields: acorn
+  - name: seed spreader
+    display:
+      char: 's'
+    description:
+      - A handheld pouch with a manual crank to broadcast seeds evenly within a small radius
+    properties: [known]
+    capabilities: [sow]
+world:
+  default: [blank]
+  palette:
+    '.': [grass]
+    'B': [grass, null, base]
+  upperleft: [-2, 2]
+  map: |
+    .....
+    ..B..
+    .....

--- a/data/schema/display.json
+++ b/data/schema/display.json
@@ -57,6 +57,11 @@
             "default": false,
             "type": "boolean",
             "description": "Whether the entity or robot should be invisible. Invisible entities and robots are not drawn, but can still be interacted with in otherwise normal ways. System robots are by default invisible."
+        },
+        "inheritable": {
+            "default": true,
+            "type": "boolean",
+            "description": "Whether robot children inherit this display."
         }
     }
 }

--- a/data/schema/entity.json
+++ b/data/schema/entity.json
@@ -55,18 +55,44 @@
         },
         "growth": {
             "default": null,
-            "type": "array",
-            "items": [
+
+            "oneOf": [
                 {
-                    "name": "minimum",
-                    "type": "number"
+                    "$ref": "range.json",
+                    "description": "For growable entities, a 2-tuple of integers specifying the minimum and maximum amount of time taken for one growth stage. The actual time for one growth stage will be chosen uniformly at random from this range; it takes two growth stages for an entity to be fully grown."
                 },
                 {
-                    "name": "maximum",
-                    "type": "number"
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "mature": {
+                            "default": null,
+                            "type": "string",
+                            "description": "The entity that will grow from the entity planted with the `sow` command."
+                        },
+                        "spread": {
+                            "default": null,
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "radius": {
+                                    "default": 1,
+                                    "type": "number",
+                                    "description": "Manhattan distance within which the entity may spread"
+                                },
+                                "density": {
+                                    "default": 0,
+                                    "type": "number",
+                                    "description": "Density within the range to seed"
+                                }
+                            }
+                        },
+                        "duration": {
+                            "$ref": "range.json"
+                        }
+                    }
                 }
-            ],
-            "description": "For growable entities, a 2-tuple of integers specifying the minimum and maximum amount of time taken for one growth stage. The actual time for one growth stage will be chosen uniformly at random from this range; it takes two growth stages for an entity to be fully grown."
+            ]
         },
         "combustion": {
             "type": "object",

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -62,6 +62,7 @@
                "turn"
                "grab"
                "harvest"
+               "sow"
                "ignite"
                "place"
                "ping"

--- a/editors/vim/swarm.vim
+++ b/editors/vim/swarm.vim
@@ -1,6 +1,6 @@
 syn keyword Keyword def end let in require
 syn keyword Builtins self parent base if inl inr case fst snd force undefined fail not format chars split charat tochar key
-syn keyword Command noop wait selfdestruct move backup volume path push stride turn grab harvest ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami waypoint structure floorplan hastag tagmembers detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows
+syn keyword Command noop wait selfdestruct move backup volume path push stride turn grab harvest sow ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami waypoint structure floorplan hastag tagmembers detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows
 syn keyword Direction east north west south down forward left back right
 syn keyword Type int text dir bool cmd void unit actor
 

--- a/editors/vscode/syntaxes/swarm.tmLanguage.json
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.json
@@ -58,7 +58,7 @@
 				},
 				{
 				"name": "keyword.other",
-				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|backup|volume|path|push|stride|turn|grab|harvest|ignite|place|ping|give|equip|unequip|make|has|equipped|count|drill|use|build|salvage|reprogram|say|listen|log|view|appear|create|halt|time|scout|whereami|waypoint|structure|floorplan|hastag|tagmembers|detect|resonate|density|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|instant|installkeyhandler|teleport|as|robotnamed|robotnumbered|knows)\\b"
+				"match": "\\b(?i)(self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|backup|volume|path|push|stride|turn|grab|harvest|sow|ignite|place|ping|give|equip|unequip|make|has|equipped|count|drill|use|build|salvage|reprogram|say|listen|log|view|appear|create|halt|time|scout|whereami|waypoint|structure|floorplan|hastag|tagmembers|detect|resonate|density|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|swap|atomic|instant|installkeyhandler|teleport|as|robotnamed|robotnumbered|knows)\\b"
 				}
 			]
 			},

--- a/src/swarm-engine/Swarm/Game/Step/Combustion.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Combustion.hs
@@ -120,18 +120,6 @@ addCombustionBot inputEntity combustibility ts loc = do
  where
   Combustibility _ durationRange maybeCombustionProduct = combustibility
 
--- Triggers the ignition of the entity underfoot with some delay.
-ignitionProgram :: Integer -> ProcessedTerm
-ignitionProgram waitTime =
-  [tmQ|
-    wait $int:waitTime;
-    try {
-      ignite down;
-      noop;
-    } {};
-    selfdestruct
-  |]
-
 -- | A system program for a "combustion robot", to burn an entity
 --   after it is ignited.
 --
@@ -228,3 +216,15 @@ addIgnitionBot ignitionDelay inputEntity ts loc =
       False
       emptyExceptions
       ts
+
+-- Triggers the ignition of the entity underfoot with some delay.
+ignitionProgram :: Integer -> ProcessedTerm
+ignitionProgram waitTime =
+  [tmQ|
+    wait $int:waitTime;
+    try {
+      ignite down;
+      noop;
+    } {};
+    selfdestruct
+  |]

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -83,6 +83,7 @@ import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Step.Util
 import Swarm.Game.Step.Util.Command
 import Swarm.Game.Step.Util.Inspect
+import Swarm.Game.Terrain (TerrainType)
 import Swarm.Game.Tick
 import Swarm.Game.Universe
 import Swarm.Game.Value
@@ -304,6 +305,25 @@ execConst runChildProg c vs s k = do
       _ -> badConst
     Grab -> mkReturn <$> doGrab Grab' PerformRemoval
     Harvest -> mkReturn <$> doGrab Harvest' PerformRemoval
+    Sow -> case vs of
+      [VText name] -> do
+        loc <- use robotLocation
+
+        -- Make sure there's nothing already here
+        nothingHere <- isNothing <$> entityAt loc
+        nothingHere `holdsOrFail` ["There is already an entity here."]
+
+        -- Make sure the robot has the thing in its inventory
+        e <- hasInInventoryOrFail name
+
+        (terrainHere, _) <- contentAt loc
+        doPlantSeed terrainHere loc e
+
+        -- Remove it from the inventory
+        robotInventory %= delete e
+
+        return $ mkReturn ()
+      _ -> badConst
     Ignite -> case vs of
       [VDir d] -> do
         Combustion.igniteCommand c d
@@ -1103,6 +1123,10 @@ execConst runChildProg c vs s k = do
 
         -- Construct the new robot and add it to the world.
         parentCtx <- use robotContext
+        let newDisplay = case r ^. robotDisplay . childInheritance of
+              Invisible -> defaultRobotDisplay & invisible .~ True
+              Inherit -> defaultRobotDisplay & inherit displayAttr (r ^. robotDisplay)
+              DefaultDisplay -> defaultRobotDisplay
         newRobot <-
           zoomRobots . addTRobotWithContext parentCtx (In cmd e s [FExec]) $
             mkRobot
@@ -1113,9 +1137,7 @@ execConst runChildProg c vs s k = do
               ( ((r ^. robotOrientation) >>= \dir -> guard (dir /= zero) >> return dir)
                   ? north
               )
-              ( defaultRobotDisplay
-                  & inherit displayAttr (r ^. robotDisplay)
-              )
+              newDisplay
               Nothing
               []
               []
@@ -1714,6 +1736,42 @@ execConst runChildProg c vs s k = do
   mkReturn :: Valuable a => a -> CESK
   mkReturn x = Out (asValue x) s k
 
+  doPlantSeed ::
+    (HasRobotStepState sig m, Has Effect.Time sig m) =>
+    TerrainType ->
+    Cosmic Location ->
+    Entity ->
+    m ()
+  doPlantSeed terrainHere loc e = do
+    when ((e `hasProperty` Growable) && isAllowedInBiome terrainHere e) $ do
+      let Growth maybeMaturesTo maybeSpread (GrowthTime (minT, maxT)) =
+            (e ^. entityGrowth) ? defaultGrowth
+
+      em <- use $ landscape . terrainAndEntities . entityMap
+      let seedEntity = fromMaybe e $ (`lookupEntityName` em) =<< maybeMaturesTo
+
+      createdAt <- getNow
+      let radius = maybe 1 spreadRadius maybeSpread
+          seedlingDensity = maybe 0 spreadDensity maybeSpread
+          -- See https://en.wikipedia.org/wiki/Triangular_number#Formula
+          seedlingArea = 1 + 2 * (radius * (radius + 1))
+          seedlingCount = floor $ seedlingDensity * fromIntegral seedlingArea
+
+      -- Grow a new entity from a seed.
+      addSeedBot
+        seedEntity
+        (minT, maxT)
+        seedlingCount
+        (fromIntegral radius)
+        loc
+        createdAt
+   where
+    isAllowedInBiome terr ent =
+      null biomeRestrictions
+        || terr `S.member` biomeRestrictions
+     where
+      biomeRestrictions = ent ^. entityBiomes
+
   -- The code for grab and harvest is almost identical, hence factored
   -- out here.
   -- Optionally defer removal from the world, for the case of the Swap command.
@@ -1740,18 +1798,8 @@ execConst runChildProg c vs s k = do
 
     -- Possibly regrow the entity, if it is growable and the 'harvest'
     -- command was used.
-    let biomeRestrictions = e ^. entityBiomes
-        isAllowedInBiome =
-          null biomeRestrictions
-            || terrainHere `S.member` biomeRestrictions
-
-    when ((e `hasProperty` Growable) && cmd == Harvest' && isAllowedInBiome) $ do
-      let GrowthTime (minT, maxT) = (e ^. entityGrowth) ? defaultGrowthTime
-
-      createdAt <- getNow
-
-      -- Grow a new entity from a seed.
-      addSeedBot e (minT, maxT) loc createdAt
+    when (cmd == Harvest') $
+      doPlantSeed terrainHere loc e
 
     -- Add the picked up item to the robot's inventory.  If the
     -- entity yields something different, add that instead.

--- a/src/swarm-lang/Swarm/Language/Capability.hs
+++ b/src/swarm-lang/Swarm/Language/Capability.hs
@@ -62,6 +62,8 @@ data Capability
     CGrab
   | -- | Execute the 'Harvest' command
     CHarvest
+  | -- | Execute the 'Sow' command
+    CSow
   | -- | Execute the 'Ignite' command
     CIgnite
   | -- | Execute the 'Place' command
@@ -239,6 +241,7 @@ constCaps = \case
   Turn -> Just CTurn
   Grab -> Just CGrab
   Harvest -> Just CHarvest
+  Sow -> Just CSow
   Ignite -> Just CIgnite
   Place -> Just CPlace
   Ping -> Just CPing

--- a/src/swarm-lang/Swarm/Language/Syntax/Constants.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Constants.hs
@@ -87,6 +87,8 @@ data Const
     Grab
   | -- | Harvest an item from the current location.
     Harvest
+  | -- | Scatter seeds of a plant
+    Sow
   | -- | Ignite a combustible item
     Ignite
   | -- | Try to place an item at the current location.
@@ -532,6 +534,10 @@ constInfo c = case c of
     command 0 short . doc (Set.fromList [Mutation EntityChange, Mutation $ RobotChange InventoryChange]) "Harvest an item from the current location." $
       [ "Leaves behind a growing seed if the harvested item is growable."
       , "Otherwise it works exactly like `grab`."
+      ]
+  Sow ->
+    command 1 short . doc (Set.singleton $ Mutation EntityChange) "Plant a seed at current location" $
+      [ "The entity this matures into may be something else."
       ]
   Ignite ->
     command 1 short

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -792,6 +792,7 @@ inferConst c = case c of
   Turn -> [tyQ| Dir -> Cmd Unit |]
   Grab -> [tyQ| Cmd Text |]
   Harvest -> [tyQ| Cmd Text |]
+  Sow -> [tyQ| Text -> Cmd Unit |]
   Ignite -> [tyQ| Dir -> Cmd Unit |]
   Place -> [tyQ| Text -> Cmd Unit |]
   Ping -> [tyQ| Actor -> Cmd (Unit + (Int * Int)) |]

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -366,6 +366,8 @@ testScenarioSolutions rs ui =
         , testSolution Default "Testing/1775-custom-terrain"
         , testSolution Default "Testing/1777-capability-cost"
         , testSolution Default "Testing/1642-biomes"
+        , testSolution (Sec 10) "Testing/1533-sow-command"
+        , testSolution Default "Testing/1533-sow-seed-maturation"
         , testGroup
             -- Note that the description of the classic world in
             -- data/worlds/classic.yaml (automatically tested to some


### PR DESCRIPTION
Closes #1533

# Demo
```
scripts/test/run-tests.sh --test-options '--pattern "sow"'
```
or
```
scripts/play.sh -i data/scenarios/Testing/1533-sow-command.yaml --autoplay
```
![Screenshot from 2024-05-03 19-12-08](https://github.com/swarm-game/swarm/assets/261693/52df7de4-c158-4973-b109-5337e38c35f1)

## Other changes

* Introduced the `ChildInheritance` type to specify how the `Display` attribute is inherited by built child robots.
* Introduce the `mature` property of `growth`.  For example, it doesn't make much sense to plant an `acorn` and call the resulting, fully-grown plant also an `acorn`.  Instead, an `acorn` matures into an `oak`.