### PR TITLE
structure grid expansion

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -63,3 +63,4 @@ Achievements
 1777-capability-cost.yaml
 1775-custom-terrain.yaml
 1642-biomes.yaml
+1780-structure-merge-expansion

--- a/data/scenarios/Testing/1780-structure-merge-expansion/00-ORDER.txt
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/00-ORDER.txt
@@ -1,0 +1,3 @@
+nonoverlapping-structure-merge.yaml
+root-map-expansion.yaml
+structure-composition.yaml

--- a/data/scenarios/Testing/1780-structure-merge-expansion/nonoverlapping-structure-merge.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/nonoverlapping-structure-merge.yaml
@@ -1,0 +1,61 @@
+version: 1
+name: Expansion of a substructure to fit its placements
+description: |
+  Define two structures and place them on the map.
+robots:
+  - name: base
+    loc: [4, -4]
+    dir: east
+known: [water, sand, tree]
+world:
+  palette:
+    '.': [grass]
+  upperleft: [-1, 1]
+  structures:
+    - name: vertical rectangle
+      structure:
+        palette:
+          'x': [blank, tree]
+        map: |
+          xx
+          xx
+          xx
+          xx
+    - name: horizontal rectangle
+      structure:
+        palette:
+          'x': [blank, sand]
+        map: |
+          xxxx
+          xxxx
+    - name: disjoint rectangles
+      structure:
+        palette:
+          'x': [blank, water]
+        map: |
+          xx
+          xx
+        placements:
+          - src: vertical rectangle
+            truncate: false
+            offset: [-7, 7]
+          - src: horizontal rectangle
+            truncate: false
+            offset: [7, -7]
+  placements:
+    - src: disjoint rectangles
+      offset: [2, -2]
+  map: |
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............
+    ...............

--- a/data/scenarios/Testing/1780-structure-merge-expansion/root-map-expansion.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/root-map-expansion.yaml
@@ -1,0 +1,34 @@
+version: 1
+name: Non-overlapping merging with expansion
+description: |
+  Define two structures and place them on the map.
+
+  Demonstrates automatic expansion of the root map grid.
+robots:
+  - name: base
+    loc: [8, 0]
+    dir: east
+known: [tree, sand, water]
+world:
+  palette:
+    '.': [grass]
+    'i': [ice]
+    'j': [dirt]
+    'k': [stone]
+    'l': [stone, sand]
+    'm': [stone, water]
+  upperleft: [3, 3]
+  structures:
+    - name: single tree
+      structure:
+        palette:
+          'x': [blank, tree]
+        map: |
+          x
+  placements:
+    - src: single tree
+      truncate: false
+      offset: [-2, -4]
+  map: |
+    i.
+    .j

