### PR TITLE
Move effect utils to `swarm-util`

### DIFF
--- a/src/swarm-doc/Swarm/Doc/Gen.hs
+++ b/src/swarm-doc/Swarm/Doc/Gen.hs
@@ -35,6 +35,7 @@ import Swarm.Doc.Util
 import Swarm.Doc.Wiki.Cheatsheet
 import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityName, entityYields)
 import Swarm.Game.Entity qualified as E
+import Swarm.Game.Failure (simpleErrorHandle)
 import Swarm.Game.Land
 import Swarm.Game.Recipe (Recipe, recipeCatalysts, recipeInputs, recipeOutputs)
 import Swarm.Game.Robot (Robot, equippedDevices, robotInventory)
@@ -43,7 +44,6 @@ import Swarm.Game.World.Gen (extractEntities)
 import Swarm.Game.World.Typecheck (Some (..), TTerm)
 import Swarm.Language.Key (specialKeyNames)
 import Swarm.Util (both, listEnums)
-import Swarm.Util.Effect (simpleErrorHandle)
 import Text.Dot (Dot, NodeId, (.->.))
 import Text.Dot qualified as Dot
 

--- a/src/swarm-doc/Swarm/Doc/Pedagogy.hs
+++ b/src/swarm-doc/Swarm/Doc/Pedagogy.hs
@@ -31,7 +31,7 @@ import Data.Set qualified as S
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Constant
-import Swarm.Game.Failure (SystemFailure)
+import Swarm.Game.Failure (SystemFailure, simpleErrorHandle)
 import Swarm.Game.Land
 import Swarm.Game.Scenario (
   Scenario,
@@ -58,7 +58,7 @@ import Swarm.Language.Pipeline (ProcessedTerm, processedSyntax)
 import Swarm.Language.Syntax
 import Swarm.Language.Text.Markdown (docToText, findCode)
 import Swarm.Language.Types (Polytype)
-import Swarm.Util.Effect (ignoreWarnings, simpleErrorHandle)
+import Swarm.Util.Effect (ignoreWarnings)
 
 -- * Constants
 

--- a/src/swarm-doc/Swarm/Doc/Wiki/Cheatsheet.hs
+++ b/src/swarm-doc/Swarm/Doc/Wiki/Cheatsheet.hs
@@ -31,6 +31,7 @@ import Swarm.Game.Device qualified as D
 import Swarm.Game.Display (displayChar)
 import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityDisplay, entityName, loadEntities)
 import Swarm.Game.Entity qualified as E
+import Swarm.Game.Failure (simpleErrorHandle)
 import Swarm.Game.Recipe (Recipe, loadRecipes, recipeCatalysts, recipeInputs, recipeOutputs, recipeTime, recipeWeight)
 import Swarm.Game.Terrain (loadTerrain, terrainByName)
 import Swarm.Language.Capability (Capability)
@@ -41,7 +42,6 @@ import Swarm.Language.Syntax qualified as Syntax
 import Swarm.Language.Text.Markdown as Markdown (docToMark)
 import Swarm.Language.Typecheck (inferConst)
 import Swarm.Util (listEnums, showT)
-import Swarm.Util.Effect (simpleErrorHandle)
 
 -- * Types
 

