### PR TITLE
Add `lens` entity and recipe for `detonator`

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -498,6 +498,13 @@
   description:
     - A pane of a brittle, clear substance, made from melting sand in a furnace.
   properties: [pickable]
+- name: lens
+  display:
+    attr: entity
+    char: 'O'
+  description:
+    - A polished, rounded piece of glass, capable of focusing rays of light.
+  properties: [pickable]
 - name: LaTeX
   display:
     attr: flower

--- a/data/recipes.yaml
+++ b/data/recipes.yaml
@@ -626,6 +626,13 @@
     - [1, furnace]
 - in:
     - [1, glass]
+    - [1, mithril]
+  out:
+    - [1, lens]
+  required:
+    - [1, drill]
+- in:
+    - [1, glass]
     - [8, copper wire]
   out:
     - [1, solar panel]
@@ -697,6 +704,12 @@
 #########################################
 ##                 MISC                ##
 #########################################
+- in:
+    - [1, lens]
+    - [1, string]
+    - [10, curry]
+  out:
+    - [1, detonator]
 - in:
     - [1, water]
     - [1, silicon]


### PR DESCRIPTION
This PR adds:

- A new entity called `lens`
    - Recipe: 1 `glass` + 1 `mithril` with a required `drill` (idea: you grind the piece of glass using a mithril-coated drill bit)
    - For now it does not convey any capabilities, but it seems ripe for some sort of pun on lenses.
- A recipe for `detonator`:
    - 1 `string` + 10 `curry` + 1 `lens`
    - Idea: curry is explosive, so you attach a string as a fuse and then ignite it by focusing sunlight with the lens.

Because of the `mithril`, these are not so easy to craft (Level 13 and 14, respectively) but I don't know any particular reason that these need to be easy to craft.  If we wanted, we could easily remove the `mithril`, which would result in them being Level 6 and 7 instead.

Closes #1017.