### PR TITLE
Refactoring: Parse JSON using ApplicativeDo + RecordWildCards

### DIFF
--- a/src/swarm-scenario/Swarm/Game/Display.hs
+++ b/src/swarm-scenario/Swarm/Game/Display.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -143,14 +144,15 @@ instance FromJSONE Display Display where
     let dOM = if isJust mc then mempty else defD ^. orientationMap
     mapM_ validateChar $ M.elems dOM
 
-    liftE $
-      Display c
-        <$> v .:? "orientationMap" .!= dOM
-        <*> v .:? "curOrientation" .!= (defD ^. curOrientation)
-        <*> (v .:? "attr") .!= (defD ^. displayAttr)
-        <*> v .:? "priority" .!= (defD ^. displayPriority)
-        <*> v .:? "invisible" .!= (defD ^. invisible)
-        <*> pure Inherit
+    liftE $ do
+      let _defaultChar = c
+      _orientationMap <- v .:? "orientationMap" .!= dOM
+      _curOrientation <- v .:? "curOrientation" .!= (defD ^. curOrientation)
+      _displayAttr <- (v .:? "attr") .!= (defD ^. displayAttr)
+      _displayPriority <- v .:? "priority" .!= (defD ^. displayPriority)
+      _invisible <- v .:? "invisible" .!= (defD ^. invisible)
+      let _childInheritance = Inherit
+      pure Display {..}
    where
     validateChar c =
       when (charWidth > 1)

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -530,23 +530,22 @@ combineEntityCapsM em =
 ------------------------------------------------------------
 
 instance FromJSON Entity where
-  parseJSON = withObject "Entity" $ \v ->
-    rehashEntity
-      <$> ( Entity 0
-              <$> v .: "display"
-              <*> v .: "name"
-              <*> v .:? "plural"
-              <*> v .: "description"
-              <*> v .:? "tags" .!= mempty
-              <*> v .:? "orientation"
-              <*> v .:? "growth"
-              <*> v .:? "combustion"
-              <*> v .:? "yields"
-              <*> v .:? "properties" .!= mempty
-              <*> v .:? "biomes" .!= mempty
-              <*> v .:? "capabilities" .!= Capabilities mempty
-              <*> pure empty
-          )
+  parseJSON = withObject "Entity" $ \v -> do
+    let _entityHash = 0
+    _entityDisplay <- v .: "display"
+    _entityName <- v .: "name"
+    _entityPlural <- v .:? "plural"
+    _entityDescription <- v .: "description"
+    _entityTags <- v .:? "tags" .!= mempty
+    _entityOrientation <- v .:? "orientation"
+    _entityGrowth <- v .:? "growth"
+    _entityCombustion <- v .:? "combustion"
+    _entityYields <- v .:? "yields"
+    _entityProperties <- v .:? "properties" .!= mempty
+    _entityBiomes <- v .:? "biomes" .!= mempty
+    _entityCapabilities <- v .:? "capabilities" .!= Capabilities mempty
+    let _entityInventory = empty
+    pure $ rehashEntity Entity {..}
 
 -- | If we have access to an 'EntityMap', we can parse the name of an
 --   'Entity' as a string and look it up in the map.

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -190,10 +192,10 @@ data GrowthSpread = GrowthSpread
   deriving (Eq, Ord, Show, Read, Generic, Hashable, ToJSON)
 
 instance FromJSON GrowthSpread where
