### PR TITLE
Add device to provide `rectypes` capability

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -1034,7 +1034,7 @@
       of values is just a fancy number.  For example, the type `Bool`{=type} is
       just a fancy version of the number 2, where the two things happen to be
       labelled `false` and `true`.  There are also types `Unit`{=type} and
-      `void`{=type} that correspond to 1 and 0, respectively.
+      `Void`{=type} that correspond to 1 and 0, respectively.
     - |
       The product of two types is a type of pairs, since, for example,
       if `t`{=type} is a type with three elements, then there are 2 * 3 = 6
@@ -1053,6 +1053,21 @@
       3) (\x. 2*x) (\y. 3*y) == 9`.
   properties: [pickable]
   capabilities: [arith, sum, prod]
+- name: hyperloop
+  display:
+    attr: device
+    char: '∞'
+  description:
+    - |
+      Is it a calculator with a strange antenna?  A strange loop with
+      a built-in calculator?  Who can say?  A `hyperloop`{=entity}
+      gives you the ability to create recursive types: the type `rec
+      t. T(t)`{=snippet} (where `T(t)`{=snippet} is some type
+      containing `t`{=type}) is the type `t`{=type} such that `t =
+      T(t)`{=snippet}. For exmple, `rec l. Unit + Int * l`{=type} is
+      the type of lists of integers.
+  properties: [pickable]
+  capabilities: [arith, sum, prod, rectype]
 - name: compass
   display:
     attr: device

--- a/data/recipes.yaml
+++ b/data/recipes.yaml
@@ -656,6 +656,11 @@
   out:
     - [1, ADT calculator]
 - in:
+    - [1, ADT calculator]
+    - [1, strange loop]
+  out:
+    - [1, hyperloop]
+- in:
     - [1, glass]
     - [1, silver]
   out:

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -680,8 +680,9 @@ stepCESK cesk = case cesk of
   -- listing the requirements of the given expression.
   Out (VRequirements src t _) s (FExec : k) -> do
     currentContext <- use $ robotContext . defReqs
+    currentTydefs <- use $ robotContext . tydefVals
     em <- use $ landscape . terrainAndEntities . entityMap
-    let (R.Requirements caps devs inv, _) = R.requirements currentContext t
+    let (R.Requirements caps devs inv, _) = R.requirements currentTydefs currentContext t
 
         devicesForCaps, requiredDevices :: Set (Set Text)
         -- possible devices to provide each required capability

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -858,7 +858,8 @@ execConst runChildProg c vs s k = do
             robotDisplay . orientationMap .= M.empty
           [dc, nc, ec, sc, wc] -> do
             robotDisplay . defaultChar .= dc
-            robotDisplay . orientationMap
+            robotDisplay
+              . orientationMap
               .= M.fromList
                 [ (DNorth, nc)
                 , (DEast, ec)
@@ -1509,6 +1510,7 @@ execConst runChildProg c vs s k = do
     m (Set Entity, Inventory)
   checkRequirements parentInventory childInventory childDevices cmd subject fixI = do
     currentContext <- use $ robotContext . defReqs
+    currentTydefs <- use $ robotContext . tydefVals
     em <- use $ landscape . terrainAndEntities . entityMap
     privileged <- isPrivilegedBot
     let -- Note that _capCtx must be empty: at least at the
@@ -1517,7 +1519,7 @@ execConst runChildProg c vs s k = do
         -- (Though perhaps there is an argument that this ought to be
         -- relaxed specifically in the cases of 'Build' and 'Reprogram'.)
         -- See #349
-        (R.Requirements (S.toList -> caps) (S.toList -> devNames) reqInvNames, _capCtx) = R.requirements currentContext cmd
+        (R.Requirements (S.toList -> caps) (S.toList -> devNames) reqInvNames, _capCtx) = R.requirements currentTydefs currentContext cmd
 
     -- Check that all required device names exist (fail with
     -- an exception if not) and convert them to 'Entity' values.

--- a/src/swarm-lang/Swarm/Language/Pipeline.hs
+++ b/src/swarm-lang/Swarm/Language/Pipeline.hs
@@ -123,7 +123,7 @@ processTerm' ctxs txt = do
 processParsedTerm' :: Contexts -> Syntax -> Either ContextualTypeErr ProcessedTerm
 processParsedTerm' ctxs t = do
   m <- inferTop (ctxs ^. tCtx) (ctxs ^. tydefCtx) t
-  let (caps, reqCtx') = requirements (ctxs ^. reqCtx) (t ^. sTerm)
+  let (caps, reqCtx') = requirements (ctxs ^. tydefCtx) (ctxs ^. reqCtx) (t ^. sTerm)
   return $ ProcessedTerm (elaborateModule m) caps reqCtx'
 
 elaborateModule :: TModule -> TModule


### PR DESCRIPTION
Closes #1898.  Adds the `hyperloop` device (recipe: `ADT calculator` + `strange loop`) which provides the ability to use recursive types (#1894).  Also refactors requirements analysis code and adds the ability for types to trigger capability requirements.