### PR TITLE
Restructure hyperloop definition

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -1061,10 +1061,10 @@
     - |
       Is it a calculator with a strange antenna?  A strange loop with
       a built-in calculator?  Who can say?  A `hyperloop`{=entity}
-      gives you the ability to create recursive types: the type `rec
-      t. T(t)`{=snippet} (where `T(t)`{=snippet} is some type
-      containing `t`{=type}) is the type `t`{=type} such that `t =
-      T(t)`{=snippet}. For exmple, `rec l. Unit + Int * l`{=type} is
+      gives you the ability to create recursive types: the type
+      `rec t. T(t)`{=snippet} (where `T(t)`{=snippet} is some type
+      containing `t`{=type}) is the type `t`{=type} such that
+      `t = T(t)`{=snippet}. For exmple, `rec l. Unit + Int * l`{=type} is
       the type of lists of integers.
   properties: [pickable]
   capabilities: [arith, sum, prod, rectype]


### PR DESCRIPTION
Closes #1910 

I'd argue that the code is behaving correctly and as intended. Snippets wrapped with backticks are/should be treated as regular texts with highlighting. Introducing line breaks inside a snippet should trigger add a newline character to the text before being rendered (which is what was happening in the first place).

This PR readjusts the description a bit to make sure that the snippets are in one line and do not have any line breaks in between.