-  parseJSON = withObject "Growth" $ \v ->
-    GrowthSpread
-      <$> v .: "radius"
-      <*> v .: "density"
+  parseJSON = withObject "Growth" $ \v -> do
+    spreadRadius <- v .: "radius"
+    spreadDensity <- v .: "density"
+    pure GrowthSpread {..}
 
 data Growth = Growth
   { maturesTo :: Maybe EntityName
@@ -209,11 +211,11 @@ instance FromJSON Growth where
     (Growth Nothing Nothing <$> parseJSON x)
       <|> parseFullGrowth x
    where
-    parseFullGrowth = withObject "Growth" $ \v ->
-      Growth
-        <$> v .:? "mature"
-        <*> v .:? "spread"
-        <*> v .: "duration"
+    parseFullGrowth = withObject "Growth" $ \v -> do
+      maturesTo <- v .:? "mature"
+      growthSpread <- v .:? "spread"
+      growthTime <- v .: "duration"
+      pure Growth {..}
 
 -- | How long an entity takes to regrow.  This represents the minimum
 --   and maximum amount of time taken by one growth stage (there are

--- a/src/swarm-scenario/Swarm/Game/Recipe.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- |
@@ -125,21 +126,13 @@ instance ToJSON (Recipe Text) where
         ++ ["weight" .= weight | weight /= 1]
 
 instance FromJSON (Recipe Text) where
-  parseJSON = withObject "Recipe" $ \v ->
-    Recipe
-      <$> v
-        .: "in"
-      <*> v
-        .: "out"
-      <*> v
-        .:? "required"
-        .!= []
-      <*> v
-        .:? "time"
-        .!= 1
-      <*> v
-        .:? "weight"
-        .!= 1
+  parseJSON = withObject "Recipe" $ \v -> do
+    _recipeInputs <- v .: "in"
+    _recipeOutputs <- v .: "out"
+    _recipeCatalysts <- v .:? "required" .!= []
+    _recipeTime <- v .:? "time" .!= 1
+    _recipeWeight <- v .:? "weight" .!= 1
+    pure Recipe {..}
 
 -- | Given an 'EntityMap', turn a list of recipes containing /names/
 --   of entities into a list of recipes containing actual 'Entity'

--- a/src/swarm-scenario/Swarm/Game/Scenario/Objective.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Objective.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -148,16 +149,16 @@ objectiveHidden :: Lens' Objective Bool
 objectiveAchievement :: Lens' Objective (Maybe AD.AchievementInfo)
 
 instance FromJSON Objective where
-  parseJSON = withObject "objective" $ \v ->
-    Objective
-      <$> (v .:? "goal" .!= mempty)
-      <*> (v .:? "teaser")
-      <*> (v .: "condition")
-      <*> (v .:? "id")
-      <*> (v .:? "optional" .!= False)
-      <*> (v .:? "prerequisite")
-      <*> (v .:? "hidden" .!= False)
-      <*> (v .:? "achievement")
+  parseJSON = withObject "objective" $ \v -> do
+    _objectiveGoal <- v .:? "goal" .!= mempty
+    _objectiveTeaser <- v .:? "teaser"
+    _objectiveCondition <- v .: "condition"
+    _objectiveId <- v .:? "id"
+    _objectiveOptional <- v .:? "optional" .!= False
+    _objectivePrerequisite <- v .:? "prerequisite"
+    _objectiveHidden <- v .:? "hidden" .!= False
+    _objectiveAchievement <- v .:? "achievement"
+    pure Objective {..}
 
 -- | TODO: #1044 Could also add an "ObjectiveFailed" constructor...
 newtype Announcement

--- a/src/swarm-scenario/Swarm/Game/Scenario/Objective.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Objective.hs
@@ -86,10 +86,10 @@ instance FromJSON PrerequisiteConfig where
   -- as a bare string without needing the "id" key.
   parseJSON val = preLogic val <|> preObject val
    where
-    preObject = withObject "prerequisite" $ \v ->
-      PrerequisiteConfig
-        <$> (v .:? "previewable" .!= False)
-        <*> v .: "logic"
+    preObject = withObject "prerequisite" $ \v -> do
+      previewable <- v .:? "previewable" .!= False
+      logic <- v .: "logic"
+      pure PrerequisiteConfig {..}
     preLogic = fmap (PrerequisiteConfig False) . parseJSON
 
 -- | An objective is a condition to be achieved by a player in a

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Cell.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Cell.hs
@@ -119,8 +119,7 @@ instance FromJSONE (TerrainEntityMaps, RobotMap) (AugmentedCell Entity) where
     objParse v =
       AugmentedCell
         <$> liftE (v .:? "waypoint")
-        <*> v
-          ..: "cell"
+        <*> v ..: "cell"
 
 ------------------------------------------------------------
 -- World editor

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Navigation/Portal.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Navigation/Portal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |
@@ -90,14 +91,12 @@ data Portal = Portal
   deriving (Show, Eq)
 
 instance FromJSON Portal where
-  parseJSON = withObject "Portal" $ \v ->
-    Portal
-      <$> v
-        .: "entrance"
-      <*> v
-        .: "exitInfo"
-      <*> v .:? "consistent" .!= False
-      <*> v .:? "reorient" .!= DForward
+  parseJSON = withObject "Portal" $ \v -> do
+    entrance <- v .: "entrance"
+    exitInfo <- v .: "exitInfo"
+    consistent <- v .:? "consistent" .!= False
+    reorient <- v .:? "reorient" .!= DForward
+    pure Portal {..}
 
 failUponDuplication ::
   (MonadFail m, Show a, Show b) =>

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Navigation/Waypoint.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Navigation/Waypoint.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
@@ -52,10 +53,10 @@ data WaypointConfig = WaypointConfig
   deriving (Show, Eq)
 
 parseWaypointConfig :: Object -> Parser WaypointConfig
-parseWaypointConfig v =
-  WaypointConfig
-    <$> v .: "name"
-    <*> v .:? "unique" .!= False
+parseWaypointConfig v = do
+  wpName <- v .: "name"
+  wpUnique <- v .:? "unique" .!= False
+  pure WaypointConfig {..}
 
 instance FromJSON WaypointConfig where
   parseJSON = withObject "Waypoint Config" parseWaypointConfig
@@ -74,10 +75,10 @@ data Waypoint = Waypoint
 -- | JSON representation is flattened; all keys are at the same level,
 -- in contrast with the underlying record.
 instance FromJSON Waypoint where
-  parseJSON = withObject "Waypoint" $ \v ->
-    Waypoint
-      <$> parseWaypointConfig v
-      <*> v .: "loc"
+  parseJSON = withObject "Waypoint" $ \v -> do
+    wpConfig <- parseWaypointConfig v
+    wpLoc <- v .: "loc"
+    pure Waypoint {..}
 
 instance HasLocation Waypoint where
   modifyLoc f (Waypoint cfg originalLoc) = Waypoint cfg $ f originalLoc

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Placement.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Placement.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
@@ -32,9 +33,9 @@ data Orientation = Orientation
 
 instance FromJSON Orientation where
   parseJSON = withObject "structure orientation" $ \v -> do
-    Orientation
-      <$> v .:? "up" .!= DNorth
-      <*> v .:? "flip" .!= False
+    up <- v .:? "up" .!= DNorth
+    flipped <- v .:? "flip" .!= False
+    pure Orientation {..}
 
 defaultOrientation :: Orientation
 defaultOrientation = Orientation DNorth False
@@ -82,10 +83,9 @@ data Placement = Placement
 
 instance FromJSON Placement where
   parseJSON = withObject "structure placement" $ \v -> do
-    sName <- v .: "src"
-    shouldTruncate <- v .:? "truncate" .!= True
-    p <-
-      Pose
-        <$> v .:? "offset" .!= origin
-        <*> v .:? "orient" .!= defaultOrientation
-    return $ Placement sName shouldTruncate p
+    src <- v .: "src"
+    truncateOverlay <- v .:? "truncate" .!= True
+    offset <- v .:? "offset" .!= origin
+    orient <- v .:? "orient" .!= defaultOrientation
+    let structurePose = Pose offset orient
+    pure Placement {..}

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Structure.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
@@ -90,19 +91,16 @@ data MergedStructure c = MergedStructure (PositionedGrid c) [LocatedStructure] [
 instance FromJSONE (TerrainEntityMaps, RobotMap) (PStructure (Maybe Cell)) where
   parseJSONE = withObjectE "structure definition" $ \v -> do
     pal <- v ..:? "palette" ..!= WorldPalette mempty
-    localStructureDefs <- v ..:? "structures" ..!= []
+    structures <- v ..:? "structures" ..!= []
 
     liftE $ do
-      placementDefs <- v .:? "placements" .!= []
+      placements <- v .:? "placements" .!= []
       waypointDefs <- v .:? "waypoints" .!= []
       maybeMaskChar <- v .:? "mask"
       (maskedArea, mapWaypoints) <- (v .:? "map" .!= "") >>= paintMap maybeMaskChar pal
-      return $
-        Structure
-          (PositionedGrid origin $ Grid maskedArea)
-          localStructureDefs
-          placementDefs
-          (waypointDefs <> mapWaypoints)
+      let area = PositionedGrid origin $ Grid maskedArea
+          waypoints = waypointDefs <> mapWaypoints
+      return Structure {..}
 
 -- | \"Paint\" a world map using a 'WorldPalette', turning it from a raw
 --   string into a nested list of 'PCell' values by looking up each

--- a/src/swarm-scenario/Swarm/Game/Universe.hs
+++ b/src/swarm-scenario/Swarm/Game/Universe.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- |
@@ -46,13 +47,11 @@ makeLenses ''Cosmic
 
 instance (FromJSON a) => FromJSON (Cosmic a) where
   parseJSON x = case x of
-    Object v -> objParse v
+    Object v -> do
+      _subworld <- v .: "subworld"
+      _planar <- v .: "loc"
+      pure Cosmic {..}
     _ -> Cosmic DefaultRootSubworld <$> parseJSON x
-   where
-    objParse v =
-      Cosmic
-        <$> v .: "subworld"
-        <*> v .: "loc"
 
 -- * Measurement
 

--- a/src/swarm-tournament/Swarm/Web/Auth.hs
+++ b/src/swarm-tournament/Swarm/Web/Auth.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -31,12 +32,10 @@ data GitHubCredentials = GitHubCredentials
   }
 
 instance FromJSON GitHubCredentials where
-  parseJSON = withObject "GitHubCredentials" $ \v ->
-    let theID = BSU.fromString <$> v .: "CLIENT_ID"
-        theSecret = BSU.fromString <$> v .: "CLIENT_SECRET"
-     in GitHubCredentials
-          <$> theID
-          <*> theSecret
+  parseJSON = withObject "GitHubCredentials" $ \v -> do
+    clientId <- BSU.fromString <$> v .: "CLIENT_ID"
+    clientSecret <- BSU.fromString <$> v .: "CLIENT_SECRET"
+    pure GitHubCredentials {..}
 
 newtype TokenExchangeCode = TokenExchangeCode BS.ByteString
 


### PR DESCRIPTION
Taking a stab at refactoring `FromJSON` instances. Initially while skimming through the swarm code, I found multiple occurrences of using applicatives for `FromJSON` instances but was hesitant to bring it up. In my experience, it's almost always ergonomic to use `do` notation with `RecordWildCards`.

Closes #1878 
