### PR TITLE
Add `format --v0.5` option to port code from older syntax

### DIFF
--- a/src/swarm-lang/Swarm/Language/Format.hs
+++ b/src/swarm-lang/Swarm/Language/Format.hs
@@ -13,7 +13,7 @@ import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Prettyprinter
 import Prettyprinter.Render.Text qualified as RT
-import Swarm.Language.Parser (readTerm, readTerm')
+import Swarm.Language.Parser (readTerm')
 import Swarm.Language.Parser.Core (LanguageVersion, defaultParserConfig, languageVersion)
 import Swarm.Language.Pretty
 import Swarm.Util ((?))

--- a/src/swarm-lang/Swarm/Language/Format.hs
+++ b/src/swarm-lang/Swarm/Language/Format.hs
@@ -7,25 +7,24 @@
 module Swarm.Language.Format where
 
 import Control.Applicative ((<|>))
+import Control.Lens ((&), (.~))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Prettyprinter
 import Prettyprinter.Render.Text qualified as RT
-import Swarm.Language.Parser (readTerm)
+import Swarm.Language.Parser (readTerm, readTerm')
+import Swarm.Language.Parser.Core (LanguageVersion, defaultParserConfig, languageVersion)
 import Swarm.Language.Pretty
 import Swarm.Util ((?))
 import System.Console.Terminal.Size qualified as Term
 import System.Exit (exitFailure)
 import System.IO (stderr)
-
-type FormatWidth = Int
+import Text.Megaparsec.Error (errorBundlePretty)
+import Witch (into)
 
 -- | From where should the input be taken?
 data FormatInput = Stdin | InputFile FilePath
-
--- | Where should the formatted code be output?
-data FormatOutput = Stdout | OutputFile FilePath | Inplace
 
 getInput :: FormatInput -> IO Text
 getInput Stdin = T.getContents
@@ -35,13 +34,25 @@ showInput :: FormatInput -> Text
 showInput Stdin = "(input)"
 showInput (InputFile fp) = T.pack fp
 
+-- | Where should the formatted code be output?
+data FormatOutput = Stdout | OutputFile FilePath | Inplace
+
+type FormatWidth = Int
+
+data FormatConfig = FormatConfig
+  { formatInput :: FormatInput
+  , formatOutput :: FormatOutput
+  , formatWidth :: Maybe FormatWidth
+  , formatLanguageVersion :: LanguageVersion
+  }
+
 -- | Validate and format swarm-lang code.
-formatSwarmIO :: FormatInput -> FormatOutput -> Maybe FormatWidth -> IO ()
-formatSwarmIO input output mWidth = do
+formatSwarmIO :: FormatConfig -> IO ()
+formatSwarmIO cfg@(FormatConfig input output mWidth _) = do
   content <- getInput input
   mWindowWidth <- (fmap . fmap) Term.width Term.size
   let w = mWidth <|> case output of Stdout -> mWindowWidth; _ -> Nothing
-  case formatSwarm w content of
+  case formatSwarm cfg {formatWidth = w} content of
     Right fmt -> case output of
       Stdout -> T.putStrLn fmt
       OutputFile outFile -> T.writeFile outFile fmt
@@ -52,11 +63,13 @@ formatSwarmIO input output mWidth = do
       T.hPutStrLn stderr $ showInput input <> ":" <> e
       exitFailure
 
-formatSwarm :: Maybe FormatWidth -> Text -> Either Text Text
-formatSwarm mWidth content = case readTerm content of
+formatSwarm :: FormatConfig -> Text -> Either Text Text
+formatSwarm (FormatConfig _ _ mWidth ver) content = case readTerm' cfg content of
   Right Nothing -> Right ""
   Right (Just ast) ->
     let mkOpt w = LayoutOptions (AvailablePerLine w 1.0)
         opt = (mkOpt <$> mWidth) ? defaultLayoutOptions
      in Right . RT.renderStrict . layoutPretty opt $ ppr ast
-  Left e -> Left e
+  Left e -> Left (into @Text $ errorBundlePretty e)
+ where
+  cfg = defaultParserConfig & languageVersion .~ ver

--- a/src/swarm-lang/Swarm/Language/LSP.hs
+++ b/src/swarm-lang/Swarm/Language/LSP.hs
@@ -23,6 +23,7 @@ import Language.LSP.VFS (VirtualFile (..), virtualFileText)
 import Swarm.Language.LSP.Hover qualified as H
 import Swarm.Language.LSP.VarUsage qualified as VU
 import Swarm.Language.Parser (readTerm')
+import Swarm.Language.Parser.Core (defaultParserConfig)
 import Swarm.Language.Parser.Util (getLocRange, showErrorPos)
 import Swarm.Language.Pipeline (processParsedTerm')
 import Swarm.Language.Pretty (prettyText)
@@ -81,7 +82,7 @@ validateSwarmCode doc version content = do
   -- However, getting rid of this seems to break error highlighting.
   flushDiagnosticsBySource 0 (Just diagnosticSourcePrefix)
 
-  let (parsingErrs, unusedVarWarnings) = case readTerm' content of
+  let (parsingErrs, unusedVarWarnings) = case readTerm' defaultParserConfig content of
         Right Nothing -> ([], [])
         Right (Just term) -> (parsingErrors, unusedWarnings)
          where

--- a/src/swarm-lang/Swarm/Language/LSP/Hover.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/Hover.hs
@@ -33,6 +33,7 @@ import Language.LSP.VFS
 import Swarm.Language.Context as Ctx
 import Swarm.Language.Module (Module (..))
 import Swarm.Language.Parser (readTerm')
+import Swarm.Language.Parser.Core (defaultParserConfig)
 import Swarm.Language.Pipeline (ProcessedTerm (..), processParsedTerm)
 import Swarm.Language.Pretty (prettyText, prettyTextLine)
 import Swarm.Language.Syntax
@@ -58,7 +59,7 @@ showHoverInfo ::
   VirtualFile ->
   Maybe (Text, Maybe J.Range)
 showHoverInfo _ p vf@(VirtualFile _ _ myRope) =
-  either (const Nothing) (fmap genHoverInfo) (readTerm' content)
+  either (const Nothing) (fmap genHoverInfo) (readTerm' defaultParserConfig content)
  where
   content = virtualFileText vf
   absolutePos =

--- a/src/swarm-lang/Swarm/Language/Parser.hs
+++ b/src/swarm-lang/Swarm/Language/Parser.hs
@@ -17,7 +17,7 @@ import Data.Bifunctor (first, second)
 import Data.Sequence (Seq)
 import Data.Text (Text)
 import Swarm.Language.Parser.Comment (populateComments)
-import Swarm.Language.Parser.Core (ParserError, runParser)
+import Swarm.Language.Parser.Core (ParserConfig, ParserError, defaultParserConfig, runParser')
 import Swarm.Language.Parser.Lex (sc)
 import Swarm.Language.Parser.Term (parseTerm)
 import Swarm.Language.Parser.Util (fullyMaybe)
@@ -31,12 +31,12 @@ import Witch (from)
 --   'Nothing' if the input was only whitespace) or a pretty-printed
 --   parse error message.
 readTerm :: Text -> Either Text (Maybe Syntax)
-readTerm = first (from . errorBundlePretty) . readTerm'
+readTerm = first (from . errorBundlePretty) . readTerm' defaultParserConfig
 
--- | A lower-level `readTerm` which returns the megaparsec bundle error
---   for precise error reporting.
-readTerm' :: Text -> Either ParserError (Maybe Syntax)
-readTerm' = second handleComments . runParser (fullyMaybe sc parseTerm)
+-- | A lower-level `readTerm` which allow configuring the parser and
+--   returns the megaparsec bundle error for precise error reporting.
+readTerm' :: ParserConfig -> Text -> Either ParserError (Maybe Syntax)
+readTerm' cfg = second handleComments . runParser' cfg (fullyMaybe sc parseTerm)
  where
   handleComments :: (Maybe Syntax, Seq Comment) -> Maybe Syntax
   handleComments (s, cs) = populateComments cs <$> s

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -9,7 +9,6 @@ module Swarm.Language.Parser.Term where
 import Control.Lens (view, (^.))
 import Control.Monad (guard)
 import Control.Monad.Combinators.Expr
-import Control.Monad.Reader (ask)
 import Data.Foldable (asum)
 import Data.List (foldl')
 import Data.Map (Map)
@@ -98,7 +97,7 @@ parseTermAtom2 =
 
     <|> parseLoc (TDelay SimpleDelay (TConst Noop) <$ try (symbol "{" *> symbol "}"))
     <|> parseLoc (SDelay SimpleDelay <$> braces parseTerm)
-    <|> parseLoc (ask >>= (guard . (== AllowAntiquoting)) >> parseAntiquotation)
+    <|> parseLoc (view antiquoting >>= (guard . (== AllowAntiquoting)) >> parseAntiquotation)
 
 -- | Construct an 'SLet', automatically filling in the Boolean field
 --   indicating whether it is recursive.

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -350,9 +350,9 @@ handleMainEvent ev = do
         then -- ignore repeated keypresses
           continueWithoutRedraw
         else -- hide for two seconds
-          do
-            uiState . uiGameplay . uiHideRobotsUntil .= t + TimeSpec 2 0
-            invalidateCacheEntry WorldCache
+        do
+          uiState . uiGameplay . uiHideRobotsUntil .= t + TimeSpec 2 0
+          invalidateCacheEntry WorldCache
     -- debug focused robot
     MetaChar 'd' | isPaused && hasDebug -> do
       debug <- uiState . uiGameplay . uiShowDebug Lens.<%= not

--- a/test/unit/TestLSP.hs
+++ b/test/unit/TestLSP.hs
@@ -9,7 +9,7 @@ module TestLSP (testLSP) where
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
 import Swarm.Language.LSP.VarUsage qualified as VU
-import Swarm.Language.Parser (readTerm')
+import Swarm.Language.Parser (readTerm)
 import Swarm.Language.Syntax qualified as S
 import System.FilePath ((</>))
 import Test.Tasty
@@ -84,7 +84,7 @@ testLSP =
 
   getWarnings :: Text -> [UnusedVar]
   getWarnings content =
-    case readTerm' content of
+    case readTerm content of
       Right (Just term) -> map simplifyWarning problems
        where
         VU.Usage _ problems = VU.getUsage mempty term

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -211,7 +211,7 @@ testLanguagePipeline =
     , testGroup
         "json encoding"
         [ testCase "simple expr" (roundTripTerm "42 + 43")
-        , testCase "module def" (roundTripTerm "def x = 41 end;\ndef y = 42 end")
+        , testCase "module def" (roundTripTerm "def x = 41 end\n\ndef y = 42 end")
         ]
     , testGroup
         "atomic - #479"


### PR DESCRIPTION
This is a followup on top of #1583 which turns `swarm format` into a tool for porting existing Swarm code into the newest syntax, via an extra `--v0.5` argument.  In particular, this PR:

- Generalizes the parser to take a configuration record, which among other things contains the language version being parsed.
- Adds code to allow the parser to parse either the current syntax or one version ago (when types did not start with capital letter) depending on the version in the configuration.
    - The idea is to have the parser always support the current version and one older version, so we can always upgrade version n to version n+1.
- Adds a new flag `--v0.5` to the `format` subcommand which causes the input to be parsed in v0.5 mode.  However, the output of `format` will always use the latest syntax.  Thus, `swarm format --v0.5` reads code in v0.5 format and prints it in the latest format, so this can be used to automatically port existing `.sw` files.

This PR also makes a few minor improvements to pretty-printing.