--- a/data/scenarios/Testing/1780-structure-merge-expansion/structure-composition.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/structure-composition.yaml
@@ -1,0 +1,111 @@
+version: 1
+name: Various structure merging arrangements
+description: |
+  Define two structures and place them on the map.
+robots:
+  - name: base
+    loc: [11, 0]
+    dir: east
+known: [water, sand]
+world:
+  palette:
+    '.': [grass]
+  upperleft: [-1, 1]
+  structures:
+    - name: vertical rectangle
+      structure:
+        palette:
+          'x': [blank, water]
+        map: |
+          xx
+          xx
+          xx
+          xx
+    - name: horizontal rectangle
+      structure:
+        palette:
+          'x': [blank, sand]
+        map: |
+          xxxx
+          xxxx
+    - name: combined rectangles blank base
+      structure:
+        palette:
+          'x': [blank]
+        map: |
+          xxxx
+          xxxx
+          xxxx
+          xxxx
+        placements:
+          - src: vertical rectangle
+          - src: horizontal rectangle
+    - name: combined rectangles empty base
+      structure:
+        palette:
+          'x': [blank]
+        map: ""
+        placements:
+          - src: vertical rectangle
+            truncate: false
+          - src: horizontal rectangle
+            truncate: false
+    - name: combined rectangles single cell base
+      structure:
+        palette:
+          'x': [blank]
+        map: |
+          x
+        placements:
+          - src: vertical rectangle
+            truncate: false
+          - src: horizontal rectangle
+            truncate: false
+    - name: multi overlap
+      structure:
+        palette:
+          'x': [blank]
+        map: |
+          xxxx
+        placements:
+          - src: vertical rectangle
+            offset: [1, 0]
+            truncate: false
+          - src: horizontal rectangle
+            truncate: false
+            offset: [0, -2]
+          - src: vertical rectangle
+            offset: [3, -2]
+            truncate: false
+          - src: horizontal rectangle
+            truncate: false
+            offset: [3, -4]
+          - src: vertical rectangle
+            offset: [5, -4]
+            truncate: false
+  placements:
+    - src: vertical rectangle
+      offset: [1, -1]
+    - src: horizontal rectangle
+      offset: [1, -1]
+    - src: multi overlap
+      offset: [1, -6]
+      truncate: false
+    - src: combined rectangles blank base
+      offset: [6, -1]
+    - src: combined rectangles empty base
+      offset: [11, -1]
+    - src: combined rectangles single cell base
+      offset: [11, -6]
+  map: |
+    ................
+    ................
+    ................
+    ................
+    ................
+    ................
+    ................
+    ................
+    ................
+    ................
+    ................

--- a/src/swarm-scenario/Swarm/Game/Scenario.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario.hs
@@ -99,6 +99,7 @@ import Swarm.Game.Scenario.Topography.Navigation.Portal
 import Swarm.Game.Scenario.Topography.Navigation.Waypoint (Parentage (..))
 import Swarm.Game.Scenario.Topography.Structure qualified as Structure
 import Swarm.Game.Scenario.Topography.Structure.Assembly qualified as Assembly
+import Swarm.Game.Scenario.Topography.Structure.Overlay
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Symmetry
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type (SymmetryAnnotatedGrid (..))
 import Swarm.Game.Scenario.Topography.WorldDescription
@@ -336,7 +337,7 @@ instance FromJSONE ScenarioInputs Scenario where
             (sequenceA . (id &&& (Assembly.mergeStructures mempty Root . Structure.structure)))
             rootLevelSharedStructures
 
-      let namedGrids = map (\(ns, Structure.MergedStructure s _ _) -> s <$ ns) mergedStructures
+      let namedGrids = map (\(ns, Structure.MergedStructure (PositionedGrid _ s) _ _) -> s <$ ns) mergedStructures
 
       allWorlds <- localE (WorldParseDependencies worldMap rootLevelSharedStructures rsMap) $ do
         rootWorld <- v ..: "world"

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure.hs
@@ -21,6 +21,7 @@ import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.Navigation.Waypoint
 import Swarm.Game.Scenario.Topography.Placement
+import Swarm.Game.Scenario.Topography.Structure.Overlay
 import Swarm.Game.Scenario.Topography.WorldPalette
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
 import Swarm.Util (failT, showT)
