### PR TITLE
Rebalance mine chances with metal drill

### DIFF
--- a/data/recipes.yaml
+++ b/data/recipes.yaml
@@ -182,7 +182,7 @@
   required:
     - [1, metal drill]
   time: 9
-  weight: 160
+  weight: 34
 - in:
     - [1, mountain]
   out:
@@ -192,7 +192,7 @@
   required:
     - [1, metal drill]
   time: 9
-  weight: 10
+  weight: 2
 - in:
     - [5, rock]
   out:
@@ -241,7 +241,7 @@
   required:
     - [1, metal drill]
   time: 6
-  weight: 10
+  weight: 5
 - in:
     - [1, mountain]
   out:
@@ -250,7 +250,7 @@
   required:
     - [1, metal drill]
   time: 7
-  weight: 10
+  weight: 5
 - in:
     - [1, mountain]
   out:
@@ -259,7 +259,7 @@
   required:
     - [1, metal drill]
   time: 7
-  weight: 10
+  weight: 3
 ## MINES
 - in:
     - [1, copper mine]


### PR DESCRIPTION
The game was kind of unbalanced with respect to `metal drill`s.  They actually had a *lower* chance of uncovering iron, copper, or quartz mines, and the chance of uncovering a `deep mine` was too low (it was likely to mine out all the mountains on the screen and never see one).  This PR (1) adjusts the iron, copper, and quartz mine probabilities to the same or better as with a regular `drill`, and (2) increases the `deep mine` probability to something more reasonable.

For those who want all the details:
-  `drill` weights when drilling a `mountain`:
    - (16 = 73%) `mountain tunnel` + 8 rock
    - (1 = 4.5%) `mountain tunnel` + lodestone + iron ore
    - (2 = 9%) `copper mine` + copper ore
    - (2 = 9%) `iron mine` + iron ore
    - (1 = 4.5%) `quartz mine` + quartz ore
- Old `metal drill` weights:
    - (160 = 79%) `mountain tunnel` + 8 rock
    - (10 = 5%) `mountain tunnel` + lodestone + iron ore
    - (10 = 5%) `copper mine`
    - (10 = 5%) `iron mine`
    - (10 = 5%) `quartz mine`
    - (1 = 0.5%) `deep mine`
- New `metal drill` weights:
    - (34 = 68%) tunnel + rock
    - (2 = 4%) tunnel + lodestone + iron ore
    - (5 = 10%) copper mine
    - (5 = 10%) iron mine
    - (3 = 6%) quartz mine
    - (1 = 2%) deep mine