### PR TITLE
minimize some To/FromJSON instances

### DIFF
--- a/src/swarm-engine/Swarm/Game/CESK.hs
+++ b/src/swarm-engine/Swarm/Game/CESK.hs
@@ -81,7 +81,7 @@ module Swarm.Game.CESK (
 
 import Control.Lens ((^.))
 import Control.Lens.Combinators (pattern Empty)
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IM
 import GHC.Generics (Generic)
@@ -98,6 +98,7 @@ import Swarm.Language.Pretty
 import Swarm.Language.Syntax
 import Swarm.Language.Types
 import Swarm.Language.Value as V
+import Swarm.Util.JSON (optionsMinimize)
 
 ------------------------------------------------------------
 -- Frames and continuations
@@ -175,7 +176,13 @@ data Frame
     FRcd Env [(Var, Value)] Var [(Var, Maybe Term)]
   | -- | We are in the middle of evaluating a record field projection.
     FProj Var
-  deriving (Eq, Show, Generic, FromJSON, ToJSON)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON Frame where
+  toJSON = genericToJSON optionsMinimize
+
+instance FromJSON Frame where
+  parseJSON = genericParseJSON optionsMinimize
 
 -- | A continuation is just a stack of frames.
 type Cont = [Frame]
@@ -213,7 +220,13 @@ data MemCell
     --   the 'MemCell', so that subsequent lookups can just use it
     --   without recomputing anything.
     V Value
-  deriving (Show, Eq, Generic, FromJSON, ToJSON)
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MemCell where
+  toJSON = genericToJSON optionsMinimize
+
+instance FromJSON MemCell where
+  parseJSON = genericParseJSON optionsMinimize
 
 emptyStore :: Store
 emptyStore = Store 0 IM.empty
@@ -272,7 +285,13 @@ data CESK
   | -- | The machine is waiting for the game to reach a certain time
     --   to resume its execution.
     Waiting TickNumber CESK
-  deriving (Eq, Show, Generic, FromJSON, ToJSON)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON CESK where
+  toJSON = genericToJSON optionsMinimize
+
+instance FromJSON CESK where
+  parseJSON = genericParseJSON optionsMinimize
 
 -- | Is the CESK machine in a final (finished) state?  If so, extract
 --   the final value and store.
@@ -409,4 +428,10 @@ data RobotUpdate
     AddEntity Count Entity
   | -- | Make the robot learn about an entity.
     LearnEntity Entity
-  deriving (Eq, Ord, Show, Generic, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, Generic)
+
+instance ToJSON RobotUpdate where
+  toJSON = genericToJSON optionsMinimize
+
+instance FromJSON RobotUpdate where
+  parseJSON = genericParseJSON optionsMinimize

--- a/src/swarm-engine/Swarm/Game/Step/Path/Type.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Type.hs
@@ -28,7 +28,7 @@ import Swarm.Game.Location
 import Swarm.Game.Robot (RID)
 import Swarm.Game.Robot.Walk (WalkabilityContext)
 import Swarm.Game.Universe (SubworldName)
-import Swarm.Util.JSON (optionsObjectSingleField)
+import Swarm.Util.JSON (optionsMinimize)
 import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Util.RingBuffer
 
@@ -74,7 +74,7 @@ data CacheRetrievalAttempt
   deriving (Show, Eq, Generic)
 
 instance ToJSON CacheRetrievalAttempt where
-  toJSON = genericToJSON optionsObjectSingleField
+  toJSON = genericToJSON optionsMinimize
 
 -- | Certain events can obligate the cache to be
 -- completely invalidated, or partially or fully preserved.
@@ -85,7 +85,7 @@ data CacheEvent
   deriving (Show, Eq, Generic)
 
 instance ToJSON CacheEvent where
-  toJSON = genericToJSON optionsObjectSingleField
+  toJSON = genericToJSON optionsMinimize
 
 data DistanceLimitChange
   = LimitIncreased
@@ -108,7 +108,7 @@ data CacheRetreivalInapplicability
   deriving (Show, Eq, Generic)
 
 instance ToJSON CacheRetreivalInapplicability where
-  toJSON = genericToJSON optionsObjectSingleField
+  toJSON = genericToJSON optionsMinimize
 
 -- | Reasons for cache being invalidated
 data InvalidationReason

--- a/src/swarm-lang/Swarm/Language/Context.hs
+++ b/src/swarm-lang/Swarm/Language/Context.hs
@@ -11,12 +11,13 @@ import Control.Algebra (Has)
 import Control.Effect.Reader (Reader, ask, local)
 import Control.Lens.Empty (AsEmpty (..))
 import Control.Lens.Prism (prism)
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import Data.Data (Data)
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import Swarm.Util.JSON (optionsUnwrapUnary)
 import Prelude hiding (lookup)
 
 -- | We use 'Text' values to represent variables.
@@ -24,7 +25,13 @@ type Var = Text
 
 -- | A context is a mapping from variable names to things.
 newtype Ctx t = Ctx {unCtx :: Map Var t}
-  deriving (Eq, Show, Functor, Foldable, Traversable, Data, Generic, FromJSON, ToJSON)
+  deriving (Eq, Show, Functor, Foldable, Traversable, Data, Generic)
+
+instance ToJSON t => ToJSON (Ctx t) where
+  toJSON = genericToJSON optionsUnwrapUnary
+
+instance FromJSON t => FromJSON (Ctx t) where
+  parseJSON = genericParseJSON optionsUnwrapUnary
 
 -- | The semigroup operation for contexts is /right/-biased union.
 instance Semigroup (Ctx t) where

--- a/src/swarm-lang/Swarm/Language/Syntax/Comments.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Comments.hs
@@ -21,7 +21,8 @@ module Swarm.Language.Syntax.Comments (
   afterComments,
 ) where
 
-import Control.Lens (AsEmpty, makeLenses)
+import Control.Lens (AsEmpty, makeLenses, pattern Empty)
+import Data.Aeson qualified as A
 import Data.Aeson.Types hiding (Key)
 import Data.Data (Data)
 import Data.Sequence (Seq)
@@ -60,9 +61,19 @@ data Comments = Comments
   { _beforeComments :: Seq Comment
   , _afterComments :: Seq Comment
   }
-  deriving (Eq, Show, Generic, Data, ToJSON, FromJSON)
+  deriving (Eq, Show, Generic, Data)
 
 makeLenses ''Comments
+
+instance ToJSON Comments where
+  toJSON = A.genericToJSON A.defaultOptions
+  omitField = \case
+    Empty -> True
+    _ -> False
+
+instance FromJSON Comments where
+  parseJSON = A.genericParseJSON A.defaultOptions
+  omittedField = Just Empty
 
 instance Semigroup Comments where
   Comments b1 a1 <> Comments b2 a2 = Comments (b1 <> b2) (a1 <> a2)

--- a/src/swarm-lang/Swarm/Language/Syntax/Loc.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Loc.hs
@@ -12,10 +12,11 @@ module Swarm.Language.Syntax.Loc (
   srcLocBefore,
 ) where
 
-import Data.Aeson.Types hiding (Key)
+import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import Data.Data (Data)
 import GHC.Generics (Generic)
 import Swarm.Language.Context (Var)
+import Swarm.Util.JSON (optionsUntagged)
 
 ------------------------------------------------------------
 -- SrcLoc
@@ -27,7 +28,13 @@ data SrcLoc
   = NoLoc
   | -- | Half-open interval from start (inclusive) to end (exclusive)
     SrcLoc Int Int
-  deriving (Eq, Ord, Show, Data, Generic, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, Data, Generic)
+
+instance ToJSON SrcLoc where
+  toJSON = genericToJSON optionsUntagged
+
+instance FromJSON SrcLoc where
+  parseJSON = genericParseJSON optionsUntagged
 
 -- | @x <> y@ is the smallest 'SrcLoc' that subsumes both @x@ and @y@.
 instance Semigroup SrcLoc where

--- a/src/swarm-lang/Swarm/Language/Value.hs
+++ b/src/swarm-lang/Swarm/Language/Value.hs
@@ -18,7 +18,7 @@ module Swarm.Language.Value (
 ) where
 
 import Control.Lens (pattern Empty)
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import Data.Bool (bool)
 import Data.List (foldl')
 import Data.Map (Map)
@@ -32,6 +32,7 @@ import Swarm.Language.Key (KeyCombo, prettyKeyCombo)
 import Swarm.Language.Pretty (prettyText)
 import Swarm.Language.Syntax
 import Swarm.Language.Syntax.Direction
+import Swarm.Util.JSON (optionsMinimize)
 
 -- | A /value/ is a term that cannot (or does not) take any more
 --   evaluation steps on its own.
@@ -91,7 +92,13 @@ data Value where
   VKey :: KeyCombo -> Value
   -- | A 'requirements' command awaiting execution.
   VRequirements :: Text -> Term -> Env -> Value
-  deriving (Eq, Show, Generic, FromJSON, ToJSON)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON Value where
+  toJSON = genericToJSON optionsMinimize
+
+instance FromJSON Value where
+  parseJSON = genericParseJSON optionsMinimize
 
 -- | Ensure that a value is not wrapped in 'VResult'.
 stripVResult :: Value -> Value

--- a/src/swarm-util/Swarm/Language/Syntax/Direction.hs
+++ b/src/swarm-util/Swarm/Language/Syntax/Direction.hs
@@ -28,6 +28,7 @@ import Data.List qualified as L (drop)
 import Data.Text hiding (filter, length, map)
 import GHC.Generics (Generic)
 import Swarm.Util qualified as Util
+import Swarm.Util.JSON (optionsMinimize)
 import Witch.From (from)
 
 ------------------------------------------------------------
@@ -92,7 +93,13 @@ instance FromJSONKey AbsoluteDir where
 --   robot's frame of reference; no special capability is needed to
 --   use them.
 data RelativeDir = DPlanar PlanarRelativeDir | DDown
-  deriving (Eq, Ord, Show, Read, Generic, Data, Hashable, ToJSON, FromJSON)
+  deriving (Eq, Ord, Show, Read, Generic, Data, Hashable)
+
+instance ToJSON RelativeDir where
+  toJSON = genericToJSON optionsMinimize
+
+instance FromJSON RelativeDir where
+  parseJSON = genericParseJSON optionsMinimize
 
 -- | Caution: Do not alter this ordering, as there exist functions that depend on it
 -- (e.g. 'Swarm.Game.Location.nearestDirection' and 'Swarm.Game.Location.relativeTo').
@@ -108,7 +115,13 @@ instance ToJSON PlanarRelativeDir where
 -- | The type of directions. Used /e.g./ to indicate which way a robot
 --   will turn.
 data Direction = DAbsolute AbsoluteDir | DRelative RelativeDir
-  deriving (Eq, Ord, Show, Read, Generic, Data, Hashable, ToJSON, FromJSON)
+  deriving (Eq, Ord, Show, Read, Generic, Data, Hashable)
+
+instance FromJSON Direction where
+  parseJSON = genericParseJSON optionsMinimize
+
+instance ToJSON Direction where
+  toJSON = genericToJSON optionsMinimize
 
 -- | Direction name is generated from the deepest nested data constructor
 -- e.g. 'DLeft' becomes "left"

--- a/src/swarm-util/Swarm/Util/JSON.hs
+++ b/src/swarm-util/Swarm/Util/JSON.hs
@@ -11,8 +11,15 @@ import Data.Aeson
 optionsUnwrapUnary :: Options
 optionsUnwrapUnary = defaultOptions {unwrapUnaryRecords = True}
 
-optionsObjectSingleField :: Options
-optionsObjectSingleField = defaultOptions {sumEncoding = ObjectWithSingleField}
+-- | @aeson@ options to try to minimize the size of the generated
+--   JSON.
+optionsMinimize :: Options
+optionsMinimize =
+  defaultOptions
+    { sumEncoding = ObjectWithSingleField
+    , omitNothingFields = True
+    , allowOmittedFields = True
+    }
 
 optionsUntagged :: Options
 optionsUntagged = defaultOptions {sumEncoding = UntaggedValue}


### PR DESCRIPTION
Towards #1907.  For the most part, eschew the default To/FromJSON deriving in favor of `sumEncoding = ObjectWithSingleField`, which encodes `Constructor val` as something like `Constructor: val` instead of `{tag: Constructor, contents: val}`.  Also omit empty `Comments` records.

In the context of #1907, this reduced the size of the generated JSON by about half.
