### PR TITLE
Implement GitHub authentication

### DIFF
--- a/app/tournament/Main.hs
+++ b/app/tournament/Main.hs
@@ -1,11 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 module Main where
 
 import Control.Monad.Trans.Reader (runReaderT)
 import Data.Maybe (fromMaybe)
+import Data.Yaml (decodeFileThrow)
 import Network.Wai.Handler.Warp (Port)
 import Options.Applicative
+
+import Swarm.Web.Tournament.Type (UserAlias (..))
 import Swarm.Game.State (Sha1 (..))
 import Swarm.Web.Tournament
 import Swarm.Web.Tournament.Database.Query
@@ -14,7 +19,7 @@ data AppOpts = AppOpts
   { userWebPort :: Maybe Port
   -- ^ Explicit port on which to run the web API
   , gameGitVersion :: Sha1
-  , isLocalSocketConnection :: Bool
+  , deploymentEnv :: DeploymentEnvironment
   }
 
 webPort :: Parser (Maybe Int)
@@ -37,13 +42,15 @@ gameVersion =
           <> help "Set the git version of the game"
       )
 
-parseNativeDev :: Parser Bool
-parseNativeDev =
-  switch
-    (long "native-dev" <> help "Running locally outside of a Docker container for development")
+parseRunningLocally :: Parser DeploymentEnvironment
+parseRunningLocally =
+  flag
+    ProdDeployment
+    (LocalDevelopment $ UserAlias "local-user")
+    (long "local" <> help "Running locally for development")
 
 cliParser :: Parser AppOpts
-cliParser = AppOpts <$> webPort <*> gameVersion <*> parseNativeDev
+cliParser = AppOpts <$> webPort <*> gameVersion <*> parseRunningLocally
 
 cliInfo :: ParserInfo AppOpts
 cliInfo =
@@ -57,22 +64,28 @@ cliInfo =
 main :: IO ()
 main = do
   opts <- execParser cliInfo
+
+  creds <- case deploymentEnv opts of
+    LocalDevelopment _ -> return $ GitHubCredentials "" ""
+    ProdDeployment -> decodeFileThrow "swarm-github-app-credentials.yaml"
+
   webMain
-    (AppData (gameGitVersion opts) persistenceFunctions)
+    (AppData (gameGitVersion opts) creds persistenceFunctions (deploymentEnv opts))
     (fromMaybe defaultPort $ userWebPort opts)
  where
   persistenceFunctions =
     PersistenceLayer
-      { lookupScenarioFileContent = withConnInfo lookupScenarioContent
-      , scenarioStorage =
+      { scenarioStorage =
           ScenarioPersistence
             { lookupCache = withConnInfo lookupScenarioSolution
             , storeCache = withConnInfo insertScenario
+            , getContent = withConnInfo lookupScenarioContent
             }
       , solutionStorage =
           ScenarioPersistence
             { lookupCache = withConnInfo lookupSolutionSubmission
             , storeCache = withConnInfo insertSolutionSubmission
+            , getContent = withConnInfo lookupSolutionContent
             }
       }
    where

--- a/src/swarm-engine/Swarm/Game/Tick.hs
+++ b/src/swarm-engine/Swarm/Game/Tick.hs
@@ -7,7 +7,8 @@ module Swarm.Game.Tick (
   addTicks,
 ) where
 
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, ToJSON (..))
+import Data.Aeson qualified as A
 import Data.Int (Int64)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..))
@@ -16,7 +17,10 @@ import Swarm.Util.WindowedCounter (Offsettable (..))
 -- | A newtype representing a count of ticks (typically since the
 --   start of a game).
 newtype TickNumber = TickNumber {getTickNumber :: Int64}
-  deriving (Eq, Ord, Show, Read, Generic, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, Read, Generic, FromJSON)
+
+instance ToJSON TickNumber where
+  toJSON = A.genericToJSON (A.defaultOptions {A.unwrapUnaryRecords = True})
 
 -- | Add an offset to a 'TickNumber'.
 addTicks :: Int -> TickNumber -> TickNumber

--- a/src/swarm-tournament/Swarm/Web/Auth.hs
+++ b/src/swarm-tournament/Swarm/Web/Auth.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Authentication logic for Swarm tournament server.
+module Swarm.Web.Auth where
+
+import Control.Monad.Catch
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Aeson
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.UTF8 as BSU
+import Data.Map qualified as M
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as DTE
+import Data.Text.Lazy qualified as TL
+import Database.SQLite.Simple.ToField
+import GHC.Generics (Generic)
+import Network.HTTP.Client qualified as HC
+import Network.HTTP.Types (hAccept, hUserAgent, parseSimpleQuery, renderSimpleQuery)
+import Servant
+import Text.Read (readMaybe)
+
+data GitHubCredentials = GitHubCredentials
+  { clientId :: BS.ByteString
+  , clientSecret :: BS.ByteString
+  }
+
+instance FromJSON GitHubCredentials where
+  parseJSON = withObject "GitHubCredentials" $ \v ->
+    GitHubCredentials
+      <$> (BSU.fromString <$> v .: "CLIENT_ID")
+      <*> (BSU.fromString <$> v .: "CLIENT_SECRET")
+
+newtype TokenExchangeCode = TokenExchangeCode BS.ByteString
+
+instance FromHttpApiData TokenExchangeCode where
+  parseUrlPiece = return . TokenExchangeCode . DTE.encodeUtf8
+
+newtype AccessToken = AccessToken BS.ByteString
+
+instance ToField AccessToken where
+  toField (AccessToken x) = toField x
+
+newtype RefreshToken = RefreshToken BS.ByteString
+
+instance ToField RefreshToken where
+  toField (RefreshToken x) = toField x
+
+data UserApiResponse = UserApiResponse
+  { login :: TL.Text
+  , id :: Int
+  , name :: TL.Text
+  }
+  deriving (Generic, FromJSON)
+
+data Expirable a = Expirable
+  { token :: a
+  , expirationSeconds :: Int
+  }
+
+fetchAuthenticatedUser ::
+  (MonadIO m, MonadThrow m, MonadFail m) =>
+  HC.Manager ->
+  AccessToken ->
+  m UserApiResponse
+fetchAuthenticatedUser manager (AccessToken tok) = do
+  req <- HC.parseUrlThrow "https://api.github.com/user"
+  resp <-
+    liftIO $
+      flip HC.httpLbs manager $
+        HC.applyBearerAuth tok $
+          req
+            { HC.requestHeaders =
+                [ (hAccept, "application/vnd.github+json")
+                , (hUserAgent, "Swarm Gaming Hub")
+                , ("X-GitHub-Api-Version", "2022-11-28")
+                ]
+            }
+  either fail return $ eitherDecode $ HC.responseBody resp
+
+data ReceivedTokens = ReceivedTokens
+  { accessToken :: Expirable AccessToken
+  , refreshToken :: Expirable RefreshToken
+  }
+
+packExchangeResponse ::
+  M.Map ByteString ByteString ->
+  Maybe ReceivedTokens
+packExchangeResponse valMap =
+  ReceivedTokens
+    <$> (Expirable <$> atVal <*> toInt "expires_in")
+    <*> (Expirable <$> rtVal <*> toInt "refresh_token_expires_in")
+ where
+  toInt k = readMaybe . BSU.toString =<< M.lookup k valMap
+
+  atVal = AccessToken <$> M.lookup "access_token" valMap
+  rtVal = RefreshToken <$> M.lookup "refresh_token" valMap
+
+exchangeCode ::
+  (MonadIO m, MonadThrow m, MonadFail m) =>
+  HC.Manager ->
+  GitHubCredentials ->
+  TokenExchangeCode ->
+  m ReceivedTokens
+exchangeCode manager creds (TokenExchangeCode code) = do
+  let qParms =
+        T.unpack . DTE.decodeUtf8 $
+          renderSimpleQuery
+            True
+            [ ("client_id", clientId creds)
+            , ("client_secret", clientSecret creds)
+            , ("code", code)
+            ]
+  req <- HC.parseUrlThrow $ "https://github.com/login/oauth/access_token" <> qParms
+  resp <- liftIO $ flip HC.httpLbs manager $ req {HC.method = "POST"}
+
+  let parms = parseSimpleQuery $ LBS.toStrict $ HC.responseBody resp
+      valMap = M.fromList parms
+
+  maybe
+    (fail "Response did not include access token")
+    return
+    $ packExchangeResponse valMap

