### PR TITLE
Recursive types

### DIFF
--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -154,7 +154,7 @@
   "Regexp that recognizes types (all uppercase strings are supposed to be types) in swarm language.")
 
 (defvar swarm-mode-keywords-regexp
-  (concat "\\b" (regexp-opt '("def" "tydef" "end" "let" "in" "require") t) "\\b")
+  (concat "\\b" (regexp-opt '("def" "tydef" "rec" "end" "let" "in" "require") t) "\\b")
   "Regexp that recognizes keywords in swarm language.")
 
 (defvar swarm-font-lock-keywords

--- a/editors/vim/swarm.vim
+++ b/editors/vim/swarm.vim
@@ -1,4 +1,4 @@
-syn keyword Keyword def tydef end let in require
+syn keyword Keyword def tydef rec end let in require
 syn keyword Builtins self parent base if inl inr case fst snd force undefined fail not format chars split charat tochar key
 syn keyword Command noop wait selfdestruct move backup volume path push stride turn grab harvest sow ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami waypoint structure floorplan hastag tagmembers detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try swap atomic instant installkeyhandler teleport as robotnamed robotnumbered knows
 syn keyword Direction east north west south down forward left back right

--- a/example/omega.sw
+++ b/example/omega.sw
@@ -1,0 +1,5 @@
+tydef D = rec d. d -> d end
+
+def selfApp : D -> D = \x. x x end
+
+def omega : D = selfApp selfApp end

--- a/example/rectypes.sw
+++ b/example/rectypes.sw
@@ -1,0 +1,107 @@
+// 'rec t. F(t)' creates a recursive type which is the solution of t = F(t).
+// For example 'rec l. Unit + Int * l' is the type l such that l = Unit + Int * l,
+// that is, arbitrary-length finite lists of Int.
+//
+// Recursive types are equal up to alpha-renaming, so e.g.
+// (rec l. Unit + Int * l) = (rec q. Unit + Int * q)
+
+////////////////////////////////////////////////////////////
+// Lists
+////////////////////////////////////////////////////////////
+
+tydef List a = rec l. Unit + a * l end
+
+def nil : List a = inl () end
+def cons : a -> List a -> List a = \x. \l. inr (x, l) end
+
+def foldr : (a -> b -> b) -> b -> List a -> b = \f. \z. \xs.
+  case xs
+    (\_. z)
+    (\c. f (fst c) (foldr f z (snd c)))
+end
+
+def map : (a -> b) -> List a -> List b = \f.
+  foldr (\y. cons (f y)) nil
+end
+
+def append : List a -> List a -> List a = \xs. \ys.
+  foldr cons ys xs
+end
+
+def concat : List (List a) -> List a = foldr append nil end
+
+def sum : List Int -> Int =
+  foldr (\x. \y. x + y) 0
+end
+
+def twentySeven = sum (cons 12 (cons 5 (cons 3 (cons 7 nil)))) end
+
+// Note that if a function returns e.g. (rec t. Unit + (Int * Int) * t),
+// that is the *same type* as List (Int * Int), so we can use any List
+// functions on the output.
+
+def someFun : Int -> (rec t. Unit + (Int * Int) * t) = \x. inr ((x, x), inl ()) end
+
+def doSomethingWithSomeFun : List (Int * Int) =
+  (cons (2,3) (cons (4,7) (someFun 5)))
+end
+
+////////////////////////////////////////////////////////////
+// Binary trees with a at internal nodes and b at leaves
+////////////////////////////////////////////////////////////
+
+tydef BTree a b = rec bt. b + bt * a * bt end
+
+def leaf : b -> BTree a b = inl end
+
+def branch : BTree a b -> a -> BTree a b -> BTree a b =
+  \l. \a. \r. inr (l, a, r)
+end
+
+def foldBTree : (b -> c) -> (c -> a -> c -> c) -> BTree a b -> c =
+  \lf. \br. \t.
+    case t
+      lf
+      // fst p, fst (snd p), snd (snd p) is annoying; see #1893
+      (\p. br (foldBTree lf br (fst p)) (fst (snd p)) (foldBTree lf br (snd (snd p))))
+end
+
+def max : Int -> Int -> Int = \a. \b. if (a > b) {a} {b} end
+
+def height : BTree a b -> Int =
+  foldBTree (\_. 0) (\l. \_. \r. 1 + max l r)
+end
+
+////////////////////////////////////////////////////////////
+// Rose trees
+////////////////////////////////////////////////////////////
+
+// It would be better to reuse the definition of List
+// and define Rose a = rec r. a * List r,
+// but we do it this way just to show off nested rec
+tydef Rose a = rec r. a * (rec l. Unit + r * l) end
+
+def foldRose : (a -> List b -> b) -> Rose a -> b = \f. \r.
+  f (fst r) (map (foldRose f) (snd r))
+end
+
+def flatten : Rose a -> List a =
+  foldRose (\a. \ts. cons a (concat ts))
+end
+
+////////////////////////////////////////////////////////////
+// Equirecursive types
+////////////////////////////////////////////////////////////
+
+// Swarm has equirecursive types, which means a recursive type is
+// *equal to* its unfolding.  This has some interesting consequences
+// including the fact that types are equal if their infinite unfoldings
+// would be equal.
+
+// For example, U1 and U2 below are the same, and the Swarm
+// typechecker can tell:
+
+tydef U1 = rec u1. Unit + u1 end
+tydef U2 = rec u2. Unit + Unit + u2 end
+
+def u : U1 -> U2 = \u. u end

--- a/src/swarm-lang/Swarm/Effect/Unify.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify.hs
@@ -52,4 +52,7 @@ data UnificationError where
   UnifyErr :: TypeF UType -> TypeF UType -> UnificationError
   -- | Encountered an undefined/unknown type constructor.
   UndefinedUserType :: UType -> UnificationError
+  -- | Encountered an unexpanded recursive type in unifyF.  This
+  --   should never happen.
+  UnexpandedRecTy :: TypeF UType -> UnificationError
   deriving (Show)

--- a/src/swarm-lang/Swarm/Effect/Unify/Naive.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify/Naive.hs
@@ -13,7 +13,7 @@
 --
 -- Not used in Swarm, and also unmaintained
 -- (e.g. "Swarm.Effect.Unify.Fast" now supports expanding type
--- aliases; this module does not). It's still here just for
+-- aliases + recursive types; this module does not). It's still here just for
 -- testing/comparison.
 module Swarm.Effect.Unify.Naive where
 
@@ -164,5 +164,8 @@ unifyF t1 t2 = case (t1, t2) of
       False -> unifyErr
       _ -> (fmap compose . sequence) (M.merge M.dropMissing M.dropMissing (M.zipWithMatched (const unify)) m1 m2)
   (TyRcdF {}, _) -> unifyErr
+  -- Don't support any extra features (e.g. recursive types), so just
+  -- add a catch-all failure case
+  (_, _) -> unifyErr
  where
   unifyErr = throwError $ UnifyErr t1 t2

--- a/src/swarm-lang/Swarm/Language/Capability.hs
+++ b/src/swarm-lang/Swarm/Language/Capability.hs
@@ -185,6 +185,8 @@ data Capability
     CHandleinput
   | -- | Capability to make other robots halt.
     CHalt
+  | -- | Capability to handle recursive types.
+    CRectype
   | -- | God-like capabilities.  For e.g. commands intended only for
     --   checking challenge mode win conditions, and not for use by
     --   players.

--- a/src/swarm-lang/Swarm/Language/Kindcheck.hs
+++ b/src/swarm-lang/Swarm/Language/Kindcheck.hs
@@ -11,14 +11,23 @@ module Swarm.Language.Kindcheck (
 import Control.Algebra (Has)
 import Control.Effect.Reader (Reader, ask)
 import Control.Effect.Throw (Throw, throwError)
+import Control.Monad.Extra (unlessM)
 import Data.Fix (Fix (..))
 import Swarm.Language.Types
 
--- | Kind checking errors that can occur.  For now, the only possible
---   error is an arity mismatch error.
+-- | Kind checking errors that can occur.
 data KindError
-  = ArityMismatch TyCon Int [Type]
-  | UndefinedTyCon TyCon Type
+  = -- | A type constructor expects n arguments, but was given these
+    --   arguments instead.
+    ArityMismatch TyCon Int [Type]
+  | -- | An undefined type constructor was encountered in the given type.
+    UndefinedTyCon TyCon Type
+  | -- | A trivial recursive type (one that does not use its bound
+    --   variable) was encountered.
+    TrivialRecTy Var Type
+  | -- | A vacuous recursive type (one that expands immediately to
+    --   itself) was encountered.
+    VacuousRecTy Var Type
   deriving (Eq, Show)
 
 -- | Check that a polytype is well-kinded.
@@ -34,6 +43,11 @@ checkPolytypeKind pty@(Forall xs t) = TydefInfo pty (Arity $ length xs) <$ check
 --   well want to generalize to arbitrary higher kinds (e.g. @(Type ->
 --   Type) -> Type@ etc.) which would require generalizing this
 --   checking code a bit.
+--
+--   Here we also check that any recursive types are non-vacuous,
+--   /i.e./ not of the form @rec t. t@, and non-trivial, /i.e./ the
+--   variable bound by the @rec@ actually occurs somewhere in the
+--   body.
 checkKind :: (Has (Reader TDCtx) sig m, Has (Throw KindError) sig m) => Type -> m ()
 checkKind ty@(Fix tyF) = case tyF of
   TyConF c tys -> do
@@ -45,5 +59,74 @@ checkKind ty@(Fix tyF) = case tyF of
         _ -> throwError $ ArityMismatch c a tys
   TyVarF _ -> return ()
   TyRcdF m -> mapM_ checkKind m
-  TyRecF _ t -> checkKind t
+  TyRecF x t -> do
+    -- It's important to call checkKind first, to rule out undefined
+    -- type constructors. Within the recursive kind check, we
+    -- substitute the given variable name for the bound de Bruijn
+    -- index 0 in the body.  This doesn't affect the checking but it
+    -- does ensure that error messages will use the variable name and
+    -- not de Bruijn indices.
+    checkKind (substRec (TyVarF x) t NZ)
+    -- Now check that the recursive type is well-formed.  We call this
+    -- with the *unsubstituted* t because the check will be looking
+    -- for de Bruijn variables specifically.
+    checkRecTy x t
   TyRecVarF _ -> return ()
+
+-- | Check that the body of a recursive type actually contains the
+--   bound variable at least once (otherwise there's no point in using
+--   @rec@) and does not consist solely of that variable.
+checkRecTy :: (Has (Reader TDCtx) sig m, Has (Throw KindError) sig m) => Var -> Type -> m ()
+checkRecTy x ty = do
+  unlessM (containsVar NZ ty) $ throwError (TrivialRecTy x ty)
+  unlessM (nonVacuous NZ ty) $ throwError (VacuousRecTy x ty)
+
+-- Note, in theory it would be more efficient to combine containsVar
+-- and nonVacuous into a single check that walks over the type only
+-- once, but we keep them separate just to simplify things.  This
+-- won't make much difference in the grand scheme of things since
+-- types are small.
+
+-- | Check whether a type contains a specific bound recursive type
+--   variable.
+containsVar :: Has (Reader TDCtx) sig m => Nat -> Type -> m Bool
+containsVar i (Fix tyF) = case tyF of
+  TyRecVarF j -> pure (i == j)
+  TyVarF {} -> pure False
+  TyConF (TCUser u) tys -> do
+    ty' <- expandTydef u tys
+    containsVar i ty'
+  TyConF _ tys -> or <$> mapM (containsVar i) tys
+  TyRcdF m -> or <$> mapM (containsVar i) m
+  TyRecF _ ty -> containsVar (NS i) ty
+
+-- | @nonVacuous ty@ checks that the recursive type @rec x. ty@ is
+--   non-vacuous, /i.e./ that it doesn't look like @rec x. x@.  Put
+--   another way, we make sure the recursive type is "productive" in
+--   the sense that unfolding it will result in a well-defined
+--   infinite type (as opposed to @rec x. x@ which just unfolds to
+--   itself).  However, we can't just check whether it literally looks
+--   like @rec x. x@ since we must also (1) expand type aliases and
+--   (2) ignore additional intervening @rec@s.  For example, given
+--   @tydef Id a = a@, the type @rec x. rec y. Id x@ is also vacuous.
+nonVacuous :: (Has (Reader TDCtx) sig m) => Nat -> Type -> m Bool
+nonVacuous i (Fix tyF) = case tyF of
+  -- The type simply consists of a variable bound by some @rec@.
+  -- Check if it's the variable we're currently looking for.
+  TyRecVarF j -> pure (i /= j)
+  -- Expand a user-defined type and keep looking.
+  TyConF (TCUser u) tys -> do
+    ty' <- expandTydef u tys
+    nonVacuous i ty'
+  -- Increment the variable we're looking for when going under a @rec@
+  -- binder.
+  TyRecF _ ty -> nonVacuous (NS i) ty
+  -- If we encounter any other kind of type constructor or record
+  -- type, rejoice!
+  TyConF {} -> pure True
+  TyRcdF {} -> pure True
+  -- This last case can't actully happen if we already checked that
+  -- the recursive type actually contains its bound variable (with
+  -- 'containsVar'), since it would correspond to something like @rec
+  -- x. y@.  However, it's still correct to return True.
+  TyVarF {} -> pure True

--- a/src/swarm-lang/Swarm/Language/Parser/Lex.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Lex.hs
@@ -164,7 +164,7 @@ primitiveTypeNames = "Cmd" : baseTypeNames
 
 -- | List of keywords built into the language.
 keywords :: [Text]
-keywords = T.words "let in def tydef end true false forall require requirements"
+keywords = T.words "let in def tydef end true false forall require requirements rec"
 
 -- | List of reserved words that cannot be used as variable names.
 reservedWords :: Set Text

--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -154,6 +154,7 @@ instance (PrettyPrec (t (Free t v)), PrettyPrec v) => PrettyPrec (Free t v) wher
   prettyPrec p (Free t) = prettyPrec p t
   prettyPrec p (Pure v) = prettyPrec p v
 
+-- XXX use case!
 instance ((UnchainableFun t), (PrettyPrec t)) => PrettyPrec (TypeF t) where
   prettyPrec _ (TyVarF v) = pretty v
   prettyPrec _ (TyRcdF m) = brackets $ hsep (punctuate "," (map prettyBinding (M.assocs m)))
@@ -173,6 +174,9 @@ instance ((UnchainableFun t), (PrettyPrec t)) => PrettyPrec (TypeF t) where
         multiLine l r = l <+> "->" <> hardline <> r
      in pparens (p > 1) . align $
           flatAlt (concatWith multiLine funs) (concatWith inLine funs)
+  -- Recursive types XXX
+  prettyPrec _ (TyRecVarF i) = pretty (show (natToInt i))
+  prettyPrec p (TyRecF _ ty) = pparens (p > 0) $ "rec." <+> prettyPrec 0 ty
   -- Fallthrough cases for type constructor application.  Handles base
   -- types, Cmd, user-defined types, or ill-kinded things like 'Int
   -- Bool'.
@@ -474,6 +478,8 @@ tyNounPhrase = \case
   TyConF c _ -> tyConNounPhrase c
   TyVarF {} -> "a type variable"
   TyRcdF {} -> "a record"
+  TyRecF {} -> "a recursive type"
+  TyRecVarF {} -> "a recursive type variable"
 
 tyConNounPhrase :: TyCon -> Doc a
 tyConNounPhrase = \case

--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -436,21 +436,32 @@ instance PrettyPrec Arity where
   prettyPrec _ (Arity a) = pretty a
 
 instance PrettyPrec KindError where
-  prettyPrec _ (ArityMismatch c a tys) =
-    nest 2 . vsep $
-      [ "Kind error:"
-      , hsep
-          [ ppr c
-          , "requires"
-          , pretty a
-          , "type"
-          , pretty (number a "argument" <> ",")
-          , "but was given"
-          , pretty (length tys)
-          ]
-      ]
-        ++ ["in the type:" <+> ppr (TyConApp c tys) | not (null tys)]
-  prettyPrec _ (UndefinedTyCon tc _ty) = "Undefined type" <+> ppr tc
+  prettyPrec _ = \case
+    ArityMismatch c a tys ->
+      nest 2 . vsep $
+        [ "Kind error:"
+        , hsep
+            [ ppr c
+            , "requires"
+            , pretty a
+            , "type"
+            , pretty (number a "argument" <> ",")
+            , "but was given"
+            , pretty (length tys)
+            ]
+        ]
+          ++ ["in the type:" <+> ppr (TyConApp c tys) | not (null tys)]
+    UndefinedTyCon tc _ty -> "Undefined type" <+> ppr tc
+    TrivialRecTy x ty ->
+      nest 2 . vsep $
+        [ "Encountered trivial recursive type" <+> ppr (TyRec x ty)
+        , "Did you forget to use" <+> pretty x <+> "in the body of the type?"
+        ]
+    VacuousRecTy x ty ->
+      nest 2 . vsep $
+        [ "Encountered vacuous recursive type" <+> ppr (TyRec x ty)
+        , "Recursive types must be productive, i.e. must not expand to themselves."
+        ]
 
 -- | Given a type and its source, construct an appropriate description
 --   of it to go in a type mismatch error message.

--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -421,7 +421,10 @@ instance PrettyPrec TypeErr where
 instance PrettyPrec UnificationError where
   prettyPrec _ = \case
     Infinite x uty ->
-      "Infinite type:" <+> ppr x <+> "=" <+> ppr uty
+      vsep
+        [ "Encountered infinite type" <+> ppr x <+> "=" <+> ppr uty <> "."
+        , "Swarm will not infer recursive types; if you want a recursive type, add an explicit type annotation."
+        ]
     UnifyErr ty1 ty2 ->
       "Can't unify" <+> ppr ty1 <+> "and" <+> ppr ty2
     UndefinedUserType ty ->

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -856,6 +856,7 @@ test-suite swarm-unit
     base,
     boolexpr,
     containers,
+    data-fix,
     filepath,
     hashable,
     lens,

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -588,6 +588,18 @@ testLanguagePipeline =
                 "1:34:\n  |\n1 | tydef Unbound a b = a + b + c end\n  |                                  ^\nUndefined type variable(s) on right-hand side of tydef: c\n"
             )
         ]
+    , testGroup
+        "recursive types"
+        [ testCase
+            "occurs check"
+            ( process
+                "def sum = \\l. case l (\\_. 0) (\\c. fst c + sum (snd c)) end"
+                "Encountered infinite type u5 = Int * (u4 + u5).\nSwarm will not infer recursive types; if you want a recursive type, add an explicit type annotation."
+            )
+        , testCase
+            "no occurs check with type annotation"
+            (valid "def sum : (rec l. Unit + Int * l) -> Int = \\l. case l (\\_. 0) (\\c. fst c + sum (snd c)) end")
+        ]
     ]
  where
   valid = flip process ""

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -599,6 +599,36 @@ testLanguagePipeline =
         , testCase
             "no occurs check with type annotation"
             (valid "def sum : (rec l. Unit + Int * l) -> Int = \\l. case l (\\_. 0) (\\c. fst c + sum (snd c)) end")
+        , testCase
+            "vacuous"
+            ( process
+                "tydef X = rec x. x end"
+                "1:1: Encountered vacuous recursive type rec x. x"
+            )
+        , testCase
+            "nonobviously vacuous"
+            ( process
+                "tydef I a = a end; tydef M a b c = b end; tydef X = rec y. rec x. M x (I x) Int end"
+                "1:43: Encountered vacuous recursive type rec x. M x (I x) Int"
+            )
+        , testCase
+            "trivial"
+            ( process
+                "tydef X = rec x. Int end"
+                "1:1: Encountered trivial recursive type rec x. Int"
+            )
+        , testCase
+            "free rec vars"
+            ( process
+                "tydef X = rec y. rec x. y end"
+                "1:1: Encountered trivial recursive type rec x. y"
+            )
+        , testCase
+            "rec type with undefined tycon"
+            ( process
+                "tydef X = rec x. U + x end"
+                "1:1: Undefined type U"
+            )
         ]
     ]
  where