--- a/src/swarm-scenario/Swarm/Game/Failure.hs
+++ b/src/swarm-scenario/Swarm/Game/Failure.hs
@@ -10,6 +10,7 @@
 -- to create common infrastructure for logging.
 module Swarm.Game.Failure (
   SystemFailure (..),
+  simpleErrorHandle,
   AssetData (..),
   Asset (..),
   Entry (..),
@@ -17,6 +18,8 @@ module Swarm.Game.Failure (
   OrderFileWarning (..),
 ) where
 
+import Control.Carrier.Throw.Either (ThrowC (..), runThrow)
+import Control.Monad ((<=<))
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
@@ -78,6 +81,12 @@ data SystemFailure
   | OrderFileWarning FilePath OrderFileWarning
   | CustomFailure Text
   deriving (Show)
+
+------------------------------------------------------------
+-- Basic error handling
+
+simpleErrorHandle :: ThrowC SystemFailure IO a -> IO a
+simpleErrorHandle = either (fail . prettyString) pure <=< runThrow
 
 ------------------------------------------------------------
 -- Pretty-printing

--- a/src/swarm-scenario/Swarm/Game/World/Render.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Render.hs
@@ -19,7 +19,7 @@ import Data.Vector qualified as V
 import Linear (V2 (..))
 import Swarm.Game.Display (defaultChar)
 import Swarm.Game.Entity.Cosmetic
-import Swarm.Game.Failure (SystemFailure)
+import Swarm.Game.Failure (SystemFailure, simpleErrorHandle)
 import Swarm.Game.Land
 import Swarm.Game.Location
 import Swarm.Game.Scenario
@@ -35,7 +35,6 @@ import Swarm.Game.World.Gen (Seed)
 import Swarm.Language.Pretty (prettyString)
 import Swarm.Util (surfaceEmpty)
 import Swarm.Util.Content
-import Swarm.Util.Effect (simpleErrorHandle)
 import Swarm.Util.Erasable (erasableToMaybe)
 import System.IO (hPutStrLn, stderr)
 

--- a/src/swarm-util/Swarm/Util/Effect.hs
+++ b/src/swarm-util/Swarm/Util/Effect.hs
@@ -9,13 +9,11 @@ import Control.Carrier.Accum.FixedStrict
 import Control.Carrier.Error.Either (ErrorC (..))
 import Control.Carrier.Throw.Either (ThrowC (..), runThrow)
 import Control.Effect.Throw
-import Control.Monad ((<=<), (>=>))
+import Control.Monad ((>=>))
 import Control.Monad.Trans.Except (ExceptT)
 import Data.Either.Extra (eitherToMaybe)
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
-import Swarm.Game.Failure (SystemFailure)
-import Swarm.Language.Pretty (prettyString)
 import Witherable
 
 -- | Transform a @Throw e1@ constraint into a @Throw e2@ constraint,
@@ -76,6 +74,3 @@ forMW ::
   (a -> m (Either w b)) ->
   m (t b)
 forMW = flip traverseW
-
-simpleErrorHandle :: ThrowC SystemFailure IO a -> IO a
-simpleErrorHandle = either (fail . prettyString) pure <=< runThrow

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -263,7 +263,6 @@ library swarm-scenario
     Swarm.Game.World.Syntax
     Swarm.Game.World.Typecheck
     Swarm.Util.Content
-    Swarm.Util.Effect
 
   other-modules: Paths_swarm
   autogen-modules: Paths_swarm
@@ -298,12 +297,9 @@ library swarm-scenario
     simple-enumeration >=0.2 && <0.3,
     tagged >=0.8 && <0.9,
     text >=1.2.4 && <2.2,
-    transformers >=0.5 && <0.7,
-    transformers >=0.5.6.2 && <0.6.2.0,
     vector >=0.12 && <0.14,
     vty >=6.1 && <6.3,
     witch >=1.1.1.0 && <1.3,
-    witherable >=0.4 && <0.5,
     yaml >=0.11 && <0.11.12.0,
 
   build-depends:
@@ -524,6 +520,7 @@ library swarm-util
     Control.Carrier.Accum.FixedStrict
     Data.BoolExpr.Simplify
     Swarm.Util
+    Swarm.Util.Effect
     Swarm.Util.Erasable
     Swarm.Util.JSON
     Swarm.Util.Lens
@@ -544,6 +541,7 @@ library swarm-util
     containers >=0.6.2 && <0.8,
     directory >=1.3 && <1.4,
     either >=5.0 && <5.1,
+    extra >=1.7 && <1.8,
     filepath >=1.4 && <1.5,
     fused-effects >=1.1.1.1 && <1.2,
     lens >=4.19 && <5.4,
@@ -555,6 +553,7 @@ library swarm-util
     transformers >=0.5 && <0.7,
     vector >=0.12 && <0.14,
     witch >=1.1.1.0 && <1.3,
+    witherable >=0.4 && <0.5,
     yaml >=0.11 && <0.11.12.0,
 
   hs-source-dirs: src/swarm-util

--- a/test/bench/Benchmark.hs
+++ b/test/bench/Benchmark.hs
@@ -16,7 +16,7 @@ import Data.Tuple.Extra (dupe)
 import Swarm.Effect (runTimeIO)
 import Swarm.Game.CESK (emptyStore, initMachine)
 import Swarm.Game.Display (defaultRobotDisplay)
-import Swarm.Game.Failure (SystemFailure)
+import Swarm.Game.Failure (SystemFailure, simpleErrorHandle)
 import Swarm.Game.Location
 import Swarm.Game.Robot (TRobot, mkRobot)
 import Swarm.Game.Robot.Walk (emptyExceptions)
@@ -34,7 +34,6 @@ import Swarm.Language.Pipeline (ProcessedTerm)
 import Swarm.Language.Pipeline.QQ (tmQ)
 import Swarm.Language.Syntax
 import Swarm.Util (parens, showT)
-import Swarm.Util.Effect (simpleErrorHandle)
 import Swarm.Util.Erasable
 import Test.Tasty.Bench (Benchmark, bcompare, bench, bgroup, defaultMain, whnfAppIO)
 


### PR DESCRIPTION
There were a bunch of fused-effects related utils that lived in a module in `swarm-scenario`; but all of them were completely generic except for the `simpleErrorHandle` function which is specific to `SystemFailure`.  So, this PR:
- Moves `simpleErrorHandle` to `Swarm.Game.Failure`
- Moves the rest of the module into the `swarm-util` package so it can be used elsewhere.

This is another refactoring in preparation for #1865.