### PR TITLE
Fix FromJSON instance for better error msgs

### DIFF
--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -192,7 +192,7 @@ data GrowthSpread = GrowthSpread
   deriving (Eq, Ord, Show, Read, Generic, Hashable, ToJSON)
 
 instance FromJSON GrowthSpread where
-  parseJSON = withObject "Growth" $ \v -> do
+  parseJSON = withObject "GrowthSpread" $ \v -> do
     spreadRadius <- v .: "radius"
     spreadDensity <- v .: "density"
     pure GrowthSpread {..}


### PR DESCRIPTION
Before:
```
ghci> let s = "[{ \"radius\": 2, \"density\": \"x\"}]"
ghci> eitherDecodeStrict s :: Either String GrowthSpread
Left "Error in $: parsing Growth failed, expected Object, but encountered Array
```

The error msg above is misleading because we weren't trying to parse `Growth` datatype but `GrowthSpread` instead.

After:
```
ghci> let s = "[{ \"radius\": 2, \"density\": \"x\"}]"
ghci> eitherDecodeStrict s :: Either String GrowthSpread
Left "Error in $: parsing GrowthSpread failed, expected Object, but encountered Array"
```