--- a/test/unit/TestPretty.hs
+++ b/test/unit/TestPretty.hs
@@ -6,6 +6,7 @@
 -- Swarm unit tests
 module TestPretty where
 
+import Data.Fix (Fix (..))
 import Swarm.Language.Pretty
 import Swarm.Language.Syntax hiding (mkOp)
 import Swarm.Language.Types
@@ -196,6 +197,18 @@ testPrettyConst =
                     ["a", "b", "c", "d"]
                     (TyUnit :+: (TyVar "a" :*: TyVar "b") :+: ((TyVar "c" :->: TyVar "d") :*: TyVar "a"))
                 )
+        ]
+    , testGroup
+        "recursive types"
+        [ testCase "nat" $
+            equalPretty "rec n. Unit + n" $
+              TyRec "n" (TyUnit :+: Fix (TyRecVarF NZ))
+        , testCase "list" $
+            equalPretty "rec list. Unit + (a * list)" $
+              TyRec "list" (TyUnit :+: (TyVar "a" :*: Fix (TyRecVarF NZ)))
+        , testCase "rose" $
+            equalPretty "rec r. a * (rec l. Unit + (r * l))" $
+              TyRec "r" (TyVar "a" :*: TyRec "l" (TyUnit :+: (Fix (TyRecVarF (NS NZ)) :*: Fix (TyRecVarF NZ))))
         ]
     ]
  where


### PR DESCRIPTION
Implements recursive types.  Example:
```
tydef List a = rec l. Unit + a * l end

def nil : List a = inl () end
def cons : a -> List a -> List a = \x. \l. inr (x, l) end

def foldr : (a -> b -> b) -> b -> List a -> b = \f. \z. \xs.
  case xs
    (\_. z)
    (\c. f (fst c) (foldr f z (snd c)))
end

def map : (a -> b) -> List a -> List b = \f.
  foldr (\y. cons (f y)) nil
end
```
As discussed at #154, this uses the syntax `rec x. F(x)` to define the type `x` which is a solution to `x = F(x)`.  However, unlike the discussion there, I ended up going with *equirecursive* types (so a recursive type is *equal to* its unfolding). For example, as you can see above, if we have a value of type `List a` (defined as `rec l. Unit + a * l`), then it actually has the equivalent type `Unit + a * List a`, so we can simply do a `case` on it, without having to `unroll` first.  This actually turned out to be *easier* to implement (and it is cooler).

There are multiple built-in functions that conceptually return a list but currently do something different (like return a fold, or take an index and return a single element, etc.)  We should consider changing them to actually return lists, but that should definitely be in a separate PR.

Closes #154.