### PR TITLE
Type synonyms

### DIFF
--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -27,7 +27,7 @@
       (let* (
              ;; Generate the current keywords with:
              ;; cabal run swarm:swarm-docs -- editors --emacs
-             (x-keywords '("def" "end" "let" "in" "require"))
+             (x-keywords '("def" "tydef" "end" "let" "in" "require"))
              (x-builtins '(
                "self"
                "parent"

--- a/editors/vim/swarm.vim
+++ b/editors/vim/swarm.vim
@@ -1,4 +1,4 @@
-syn keyword Keyword def end let in require
+syn keyword Keyword def tydef end let in require
 syn keyword Builtins self parent base if inl inr case fst snd force undefined fail not format chars split charat tochar key
 syn keyword Command noop wait selfdestruct move backup volume path push stride turn grab harvest sow ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami waypoint structure floorplan hastag tagmembers detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows
 syn keyword Direction east north west south down forward left back right

--- a/example/maybe.sw
+++ b/example/maybe.sw
@@ -1,0 +1,9 @@
+tydef Maybe a = Unit + a end
+
+def just : a -> Maybe a = inr end
+
+def nothing : Maybe a = inl () end
+
+def positive : Int -> Maybe Int = \x.
+  if (x > 0) {just x} {nothing}
+end

--- a/feedback.yaml
+++ b/feedback.yaml
@@ -1,3 +1,4 @@
 loops:
+  build: cabal build -j -O0 all
   test: cabal test -j -O0 --test-show-details=direct swarm:swarm-integration swarm:swarm-unit
   unit: cabal test -j -O0 --test-show-details=direct swarm:swarm-unit

--- a/src/swarm-engine/Swarm/Game/CESK.hs
+++ b/src/swarm-engine/Swarm/Game/CESK.hs
@@ -290,7 +290,7 @@ initMachine t e s = initMachine' t e s []
 
 -- | Like 'initMachine', but also take an explicit starting continuation.
 initMachine' :: ProcessedTerm -> Env -> Store -> Cont -> CESK
-initMachine' (ProcessedTerm (Module t' ctx) _ reqCtx) e s k =
+initMachine' (ProcessedTerm (Module t' ctx _tydefs) _ reqCtx) e s k =
   case t' ^. sType of
     -- If the starting term has a command type...
     Forall _ (TyCmd _) ->
@@ -298,6 +298,7 @@ initMachine' (ProcessedTerm (Module t' ctx) _ reqCtx) e s k =
         -- ...but doesn't contain any definitions, just create a machine
         -- that will evaluate it and then execute it.
         Empty -> In t e s (FExec : k)
+        -- XXX do we also need to load tydefs?
         -- Or, if it does contain definitions, then load the resulting
         -- context after executing it.
         _ -> In t e s (FExec : FLoadEnv ctx reqCtx : k)

--- a/src/swarm-engine/Swarm/Game/Robot/Context.hs
+++ b/src/swarm-engine/Swarm/Game/Robot/Context.hs
@@ -19,7 +19,7 @@ import Swarm.Game.CESK qualified as C
 import Swarm.Language.Context qualified as Ctx
 import Swarm.Language.Requirement (ReqCtx)
 import Swarm.Language.Typed (Typed (..))
-import Swarm.Language.Types (TCtx)
+import Swarm.Language.Types (TCtx, TDCtx)
 import Swarm.Language.Value as V
 
 -- | A record that stores the information
@@ -37,13 +37,15 @@ data RobotContext = RobotContext
   , _defStore :: C.Store
   -- ^ A store containing memory cells allocated to hold
   --   definitions.
+  , _tydefVals :: TDCtx
+  -- ^ Type synonym definitions.
   }
   deriving (Eq, Show, Generic, Ae.FromJSON, Ae.ToJSON)
 
 makeLenses ''RobotContext
 
 emptyRobotContext :: RobotContext
-emptyRobotContext = RobotContext Ctx.empty Ctx.empty Ctx.empty C.emptyStore
+emptyRobotContext = RobotContext Ctx.empty Ctx.empty Ctx.empty C.emptyStore Ctx.empty
 
 type instance Index RobotContext = Ctx.Var
 type instance IxValue RobotContext = Typed Value

--- a/src/swarm-engine/Swarm/Game/Scenario/Scoring/GenericMetrics.hs
+++ b/src/swarm-engine/Swarm/Game/Scenario/Scoring/GenericMetrics.hs
@@ -9,6 +9,7 @@ import Data.Aeson
 import Data.Ord (Down (Down))
 import GHC.Generics (Generic)
 import Swarm.Util (maxOn)
+import Swarm.Util.JSON (optionsUntagged)
 
 -- | This is a subset of the "ScenarioStatus" type
 -- that excludes the "NotStarted" case.
@@ -17,17 +18,11 @@ data Progress
   | Completed
   deriving (Eq, Ord, Show, Read, Generic)
 
-untaggedJsonOptions :: Options
-untaggedJsonOptions =
-  defaultOptions
-    { sumEncoding = UntaggedValue
-    }
-
 instance FromJSON Progress where
-  parseJSON = genericParseJSON untaggedJsonOptions
+  parseJSON = genericParseJSON optionsUntagged
 
 instance ToJSON Progress where
-  toJSON = genericToJSON untaggedJsonOptions
+  toJSON = genericToJSON optionsUntagged
 
 data Metric a = Metric Progress a
   deriving (Eq, Ord, Show, Read, Generic, FromJSON, ToJSON)

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -650,7 +650,8 @@ stepCESK cesk = case cesk of
   In tm@(TDef r x _ t) e s k -> withExceptions s k $ do
     hasCapabilityFor CEnv tm
     return $ Out (VDef r x t e) s k
-
+  -- Type definitions just turn into a no-op.
+  In (TTydef {}) e s k -> return $ In (TConst Noop) e s k
   -- Bind expressions don't evaluate: just package it up as a value
   -- until such time as it is to be executed.
   In (TBind mx t1 t2) e s k -> return $ Out (VBind mx t1 t2 e) s k

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -791,12 +791,17 @@ stepCESK cesk = case cesk of
   -- environment, store, and type and capability contexts into the robot's
   -- top-level environment and contexts, so they will be available to
   -- future programs.
