### PR TITLE
Bring speedrun scenarios in line with classic scenario

### DIFF
--- a/data/scenarios/Speedruns/curry.yaml
+++ b/data/scenarios/Speedruns/curry.yaml
@@ -18,6 +18,7 @@ robots:
       - 3D printer
       - dictionary
       - grabber
+      - welder
       - life support system
       - logger
       - toolkit
@@ -30,6 +31,7 @@ robots:
       - [70, grabber]
       - [100, solar panel]
       - [50, scanner]
+      - [50, clock]
       - [5, toolkit]
 world:
   offset: true

--- a/data/scenarios/Speedruns/forester.yaml
+++ b/data/scenarios/Speedruns/forester.yaml
@@ -18,6 +18,7 @@ robots:
       - 3D printer
       - dictionary
       - grabber
+      - welder
       - life support system
       - logger
       - toolkit
@@ -30,6 +31,7 @@ robots:
       - [70, grabber]
       - [100, solar panel]
       - [50, scanner]
+      - [50, clock]
       - [5, toolkit]
 world:
   offset: true

--- a/data/scenarios/Speedruns/mithril.yaml
+++ b/data/scenarios/Speedruns/mithril.yaml
@@ -18,6 +18,7 @@ robots:
       - 3D printer
       - dictionary
       - grabber
+      - welder
       - life support system
       - logger
       - toolkit
@@ -30,6 +31,7 @@ robots:
       - [70, grabber]
       - [100, solar panel]
       - [50, scanner]
+      - [50, clock]
       - [5, toolkit]
 world:
   offset: true


### PR DESCRIPTION
At some point in the past a `welder` device and 50 `clock`s were added to the equipment and inventory, respectively, of the `base` robot in the `classic` scenario.  This just updates the speedrun scenarios to match.