### PR TITLE
Represent types with applications of type constructors

### DIFF
--- a/src/swarm-lang/Swarm/Language/Kindcheck.hs
+++ b/src/swarm-lang/Swarm/Language/Kindcheck.hs
@@ -1,0 +1,40 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Kind checking for the Swarm language.
+module Swarm.Language.Kindcheck (
+  KindError (..),
+  checkPolytypeKind,
+  checkKind,
+) where
+
+import Control.Algebra (Has)
+import Control.Effect.Throw (Throw, throwError)
+import Data.Fix (Fix (..))
+import Swarm.Language.Types (Poly (..), Polytype, TyCon, Type, TypeF (..), getArity, tcArity)
+
+-- | Kind checking errors that can occur.  For now, the only possible
+--   error is an arity mismatch error.
+data KindError
+  = ArityMismatch TyCon [Type]
+  deriving (Eq, Show)
+
+-- | Check that a polytype is well-kinded.
+checkPolytypeKind :: Has (Throw KindError) sig m => Polytype -> m ()
+checkPolytypeKind (Forall _ t) = checkKind t
+
+-- | Check that a type is well-kinded. For now, we don't allow
+--   higher-kinded types, *i.e.* all kinds will be of the form @Type
+--   -> Type -> ... -> Type@ which can be represented by a number (the
+--   arity); every type constructor must also be fully applied. So, we
+--   only have to check that each type constructor is applied to the
+--   correct number of type arguments.  In the future, we might very
+--   well want to generalize to arbitrary higher kinds (e.g. @(Type ->
+--   Type) -> Type@ etc.) which would require generalizing this
+--   checking code a bit.
+checkKind :: Has (Throw KindError) sig m => Type -> m ()
+checkKind (Fix (TyConF c tys)) = case compare (length tys) (getArity (tcArity c)) of
+  EQ -> mapM_ checkKind tys
+  _ -> throwError $ ArityMismatch c tys
+checkKind (Fix (TyVarF _)) = return ()
+checkKind (Fix (TyRcdF m)) = mapM_ checkKind m

--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -34,7 +34,7 @@ import Swarm.Language.Parser.Util (getLocRange)
 import Swarm.Language.Syntax
 import Swarm.Language.Typecheck
 import Swarm.Language.Types
-import Swarm.Util (showEnum, showLowT, unsnocNE, number)
+import Swarm.Util (number, showEnum, showLowT, unsnocNE)
 import Witch
 
 ------------------------------------------------------------
@@ -413,20 +413,20 @@ instance PrettyPrec Arity where
   prettyPrec _ (Arity a) = pretty a
 
 instance PrettyPrec KindError where
