### PR TITLE
pass tydefs from inferred module into requirements analysis

### DIFF
--- a/src/swarm-lang/Swarm/Language/Pipeline.hs
+++ b/src/swarm-lang/Swarm/Language/Pipeline.hs
@@ -123,7 +123,8 @@ processTerm' ctxs txt = do
 processParsedTerm' :: Contexts -> Syntax -> Either ContextualTypeErr ProcessedTerm
 processParsedTerm' ctxs t = do
   m <- inferTop (ctxs ^. tCtx) (ctxs ^. tydefCtx) t
-  let (caps, reqCtx') = requirements (ctxs ^. tydefCtx) (ctxs ^. reqCtx) (t ^. sTerm)
+  let tydefs = (ctxs ^. tydefCtx) <> (m ^. moduleTydefs)
+      (caps, reqCtx') = requirements tydefs (ctxs ^. reqCtx) (t ^. sTerm)
   return $ ProcessedTerm (elaborateModule m) caps reqCtx'
 
 elaborateModule :: TModule -> TModule


### PR DESCRIPTION
Closes #1911.  I understand the bug now: when inferring the type of a term, we also return a context of type alias definitions in the term.  However, those type aliases might occur in types later in the term itself, so we need to pass those additional type aliases into the `requirements` function (which now looks at types and needs to be able to unfold type aliases).

(Once again, it's not really correct to be doing requirements analysis separately from type checking, and leads to bugs like this.  See #231.)

What I am still really confused by is why the test suite did not catch this problem.  The unit tests do in fact contain some terms like this, which contain a `tydef` followed by a use of the defined type.  And the tests in `TestLanguagePipeline` call `processTerm` which seems like it should have triggered this...