@@ -60,7 +61,7 @@ instance FromJSONE (TerrainEntityMaps, RobotMap) (NamedArea (PStructure (Maybe C
         ..: "structure"
 
 data PStructure c = Structure
-  { area :: Grid c
+  { area :: PositionedGrid c
   , structures :: [NamedStructure c]
   -- ^ structure definitions from parents shall be accessible by children
   , placements :: [Placement]
@@ -84,7 +85,7 @@ instance HasLocation LocatedStructure where
   modifyLoc f (LocatedStructure x y originalLoc) =
     LocatedStructure x y $ f originalLoc
 
-data MergedStructure c = MergedStructure (Grid c) [LocatedStructure] [Originated Waypoint]
+data MergedStructure c = MergedStructure (PositionedGrid c) [LocatedStructure] [Originated Waypoint]
 
 instance FromJSONE (TerrainEntityMaps, RobotMap) (PStructure (Maybe Cell)) where
   parseJSONE = withObjectE "structure definition" $ \v -> do
@@ -98,7 +99,7 @@ instance FromJSONE (TerrainEntityMaps, RobotMap) (PStructure (Maybe Cell)) where
       (maskedArea, mapWaypoints) <- (v .:? "map" .!= "") >>= paintMap maybeMaskChar pal
       return $
         Structure
-          (Grid maskedArea)
+          (PositionedGrid origin $ Grid maskedArea)
           localStructureDefs
           placementDefs
           (waypointDefs <> mapWaypoints)

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure/Overlay.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure/Overlay.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Generic overlay operations on grids
+module Swarm.Game.Scenario.Topography.Structure.Overlay (
+  PositionedGrid (..),
+) where
+
+import Control.Applicative
+import Data.Function (on)
+import Data.Int (Int32)
+import Data.Tuple (swap)
+import Linear
+import Swarm.Game.Location
+import Swarm.Game.Scenario.Topography.Area
+import Swarm.Util (applyWhen)
+
+data PositionedGrid a = PositionedGrid
+  { gridPosition :: Location
+  , gridContent :: Grid a
+  }
+  deriving (Eq)
+
+instance Show (PositionedGrid a) where
+  show (PositionedGrid p g) =
+    unwords
+      [ "Grid with dimension"
+      , renderRectDimensions $ getGridDimensions g
+      , "located at"
+      , show p
+      ]
+
+data OverlayPair a = OverlayPair
+  { _base :: a
+  , _overlay :: a
+  }
+
+getBottomRightCorner :: PositionedGrid a -> Location
+getBottomRightCorner (PositionedGrid loc g) =
+  computeBottomRightFromUpperLeft (getGridDimensions g) loc
+
+getNorthwesternExtent :: Location -> Location -> Location
+getNorthwesternExtent (Location ulx1 uly1) (Location ulx2 uly2) =
+  Location westernMostX northernMostY
+ where
+  westernMostX = min ulx1 ulx2
+  northernMostY = max uly1 uly2
+
+getSoutheasternExtent :: Location -> Location -> Location
+getSoutheasternExtent (Location brx1 bry1) (Location brx2 bry2) =
+  Location easternMostX southernMostY
+ where
+  easternMostX = max brx1 brx2
+  southernMostY = min bry1 bry2
+
+computeMergedArea :: OverlayPair (PositionedGrid a) -> AreaDimensions
+computeMergedArea (OverlayPair pg1 pg2) =
+  cornersToArea ul br
+ where
+  ul = (getNorthwesternExtent `on` gridPosition) pg1 pg2
+  br = (getSoutheasternExtent `on` getBottomRightCorner) pg1 pg2
+
+zipGridRows ::
+  Alternative f =>
+  AreaDimensions ->
+  OverlayPair (Grid (f a)) ->
+  Grid (f a)
+zipGridRows dims (OverlayPair (Grid paddedBaseRows) (Grid paddedOverlayRows)) =
+  mapRows (pad2D paddedBaseRows . pad2D paddedOverlayRows) emptyGrid
+ where
+  -- Right-bias; that is, take the last non-empty value
+  pad2D = zipPadded $ zipPadded $ flip (<|>)
+  emptyGrid = fillGrid dims empty
+
+-- |
+-- First arg: base layer
+-- Second arg: overlay layer
+--
+-- The upper-left corner of the base layer is the original "origin".
+--
+-- If the overlay is to the west or north of the base layer,
+-- then we must pad the base layer on the left or top.
+-- And since the area expands relative to the "origin" of the
+-- base layer, we must shift the combined grid's "origin" location
+-- to the new position of the base layer's upper-left corner.
+--
+-- If the overlay is to the east/south, we do not have to
+-- modify the origin, since no padding is added to the left/top
+-- of the base layer.
+instance (Alternative f) => Semigroup (PositionedGrid (f a)) where
+  a1@(PositionedGrid baseLoc baseGrid) <> a2@(PositionedGrid overlayLoc overlayGrid) =
+    PositionedGrid newOrigin combinedGrid
+   where
+    mergedSize = computeMergedArea $ OverlayPair a1 a2
+    combinedGrid = zipGridRows mergedSize paddedOverlayPair
+
+    -- We subtract the base origin from the
+    -- overlay position, such that the displacement vector
+    -- will have:
+    -- \* negative X component if the origin must be shifted east
+    -- \* positive Y component if the origin must be shifted south
+    originDelta@(V2 deltaX deltaY) = overlayLoc .-. baseLoc
+    -- Note that the adjustment vector will only ever have
+    -- a non-negative X component (i.e. loc of upper-left corner must be shifted east) and
+    -- a non-positive Y component (i.e. loc of upper-left corner must be shifted south).
+    -- We don't have to adjust the origin if the base layer lies
+    -- to the northwest of the overlay layer.
+    clampedDelta = V2 (min 0 deltaX) (max 0 deltaY)
+    newOrigin = baseLoc .-^ clampedDelta
+
+    paddedOverlayPair =
+      padSouthwest originDelta $
+        OverlayPair baseGrid overlayGrid
+
+-- | NOTE: We only make explicit grid adjustments for
+-- left/top padding.  Any padding that is needed on the right/bottom
+-- of either grid will be taken care of by the 'zipPadded' function.
+padSouthwest ::
+  Alternative f =>
+  V2 Int32 ->
+  OverlayPair (Grid (f a)) ->
+  OverlayPair (Grid (f a))
+padSouthwest (V2 deltaX deltaY) (OverlayPair baseGrid overlayGrid) =
+  OverlayPair paddedBaseGrid paddedOverlayGrid
+ where
+  prefixPadRows = mapRows (padRows <>)
+   where
+    padRows = replicate (abs $ fromIntegral deltaY) []
+
+  prefixPadColumns = mapRows $ map (padding <>)
+   where
+    padding = replicate (abs $ fromIntegral deltaX) empty
+
+  -- Assume only the *overlay* requires vertical (top-)padding.
+  -- However, if the conditional is true, then
+  -- the *base* needs vertical padding instead.
+  (baseVerticalPadFunc, overlayVerticalPadFunc) =
+    applyWhen (deltaY > 0) swap (id, prefixPadRows)
+
+  -- Assume only the *overlay* requires horizontal (left-)padding.
+  -- However, if the conditional is true, then
+  -- the *base* needs horizontal padding instead.
+  (baseHorizontalPadFunc, overlayHorizontalPadFunc) =
+    applyWhen (deltaX < 0) swap (id, prefixPadColumns)
+
+  paddedBaseGrid = baseVerticalPadFunc $ baseHorizontalPadFunc baseGrid
+  paddedOverlayGrid = overlayVerticalPadFunc $ overlayHorizontalPadFunc overlayGrid
+
+-- * Utils
+
+-- | Apply a function to combine elements from two lists
+-- of potentially different lengths.
+-- Produces a result with length equal to the longer list.
+-- Elements from the longer list are placed directly in the
+-- resulting list when the shorter list runs out of elements.
+zipPadded :: (a -> a -> a) -> [a] -> [a] -> [a]
+zipPadded _ [] ys = ys
+zipPadded _ xs [] = xs
+zipPadded f (x : xs) (y : ys) = f x y : zipPadded f xs ys

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure/Overlay.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure/Overlay.hs
@@ -125,13 +125,12 @@ padSouthwest ::
 padSouthwest (V2 deltaX deltaY) (OverlayPair baseGrid overlayGrid) =
   OverlayPair paddedBaseGrid paddedOverlayGrid
  where
-  prefixPadRows = mapRows (padRows <>)
+  prefixPadDimension delta f = mapRows $ f (padding <>)
    where
-    padRows = replicate (abs $ fromIntegral deltaY) []
+    padding = replicate (abs $ fromIntegral delta) empty
 
-  prefixPadColumns = mapRows $ map (padding <>)
-   where
-    padding = replicate (abs $ fromIntegral deltaX) empty
+  prefixPadRows = prefixPadDimension deltaY id
+  prefixPadColumns = prefixPadDimension deltaX map
 
   -- Assume only the *overlay* requires vertical (top-)padding.
   -- However, if the conditional is true, then

--- a/src/swarm-scenario/Swarm/Game/World/Coords.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Coords.hs
@@ -8,6 +8,7 @@ module Swarm.Game.World.Coords (
   Coords (..),
   locToCoords,
   coordsToLoc,
+  addTuple,
   BoundsRectangle,
 )
 where
@@ -42,6 +43,9 @@ locToCoords (Location x y) = Coords (-y, x)
 -- | Convert an internal 'Coords' value to an external @(x,y)@ location.
 coordsToLoc :: Coords -> Location
 coordsToLoc (Coords (r, c)) = Location c (-r)
+
+addTuple :: Coords -> (Int32, Int32) -> Coords
+addTuple (Coords (r, c)) (addR, addC) = Coords (r + addR, c + addC)
 
 -- | Represents the top-left and bottom-right coordinates
 -- of a bounding rectangle of cells in the world map

--- a/src/swarm-scenario/Swarm/Game/World/Render.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Render.hs
@@ -27,6 +27,7 @@ import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.Center
 import Swarm.Game.Scenario.Topography.EntityFacade (EntityFacade (..), mkFacade)
+import Swarm.Game.Scenario.Topography.Structure.Overlay
 import Swarm.Game.State.Landscape
 import Swarm.Game.Universe
 import Swarm.Game.World qualified as W
@@ -111,11 +112,11 @@ getBoundingBox vc scenarioWorld maybeSize =
   mkBoundingBox areaDimens upperLeftLoc =
     both W.locToCoords locationBounds
    where
-    lowerRightLocation = upperLeftToBottomRight areaDimens upperLeftLoc
+    lowerRightLocation = computeBottomRightFromUpperLeft areaDimens upperLeftLoc
     locationBounds = (upperLeftLoc, lowerRightLocation)
 
-  worldArea = area scenarioWorld
-  mapAreaDims = getAreaDimensions worldArea
+  worldArea = gridContent $ area scenarioWorld
+  mapAreaDims = getGridDimensions worldArea
   areaDims@(AreaDimensions w h) =
     fromMaybe (AreaDimensions 20 10) $
       maybeSize <|> surfaceEmpty isEmpty mapAreaDims

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -17,6 +17,7 @@ import Data.Map qualified as M
 import Data.Yaml qualified as Y
 import Graphics.Vty qualified as V
 import Swarm.Game.Land
+import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.EntityFacade
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
@@ -146,7 +147,9 @@ saveMapFile = do
   maybeBounds <- use $ uiState . uiGameplay . uiWorldEditor . editingBounds . boundsRect
   w <- use $ gameState . landscape . multiWorld
   tm <- use $ gameState . landscape . terrainAndEntities . terrainMap
-  let mapCellGrid = EU.getEditedMapRectangle tm (worldEditor ^. worldOverdraw) maybeBounds w
+  let mapCellGrid =
+        mapRows (map (map Just)) $
+          EU.getEditedMapRectangle tm (worldEditor ^. worldOverdraw) maybeBounds w
 
   let fp = worldEditor ^. outputFilePath
   maybeScenarioPair <- use $ uiState . uiGameplay . scenarioRef

--- a/src/swarm-tui/Swarm/TUI/Editor/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Util.hs
@@ -13,6 +13,7 @@ import Swarm.Game.Entity
 import Swarm.Game.Scenario.Topography.Area qualified as EA
 import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.EntityFacade
+import Swarm.Game.Scenario.Topography.Structure.Overlay
 import Swarm.Game.Scenario.Topography.WorldDescription
 import Swarm.Game.Terrain (TerrainMap, TerrainType)
 import Swarm.Game.Universe
@@ -33,8 +34,8 @@ getEditingBounds myWorld =
  where
   newBounds = Cosmic DefaultRootSubworld (W.locToCoords upperLeftLoc, W.locToCoords lowerRightLoc)
   upperLeftLoc = ul myWorld
-  a = EA.getAreaDimensions $ area myWorld
-  lowerRightLoc = EA.upperLeftToBottomRight a upperLeftLoc
+  a = EA.getGridDimensions $ gridContent $ area myWorld
+  lowerRightLoc = EA.computeBottomRightFromUpperLeft a upperLeftLoc
 
 getEditorContentAt ::
   TerrainMap ->

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -236,6 +236,7 @@ library swarm-scenario
     Swarm.Game.Scenario.Topography.Placement
     Swarm.Game.Scenario.Topography.Structure
     Swarm.Game.Scenario.Topography.Structure.Assembly
+    Swarm.Game.Scenario.Topography.Structure.Overlay
     Swarm.Game.Scenario.Topography.Structure.Recognition
     Swarm.Game.Scenario.Topography.Structure.Recognition.Log
     Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute
@@ -799,6 +800,7 @@ test-suite swarm-unit
     TestLanguagePipeline
     TestNotification
     TestOrdering
+    TestOverlay
     TestParse
     TestPedagogy
     TestPretty

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -36,6 +36,7 @@ import TestLSP (testLSP)
 import TestLanguagePipeline (testLanguagePipeline)
 import TestNotification (testNotification)
 import TestOrdering (testOrdering)
+import TestOverlay (testOverlay)
 import TestParse (testParse)
 import TestPedagogy (testPedagogy)
 import TestPretty (testPrettyConst)
@@ -68,6 +69,7 @@ tests s =
     , testInventory
     , testNotification (s ^. gameState)
     , testOrdering
+    , testOverlay
     , testMisc
     , testLSP
     ]

--- a/test/unit/TestOverlay.hs
+++ b/test/unit/TestOverlay.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Unit tests for generic grid overlay logic
+module TestOverlay where
+
+import Swarm.Game.Location
+import Swarm.Game.Scenario.Topography.Area
+import Swarm.Game.Scenario.Topography.Structure.Overlay
+import Test.Tasty
+import Test.Tasty.HUnit
+
+testOverlay :: TestTree
+testOverlay =
+  testGroup
+    "Overlay"
+    [ -- Overlay is to the east and north of the base.
+      -- Therefore, the origin of the combined grid must
+      -- be adjusted southward to match its original position
+      -- in the base layer.
+      mkOriginTestCase "Southward" (Location 3 2) (Location 0 (-2))
+    , -- Overlay is to the west and south of the base.
+      -- Therefore, the origin of the combined grid must
+      -- be adjusted eastward to match its original position
+      -- in the base layer.
+      mkOriginTestCase "Eastward" (Location (-7) (-1)) (Location 7 0)
+    ]
+
+mkOriginTestCase ::
+  String ->
+  Location ->
+  Location ->
+  TestTree
+mkOriginTestCase adjustmentDescription overlayLocation expectedBaseLoc =
+  testCase (unwords [adjustmentDescription, "origin adjustment"]) $ do
+    assertEqual "Base loc wrong" expectedBaseLoc actualBaseLoc
+ where
+  baseLayer = PositionedGrid (Location 0 0) $ Grid [[] :: [Maybe Int]]
+  overlayLayer = PositionedGrid overlayLocation $ Grid [[]]
+  PositionedGrid actualBaseLoc _ = baseLayer <> overlayLayer


### PR DESCRIPTION
Closes #1780.

This change allows "child" structures to be placed outside of the bounds of their "parent" map.  Until now, any child structures that exceed the bounds of their parent were simply truncated.

# Demo
```
scripts/play.sh -i data/scenarios/Testing/1780-structure-merge-expansion/structure-composition.yaml
```