--- a/src/swarm-tournament/Swarm/Web/Tournament.hs
+++ b/src/swarm-tournament/Swarm/Web/Tournament.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -10,6 +11,8 @@
 module Swarm.Web.Tournament (
   defaultPort,
   AppData (..),
+  GitHubCredentials (..),
+  DeploymentEnvironment (..),
 
   -- ** Development
   webMain,
@@ -17,25 +20,32 @@ module Swarm.Web.Tournament (
 ) where
 
 import Commonmark qualified as Mark (commonmark, renderHtml)
-import Control.Lens
+import Control.Lens hiding (Context)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Reader (runReaderT)
 import Data.Aeson
-import Data.ByteString.Lazy (ByteString)
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Either.Extra (maybeToEither)
 import Data.Int (Int64)
 import Data.Map (Map)
+import Data.Maybe (fromMaybe)
+
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
-import Data.Text.Lazy.Encoding (decodeUtf8', encodeUtf8)
+import Data.Text.Lazy.Encoding (decodeUtf8, decodeUtf8', encodeUtf8)
 import Data.Yaml (decodeEither', defaultEncodeOptions, encodeWith)
-import Network.HTTP.Types (ok200)
-import Network.Wai (responseLBS)
+import GHC.Generics (Generic)
+import Network.HTTP.Client qualified as HC
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types (hCookie, ok200, renderSimpleQuery)
+import Network.Wai (Request, requestHeaders, responseLBS)
 import Network.Wai.Application.Static (defaultFileServerSettings, ssIndices)
 import Network.Wai.Handler.Warp qualified as Warp
+import Swarm.Web.Auth
+
 import Network.Wai.Parse (
   defaultParseRequestBodyOptions,
   setMaxRequestFileSize,
@@ -43,13 +53,9 @@ import Network.Wai.Parse (
   setMaxRequestNumFiles,
  )
 import Servant
-import Servant.Docs qualified as SD
-import Servant.Docs.Internal qualified as SD (renderCurlBasePath)
 import Servant.Multipart
-import Swarm.Game.Scenario (ScenarioMetadata (ScenarioMetadata), scenarioMetadata)
-import Swarm.Game.Scenario.Scoring.CodeSize (ScenarioCodeMetrics (..))
+import Swarm.Game.Scenario (ScenarioMetadata, scenarioMetadata)
 import Swarm.Game.State (Sha1 (..))
-import Swarm.Game.Tick (TickNumber (..))
 import Swarm.Web.Tournament.Database.Query
 import Swarm.Web.Tournament.Type
 import Swarm.Web.Tournament.Validate
@@ -57,8 +63,8 @@ import Swarm.Web.Tournament.Validate.FailureMode
 import Swarm.Web.Tournament.Validate.Upload
 import WaiAppStatic.Types (unsafeToPiece)
 
-placeholderAlias :: UserAlias
-placeholderAlias = UserAlias "Karl"
+import Servant.Server.Experimental.Auth (AuthHandler, AuthServerData, mkAuthHandler)
+import Web.Cookie
 
 defaultPort :: Warp.Port
 defaultPort = 5500
@@ -66,58 +72,34 @@ defaultPort = 5500
 -- | NOTE: The default Servant server timeout is 30 sec;
 -- see https://hackage.haskell.org/package/http-client-0.7.17/docs/Network-HTTP-Client-Internal.html#t:ResponseTimeout
 defaultSolutionTimeout :: SolutionTimeout
-defaultSolutionTimeout = SolutionTimeout 15
+defaultSolutionTimeout = SolutionTimeout 20
+
+data DeploymentEnvironment
+  = LocalDevelopment UserAlias
+  | ProdDeployment
 
 data AppData = AppData
   { swarmGameGitVersion :: Sha1
-  , persistence :: PersistenceLayer
+  , gitHubCredentials :: GitHubCredentials
+  , persistence :: PersistenceLayer IO
+  , developmentMode :: DeploymentEnvironment
   }
 
+type LoginType = Headers '[Header "Location" TL.Text, Header "Set-Cookie" SetCookie] NoContent
+type LoginHandler = Handler LoginType
+
 type TournamentAPI =
-  "upload" :> "scenario" :> MultipartForm Mem (MultipartData Mem) :> Post '[JSON] ScenarioCharacterization
-    :<|> "upload" :> "solution" :> MultipartForm Mem (MultipartData Mem) :> Post '[JSON] SolutionFileCharacterization
+  "api" :> "private" :> "upload" :> "scenario" :> Header "Referer" TL.Text :> AuthProtect "cookie-auth" :> MultipartForm Mem (MultipartData Mem) :> Verb 'POST 303 '[JSON] (Headers '[Header "Location" TL.Text] ScenarioCharacterization)
+    :<|> "api" :> "private" :> "upload" :> "solution" :> Header "Referer" TL.Text :> AuthProtect "cookie-auth" :> MultipartForm Mem (MultipartData Mem) :> Verb 'POST 303 '[JSON] (Headers '[Header "Location" TL.Text] SolutionFileCharacterization)
     :<|> "scenario" :> Capture "sha1" Sha1 :> "metadata" :> Get '[JSON] ScenarioMetadata
     :<|> "scenario" :> Capture "sha1" Sha1 :> "fetch" :> Get '[PlainText] TL.Text
-    :<|> "games" :> Get '[JSON] [TournamentGame]
-
-swarmApi :: Proxy TournamentAPI
-swarmApi = Proxy
-
-type ToplevelAPI =
-  TournamentAPI
-    :<|> "api" :> Raw
-    :<|> Raw
-
-api :: Proxy ToplevelAPI
-api = Proxy
-
-swarmApiHtml :: ByteString
-swarmApiHtml =
-  encodeUtf8
-    . either (error . show) (Mark.renderHtml @())
-    . Mark.commonmark ""
-    $ T.pack swarmApiMarkdown
-
-swarmApiMarkdown :: String
-swarmApiMarkdown =
-  SD.markdownWith
-    ( SD.defRenderingOptions
-        & SD.requestExamples .~ SD.FirstContentType
-        & SD.responseExamples .~ SD.FirstContentType
-        & SD.renderCurlBasePath ?~ "http://localhost:" <> show defaultPort
-    )
-    $ SD.docsWithIntros [intro] swarmApi
- where
-  intro =
-    SD.DocIntro
-      "Swarm tournament hosting API"
-      [ "All of the valid endpoints are documented below."
-      ]
-
-toServantError :: Describable a => a -> ServerError
-toServantError x = err500 {errBody = encodeUtf8 $ TL.fromStrict $ describeText x}
-
--- * Handlers
+    :<|> "solution" :> Capture "sha1" Sha1 :> "fetch" :> Get '[PlainText] TL.Text
+    :<|> "list" :> "games" :> Get '[JSON] [TournamentGame]
+    :<|> "list" :> "game" :> Capture "sha1" Sha1 :> Get '[JSON] GameWithSolutions
+    :<|> "api" :> "private" :> "login" :> "status" :> AuthProtect "cookie-auth" :> Get '[JSON] UserAlias
+    :<|> "github-auth-callback" :> QueryParam "code" TokenExchangeCode :> Verb 'GET 303 '[JSON] LoginType
+    :<|> "api" :> "private" :> "login" :> "local" :> Header "Referer" TL.Text :> Verb 'GET 303 '[JSON] LoginType
+    :<|> "api" :> "private" :> "login" :> "logout" :> Header "Referer" TL.Text :> Verb 'GET 303 '[JSON] LoginType
 
 mkApp :: AppData -> Servant.Server TournamentAPI
 mkApp appData =
@@ -125,74 +107,224 @@ mkApp appData =
     :<|> uploadSolution appData
     :<|> getScenarioMetadata appData
     :<|> downloadRedactedScenario appData
+    :<|> downloadSolution appData
     :<|> listScenarios
+    :<|> listSolutions
+    :<|> echoUsername
+    :<|> doGithubCallback (gitHubCredentials appData)
+    :<|> doLocalDevelopmentLogin (developmentMode appData)
+    :<|> doLogout
+ where
+  echoUsername = return
 
-uploadScenario :: AppData -> MultipartData Mem -> Handler ScenarioCharacterization
-uploadScenario (AppData gameVersion persistenceLayer) multipartData =
-  Handler . withExceptT toServantError . ExceptT $
+type ToplevelAPI =
+  TournamentAPI
+    :<|> "api" :> Raw
+    :<|> Raw
+
+tournamentsApiHtml :: LBS.ByteString
+tournamentsApiHtml =
+  encodeUtf8
+    . either (error . show) (Mark.renderHtml @())
+    . Mark.commonmark ""
+    $ T.pack "No documentation at this time."
+
+toServantError :: Describable a => a -> ServerError
+toServantError x = err500 {errBody = encodeUtf8 $ TL.fromStrict $ describeText x}
+
+-- | We need to specify the data returned after authentication
+type instance AuthServerData (AuthProtect "cookie-auth") = UserAlias
+
+myAppCookieName :: BS.ByteString
+myAppCookieName = "servant-auth-cookie"
+
+data LoginProblem = LoginProblem
+  { problemMessage :: TL.Text
+  , loginLink :: TL.Text
+  }
+  deriving (Generic, ToJSON)
+
+--- | The auth handler wraps a function from Request -> Handler UserAlias.
+--- We look for a token in the request headers that we expect to be in the cookie.
+--- The token is then passed to our `lookupAccount` function.
+authHandler :: GitHubCredentials -> DeploymentEnvironment -> AuthHandler Request UserAlias
+authHandler creds deployMode = mkAuthHandler handler
+ where
+  url = case deployMode of
+    LocalDevelopment _ -> "api/private/login/local"
+    ProdDeployment -> decodeUtf8 . LBS.fromStrict $ genLoginUrl creds
+
+  throw401 msg = throwError $ err401 {errBody = encode $ LoginProblem msg url}
+  handler req = either throw401 lookupAccount $ do
+    cookie <- maybeToEither "Missing cookie header" $ lookup hCookie $ requestHeaders req
+    maybeToEither "Missing token in cookie" $
+      fmap (decodeUtf8 . LBS.fromStrict) $
+        lookup myAppCookieName $
+          parseCookies cookie
+
+  userLookup cookieText = runReaderT (getUsernameFromCookie cookieText) databaseFilename
+
+  -- \| A method that, when given a cookie/password, will return a UserAlias.
+  lookupAccount :: TL.Text -> Handler UserAlias
+  lookupAccount cookieText = do
+    maybeUser <- liftIO $ userLookup cookieText
+    case maybeUser of
+      Nothing -> throwError (err403 {errBody = encode $ LoginProblem "Invalid cookie password" url})
+      Just usr -> return usr
+
+-- * Handlers
+
+uploadScenario ::
+  AppData ->
+  Maybe TL.Text ->
+  UserAlias ->
+  MultipartData Mem ->
+  Handler (Headers '[Header "Location" TL.Text] ScenarioCharacterization)
+uploadScenario (AppData gameVersion _ persistenceLayer _) maybeRefererUrl userName multipartData =
+  Handler . fmap addH . withExceptT toServantError . ExceptT $
     validateScenarioUpload
       args
       gameVersion
  where
+  addH = addHeader (fromMaybe "/list-games.html" maybeRefererUrl)
   args =
     CommonValidationArgs
       defaultSolutionTimeout
       $ PersistenceArgs
-        placeholderAlias
+        userName
         multipartData
         (scenarioStorage persistenceLayer)
 
-uploadSolution :: AppData -> MultipartData Mem -> Handler SolutionFileCharacterization
-uploadSolution (AppData _ persistenceLayer) multipartData =
-  Handler . withExceptT toServantError . ExceptT $
+uploadSolution ::
+  AppData ->
+  Maybe TL.Text ->
+  UserAlias ->
+  MultipartData Mem ->
+  Handler (Headers '[Header "Location" TL.Text] SolutionFileCharacterization)
+uploadSolution (AppData _ _ persistenceLayer _) maybeRefererUrl userName multipartData =
+  Handler . fmap addH . withExceptT toServantError . ExceptT $
     validateSubmittedSolution
       args
-      (lookupScenarioFileContent persistenceLayer)
+      ((getContent . scenarioStorage) persistenceLayer)
  where
+  addH = addHeader (fromMaybe "/list-solutions.html" maybeRefererUrl)
   args =
     CommonValidationArgs
       defaultSolutionTimeout
       $ PersistenceArgs
-        placeholderAlias
+        userName
         multipartData
         (solutionStorage persistenceLayer)
 
 getScenarioMetadata :: AppData -> Sha1 -> Handler ScenarioMetadata
-getScenarioMetadata (AppData _ persistenceLayer) scenarioSha1 =
+getScenarioMetadata (AppData _ _ persistenceLayer _) scenarioSha1 =
   Handler . withExceptT toServantError $ do
     doc <-
       ExceptT $
         maybeToEither (DatabaseRetrievalFailure scenarioSha1)
-          <$> lookupScenarioFileContent persistenceLayer scenarioSha1
+          <$> (getContent . scenarioStorage) persistenceLayer scenarioSha1
 
     s <- withExceptT RetrievedInstantiationFailure $ initScenarioObjectWithEnv doc
     return $ view scenarioMetadata s
 
+genLoginUrl :: GitHubCredentials -> BS.ByteString
+genLoginUrl creds =
+  "https://github.com/login/oauth/authorize"
+    <> renderSimpleQuery
+      True
+      [ ("client_id", clientId creds)
+      ]
+
+downloadSolution :: AppData -> Sha1 -> Handler TL.Text
+downloadSolution (AppData _ _ persistenceLayer _) solutionSha1 = do
+  Handler . withExceptT toServantError $ do
+    ExceptT $
+      maybeToEither (DatabaseRetrievalFailure solutionSha1)
+        <$> (fmap $ fmap decodeUtf8) ((getContent . solutionStorage) persistenceLayer solutionSha1)
+
 downloadRedactedScenario :: AppData -> Sha1 -> Handler TL.Text
-downloadRedactedScenario (AppData _ persistenceLayer) scenarioSha1 = do
+downloadRedactedScenario (AppData _ _ persistenceLayer _) scenarioSha1 = do
   Handler . withExceptT toServantError $ do
     doc <-
       ExceptT $
         maybeToEither (DatabaseRetrievalFailure scenarioSha1)
-          <$> lookupScenarioFileContent persistenceLayer scenarioSha1
+          <$> (getContent . scenarioStorage) persistenceLayer scenarioSha1
 
     rawYamlDict :: Map Key Value <- withExceptT YamlParseFailure . except . decodeEither' $ LBS.toStrict doc
     let redactedDict = M.delete "solution" rawYamlDict
     withExceptT DecodingFailure . except . decodeUtf8' . LBS.fromStrict $
       encodeWith defaultEncodeOptions redactedDict
 
--- NOTE: This is currently the only API endpoint that invokes
--- 'runReaderT' directly
 listScenarios :: Handler [TournamentGame]
 listScenarios =
-  Handler $
+  Handler $ liftIO $ runReaderT listGames databaseFilename
+
+listSolutions :: Sha1 -> Handler GameWithSolutions
+listSolutions sha1 =
+  Handler $ liftIO $ runReaderT (listSubmissions sha1) databaseFilename
+
+doGithubCallback ::
+  GitHubCredentials ->
+  Maybe TokenExchangeCode ->
+  LoginHandler
+doGithubCallback creds maybeCode = do
+  c <- maybe (fail "Missing 'code' parameter") return maybeCode
+
+  manager <- liftIO $ HC.newManager tlsManagerSettings
+  receivedTokens <- exchangeCode manager creds c
+
+  let aToken = token $ accessToken receivedTokens
+  userInfo <- fetchAuthenticatedUser manager aToken
+
+  doLoginResponse refererUrl (UserAlias $ login userInfo) receivedTokens
+ where
+  refererUrl = "/list-games.html"
+
+doLocalDevelopmentLogin :: DeploymentEnvironment -> Maybe TL.Text -> LoginHandler
+doLocalDevelopmentLogin envType maybeRefererUrl =
+  case envType of
+    ProdDeployment -> error "Login bypass not available in production"
+    LocalDevelopment user ->
+      doLoginResponse refererUrl user $
+        ReceivedTokens
+          (Expirable (AccessToken "abcd") 100)
+          (Expirable (RefreshToken "efgh") 10000)
+ where
+  refererUrl = fromMaybe "foo" maybeRefererUrl
+
+makeCookieHeader :: BS.ByteString -> SetCookie
+makeCookieHeader val =
+  defaultSetCookie
+    { setCookieName = myAppCookieName
+    , setCookieValue = val
+    , setCookiePath = Just "/api/private"
+    }
+
+doLogout :: Maybe TL.Text -> LoginHandler
+doLogout maybeRefererUrl =
+  return $
+    addHeader (fromMaybe "/list-games.html" maybeRefererUrl) $
+      addHeader ((makeCookieHeader "") {setCookieMaxAge = Just 0}) NoContent
+
+doLoginResponse ::
+  TL.Text ->
+  UserAlias ->
+  ReceivedTokens ->
+  LoginHandler
+doLoginResponse refererUrl userAlias receivedTokens = do
+  cookieString <-
     liftIO $
-      runReaderT listGames databaseFilename
+      flip runReaderT databaseFilename $
+        insertGitHubAuth userAlias receivedTokens
+
+  return $
+    addHeader refererUrl $
+      addHeader (makeCookieHeader $ LBS.toStrict $ encodeUtf8 cookieString) NoContent
 
 -- * Web app declaration
 
 app :: AppData -> Application
-app appData = Servant.serveWithContext api context server
+app appData = Servant.serveWithContext (Proxy :: Proxy ToplevelAPI) context server
  where
   size100kB = 100_000 :: Int64
 
@@ -206,7 +338,8 @@ app appData = Servant.serveWithContext api context server
             $ defaultParseRequestBodyOptions
       }
 
-  context = multipartOpts :. EmptyContext
+  thisAuthHandler = authHandler (gitHubCredentials appData) (developmentMode appData)
+  context = thisAuthHandler :. multipartOpts :. EmptyContext
 
   server :: Server ToplevelAPI
   server =
@@ -218,8 +351,8 @@ app appData = Servant.serveWithContext api context server
           }
    where
     serveDocs _ resp =
-      resp $ responseLBS ok200 [plain] swarmApiHtml
-    plain = ("Content-Type", "text/html")
+      resp $ responseLBS ok200 [htmlType] tournamentsApiHtml
+    htmlType = ("Content-Type", "text/html")
 
 webMain ::
   AppData ->
@@ -228,46 +361,3 @@ webMain ::
 webMain appData port = Warp.runSettings settings $ app appData
  where
   settings = Warp.setPort port Warp.defaultSettings
-
--- * Instances for documentation
-
-instance SD.ToSample T.Text where
-  toSamples _ = SD.samples ["foo"]
-
-instance SD.ToSample TL.Text where
-  toSamples _ = SD.samples ["foo"]
-
-instance SD.ToSample TournamentGame where
-  toSamples _ = SD.samples [TournamentGame "foo" "bar" (Sha1 "abc") 10 (Sha1 "def")]
-
-fakeSolnCharacterization :: SolutionCharacterization
-fakeSolnCharacterization =
-  SolutionCharacterization
-    10
-    (TickNumber 100)
-    0
-    (ScenarioCodeMetrics 10 5)
-
-instance SD.ToSample ScenarioMetadata where
-  toSamples _ = SD.samples [ScenarioMetadata 1 "foo" $ Just "bar"]
-
-instance SD.ToSample SolutionFileCharacterization where
-  toSamples _ = SD.samples [SolutionFileCharacterization (Sha1 "abcdef") fakeSolnCharacterization]
-
-instance SD.ToSample ScenarioCharacterization where
-  toSamples _ = SD.samples [ScenarioCharacterization (FileMetadata "foo.yaml" (Sha1 "abcdef")) fakeSolnCharacterization]
-
-instance ToMultipartSample Mem (MultipartData Mem) where
-  toMultipartSamples _proxy =
-    [
-      ( "sample 1"
-      , MultipartData
-          [Input "username" "Elvis Presley"]
-          [ FileData
-              "scenario-file"
-              "my-scenario.yaml"
-              "application/yaml"
-              "tmpservant-multipart000.buf"
-          ]
-      )
-    ]

--- a/src/swarm-tournament/Swarm/Web/Tournament/Type.hs
+++ b/src/swarm-tournament/Swarm/Web/Tournament/Type.hs
@@ -10,6 +10,8 @@ module Swarm.Web.Tournament.Type where
 import Data.Aeson
 import Data.ByteString.Lazy qualified as LBS
 import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
+import Data.Time (UTCTime)
 import Database.SQLite.Simple.ToField
 import GHC.Generics (Generic)
 import Servant
@@ -21,7 +23,8 @@ import Swarm.Game.Tick (TickNumber (..))
 import Swarm.Game.World.Gen (Seed)
 import System.Time.Extra
 
-newtype UserAlias = UserAlias T.Text
+newtype UserAlias = UserAlias TL.Text
+  deriving (Generic, ToJSON)
 
 instance ToField UserAlias where
   toField (UserAlias x) = toField x
@@ -46,10 +49,24 @@ data TournamentGame = TournamentGame
   , scenarioHash :: Sha1
   , submissionCount :: Int
   , swarmGitSha1 :: Sha1
+  , scenarioTitle :: T.Text
   }
   deriving (Generic, ToJSON)
 
-data AssociatedSolutionSolutionCharacterization = AssociatedSolutionSolutionCharacterization
+data TournamentSolution = TournamentSolution
+  { submissionTime :: UTCTime
+  , solutionSubmitter :: T.Text
+  , submissionScore :: SolutionFileCharacterization
+  }
+  deriving (Generic, ToJSON)
+
+data GameWithSolutions = GameWithSolutions
+  { theGame :: TournamentGame
+  , theSolutions :: [TournamentSolution]
+  }
+  deriving (Generic, ToJSON)
+
+data AssociatedSolutionCharacterization = AssociatedSolutionCharacterization
   { forScenario :: Sha1
   , characterization :: SolutionCharacterization
   }

--- a/src/swarm-tournament/Swarm/Web/Tournament/Validate/Upload.hs
+++ b/src/swarm-tournament/Swarm/Web/Tournament/Validate/Upload.hs
@@ -18,11 +18,11 @@ import Swarm.Web.Tournament.Database.Query
 import Swarm.Web.Tournament.Type
 import Swarm.Web.Tournament.Validate.FailureMode
 
-data PersistenceArgs a
+data PersistenceArgs m a
   = PersistenceArgs
       UserAlias
       (MultipartData Mem)
-      (ScenarioPersistence a)
+      (ScenarioPersistence m a)
 
 obtainFileUpload ::
   MultipartData Mem ->
@@ -45,10 +45,10 @@ obtainFileUpload multipartData =
   maybeNonemptyFiles = NE.nonEmpty $ files multipartData
 
 withFileCache ::
-  PersistenceArgs a ->
+  PersistenceArgs IO a ->
   (GenericUploadFailure -> e) ->
-  (FileUpload -> ExceptT e IO (AssociatedSolutionSolutionCharacterization, a)) ->
-  ExceptT e IO (FileMetadata, AssociatedSolutionSolutionCharacterization)
+  (FileUpload -> ExceptT e IO (AssociatedSolutionCharacterization, a)) ->
+  ExceptT e IO (FileMetadata, AssociatedSolutionCharacterization)
 withFileCache (PersistenceArgs userAlias multipartData persistenceFunctions) errorWrapper cacheStoreFunction = do
   file <- withExceptT errorWrapper $ obtainFileUpload multipartData
   maybePreexisting <-

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -466,6 +466,7 @@ library swarm-tournament
   visibility: public
   -- cabal-gild: discover src/swarm-tournament
   exposed-modules:
+    Swarm.Web.Auth
     Swarm.Web.Tournament
     Swarm.Web.Tournament.Database.Query
     Swarm.Web.Tournament.Type
@@ -482,8 +483,12 @@ library swarm-tournament
     bytestring,
     commonmark,
     containers,
+    cookie,
+    exceptions,
     extra,
     fused-effects,
+    http-client,
+    http-client-tls >=0.3.6.3 && <0.3.7,
     http-types,
     lens,
     mtl,
@@ -498,6 +503,7 @@ library swarm-tournament
     wai-app-static >=3.1.8 && <3.2,
     wai-extra,
     warp,
+    utf8-string,
     yaml,
 
   build-depends:
@@ -768,6 +774,7 @@ executable swarm-host-tournament
     optparse-applicative >=0.16 && <0.19,
     transformers,
     warp,
+    yaml,
 
   build-depends:
     swarm:swarm-engine,

--- a/test/tournament-host/Main.hs
+++ b/test/tournament-host/Main.hs
@@ -37,19 +37,24 @@ main = do
     ScenarioPersistence
       { lookupCache = const $ return Nothing
       , storeCache = const $ return $ Sha1 "bogus"
+      , getContent = const $ return Nothing
       }
 
   mkPersistenceLayer scenariosMap =
     PersistenceLayer
-      { lookupScenarioFileContent = \x -> return $ content <$> NEM.lookup x scenariosMap
-      , scenarioStorage = noPersistence
+      { scenarioStorage =
+          noPersistence
+            { getContent = return . fmap content . (`NEM.lookup` scenariosMap)
+            }
       , solutionStorage = noPersistence
       }
 
   mkAppData scenariosMap =
     Tournament.AppData
       { Tournament.swarmGameGitVersion = Sha1 "abcdef"
+      , Tournament.gitHubCredentials = Tournament.GitHubCredentials "" ""
       , Tournament.persistence = mkPersistenceLayer scenariosMap
+      , Tournament.developmentMode = Tournament.LocalDevelopment
       }
 
 type LocalFileLookup = NEMap Sha1 FilePathAndContent
@@ -72,12 +77,12 @@ testScenarioUpload :: LocalFileLookup -> Tournament.AppData -> Assertion
 testScenarioUpload fileLookup appData =
   mapM_ f testScenarioPaths
  where
-  f x = uploadForm appData "/upload/scenario" [partFileSource "file" x]
+  f x = uploadForm appData "/api/private/upload/scenario" [partFileSource "file" x]
   testScenarioPaths = map filePath $ NE.toList $ NEM.elems fileLookup
 
 testSolutionUpload :: LocalFileLookup -> Tournament.AppData -> Assertion
 testSolutionUpload fileLookup appData =
-  uploadForm appData "/upload/solution" form
+  uploadForm appData "/api/private/upload/solution" form
  where
   solutionFilePath = "data/scenarios/Challenges/_arbitrage/solution.sw"
   Sha1 scenarioSha1 = NE.head $ NEM.keys fileLookup
@@ -92,10 +97,16 @@ uploadForm :: Tournament.AppData -> String -> [PartM IO] -> Assertion
 uploadForm appData urlPath form =
   testWithApplication (pure tournamentApp) $ \p -> do
     manager <- newManager defaultManagerSettings
-    req <- parseRequest $ "http://localhost:" ++ show p ++ urlPath
-    resp <- flip httpLbs manager =<< formDataBody form req
 
-    print $ responseBody resp
+    let baseUrl = "http://localhost:" ++ show p
+    reqLogin <- parseRequest $ baseUrl ++ "/api/private/login/local"
+    respLogin <- httpLbs reqLogin manager
+
+    req <- parseRequest $ baseUrl ++ urlPath
+    resp <-
+      flip httpLbs manager
+        =<< formDataBody form (req {cookieJar = Just $ responseCookieJar respLogin})
+
     assertEqual "Server response should be 200" ok200 $ responseStatus resp
  where
   tournamentApp = Tournament.app appData

--- a/tournament/schema/swarm-sqlite-schema.sql
+++ b/tournament/schema/swarm-sqlite-schema.sql
@@ -1,20 +1,29 @@
+PRAGMA foreign_keys = ON;
+
 BEGIN TRANSACTION;
+
 CREATE TABLE IF NOT EXISTS "users" (
-	"id"	INTEGER NOT NULL UNIQUE,
 	"alias"	TEXT NOT NULL,
-	"created_at"	DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	PRIMARY KEY("id" AUTOINCREMENT)
+	"cookie" TEXT NOT NULL UNIQUE DEFAULT (lower(hex(randomblob(16)))),
+	"github_access_token"	TEXT NOT NULL,
+	"github_access_token_expires_at"	DATETIME NOT NULL,
+	"github_refresh_token"	TEXT NOT NULL,
+	"github_refresh_token_expires_at"	DATETIME NOT NULL,
+	PRIMARY KEY("alias")
 );
+
 CREATE TABLE IF NOT EXISTS "scenarios" (
 	"content_sha1"	TEXT NOT NULL UNIQUE,
-	"uploader"	INTEGER NOT NULL,
+	"uploader"	TEXT NOT NULL,
 	"original_filename"	TEXT,
+	"title"	TEXT,
 	"swarm_git_sha1"	TEXT,
 	"uploaded_at"	DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	"content"	TEXT NOT NULL,
 	PRIMARY KEY("content_sha1"),
-	FOREIGN KEY(uploader) REFERENCES users(id)
+	FOREIGN KEY(uploader) REFERENCES users(alias)
 );
+
 CREATE TABLE IF NOT EXISTS "evaluated_solution" (
 	"id"	INTEGER NOT NULL UNIQUE,
 	"evaluated_at"	DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -28,27 +37,48 @@ CREATE TABLE IF NOT EXISTS "evaluated_solution" (
 	PRIMARY KEY("id" AUTOINCREMENT),
 	FOREIGN KEY(scenario) REFERENCES scenarios(content_sha1)
 );
+
 CREATE TABLE IF NOT EXISTS "solution_submission" (
 	"content_sha1"	TEXT NOT NULL,
-	"uploader"	INTEGER NOT NULL,
+	"uploader"	TEXT NOT NULL,
 	"uploaded_at"	DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	"solution_evaluation"	INTEGER,
+	"content"	TEXT NOT NULL,
 	PRIMARY KEY("content_sha1"),
+	FOREIGN KEY(uploader) REFERENCES users(alias),
 	FOREIGN KEY(solution_evaluation) REFERENCES evaluated_solution(id)
 );
 
-CREATE VIEW submissions AS
+CREATE VIEW agg_scenario_submissions AS
  SELECT scenarios.original_filename,
     scenarios.content_sha1 AS scenario,
     scenarios.uploaded_at AS scenario_uploaded_at,
     COALESCE(foo.submission_count, 0) AS submission_count,
-    users.alias AS scenario_uploader,
-    scenarios.swarm_git_sha1
+    scenarios.uploader AS scenario_uploader,
+    scenarios.swarm_git_sha1,
+	scenarios.title
    FROM ((scenarios
      LEFT JOIN ( SELECT evaluated_solution.scenario,
             count(*) AS submission_count
            FROM evaluated_solution
           WHERE (NOT evaluated_solution.builtin)
           GROUP BY evaluated_solution.scenario) foo ON (scenarios.content_sha1 = foo.scenario))
-     JOIN users ON (scenarios.uploader = users.id));
+     );
+
+
+CREATE VIEW all_solution_submissions AS
+SELECT
+	evaluated_solution.scenario,
+    solution_submission.uploaded_at,
+	evaluated_solution.seed,
+	evaluated_solution.wall_time_seconds,
+	evaluated_solution.ticks,
+	evaluated_solution.char_count,
+	evaluated_solution.ast_size,
+    solution_submission.uploader AS solution_submitter,
+    solution_submission.content_sha1 AS solution_sha1
+   FROM solution_submission
+	 JOIN evaluated_solution ON evaluated_solution.id = solution_submission.solution_evaluation
+   WHERE NOT evaluated_solution.builtin;
+
 COMMIT;

--- a/tournament/scripts/demo/server-native.sh
+++ b/tournament/scripts/demo/server-native.sh
@@ -7,7 +7,7 @@ cd $(git rev-parse --show-toplevel)
 GIT_HASH=$(git rev-parse HEAD)
 
 cabal run -j -O0 swarm:swarm-host-tournament -- \
-    --native-dev \
     --port 8080 \
     --version $GIT_HASH \
+    --local \
     "$@"

--- a/tournament/scripts/deploy/redeploy-web-files.sh
+++ b/tournament/scripts/deploy/redeploy-web-files.sh
@@ -3,4 +3,4 @@
 cd $(git rev-parse --show-toplevel)
 
 scp -r tournament/web lightsail:tournament
-scp -r data lightsail:.local/share/swarm
+rsync -r data lightsail:.local/share/swarm

--- a/tournament/scripts/docker/build-server-executable.sh
+++ b/tournament/scripts/docker/build-server-executable.sh
@@ -12,4 +12,12 @@ BUILD_TARGET=swarm:swarm-host-tournament
 CABAL_ARGS="-j -O0 --enable-executable-static $BUILD_TARGET"
 
 cabal build $CABAL_ARGS
-cp $(cabal list-bin $CABAL_ARGS) $1
+#cp $(cabal list-bin $CABAL_ARGS) $1
+BIN_PATH=$(cabal list-bin $CABAL_ARGS)
+strip $BIN_PATH
+
+BIN_NAME=swarm-host-tournament
+TEMP_UPLOAD_BIN_NAME=$BIN_NAME.new
+
+rsync -P $BIN_PATH lightsail:$TEMP_UPLOAD_BIN_NAME
+ssh lightsail -C "mv $TEMP_UPLOAD_BIN_NAME $BIN_NAME && sudo systemctl restart swarm-tournament"

--- a/tournament/web/list-solutions.html
+++ b/tournament/web/list-solutions.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>Uploaded scenarios</title>
+    <title>Solution submissions</title>
 
     <link rel="stylesheet" href="style/tablesort.css"/>
     <link rel="stylesheet" href="style/list-games.css"/>
@@ -17,29 +17,40 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.1.0/tablesort.min.js"></script>
     <script src="script/common.js"></script>
-    <script src="script/list-games.js"></script>
+    <script src="script/list-solutions.js"></script>
 
     <script>
       window.onload=()=>{
 
         getLoginStatus();
 
+        const queryString = window.location.search;
+        const urlParams = new URLSearchParams(queryString);
+        const scenarioHash = urlParams.get('scenario')
+        document.getElementById('scenario-field').value=scenarioHash;
+
         const tableElement = document.querySelector("table");
-        doFetch(tableElement);
+        doFetch(tableElement, scenarioHash);
       }
     </script>
   </head>
   <body>
     <div id="login-info-container"></div>
-    <h1>Uploaded scenarios</h1>
+    [<a href="/list-games.html">Back to scenarios</a>]
+    <h1 id="main-header">Scenario info</h1>
+    
+    <h2>Solution submissions</h2>
     <table id="my-table">
         <thead>
           <tr data-sort-method="none">
-            <th>Title</th>
-            <th>File</th>
             <th>Uploader</th>
-            <th>Soln. submissions</th>
-            <th>Swarm version</th>
+            <th>Submitted at</th>
+            <th>Seed</th>
+            <th>Source length</th>
+            <th>AST Size</th>
+            <th>Ticks elapsed</th>
+            <th>Evaluation time</th>
+            <th>Download</th>
           </tr>
         </thead>
         <tbody id="my-table-body">
@@ -51,9 +62,10 @@
       </div>
 
       <br/>
-      <h2>Upload new scenario</h2>
-      <form action="/api/private/upload/scenario" method="POST" enctype="multipart/form-data">
-        <input type="file" name="scenario-filename"/>
+      <h2>Upload solution</h2>
+      <form action="/api/private/upload/solution" method="POST" enctype="multipart/form-data">
+        <input type="file" name="solution-filename"/>
+        <input type="hidden" name="scenario" id="scenario-field"/>
         <input type="submit"/>
       </form>
   </body>

--- a/tournament/web/script/common.js
+++ b/tournament/web/script/common.js
@@ -1,0 +1,68 @@
+function wrapWithElement(elName, content) {
+    const e = document.createElement(elName);
+    e.appendChild(content);
+    return e;
+}
+
+function mkLink(text, url) {
+    const anchor = document.createElement("a");
+    anchor.href = url
+    anchor.textContent = text;
+    return anchor;
+}
+
+function regularSpan(textVal) {
+    const span = document.createElement("span");
+    span.appendChild(document.createTextNode(textVal));
+    return span;
+}
+
+function renderGitHash(hashVal) {
+    const span = document.createElement("code");
+    span.appendChild(document.createTextNode(hashVal.substring(0,7)));
+    span.setAttribute('title', hashVal);
+    return span;
+}
+
+function getLoginStatus(myTable) {
+    
+    const loginInfoBox = document.getElementById('login-info-container');
+    
+    fetch("api/private/login/status")
+    .then((response) => {
+        if (response.ok) {
+            response.json().then(data => {
+                const msg = "Logged in as " + data;
+                loginInfoBox.appendChild(document.createTextNode(msg));
+
+                const a = document.createElement("a");
+                a.setAttribute('href', "api/private/login/logout");
+                a.appendChild(document.createTextNode("Logout"));
+                
+                loginInfoBox.appendChild(document.createElement("br"));
+                loginInfoBox.appendChild(a);
+            });
+        } else {
+            var login_message = "Unknown login problem";
+
+            if (response.status == 401) {
+                login_message = "Please log in";
+            } else if (response.status == 403) {
+                login_message = "Log in again";
+            }
+        
+            response.json().then(data => {
+                
+                const a = document.createElement("a");
+                a.setAttribute('href', data.loginLink);
+
+                a.appendChild(document.createTextNode(login_message));
+                
+                loginInfoBox.appendChild(a);
+                loginInfoBox.appendChild(document.createElement("br"));
+                loginInfoBox.appendChild(document.createTextNode("(" + data.problemMessage + ")"));
+            });
+
+        }
+    });
+}

--- a/tournament/web/script/list-games.js
+++ b/tournament/web/script/list-games.js
@@ -1,30 +1,14 @@
-
-function mkLink(text, url) {
-    const anchor = document.createElement("a");
-    anchor.href = url
-    anchor.textContent = text;
-    return anchor;
-}
-
 function insertTableRows(myTableBody, entries) {
     for (const entry of entries) {
         const rowItem = document.createElement("tr");
 
-        const fieldVals = [
-            entry.scenarioUploader,
-            entry.submissionCount,
-            entry.swarmGitSha1,
-        ];
-
         const cellVals = [
+            regularSpan(entry.scenarioTitle),
             mkLink(entry.originalFilename, "scenario/" + entry.scenarioHash + "/fetch"),
+            mkLink(entry.scenarioUploader, "https://github.com/" + entry.scenarioUploader),
+            mkLink("View (" + entry.submissionCount + ")", "list-solutions.html?scenario=" + entry.scenarioHash),
+            renderGitHash(entry.swarmGitSha1),
         ];
-
-        for (const val of fieldVals) {
-            const span = document.createElement("span");
-            span.appendChild(document.createTextNode(val));
-            cellVals.push(span);
-        }
 
         for (const val of cellVals) {
             const cellElement = document.createElement("td");
@@ -39,24 +23,24 @@ function insertTableRows(myTableBody, entries) {
 function doFetch(myTable) {
     document.getElementById("spinner-container").style.display = 'flex';
     
-    fetch("games")
+    fetch("list/games")
     .then((response) => {
-        if (!response.ok) {
-            throw new Error(`HTTP error, status = ${response.status}`);
+        if (response.ok) {
+
+            const data = response.json().then(data => {
+
+                const myTableBody = myTable.querySelector("tbody");
+                insertTableRows(myTableBody, data);
+                // Documentation: http://tristen.ca/tablesort/demo/
+                new Tablesort(document.getElementById('my-table'));
+            });
+
+        } else {
+            const p = document.createElement("p");
+            p.appendChild(document.createTextNode(`Error: HTTP error, status = ${response.status}`));
+            document.body.insertBefore(p, myTable);
         }
-        return response.json();
-    })
-    .then((data) => {
-        const myTableBody = myTable.querySelector("tbody");
-        insertTableRows(myTableBody, data);
-        // Documentation: http://tristen.ca/tablesort/demo/
-        new Tablesort(document.getElementById('my-table'));
-        document.getElementById("spinner-container").style.display = 'none';
-    })
-    .catch((error) => {
-        const p = document.createElement("p");
-        p.appendChild(document.createTextNode(`Error: ${error.message}`));
-        document.body.insertBefore(p, myTable);
+
         document.getElementById("spinner-container").style.display = 'none';
     });
 }

--- a/tournament/web/script/list-solutions.js
+++ b/tournament/web/script/list-solutions.js
@@ -1,0 +1,90 @@
+function insertTableRows(myTableBody, entries) {
+    for (const entry of entries) {
+        const rowItem = document.createElement("tr");
+        const cellVals = [
+            mkLink(entry.solutionSubmitter, "https://github.com/" + entry.solutionSubmitter),
+            regularSpan(entry.submissionTime),
+            regularSpan(entry.submissionScore.solutionCharacterization.scenarioSeed),
+            regularSpan(entry.submissionScore.solutionCharacterization.solutionCodeMetrics.sourceTextLength),
+            regularSpan(entry.submissionScore.solutionCharacterization.solutionCodeMetrics.astSize),
+            regularSpan(entry.submissionScore.solutionCharacterization.solutionTicks),
+            regularSpan(entry.submissionScore.solutionCharacterization.solutionWallTime.toFixed(2) + "s"),
+            mkLink("Download", "solution/" + entry.submissionScore.solutionHash + "/fetch"),
+        ];
+
+        for (const val of cellVals) {
+            const cellElement = document.createElement("td");
+            cellElement.appendChild(val);
+            rowItem.append(cellElement);
+        }
+
+        myTableBody.appendChild(rowItem);
+    }
+}
+
+function mkDefinitionEntryElements(title, element) {
+    return [
+        wrapWithElement("dt", document.createTextNode(title)),
+        wrapWithElement("dd", element),
+    ];
+}
+
+function renderGameInfoBox(entry) {
+
+    const dl = document.createElement("dl");
+    const pairs = [
+        mkDefinitionEntryElements("Title:", regularSpan(entry.scenarioTitle)),
+        mkDefinitionEntryElements("File:", mkLink(entry.originalFilename, "scenario/" + entry.scenarioHash + "/fetch")),
+        mkDefinitionEntryElements("Uploader:", regularSpan(entry.scenarioUploader)),
+        mkDefinitionEntryElements("Swarm version:", renderGitHash(entry.swarmGitSha1)),
+    ];
+
+    for (const e of pairs.flat()) {
+        dl.append(e);
+    }
+
+    return dl;
+}
+
+function doFetch(myTable, gameSha1) {
+    document.getElementById("spinner-container").style.display = 'flex';
+    
+    fetch("list/game/" + gameSha1)
+    .then((response) => {
+        if (response.ok) {
+            response.json().then(data => {
+                const infoBox = renderGameInfoBox(data.theGame);
+
+                const mainHeaderElement = document.getElementById('main-header');
+
+                mainHeaderElement.parentNode.insertBefore(infoBox, mainHeaderElement.nextSibling);
+
+                const tableElement = document.getElementById('my-table');
+                const myTableBody = myTable.querySelector("tbody");
+                insertTableRows(myTableBody, data.theSolutions);
+                // Documentation: http://tristen.ca/tablesort/demo/
+                new Tablesort(tableElement);
+            });
+
+        } else {
+            if (response.status == 401) {
+
+                response.text().then(login_url => {
+                    const login_message = "Please log in";
+                    const a = document.createElement("a");
+                    a.setAttribute('href', login_url);
+
+                    a.appendChild(document.createTextNode(login_message));
+                    document.body.insertBefore(a, myTable);
+                });
+
+            } else {
+                const p = document.createElement("p");
+                p.appendChild(document.createTextNode(`Error: HTTP error, status = ${response.status}`));
+                document.body.insertBefore(p, myTable);
+            }
+        }
+
+        document.getElementById("spinner-container").style.display = 'none';
+    });
+}


### PR DESCRIPTION
## Authentication flow

1. Users are represented by a GitHub username (primary key) and an "authentication cookie" in the SQLite database.
2. Site prompts user to login when the cookie is nonexistent or does not match any user in the database.
3. Upon clicking the login link, redirects user to the GitHub login page.  GitHub sends a code to our callback url.  We use that code to look up the username of the person who is logging in.  We generate and store a new cookie in the database row for that username and set the cookie value on the user's client.
4. As long as the client keeps sending the cookie value known to the server, all uploads/activity will be attributed to their GitHub username.

## New features

* Login/Logout
* All uploaded content is attributed to an authenticated GitHub user
* Separate pages for scenario lists and solution lists
* Download a solution file
* Unit tests exercise cookies/login flow