### PR TITLE
Help menu consistency fix

### DIFF
--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -827,7 +827,7 @@ helpWidget theSeed mport =
     , ("Ctrl-z", "decrease speed")
     , ("Ctrl-w", "increase speed")
     , ("Ctrl-q", "quit or restart the current scenario")
-    , ("Ctrl-s", "collapse/expand REPL")
+    , ("Meta-,", "collapse/expand REPL")
     , ("Meta-h", "hide robots for 2s")
     , ("Meta-w", "focus on the world map")
     , ("Meta-e", "focus on the robot inventory")


### PR DESCRIPTION
Fix the F1 Help menu to be consistent with in-game controls. Closes #1827.