-  Out (VResult v e) s (FLoadEnv ctx rctx : k) -> do
+  Out (VResult v e) s (FLoadEnv (Contexts ctx rctx tdctx) : k) -> do
     robotContext . defVals %= (`union` e)
     robotContext . defTypes %= (`union` ctx)
     robotContext . defReqs %= (`union` rctx)
+    robotContext . tydefVals %= (`union` tdctx)
     return $ Out v s k
-  Out v s (FLoadEnv {} : k) -> return $ Out v s k
+  Out v s (FLoadEnv (Contexts ctx rctx tdctx) : k) -> do
+    robotContext . defTypes %= (`union` ctx)
+    robotContext . defReqs %= (`union` rctx)
+    robotContext . tydefVals %= (`union` tdctx)
+    return $ Out v s k
   -- Any other type of value wiwth an FExec frame is an error (should
   -- never happen).
   Out _ s (FExec : _) -> badMachineState s "FExec frame with non-executable value"

--- a/src/swarm-engine/Swarm/Game/Step/Path/Type.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Type.hs
@@ -17,7 +17,7 @@
 module Swarm.Game.Step.Path.Type where
 
 import Control.Lens
-import Data.Aeson (Options (..), SumEncoding (ObjectWithSingleField), ToJSON (..), defaultOptions, genericToJSON)
+import Data.Aeson (ToJSON (..), genericToJSON)
 import Data.IntMap.Strict (IntMap)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
@@ -28,6 +28,7 @@ import Swarm.Game.Location
 import Swarm.Game.Robot (RID)
 import Swarm.Game.Robot.Walk (WalkabilityContext)
 import Swarm.Game.Universe (SubworldName)
+import Swarm.Util.JSON (optionsObjectSingleField)
 import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Util.RingBuffer
 
@@ -67,19 +68,13 @@ data CacheLogEntry = CacheLogEntry
   }
   deriving (Show, Eq, Generic, ToJSON)
 
-objectSingleFieldEncoding :: Options
-objectSingleFieldEncoding =
-  defaultOptions
-    { sumEncoding = ObjectWithSingleField
-    }
-
 data CacheRetrievalAttempt
   = Success
   | RecomputationRequired CacheRetreivalInapplicability
   deriving (Show, Eq, Generic)
 
 instance ToJSON CacheRetrievalAttempt where
-  toJSON = genericToJSON objectSingleFieldEncoding
+  toJSON = genericToJSON optionsObjectSingleField
 
 -- | Certain events can obligate the cache to be
 -- completely invalidated, or partially or fully preserved.
@@ -90,7 +85,7 @@ data CacheEvent
   deriving (Show, Eq, Generic)
 
 instance ToJSON CacheEvent where
-  toJSON = genericToJSON objectSingleFieldEncoding
+  toJSON = genericToJSON optionsObjectSingleField
 
 data DistanceLimitChange
   = LimitIncreased
@@ -113,7 +108,7 @@ data CacheRetreivalInapplicability
   deriving (Show, Eq, Generic)
 
 instance ToJSON CacheRetreivalInapplicability where
-  toJSON = genericToJSON objectSingleFieldEncoding
+  toJSON = genericToJSON optionsObjectSingleField
 
 -- | Reasons for cache being invalidated
 data InvalidationReason

--- a/src/swarm-lang/Swarm/Effect/Unify.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify.hs
@@ -50,4 +50,6 @@ data UnificationError where
   Infinite :: IntVar -> UType -> UnificationError
   -- | Mismatch error between the given terms.
   UnifyErr :: TypeF UType -> TypeF UType -> UnificationError
+  -- | Encountered an undefined/unknown type constructor.
+  UndefinedUserType :: UType -> UnificationError
   deriving (Show)

--- a/src/swarm-lang/Swarm/Effect/Unify/Naive.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify/Naive.hs
@@ -11,7 +11,10 @@
 -- substitutions, and returns a substitution from unification which
 -- must then be composed with the substitution being tracked.
 --
--- Not used in Swarm, but useful for testing/comparison.
+-- Not used in Swarm, and also unmaintained
+-- (e.g. "Swarm.Effect.Unify.Fast" now supports expanding type
+-- aliases; this module does not). It's still here just for
+-- testing/comparison.
 module Swarm.Effect.Unify.Naive where
 
 import Control.Algebra

--- a/src/swarm-lang/Swarm/Language/Context.hs
+++ b/src/swarm-lang/Swarm/Language/Context.hs
@@ -8,7 +8,7 @@
 module Swarm.Language.Context where
 
 import Control.Algebra (Has)
-import Control.Effect.Reader (Reader, local)
+import Control.Effect.Reader (Reader, ask, local)
 import Control.Lens.Empty (AsEmpty (..))
 import Control.Lens.Prism (prism)
 import Data.Aeson (FromJSON, ToJSON)
@@ -52,6 +52,10 @@ singleton x t = Ctx (M.singleton x t)
 -- | Look up a variable in a context.
 lookup :: Var -> Ctx t -> Maybe t
 lookup x (Ctx c) = M.lookup x c
+
+-- | Look up a variable in a context in an ambient Reader effect.
+lookupR :: Has (Reader (Ctx t)) sig m => Var -> m (Maybe t)
+lookupR x = lookup x <$> ask
 
 -- | Delete a variable from a context.
 delete :: Var -> Ctx t -> Ctx t

--- a/src/swarm-lang/Swarm/Language/LSP.hs
+++ b/src/swarm-lang/Swarm/Language/LSP.hs
@@ -89,7 +89,7 @@ validateSwarmCode doc version content = do
           VU.Usage _ problems = VU.getUsage mempty term
           unusedWarnings = mapMaybe (VU.toErrPos content) problems
 
-          parsingErrors = case processParsedTerm' mempty mempty term of
+          parsingErrors = case processParsedTerm' mempty term of
             Right _ -> []
             Left e -> pure $ showTypeErrorPos content e
         Left e -> (pure $ showErrorPos e, [])

