### PR TITLE
Make log error messages ephemeral

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -1234,6 +1234,8 @@ execConst runChildProg c vs s k = do
             -- it's slightly technically incorrect, and (3) why it is still way
             -- better than what we had before.
             robotContext . defReqs <>= (pt ^. processedReqCtx)
+            void $ traceLog CmdStatus Info "run: OK."
+
             return $ initMachine' pt empty s k
       _ -> badConst
     Not -> case vs of

--- a/src/swarm-engine/Swarm/Log.hs
+++ b/src/swarm-engine/Swarm/Log.hs
@@ -44,6 +44,8 @@ data RobotLogSource
     Logged
   | -- | Produced as the result of an error.
     RobotError
+  | -- | Produced as a status message from a command.
+    CmdStatus
   deriving (Show, Eq, Ord, Generic, FromJSON, ToJSON)
 
 -- | Source of a log entry.


### PR DESCRIPTION
Closes #1291.  The idea is that log entries produced by `log` or `say` will always be shown; but other log messages (error messages, status reports, etc.) are "ephemeral", meaning they will be shown as long as they are the most recent log entry, but will no longer be shown once a new log entry is added.  The motivation is that it is often unhelpful to see one's log full of error messages.

- All the log messages are still retained in the `RobotLog`; we just filter out some entries when displaying the log in the info panel.
- All unfiltered log entries are still shown in the Messages dialog.
- Also added a `run: OK.` log entry for successful execution of `run`, so that it in the common situation when you are trying repeatedly to `run` a file and then fixing type errors, you can immediately tell when you are successful since the error will disappear to be replaced by an `OK` message.

To test this, start a new game and try executing some commands that cause an error (e.g. `run` a non-existent file, or execute `move` with the base robot, etc.) as well as executing `log` or `say`.  Observe that `log` and `say` entries persist, whereas error messages are shown only until a new log entry is added.