-  prettyPrec _ (ArityMismatch c tys) = nest 2 . vsep $
-    [ "Kind error:"
-    , hsep
-      [ ppr c
-      , "requires"
-      , ppr (tcArity c)
-      , "type"
-      , pretty (number (getArity (tcArity c)) "argument" <> ",")
-      , "but was given"
-      , pretty (length tys)
+  prettyPrec _ (ArityMismatch c tys) =
+    nest 2 . vsep $
+      [ "Kind error:"
+      , hsep
+          [ ppr c
+          , "requires"
+          , ppr (tcArity c)
+          , "type"
+          , pretty (number (getArity (tcArity c)) "argument" <> ",")
+          , "but was given"
+          , pretty (length tys)
+          ]
       ]
-    ]
-    ++
-    [ "in the type:" <+> ppr (TyConApp c tys) | not (null tys) ]
+        ++ ["in the type:" <+> ppr (TyConApp c tys) | not (null tys)]
 
 -- | Given a type and its source, construct an appropriate description
 --   of it to go in a type mismatch error message.

--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -122,6 +122,15 @@ data Wildcard = Wildcard
 instance PrettyPrec Wildcard where
   prettyPrec _ _ = "_"
 
+instance PrettyPrec TyCon where
+  prettyPrec _ = \case
+    TCBase b -> ppr b
+    TCCmd -> "Cmd"
+    TCDelay -> "Delay"
+    TCSum -> "Sum"
+    TCProd -> "Prod"
+    TCFun -> "Fun"
+
 -- | Split a function type chain, so that we can pretty print
 --   the type parameters aligned on each line when they don't fit.
 class UnchainableFun t where
@@ -132,7 +141,7 @@ instance UnchainableFun Type where
   unchainFun ty = pure ty
 
 instance UnchainableFun (Free TypeF ty) where
-  unchainFun (Free (TyFunF ty1 ty2)) = ty1 <| unchainFun ty2
+  unchainFun (Free (TyConF TCFun [ty1, ty2])) = ty1 <| unchainFun ty2
   unchainFun ty = pure ty
 
 instance (PrettyPrec (t (Fix t))) => PrettyPrec (Fix t) where
@@ -143,24 +152,28 @@ instance (PrettyPrec (t (Free t v)), PrettyPrec v) => PrettyPrec (Free t v) wher
   prettyPrec p (Pure v) = prettyPrec p v
 
 instance ((UnchainableFun t), (PrettyPrec t)) => PrettyPrec (TypeF t) where
-  prettyPrec _ (TyBaseF b) = ppr b
   prettyPrec _ (TyVarF v) = pretty v
-  prettyPrec p (TySumF ty1 ty2) =
+  prettyPrec _ (TyRcdF m) = brackets $ hsep (punctuate "," (map prettyBinding (M.assocs m)))
+  -- Special cases for type constructors with special syntax.
+  prettyPrec p (TyConF TCSum [ty1, ty2]) =
     pparens (p > 1) $
       prettyPrec 2 ty1 <+> "+" <+> prettyPrec 1 ty2
-  prettyPrec p (TyProdF ty1 ty2) =
+  prettyPrec p (TyConF TCProd [ty1, ty2]) =
     pparens (p > 2) $
       prettyPrec 3 ty1 <+> "*" <+> prettyPrec 2 ty2
-  prettyPrec p (TyCmdF ty) = pparens (p > 9) $ "Cmd" <+> prettyPrec 10 ty
-  prettyPrec _ (TyDelayF ty) = braces $ ppr ty
-  prettyPrec p (TyFunF ty1 ty2) =
+  prettyPrec _ (TyConF TCDelay [ty]) = braces $ ppr ty
+  prettyPrec p (TyConF TCFun [ty1, ty2]) =
     let (iniF, lastF) = unsnocNE $ ty1 <| unchainFun ty2
         funs = (prettyPrec 1 <$> iniF) <> [ppr lastF]
         inLine l r = l <+> "->" <+> r
         multiLine l r = l <+> "->" <> hardline <> r
      in pparens (p > 0) . align $
           flatAlt (concatWith multiLine funs) (concatWith inLine funs)
-  prettyPrec _ (TyRcdF m) = brackets $ hsep (punctuate "," (map prettyBinding (M.assocs m)))
+  -- Fallthrough cases for type constructor application.  Handles base
+  -- types, Cmd, user-defined types, or ill-kinded things like 'Int
+  -- Bool'.
+  prettyPrec _ (TyConF c []) = ppr c
+  prettyPrec p (TyConF c tys) = pparens (p > 9) $ ppr c <+> hsep (map (prettyPrec 10) tys)
 
 instance PrettyPrec Polytype where
   prettyPrec _ (Forall [] t) = ppr t
@@ -412,25 +425,32 @@ hasAnyUVars = ucata (const True) or
 -- | Check whether a type consists of a top-level type constructor
 --   immediately applied to unification variables.
 isTopLevelConstructor :: UType -> Maybe (TypeF ())
-isTopLevelConstructor (UTyCmd (Pure {})) = Just $ TyCmdF ()
-isTopLevelConstructor (UTyDelay (Pure {})) = Just $ TyDelayF ()
-isTopLevelConstructor (UTySum (Pure {}) (Pure {})) = Just $ TySumF () ()
-isTopLevelConstructor (UTyProd (Pure {}) (Pure {})) = Just $ TyProdF () ()
-isTopLevelConstructor (UTyFun (Pure {}) (Pure {})) = Just $ TyFunF () ()
+isTopLevelConstructor (Free (TyRcdF m))
+  | all isPure m = Just (TyRcdF M.empty)
+isTopLevelConstructor (UTyConApp c ts)
+  | all isPure ts = Just (TyConF c [])
 isTopLevelConstructor _ = Nothing
+
+isPure :: Free f a -> Bool
+isPure (Pure {}) = True
+isPure _ = False
 
 -- | Return an English noun phrase describing things with the given
 --   top-level type constructor.
 tyNounPhrase :: TypeF () -> Doc a
 tyNounPhrase = \case
-  TyBaseF b -> baseTyNounPhrase b
+  TyConF c _ -> tyConNounPhrase c
   TyVarF {} -> "a type variable"
-  TyCmdF {} -> "a command"
-  TyDelayF {} -> "a delayed expression"
-  TySumF {} -> "a sum"
-  TyProdF {} -> "a pair"
-  TyFunF {} -> "a function"
   TyRcdF {} -> "a record"
+
+tyConNounPhrase :: TyCon -> Doc a
+tyConNounPhrase = \case
+  TCBase b -> baseTyNounPhrase b
+  TCCmd -> "a command"
+  TCDelay -> "a delayed expression"
+  TCSum -> "a sum"
+  TCProd -> "a pair"
+  TCFun -> "a function"
 
 -- | Return an English noun phrase describing things with the given
 --   base type.

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -47,6 +47,7 @@ module Swarm.Language.Typecheck (
 import Control.Arrow ((***))
 import Control.Carrier.Error.Either (ErrorC, runError)
 import Control.Carrier.Reader (ReaderC, runReader)
+import Control.Carrier.Throw.Either (ThrowC, runThrow)
 import Control.Category ((>>>))
 import Control.Effect.Catch (Catch, catchError)
 import Control.Effect.Error (Error)
@@ -57,7 +58,7 @@ import Control.Lens.Indexed (itraverse)
 import Control.Monad (forM_, when, (<=<), (>=>))
 import Control.Monad.Free (Free (..))
 import Data.Data (Data, gmapM)
-import Data.Foldable (fold)
+import Data.Foldable (fold, traverse_)
 import Data.Functor.Identity
 import Data.Generics (mkM)
 import Data.Map (Map, (!))
@@ -71,6 +72,7 @@ import Swarm.Effect.Unify qualified as U
 import Swarm.Effect.Unify.Fast qualified as U
 import Swarm.Language.Context hiding (lookup)
 import Swarm.Language.Context qualified as Ctx
+import Swarm.Language.Kindcheck (KindError, checkKind, checkPolytypeKind)
 import Swarm.Language.Module
 import Swarm.Language.Parser.QQ (tyQ)
 import Swarm.Language.Syntax
@@ -411,6 +413,21 @@ throwTypeErr l te = do
   stk <- ask @TCStack
   throwError $ mkTypeErr l stk te
 
+-- | Adapt some other error type to a 'ContextualTypeErr'.
+adaptToTypeErr ::
+  ( Has (Throw ContextualTypeErr) sig m
+  , Has (Reader TCStack) sig m
+  ) =>
+  SrcLoc ->
+  (e -> TypeErr) ->
+  ThrowC e m a ->
+  m a
+adaptToTypeErr l adapt m = do
+  res <- runThrow m
+  case res of
+    Left e -> throwTypeErr l (adapt e)
+    Right a -> return a
+
 -- | Errors that can occur during type checking.  The idea is that
 --   each error carries information that can be used to help explain
 --   what went wrong (though the amount of information carried can and
@@ -419,6 +436,8 @@ throwTypeErr l te = do
 data TypeErr
   = -- | An undefined variable was encountered.
     UnboundVar Var
+  | -- | A kind error was encountered.
+    KindErr KindError
   | -- | A Skolem variable escaped its local context.
     EscapedSkolem Var
   | -- | Occurs check failure, i.e. infinite type.
@@ -531,8 +550,8 @@ decomposeFunTy
 decomposeFunTy = decomposeTyConApp2 TCFun
 decomposeProdTy = decomposeTyConApp2 TCProd
 
--- ------------------------------------------------------------
--- -- Type inference / checking
+------------------------------------------------------------
+-- Type inference / checking
 
 -- | Top-level type inference function: given a context of definition
 --   types and a top-level term, either return a type error or its
@@ -542,6 +561,16 @@ inferTop ctx = runTC ctx . inferModule
 
 -- | Infer the signature of a top-level expression which might
 --   contain definitions.
+--
+-- Note that we choose to do kind checking inline as we go during
+-- typechecking.  This has pros and cons.  The benefit is that we get
+-- to piggyback on the existing source location tracking and
+-- typechecking stack, so we can generate better error messages.  The
+-- downside is that we have to be really careful not to miss any types
+-- along the way; there is no difference, at the Haskell type level,
+-- between ill- and well-kinded Swarm types, so we just have to make
+-- sure that we call checkKind on every type embedded in the term
+-- being checked.
 inferModule ::
   ( Has Unification sig m
   , Has (Reader UCtx) sig m
@@ -565,6 +594,7 @@ inferModule s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
   -- If a (poly)type signature has been provided, skolemize it and
   -- check the definition.
   SDef r x (Just pty) t1 -> withFrame l (TCDef (lvVar x)) $ do
+    adaptToTypeErr l KindErr $ checkPolytypeKind pty
     let upty = toU pty
     uty <- skolemize upty
     t1' <- withBinding (lvVar x) upty $ check t1 uty
@@ -673,6 +703,7 @@ infer s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
   -- under an extended context and return the appropriate function
   -- type.
   SLam x (Just argTy) body -> do
+    adaptToTypeErr l KindErr $ checkKind argTy
     let uargTy = toU argTy
     body' <- withBinding (lvVar x) (Forall [] uargTy) $ infer body
     return $ Syntax' l (SLam x (Just argTy) body') cs (UTyFun uargTy (body' ^. sType))
@@ -751,6 +782,7 @@ infer s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
   -- However, we must be careful to deal properly with polymorphic
   -- type annotations.
   SAnnotate c pty -> do
+    adaptToTypeErr l KindErr $ checkPolytypeKind pty
     let upty = toU pty
     -- Typecheck against skolemized polytype.
     uty <- skolemize upty
@@ -926,6 +958,7 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
   -- To check a lambda, make sure the expected type is a function type.
   SLam x mxTy body -> do
     (argTy, resTy) <- decomposeFunTy s (Expected, expected)
+    traverse_ (adaptToTypeErr l KindErr . checkKind) mxTy
     case toU mxTy of
       Just xTy -> do
         res <- argTy =:= xTy
@@ -959,8 +992,10 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
         -- we skip this check.
         when (c == Atomic) $ validAtomic at
         return $ Syntax' l (SApp atomic' at') cs (UTyCmd argTy)
+
   -- Checking the type of a let-expression.
   SLet r x mxTy t1 t2 -> do
+    traverse_ (adaptToTypeErr l KindErr . checkPolytypeKind) mxTy
     (upty, t1') <- case mxTy of
       -- No type annotation was provided for the let binding, so infer its type.
       Nothing -> do

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -8,14 +8,21 @@
 -- Types for the Swarm programming language and related utilities.
 module Swarm.Language.Types (
   -- * Basic definitions
+
+  -- ** Base types and type constructors
   BaseTy (..),
   baseTyName,
+  TyCon (..),
+  tcArity,
   Var,
+
+  -- ** Type structure functor
   TypeF (..),
 
   -- * @Type@
   Type,
   tyVars,
+  pattern TyConApp,
   pattern TyBase,
   pattern TyVar,
   pattern TyVoid,
@@ -36,6 +43,7 @@ module Swarm.Language.Types (
   -- * @UType@
   IntVar (..),
   UType,
+  pattern UTyConApp,
   pattern UTyBase,
   pattern UTyVar,
   pattern UTyVoid,
@@ -92,7 +100,7 @@ import Text.Show.Deriving (deriveShow1)
 import Witch
 
 ------------------------------------------------------------
--- Types
+-- Base types
 ------------------------------------------------------------
 
 -- | Base types.
@@ -121,27 +129,61 @@ data BaseTy
 baseTyName :: BaseTy -> Text
 baseTyName = into @Text . drop 1 . show
 
+------------------------------------------------------------
+-- Type constructors
+------------------------------------------------------------
+
+-- | Type constructors.
+data TyCon
+  = -- | Base types are (nullary) type constructors.
+    TCBase BaseTy
+  | -- | Command types.
+    TCCmd
+  | -- | Delayed computations.
+    TCDelay
+  | -- | Sum types.
+    TCSum
+  | -- | Product types.
+    TCProd
+  | -- | Function types.
+    TCFun
+  deriving (Eq, Ord, Show, Data, Generic, FromJSON, ToJSON)
+
+newtype Arity = Arity {getArity :: Int}
+  deriving (Eq, Ord, Show)
+
+-- | The arity, /i.e./ number of type arguments, of each type
+--   constructor.  Eventually, if we generalize to higher-kinded
+--   types, we'll need to upgrade this to return a full-fledged kind
+--   instead of just an arity.
+tcArity :: TyCon -> Arity
+tcArity =
+  Arity . \case
+    TCBase _ -> 0
+    TCCmd -> 1
+    TCDelay -> 1
+    TCSum -> 2
+    TCProd -> 2
+    TCFun -> 2
+
+------------------------------------------------------------
+-- Types
+------------------------------------------------------------
+
 -- | A "structure functor" encoding the shape of type expressions.
 --   Actual types are then represented by taking a fixed point of this
 --   functor.  We represent types in this way, via a "two-level type",
 --   so that we can easily use generic recursion schemes to implement
 --   things like substitution.
 data TypeF t
-  = -- | A base type.
-    TyBaseF BaseTy
+  = -- | A type constructor applied to some type arguments. For now,
+    --   all type constructor applications are required to be fully
+    --   saturated (higher kinds are not supported), so we just
+    --   directly store a list of all arguments (as opposed to
+    --   iterating binary application).
+    TyConF TyCon [t]
   | -- | A type variable.
     TyVarF Var
-  | -- | Commands, with return type.  Note that
-    --   commands form a monad.
-    TyCmdF t
-  | -- | Type of delayed computations.
-    TyDelayF t
-  | -- | Sum type.
-    TySumF t t
-  | -- | Product type.
-    TyProdF t t
-  | -- | Function type.
-    TyFunF t t
   | -- | Record type.
     TyRcdF (Map Var t)
   deriving (Show, Eq, Functor, Foldable, Traversable, Generic, Generic1, Data, FromJSON, ToJSON)
@@ -272,107 +314,119 @@ instance (WithU t, Traversable f) => WithU (f t) where
 -- Pattern synonyms
 ------------------------------------------------------------
 
+--------------------------------------------------
+-- Type
+
+pattern TyConApp :: TyCon -> [Type] -> Type
+pattern TyConApp c tys = Fix (TyConF c tys)
+
 pattern TyBase :: BaseTy -> Type
-pattern TyBase b = Fix (TyBaseF b)
+pattern TyBase b = TyConApp (TCBase b) []
 
 pattern TyVar :: Var -> Type
 pattern TyVar v = Fix (TyVarF v)
 
 pattern TyVoid :: Type
-pattern TyVoid = Fix (TyBaseF BVoid)
+pattern TyVoid = TyBase BVoid
 
 pattern TyUnit :: Type
-pattern TyUnit = Fix (TyBaseF BUnit)
+pattern TyUnit = TyBase BUnit
 
 pattern TyInt :: Type
-pattern TyInt = Fix (TyBaseF BInt)
+pattern TyInt = TyBase BInt
 
 pattern TyText :: Type
-pattern TyText = Fix (TyBaseF BText)
+pattern TyText = TyBase BText
 
 pattern TyDir :: Type
-pattern TyDir = Fix (TyBaseF BDir)
+pattern TyDir = TyBase BDir
 
 pattern TyBool :: Type
-pattern TyBool = Fix (TyBaseF BBool)
+pattern TyBool = TyBase BBool
 
 pattern TyActor :: Type
-pattern TyActor = Fix (TyBaseF BActor)
+pattern TyActor = TyBase BActor
 
 pattern TyKey :: Type
-pattern TyKey = Fix (TyBaseF BKey)
+pattern TyKey = TyBase BKey
 
 infixr 5 :+:
 
 pattern (:+:) :: Type -> Type -> Type
-pattern ty1 :+: ty2 = Fix (TySumF ty1 ty2)
+pattern ty1 :+: ty2 = TyConApp TCSum [ty1, ty2]
 
 infixr 6 :*:
 
 pattern (:*:) :: Type -> Type -> Type
-pattern ty1 :*: ty2 = Fix (TyProdF ty1 ty2)
+pattern ty1 :*: ty2 = TyConApp TCProd [ty1, ty2]
 
 infixr 1 :->:
 
 pattern (:->:) :: Type -> Type -> Type
-pattern ty1 :->: ty2 = Fix (TyFunF ty1 ty2)
+pattern ty1 :->: ty2 = TyConApp TCFun [ty1, ty2]
 
 pattern TyRcd :: Map Var Type -> Type
 pattern TyRcd m = Fix (TyRcdF m)
 
 pattern TyCmd :: Type -> Type
-pattern TyCmd ty1 = Fix (TyCmdF ty1)
+pattern TyCmd ty = TyConApp TCCmd [ty]
 
 pattern TyDelay :: Type -> Type
-pattern TyDelay ty1 = Fix (TyDelayF ty1)
+pattern TyDelay ty = TyConApp TCDelay [ty]
+
+--------------------------------------------------
+-- UType
+
+pattern UTyConApp :: TyCon -> [UType] -> UType
+pattern UTyConApp c tys = Free (TyConF c tys)
 
 pattern UTyBase :: BaseTy -> UType
-pattern UTyBase b = Free (TyBaseF b)
+pattern UTyBase b = UTyConApp (TCBase b) []
 
 pattern UTyVar :: Var -> UType
 pattern UTyVar v = Free (TyVarF v)
 
 pattern UTyVoid :: UType
-pattern UTyVoid = Free (TyBaseF BVoid)
+pattern UTyVoid = UTyBase BVoid
 
 pattern UTyUnit :: UType
-pattern UTyUnit = Free (TyBaseF BUnit)
+pattern UTyUnit = UTyBase BUnit
 
 pattern UTyInt :: UType
-pattern UTyInt = Free (TyBaseF BInt)
+pattern UTyInt = UTyBase BInt
 
 pattern UTyText :: UType
-pattern UTyText = Free (TyBaseF BText)
+pattern UTyText = UTyBase BText
 
 pattern UTyDir :: UType
-pattern UTyDir = Free (TyBaseF BDir)
+pattern UTyDir = UTyBase BDir
 
 pattern UTyBool :: UType
-pattern UTyBool = Free (TyBaseF BBool)
+pattern UTyBool = UTyBase BBool
 
 pattern UTyActor :: UType
-pattern UTyActor = Free (TyBaseF BActor)
+pattern UTyActor = UTyBase BActor
 
 pattern UTyKey :: UType
-pattern UTyKey = Free (TyBaseF BKey)
+pattern UTyKey = UTyBase BKey
 
 pattern UTySum :: UType -> UType -> UType
-pattern UTySum ty1 ty2 = Free (TySumF ty1 ty2)
+pattern UTySum ty1 ty2 = UTyConApp TCSum [ty1, ty2]
 
 pattern UTyProd :: UType -> UType -> UType
-pattern UTyProd ty1 ty2 = Free (TyProdF ty1 ty2)
+pattern UTyProd ty1 ty2 = UTyConApp TCProd [ty1, ty2]
 
 pattern UTyFun :: UType -> UType -> UType
-pattern UTyFun ty1 ty2 = Free (TyFunF ty1 ty2)
+pattern UTyFun ty1 ty2 = UTyConApp TCFun [ty1, ty2]
 
 pattern UTyRcd :: Map Var UType -> UType
 pattern UTyRcd m = Free (TyRcdF m)
 
 pattern UTyCmd :: UType -> UType
-pattern UTyCmd ty1 = Free (TyCmdF ty1)
+pattern UTyCmd ty = UTyConApp TCCmd [ty]
 
 pattern UTyDelay :: UType -> UType
-pattern UTyDelay ty1 = Free (TyDelayF ty1)
+pattern UTyDelay ty = UTyConApp TCDelay [ty]
 
 pattern PolyUnit :: Polytype
 pattern PolyUnit = Forall [] (TyCmd TyUnit)

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -13,6 +13,7 @@ module Swarm.Language.Types (
   BaseTy (..),
   baseTyName,
   TyCon (..),
+  Arity (..),
   tcArity,
   Var,
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -129,6 +129,7 @@ library swarm-lang
     Swarm.Language.Elaborate
     Swarm.Language.Format
     Swarm.Language.Key
+    Swarm.Language.Kindcheck
     Swarm.Language.LSP
     Swarm.Language.LSP.Hover
     Swarm.Language.LSP.VarUsage

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -386,6 +386,100 @@ testLanguagePipeline =
             )
         ]
     , testGroup
+        "kind checking"
+        [ testCase
+            "Cmd with no arguments"
+            ( process
+                "def x : Cmd = move end"
+                ( T.init $
+                    T.unlines
+                      [ "1:1: Kind error:"
+                      , "  Cmd requires 1 type argument, but was given 0"
+                      , ""
+                      , "  - While checking the definition of x"
+                      ]
+                )
+            )
+        , testCase
+            "Cmd with too many arguments"
+            ( process
+                "def x : Cmd Int Unit = move end"
+                ( T.init $
+                    T.unlines
+                      [ "1:1: Kind error:"
+                      , "  Cmd requires 1 type argument, but was given 2"
+                      , "  in the type: Cmd Int Unit"
+                      , ""
+                      , "  - While checking the definition of x"
+                      ]
+                )
+            )
+        , testCase
+            "Base type applied to one argument"
+            ( process
+                "def isZero : Int Bool = \\n. n == 0 end"
+                ( T.init $
+                    T.unlines
+                      [ "1:1: Kind error:"
+                      , "  Int requires 0 type arguments, but was given 1"
+                      , "  in the type: Int Bool"
+                      , ""
+                      , "  - While checking the definition of isZero"
+                      ]
+                )
+            )
+        , testCase
+            "Base type applied to several arguments"
+            ( process
+                "def isZero : Int (Bool -> Bool) Text (Unit * Unit) = \\n. n == 0 end"
+                ( T.init $
+                    T.unlines
+                      [ "1:1: Kind error:"
+                      , "  Int requires 0 type arguments, but was given 3"
+                      , "  in the type: Int (Bool -> Bool) Text (Unit * Unit)"
+                      , ""
+                      , "  - While checking the definition of isZero"
+                      ]
+                )
+            )
+        , testCase
+            "Kind error in lambda type annotation"
+            ( process
+                "\\x : Int Int. x + 1"
+                ( T.init $
+                    T.unlines
+                      [ "1:1: Kind error:"
+                      , "  Int requires 0 type arguments, but was given 1"
+                      , "  in the type: Int Int"
+                      ]
+                )
+            )
+        , testCase
+            "Kind error in type annotation"
+            ( process
+                "(\\x. x) : Int Int"
+                ( T.init $
+                    T.unlines
+                      [ "1:1: Kind error:"
+                      , "  Int requires 0 type arguments, but was given 1"
+                      , "  in the type: Int Int"
+                      ]
+                )
+            )
+        , testCase
+            "Kind error in let expression"
+            ( process
+                "let x : Int Int = 3 in x + 5"
+                ( T.init $
+                    T.unlines
+                      [ "1:1: Kind error:"
+                      , "  Int requires 0 type arguments, but was given 1"
+                      , "  in the type: Int Int"
+                      ]
+                )
+            )
+        ]
+    , testGroup
         "typechecking errors"
         [ testCase
             "applying a pair"


### PR DESCRIPTION
We used to represent types with a different constructor for each different sort of type, e.g. there was a constructor `TyFunF` which took two types as arguments, etc.  This refactoring creates a new type `TyCon` which has things like `TCFun` and `TCBase` and represents various types as an application of a `TyCon` to some arguments.  For example function type `t1 -> t2` would be represented no longer as `TyFunF t1 t2` but instead as `TyConApp TCFun [t1, t2]`.

This is slightly more roundabout, and it does make parsing slightly trickier, but it greatly simplifies and shortens code for e.g. unification, extracting free variables, etc. (because what used to be many essentially identical cases now turn into a single case).  It also paves the way for #1865, so we have a way to represent new type constructors defined by the user.  E.g. if the user defined `tydef Maybe a = Unit + a` then we would represent the type `Maybe Int` as something like `TyConApp (TCUser "Maybe") [TyBase BInt]`.

This also means that types like `Int Unit` are no longer a parse error, so we need kind checking to rule out applications of type constructors to the wrong number of arguments; this PR adds such kind checking as well.  Having some sort of kind checking is unavoidable when allowing the user to define their own new type constructors (with an arbitrary number of arguments).