--- a/src/swarm-lang/Swarm/Language/LSP/Hover.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/Hover.hs
@@ -130,6 +130,7 @@ narrowToPosition s0@(Syntax' _ t _ ty) pos = fromMaybe s0 $ case t of
   TVar {} -> Nothing
   TRequire {} -> Nothing
   TRequireDevice {} -> Nothing
+  TTydef {} -> Nothing
   -- these should not show up in surface language
   TRef {} -> Nothing
   TRobot {} -> Nothing
@@ -188,6 +189,7 @@ explain trm = case trm ^. sTerm of
   TVar v -> pure $ typeSignature v ty ""
   SRcd {} -> literal "A record literal."
   SProj {} -> literal "A record projection."
+  TTydef {} -> literal "A type synonym definition."
   -- type ascription
   SAnnotate lhs typeAnn ->
     Node

--- a/src/swarm-lang/Swarm/Language/Module.hs
+++ b/src/swarm-lang/Swarm/Language/Module.hs
@@ -10,6 +10,7 @@ module Swarm.Language.Module (
   Module (..),
   moduleSyntax,
   moduleCtx,
+  moduleTydefs,
   TModule,
   UModule,
   trivMod,
@@ -31,8 +32,13 @@ import Swarm.Language.Types (Polytype, UPolytype, UType)
 --   inference on a top-level expression, which in particular can
 --   contain definitions ('Swarm.Language.Syntax.TDef').  A module
 --   contains the type-annotated AST of the expression itself, as well
---   as the context giving the types of any defined variables.
-data Module s t = Module {_moduleSyntax :: Syntax' s, _moduleCtx :: Ctx t}
+--   as a context which maps term variable names to their types, and
+--   another context which maps type synonym names to their definitions.
+data Module s t = Module
+  { _moduleSyntax :: Syntax' s
+  , _moduleCtx :: Ctx t
+  , _moduleTydefs :: Ctx Polytype
+  }
   deriving (Show, Eq, Functor, Data, Generic, FromJSON, ToJSON)
 
 makeLenses ''Module
@@ -51,4 +57,4 @@ type UModule = Module UType UPolytype
 
 -- | The trivial module for a given AST, with the empty context.
 trivMod :: Syntax' s -> Module s t
-trivMod t = Module t empty
+trivMod t = Module t empty empty

--- a/src/swarm-lang/Swarm/Language/Module.hs
+++ b/src/swarm-lang/Swarm/Language/Module.hs
@@ -22,7 +22,7 @@ import Data.Yaml (FromJSON, ToJSON)
 import GHC.Generics (Generic)
 import Swarm.Language.Context (Ctx, empty)
 import Swarm.Language.Syntax (Syntax')
-import Swarm.Language.Types (Polytype, UPolytype, UType)
+import Swarm.Language.Types (Polytype, TDCtx, UPolytype, UType)
 
 ------------------------------------------------------------
 -- Modules
@@ -37,7 +37,7 @@ import Swarm.Language.Types (Polytype, UPolytype, UType)
 data Module s t = Module
   { _moduleSyntax :: Syntax' s
   , _moduleCtx :: Ctx t
-  , _moduleTydefs :: Ctx Polytype
+  , _moduleTydefs :: TDCtx
   }
   deriving (Show, Eq, Functor, Data, Generic, FromJSON, ToJSON)
 

--- a/src/swarm-lang/Swarm/Language/Parser/Lex.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Lex.hs
@@ -34,6 +34,7 @@ module Swarm.Language.Parser.Lex (
   locTyName,
   identifier,
   tyVar,
+  tyName,
   tmVar,
   textLiteral,
   integer,
@@ -211,14 +212,14 @@ locIdentifier idTy = do
           failT ["reserved word", squote t, "cannot be used as variable name"]
       | otherwise -> return t
     SwarmLangLatest
-      | t `S.member` reservedWords || T.toLower t `S.member` reservedWords ->
-          failT ["Reserved word", squote t, "cannot be used as a variable name"]
       | IDTyVar <- idTy
       , T.toTitle t `S.member` reservedWords ->
           failT ["Reserved type name", squote t, "cannot be used as a type variable name; perhaps you meant", squote (T.toTitle t) <> "?"]
       | IDTyName <- idTy
-      , T.toTitle t `S.member` reservedWords ->
+      , t `S.member` reservedWords ->
           failT ["Reserved type name", squote t, "cannot be redefined."]
+      | t `S.member` reservedWords || T.toLower t `S.member` reservedWords ->
+          failT ["Reserved word", squote t, "cannot be used as a variable name"]
       | IDTyName <- idTy
       , isLower (T.head t) ->
           failT ["Type synonym names must start with an uppercase letter"]
@@ -247,6 +248,11 @@ identifier = fmap lvVar . locIdentifier
 --   name.
 tyVar :: Parser Var
 tyVar = identifier IDTyVar
+
+-- | Parse a (user-defined) type constructor name, which must start
+--   with an uppercase letter.
+tyName :: Parser Var
+tyName = identifier IDTyName
 
 -- | Parse a term variable, which can start in any case and just
 --   cannot be the same (case-insensitively) as a lowercase reserved

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -7,7 +7,7 @@
 module Swarm.Language.Parser.Term where
 
 import Control.Lens (view, (^.))
-import Control.Monad (guard)
+import Control.Monad (guard, join)
 import Control.Monad.Combinators.Expr
 import Data.Foldable (asum)
 import Data.List (foldl')
@@ -22,8 +22,10 @@ import Swarm.Language.Parser.Record (parseRecord)
 import Swarm.Language.Parser.Type
 import Swarm.Language.Syntax
 import Swarm.Language.Types
+import Swarm.Util (findDup)
 import Text.Megaparsec hiding (runParser)
 import Text.Megaparsec.Char
+import Witch (into)
 
 -- Imports for doctests (cabal-docspec needs this)
 
@@ -86,6 +88,9 @@ parseTermAtom2 =
           <$> (reserved "def" *> locTmVar)
           <*> optional (symbol ":" *> parsePolytype)
           <*> (symbol "=" *> parseTerm <* reserved "end")
+        <|> TTydef
+          <$> (reserved "tydef" *> locTyName)
+          <*> join (bindTydef <$> many tyVar <*> (symbol "=" *> parseType <* reserved "end"))
         <|> SRcd <$> brackets (parseRecord (optional (symbol "=" *> parseTerm)))
         <|> parens (view sTerm . mkTuple <$> (parseTerm `sepBy` symbol ","))
     )
@@ -108,6 +113,21 @@ sLet x ty t1 = SLet (lvVar x `S.member` setOf freeVarsV t1) x ty t1
 --   indicating whether it is recursive.
 sDef :: LocVar -> Maybe Polytype -> Syntax -> Term
 sDef x ty t = SDef (lvVar x `S.member` setOf freeVarsV t) x ty t
+
+-- | Create a polytype from a list of variable binders and a type.
+--   Ensure that no binder is repeated, and all type variables in the
+--   type are present in the list of binders (/i.e./ the type contains
+--   no free type variables).
+bindTydef :: [Var] -> Type -> Parser Polytype
+bindTydef xs ty
+  | Just repeated <- findDup xs = fail $ "Duplicate variable on left-hand side of tydef: " ++ into @String repeated
+  | not (S.null free) =
+      fail $
+        "Undefined type variable(s) on right-hand side of tydef: "
+          ++ unwords (map (into @String) (S.toList free))
+  | otherwise = return $ Forall xs ty
+ where
+  free = tyVars ty `S.difference` S.fromList xs
 
 parseAntiquotation :: Parser Term
 parseAntiquotation =

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -175,7 +175,9 @@ fixDefMissingSemis term =
   mkBind t1 t2 = Syntax ((t1 ^. sLoc) <> (t2 ^. sLoc)) $ SBind Nothing t1 t2
   nestedDefs term' acc = case term' of
     def@(Syntax _ SDef {}) -> def : acc
+    def@(Syntax _ TTydef {}) -> def : acc
     (Syntax _ (SApp nestedTerm def@(Syntax _ SDef {}))) -> nestedDefs nestedTerm (def : acc)
+    (Syntax _ (SApp nestedTerm def@(Syntax _ TTydef {}))) -> nestedDefs nestedTerm (def : acc)
     -- Otherwise returns an empty list to keep the term unchanged
     _ -> []
 

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -22,10 +22,9 @@ import Swarm.Language.Parser.Record (parseRecord)
 import Swarm.Language.Parser.Type
 import Swarm.Language.Syntax
 import Swarm.Language.Types
-import Swarm.Util (findDup)
+import Swarm.Util (failT, findDup)
 import Text.Megaparsec hiding (runParser)
 import Text.Megaparsec.Char
-import Witch (into)
 
 -- Imports for doctests (cabal-docspec needs this)
 
@@ -120,11 +119,11 @@ sDef x ty t = SDef (lvVar x `S.member` setOf freeVarsV t) x ty t
 --   no free type variables).
 bindTydef :: [Var] -> Type -> Parser Polytype
 bindTydef xs ty
-  | Just repeated <- findDup xs = fail $ "Duplicate variable on left-hand side of tydef: " ++ into @String repeated
+  | Just repeated <- findDup xs =
+      failT ["Duplicate variable on left-hand side of tydef:", repeated]
   | not (S.null free) =
-      fail $
-        "Undefined type variable(s) on right-hand side of tydef: "
-          ++ unwords (map (into @String) (S.toList free))
+      failT $
+        "Undefined type variable(s) on right-hand side of tydef:" : S.toList free
   | otherwise = return $ Forall xs ty
  where
   free = tyVars ty `S.difference` S.fromList xs

--- a/src/swarm-lang/Swarm/Language/Parser/Type.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Type.hs
@@ -26,6 +26,7 @@ import Swarm.Language.Parser.Lex (
   reserved,
   reservedCS,
   symbol,
+  tyName,
   tyVar,
  )
 import Swarm.Language.Parser.Record (parseRecord)
@@ -102,3 +103,4 @@ parseTyCon = do
         SwarmLangLatest -> reservedCS
   choice (map (\b -> TCBase b <$ reservedCase (baseTyName b)) listEnums)
     <|> TCCmd <$ reservedCase "Cmd"
+    <|> TCUser <$> tyName

--- a/src/swarm-lang/Swarm/Language/Pipeline.hs
+++ b/src/swarm-lang/Swarm/Language/Pipeline.hs
@@ -10,6 +10,9 @@
 -- text representing a Swarm program into something useful, this is
 -- probably the module you want.
 module Swarm.Language.Pipeline (
+  -- * Contexts
+  Contexts (..),
+
   -- * ProcessedTerm
   ProcessedTerm (..),
   processedModule,
@@ -32,7 +35,6 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Yaml as Y
 import GHC.Generics (Generic)
-import Swarm.Language.Context
 import Swarm.Language.Elaborate
 import Swarm.Language.Module
 import Swarm.Language.Parser (readTerm)
@@ -42,6 +44,21 @@ import Swarm.Language.Syntax
 import Swarm.Language.Typecheck
 import Swarm.Language.Types
 import Witch (into)
+
+data Contexts = Contexts
+  { _tCtx :: TCtx
+  , _reqCtx :: ReqCtx
+  , _tydefCtx :: TDCtx
+  }
+  deriving (Eq, Show, Generic, Data, ToJSON, FromJSON)
+
+makeLenses ''Contexts
+
+instance Semigroup Contexts where
+  Contexts t1 r1 y1 <> Contexts t2 r2 y2 = Contexts (t1 <> t2) (r1 <> r2) (y1 <> y2)
+
+instance Monoid Contexts where
+  mempty = Contexts mempty mempty mempty
 
 -- | A record containing the results of the language processing
 --   pipeline.  Put a 'Term' in, and get one of these out.  A
@@ -90,24 +107,24 @@ instance ToJSON ProcessedTerm where
 --   Return either the end result (or @Nothing@ if the input was only
 --   whitespace) or a pretty-printed error message.
 processTerm :: Text -> Either Text (Maybe ProcessedTerm)
-processTerm = processTerm' empty empty
+processTerm = processTerm' mempty
 
 -- | Like 'processTerm', but use a term that has already been parsed.
 processParsedTerm :: Syntax -> Either ContextualTypeErr ProcessedTerm
-processParsedTerm = processParsedTerm' empty empty
+processParsedTerm = processParsedTerm' mempty
 
 -- | Like 'processTerm', but use explicit starting contexts.
-processTerm' :: TCtx -> ReqCtx -> Text -> Either Text (Maybe ProcessedTerm)
-processTerm' ctx capCtx txt = do
+processTerm' :: Contexts -> Text -> Either Text (Maybe ProcessedTerm)
+processTerm' ctxs txt = do
   mt <- readTerm txt
-  first (prettyTypeErrText txt) $ traverse (processParsedTerm' ctx capCtx) mt
+  first (prettyTypeErrText txt) $ traverse (processParsedTerm' ctxs) mt
 
 -- | Like 'processTerm'', but use a term that has already been parsed.
-processParsedTerm' :: TCtx -> ReqCtx -> Syntax -> Either ContextualTypeErr ProcessedTerm
-processParsedTerm' ctx capCtx t = do
-  m <- inferTop ctx t
-  let (caps, capCtx') = requirements capCtx (t ^. sTerm)
-  return $ ProcessedTerm (elaborateModule m) caps capCtx'
+processParsedTerm' :: Contexts -> Syntax -> Either ContextualTypeErr ProcessedTerm
+processParsedTerm' ctxs t = do
+  m <- inferTop (ctxs ^. tCtx) (ctxs ^. tydefCtx) t
+  let (caps, reqCtx') = requirements (ctxs ^. reqCtx) (t ^. sTerm)
+  return $ ProcessedTerm (elaborateModule m) caps reqCtx'
 
 elaborateModule :: TModule -> TModule
 elaborateModule (Module ast ctx tydefs) = Module (elaborate ast) ctx tydefs

--- a/src/swarm-lang/Swarm/Language/Pipeline.hs
+++ b/src/swarm-lang/Swarm/Language/Pipeline.hs
@@ -110,4 +110,4 @@ processParsedTerm' ctx capCtx t = do
   return $ ProcessedTerm (elaborateModule m) caps capCtx'
 
 elaborateModule :: TModule -> TModule
-elaborateModule (Module ast ctx) = Module (elaborate ast) ctx
+elaborateModule (Module ast ctx tydefs) = Module (elaborate ast) ctx tydefs

--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -131,6 +131,7 @@ instance PrettyPrec TyCon where
     TCSum -> "Sum"
     TCProd -> "Prod"
     TCFun -> "Fun"
+    TCUser t -> pretty t
 
 -- | Split a function type chain, so that we can pretty print
 --   the type parameters aligned on each line when they don't fit.
@@ -321,7 +322,8 @@ prettyDefinition defName x mty t1 =
   eqAndLambdaLine = if null defLambdaList then "=" else line <> defEqLambdas
 
 prettyTydef :: Var -> Polytype -> Doc ann
-prettyTydef _x _pty = "tydef" -- XXX to do
+prettyTydef x (Forall [] ty) = "tydef" <+> pretty x <+> "=" <+> ppr ty <+> "end"
+prettyTydef x (Forall xs ty) = "tydef" <+> pretty x <+> hsep (map pretty xs) <+> "=" <+> ppr ty <+> "end"
 
 prettyPrecApp :: Int -> Syntax' ty -> Syntax' ty -> Doc a
 prettyPrecApp p t1 t2 =
@@ -413,25 +415,28 @@ instance PrettyPrec UnificationError where
       "Infinite type:" <+> ppr x <+> "=" <+> ppr uty
     UnifyErr ty1 ty2 ->
       "Can't unify" <+> ppr ty1 <+> "and" <+> ppr ty2
+    UndefinedUserType ty ->
+      "Undefined user type" <+> ppr ty
 
 instance PrettyPrec Arity where
   prettyPrec _ (Arity a) = pretty a
 
 instance PrettyPrec KindError where
-  prettyPrec _ (ArityMismatch c tys) =
+  prettyPrec _ (ArityMismatch c a tys) =
     nest 2 . vsep $
       [ "Kind error:"
       , hsep
           [ ppr c
           , "requires"
-          , ppr (tcArity c)
+          , pretty a
           , "type"
-          , pretty (number (getArity (tcArity c)) "argument" <> ",")
+          , pretty (number a "argument" <> ",")
           , "but was given"
           , pretty (length tys)
           ]
       ]
         ++ ["in the type:" <+> ppr (TyConApp c tys) | not (null tys)]
+  prettyPrec _ (UndefinedTyCon tc _ty) = "Undefined type" <+> ppr tc
 
 -- | Given a type and its source, construct an appropriate description
 --   of it to go in a type mismatch error message.
@@ -477,6 +482,7 @@ tyConNounPhrase = \case
   TCSum -> "a sum"
   TCProd -> "a pair"
   TCFun -> "a function"
+  TCUser t -> pretty t
 
 -- | Return an English noun phrase describing things with the given
 --   base type.

--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -282,6 +282,7 @@ instance PrettyPrec (Term' ty) where
       [ prettyDefinition "def" x mty t1
       , "end"
       ]
+  prettyPrec _ (TTydef (LV _ x) pty) = prettyTydef x pty
   -- Special case for printing consecutive defs: don't worry about
   -- precedence, and print a blank line with no semicolon
   prettyPrec _ (SBind Nothing t1@(Syntax' _ (SDef {}) _ _) t2) =
@@ -318,6 +319,9 @@ prettyDefinition defName x mty t1 =
   defType' = maybe "" (\ty -> ":" <+> ppr ty) mty
   defEqLambdas = hsep ("=" : map prettyLambda defLambdaList)
   eqAndLambdaLine = if null defLambdaList then "=" else line <> defEqLambdas
+
+prettyTydef :: Var -> Polytype -> Doc ann
+prettyTydef _x _pty = "tydef" -- XXX to do
 
 prettyPrecApp :: Int -> Syntax' ty -> Syntax' ty -> Doc a
 prettyPrecApp p t1 t2 =

--- a/src/swarm-lang/Swarm/Language/Syntax/AST.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/AST.hs
@@ -93,6 +93,8 @@ data Term' ty
     --   value in subsequent commands. The @Bool@ indicates whether the
     --   definition is known to be recursive.
     SDef Bool LocVar (Maybe Polytype) (Syntax' ty)
+  | -- | A type synonym definition.
+    TTydef LocVar Polytype
   | -- | A monadic bind for commands, of the form @c1 ; c2@ or @x <- c1; c2@.
     SBind (Maybe LocVar) (Syntax' ty) (Syntax' ty)
   | -- | Delay evaluation of a term, written @{...}@.  Swarm is an

--- a/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
@@ -128,4 +128,4 @@ pattern TAnnotate t pt = SAnnotate (STerm t) pt
 
 -- COMPLETE pragma tells GHC using this set of patterns is complete for Term
 
-{-# COMPLETE TUnit, TConst, TDir, TInt, TAntiInt, TText, TAntiText, TBool, TRequireDevice, TRequire, TRequirements, TVar, TPair, TLam, TApp, TLet, TDef, TBind, TDelay, TRcd, TProj, TAnnotate #-}
+{-# COMPLETE TUnit, TConst, TDir, TInt, TAntiInt, TText, TAntiText, TBool, TRequireDevice, TRequire, TRequirements, TVar, TPair, TLam, TApp, TLet, TDef, TTydef, TBind, TDelay, TRcd, TProj, TAnnotate #-}

--- a/src/swarm-lang/Swarm/Language/Syntax/Util.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Util.hs
@@ -128,6 +128,7 @@ freeVarsS f = go S.empty
     TRef {} -> pure s
     TRequireDevice {} -> pure s
     TRequire {} -> pure s
+    TTydef {} -> pure s
     SRequirements x s1 -> rewrap $ SRequirements x <$> go bound s1
     TVar x
       | x `S.member` bound -> pure s

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -40,6 +40,7 @@ module Swarm.Language.Types (
   pattern TyRcd,
   pattern TyCmd,
   pattern TyDelay,
+  pattern TyUser,
 
   -- * @UType@
   IntVar (..),
@@ -61,6 +62,7 @@ module Swarm.Language.Types (
   pattern UTyRcd,
   pattern UTyCmd,
   pattern UTyDelay,
+  pattern UTyUser,
 
   -- ** Utilities
   ucata,
@@ -77,12 +79,23 @@ module Swarm.Language.Types (
   TCtx,
   UCtx,
 
+  -- * User type definitions
+  TydefInfo (..),
+  tydefType,
+  tydefArity,
+  substTydef,
+  expandTydef,
+  TDCtx,
+
   -- * The 'WithU' class
   WithU (..),
 ) where
 
+import Control.Algebra (Has)
+import Control.Effect.Reader (Reader, ask)
+import Control.Lens (makeLenses, view)
 import Control.Monad.Free
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import Data.Aeson.TH (defaultOptions, deriveFromJSON1, deriveToJSON1)
 import Data.Data (Data)
 import Data.Eq.Deriving (deriveEq1)
@@ -90,13 +103,17 @@ import Data.Fix
 import Data.Foldable (fold)
 import Data.Kind qualified
 import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import Data.Set qualified as S
 import Data.String (IsString (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic, Generic1)
-import Swarm.Language.Context
+import Swarm.Language.Context (Ctx, Var)
+import Swarm.Language.Context qualified as Ctx
+import Swarm.Util.JSON (optionsUnwrapUnary)
 import Text.Show.Deriving (deriveShow1)
 import Witch
 
@@ -148,24 +165,20 @@ data TyCon
     TCProd
   | -- | Function types.
     TCFun
+  | -- | User-defined type constructor.
+    TCUser Var
   deriving (Eq, Ord, Show, Data, Generic, FromJSON, ToJSON)
 
+-- | The arity of a type, /i.e./ the number of type parameters it
+--   expects.
 newtype Arity = Arity {getArity :: Int}
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic, Data)
 
--- | The arity, /i.e./ number of type arguments, of each type
---   constructor.  Eventually, if we generalize to higher-kinded
---   types, we'll need to upgrade this to return a full-fledged kind
---   instead of just an arity.
-tcArity :: TyCon -> Arity
-tcArity =
-  Arity . \case
-    TCBase _ -> 0
-    TCCmd -> 1
-    TCDelay -> 1
-    TCSum -> 2
-    TCProd -> 2
-    TCFun -> 2
+instance ToJSON Arity where
+  toJSON = genericToJSON optionsUnwrapUnary
+
+instance FromJSON Arity where
+  parseJSON = genericParseJSON optionsUnwrapUnary
 
 ------------------------------------------------------------
 -- Types
@@ -238,19 +251,6 @@ instance IsString Type where
 
 instance IsString UType where
   fromString x = UTyVar (from @String x)
-
-------------------------------------------------------------
--- Contexts
-------------------------------------------------------------
-
--- | A @TCtx@ is a mapping from variables to polytypes.  We generally
---   get one of these at the end of the type inference process.
-type TCtx = Ctx Polytype
-
--- | A @UCtx@ is a mapping from variables to polytypes with
---   unification variables.  We generally have one of these while we
---   are in the midst of the type inference process.
-type UCtx = Ctx UPolytype
 
 ------------------------------------------------------------
 -- Polytypes
@@ -375,6 +375,9 @@ pattern TyCmd ty = TyConApp TCCmd [ty]
 pattern TyDelay :: Type -> Type
 pattern TyDelay ty = TyConApp TCDelay [ty]
 
+pattern TyUser :: Var -> [Type] -> Type
+pattern TyUser v tys = TyConApp (TCUser v) tys
+
 --------------------------------------------------
 -- UType
 
@@ -429,5 +432,84 @@ pattern UTyCmd ty = UTyConApp TCCmd [ty]
 pattern UTyDelay :: UType -> UType
 pattern UTyDelay ty = UTyConApp TCDelay [ty]
 
+pattern UTyUser :: Var -> [UType] -> UType
+pattern UTyUser v tys = UTyConApp (TCUser v) tys
+
 pattern PolyUnit :: Polytype
 pattern PolyUnit = Forall [] (TyCmd TyUnit)
+
+------------------------------------------------------------
+-- Contexts
+------------------------------------------------------------
+
+-- | A @TCtx@ is a mapping from variables to polytypes.  We generally
+--   get one of these at the end of the type inference process.
+type TCtx = Ctx Polytype
+
+-- | A @UCtx@ is a mapping from variables to polytypes with
+--   unification variables.  We generally have one of these while we
+--   are in the midst of the type inference process.
+type UCtx = Ctx UPolytype
+
+------------------------------------------------------------
+-- Type definitions
+------------------------------------------------------------
+
+data TydefInfo = TydefInfo
+  { _tydefType :: Polytype
+  , _tydefArity :: Arity
+  }
+  deriving (Eq, Show, Generic, Data, FromJSON, ToJSON)
+
+makeLenses ''TydefInfo
+
+-- | A @TDCtx@ is a mapping from user-defined type constructor names
+--   to their definitions and arities/kinds.
+type TDCtx = Ctx TydefInfo
+
+-- | Expand an application "T ty1 ty2 ... tyn" by looking up the
+--   definition of T and substituting ty1 .. tyn for its arguments.
+--
+--   Note that this has already been kind-checked so we know the
+--   number of arguments must match up; we don't worry about what
+--   happens if the lists have different lengths since in theory that
+--   can never happen.
+expandTydef :: Has (Reader TDCtx) sig m => Var -> [UType] -> m UType
+expandTydef userTyCon tys = do
+  mtydefInfo <- Ctx.lookupR userTyCon
+  tdCtx <- ask @TDCtx
+  -- In theory, if everything has kind checked, we should never encounter an undefined
+  -- type constructor here.
+  let tydefInfo = fromMaybe (error $ "Encountered undefined type constructor " ++ into @String userTyCon ++ " in expandTyDef (tdCtx = " ++ show tdCtx ++ ")") mtydefInfo
+  return $ substTydef tydefInfo tys
+
+-- | Substitute the given types into the body of the given type
+--   synonym definition.
+substTydef :: TydefInfo -> [UType] -> UType
+substTydef (TydefInfo (Forall as ty) _) tys = ucata Pure substF (toU ty)
+ where
+  tyMap = M.fromList $ zip as tys
+
+  substF tyF@(TyVarF x) = case M.lookup x tyMap of
+    Nothing -> Free tyF
+    Just uty -> uty
+  substF tyF = Free tyF
+
+------------------------------------------------------------
+-- Arity
+------------------------------------------------------------
+
+-- | The arity, /i.e./ number of type arguments, of each type
+--   constructor.  Eventually, if we generalize to higher-kinded
+--   types, we'll need to upgrade this to return a full-fledged kind
+--   instead of just an arity.
+tcArity :: TDCtx -> TyCon -> Maybe Arity
+tcArity tydefs =
+  fmap Arity . \case
+    TCBase _ -> Just 0
+    TCCmd -> Just 1
+    TCDelay -> Just 1
+    TCSum -> Just 2
+    TCProd -> Just 2
+    TCFun -> Just 2
+    TCUser t -> getArity . view tydefArity <$> Ctx.lookup t tydefs

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -113,6 +114,7 @@ import Data.Text qualified as T
 import GHC.Generics (Generic, Generic1)
 import Swarm.Language.Context (Ctx, Var)
 import Swarm.Language.Context qualified as Ctx
+import Swarm.Util (parens, showT)
 import Swarm.Util.JSON (optionsUnwrapUnary)
 import Text.Show.Deriving (deriveShow1)
 import Witch
@@ -480,7 +482,15 @@ expandTydef userTyCon tys = do
   tdCtx <- ask @TDCtx
   -- In theory, if everything has kind checked, we should never encounter an undefined
   -- type constructor here.
-  let tydefInfo = fromMaybe (error $ "Encountered undefined type constructor " ++ into @String userTyCon ++ " in expandTyDef (tdCtx = " ++ show tdCtx ++ ")") mtydefInfo
+  let errMsg =
+        into @String $
+          T.unwords
+            [ "Encountered undefined type constructor"
+            , userTyCon
+            , "in expandTyDef"
+            , parens ("tdCtx = " <> showT tdCtx)
+            ]
+      tydefInfo = fromMaybe (error errMsg) mtydefInfo
   return $ substTydef tydefInfo tys
 
 -- | Substitute the given types into the body of the given type

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -95,7 +95,7 @@ import Swarm.Game.Step (finishGameTick, gameTick)
 import Swarm.Language.Capability (Capability (CGod, CMake), constCaps)
 import Swarm.Language.Context
 import Swarm.Language.Key (KeyCombo, mkKeyCombo)
-import Swarm.Language.Module (Module (..))
+import Swarm.Language.Module (moduleSyntax)
 import Swarm.Language.Parser.Lex (reservedWords)
 import Swarm.Language.Pipeline (ProcessedTerm (..), processTerm', processedSyntax)
 import Swarm.Language.Pipeline.QQ (tmQ)
@@ -351,9 +351,9 @@ handleMainEvent ev = do
         then -- ignore repeated keypresses
           continueWithoutRedraw
         else -- hide for two seconds
-        do
-          uiState . uiGameplay . uiHideRobotsUntil .= t + TimeSpec 2 0
-          invalidateCacheEntry WorldCache
+          do
+            uiState . uiGameplay . uiHideRobotsUntil .= t + TimeSpec 2 0
+            invalidateCacheEntry WorldCache
     -- debug focused robot
     MetaChar 'd' | isPaused && hasDebug -> do
       debug <- uiState . uiGameplay . uiShowDebug Lens.<%= not
@@ -1122,9 +1122,9 @@ runBaseTerm topCtx =
   -- The player typed something at the REPL and hit Enter; this
   -- function takes the resulting ProcessedTerm (if the REPL
   -- input is valid) and sets up the base robot to run it.
-  startBaseProgram t@(ProcessedTerm (Module tm _) reqs reqCtx) =
+  startBaseProgram t@(ProcessedTerm m reqs reqCtx) =
     -- Set the REPL status to Working
-    (gameState . gameControls . replStatus .~ REPLWorking (Typed Nothing (tm ^. sType) reqs))
+    (gameState . gameControls . replStatus .~ REPLWorking (Typed Nothing (m ^. moduleSyntax . sType) reqs))
       -- The `reqCtx` maps names of variables defined in the
       -- term (by `def` statements) to their requirements.
       -- E.g. if we had `def m = move end`, the reqCtx would

--- a/src/swarm-util/Swarm/Util/JSON.hs
+++ b/src/swarm-util/Swarm/Util/JSON.hs
@@ -4,9 +4,15 @@
 -- Utilities for JSON de/serialization.
 module Swarm.Util.JSON where
 
-import Data.Aeson qualified as A
+import Data.Aeson
 
 -- | @aeson@ options specifying to unwrap unary records so they are
 --   encoded as a simple value instead of as a JSON object.
-optionsUnwrapUnary :: A.Options
-optionsUnwrapUnary = A.defaultOptions {A.unwrapUnaryRecords = True}
+optionsUnwrapUnary :: Options
+optionsUnwrapUnary = defaultOptions {unwrapUnaryRecords = True}
+
+optionsObjectSingleField :: Options
+optionsObjectSingleField = defaultOptions {sumEncoding = ObjectWithSingleField}
+
+optionsUntagged :: Options
+optionsUntagged = defaultOptions {sumEncoding = UntaggedValue}

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -101,13 +101,12 @@ testLanguagePipeline =
             "Disallow uppercase type variable names"
             ( process
                 "def id : A -> A = \\x. x end"
-                ( T.unlines
-                    [ "1:11:"
-                    , "  |"
-                    , "1 | def id : A -> A = \\x. x end"
-                    , "  |           ^"
-                    , "Type variable names must start with a lowercase letter"
-                    ]
+                ( T.init $
+                    T.unlines
+                      [ "1:1: Undefined type A"
+                      , ""
+                      , "  - While checking the definition of id"
+                      ]
                 )
             )
         , testCase
@@ -535,6 +534,59 @@ testLanguagePipeline =
         , testCase
             "local bind is polymorphic"
             (valid "def foo : Cmd (Int * Text) = f <- return (\\x.x); return (f 3, f \"hi\") end")
+        ]
+    , testGroup
+        "type synonyms"
+        [ testCase
+            "X"
+            (valid "tydef X = Int end; let n : X = 3 in log (format n)")
+        , testCase
+            "Maybe"
+            (valid "tydef Maybe a = Unit + a end; let x : Maybe Int = inr 3 in case x (\\_. move) (\\n. log (format (n+2)))")
+        , testCase
+            "multi-args"
+            ( valid $
+                T.unlines
+                  [ "tydef Foo a b c = a + (b * Int) + Cmd c end;"
+                  , "let f1 : Foo (Cmd Unit) Int Text = inl move in"
+                  , "  let f2 : Foo Int (Cmd Unit) Unit = inr (inl (move, 3)) in"
+                  , "  let f3 : Foo Int Int Text = inr (inr grab) in"
+                  , "  move"
+                  ]
+            )
+        , testCase
+            "multiple tydefs"
+            (valid "tydef X = Int end; tydef Y = Unit end; def f : X -> Y = \\n. () end")
+        , testCase
+            "sequential tydefs don't need semicolon"
+            (valid "tydef X = Int end tydef Y = Unit end")
+        , testCase
+            "sequential tydef + def don't need semicolon"
+            (valid "tydef X = Int end def x : X = 5 end")
+        , testCase
+            "recursive tydef not allowed"
+            ( process
+                "tydef X = Unit + X end"
+                "1:1: Undefined type X"
+            )
+        , testCase
+            "nested tydef not allowed"
+            ( process
+                "def f : Cmd Unit = tydef X = Int end; move end"
+                "1:20: Definitions may only be at the top level: `tydef X = Int end`\n\n  - While checking the left-hand side of a semicolon\n  - While checking the definition of f"
+            )
+        , testCase
+            "tydef with repeated variables"
+            ( process
+                "tydef Repeated a b a = a + b end"
+                "1:33:\n  |\n1 | tydef Repeated a b a = a + b end\n  |                                 ^\nDuplicate variable on left-hand side of tydef: a\n"
+            )
+        , testCase
+            "tydef with unbound variables"
+            ( process
+                "tydef Unbound a b = a + b + c end"
+                "1:34:\n  |\n1 | tydef Unbound a b = a + b + c end\n  |                                  ^\nUndefined type variable(s) on right-hand side of tydef: c\n"
+            )
         ]
     ]
  where

--- a/test/unit/TestPretty.hs
+++ b/test/unit/TestPretty.hs
@@ -180,6 +180,23 @@ testPrettyConst =
                 ((TyInt :*: TyInt) :*: (TyInt :*: TyInt)) :->: TyCmd TyInt
             )
         ]
+    , testGroup
+        "tydef"
+        [ testCase "tydef alias" $
+            equalPretty "tydef X = Int end" $
+              TTydef (LV NoLoc "X") (Forall [] TyInt)
+        , testCase "tydef Maybe" $
+            equalPretty "tydef Maybe a = Unit + a end" $
+              TTydef (LV NoLoc "Maybe") (Forall ["a"] (TyUnit :+: TyVar "a"))
+        , testCase "tydef multi-arg" $
+            equalPretty "tydef Foo a b c d = Unit + ((a * b) + ((c -> d) * a)) end" $
+              TTydef
+                (LV NoLoc "Foo")
+                ( Forall
+                    ["a", "b", "c", "d"]
+                    (TyUnit :+: (TyVar "a" :*: TyVar "b") :+: ((TyVar "c" :->: TyVar "d") :*: TyVar "a"))
+                )
+        ]
     ]
  where
   equalPretty :: PrettyPrec a => String -> a -> Assertion

--- a/test/unit/TestScoring.hs
+++ b/test/unit/TestScoring.hs
@@ -3,6 +3,7 @@
 -- | High score records
 module TestScoring where
 
+import Control.Lens ((^.))
 import Data.Text.IO qualified as TIO
 import Data.Time.Calendar.OrdinalDate
 import Data.Time.LocalTime
@@ -11,7 +12,6 @@ import Swarm.Game.Scenario.Scoring.CodeSize
 import Swarm.Game.Scenario.Scoring.ConcreteMetrics
 import Swarm.Game.Scenario.Scoring.GenericMetrics
 import Swarm.Game.Tick (TickNumber (..))
-import Swarm.Language.Module
 import Swarm.Language.Pipeline
 import Swarm.Language.Syntax
 import System.FilePath ((</>))
@@ -61,10 +61,10 @@ testHighScores =
 compareAstSize :: Int -> FilePath -> TestTree
 compareAstSize expectedSize path = testCase (unwords ["size of", path]) $ do
   contents <- TIO.readFile $ baseTestPath </> path
-  ProcessedTerm (Module stx _) _ _ <- case processTermEither contents of
+  pt <- case processTermEither contents of
     Right x -> return x
     Left y -> assertFailure (into @String y)
-  let actualSize = measureAstSize stx
+  let actualSize = measureAstSize (pt ^. processedSyntax)
   assertEqual "incorrect size" expectedSize actualSize
 
 betterReplTimeAfterCodeSizeRecord :: TestTree


### PR DESCRIPTION
Adds type synonym declarations to the language, like so:
```
tydef Maybe a = Unit + a end
def lookdown : Cmd (Maybe Text) = scan down end

> lookdown
it2 : Maybe Text = inl ()
```

`tydef` behaves very similarly to `def` except that it defines a new (parameterized) type instead of a new term.

Note that higher-kinded types are not yet supported; for example we cannot say `tydef Foo f = Unit + f Int` (in fact this would be a syntax error since type variables cannot be at the head of an application).  However there is nothing stopping us from adding that in the future; I just wanted to keep things simple for now.

If you know of any scenario code that would be a good candidate for using type synonyms, let me know --- it would be nice to update a few scenarios as a better stress test of type synonyms before merging this.

Closes #153.