### PR TITLE
Fix variable lookup during requirements analysis

### DIFF
--- a/src/swarm-lang/Swarm/Language/Requirement.hs
+++ b/src/swarm-lang/Swarm/Language/Requirement.hs
@@ -26,7 +26,7 @@ import Control.Algebra (Has, run)
 import Control.Carrier.Accum.Strict (execAccum)
 import Control.Carrier.Reader (runReader)
 import Control.Effect.Accum (Accum, add)
-import Control.Effect.Reader (Reader, local)
+import Control.Effect.Reader (Reader, ask, local)
 import Control.Monad (when)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Bifunctor (first)
@@ -225,7 +225,9 @@ termRequirements tdCtx ctx = run . execAccum mempty . runReader tdCtx . runReade
     -- that's OK.  In particular, only variables bound by 'TDef' go
     -- in the context; variables bound by a lambda or let will not
     -- be there.
-    TVar x -> forM_ (Ctx.lookup x ctx) add
+    TVar x -> do
+      reqs <- ask @ReqCtx
+      forM_ (Ctx.lookup x reqs) add
     -- A lambda expression requires the 'CLambda' capability, and
     -- also all the capabilities of the body.  We assume that the
     -- lambda will eventually get applied, at which point it will

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -846,6 +846,7 @@ test-suite swarm-unit
     TestPretty
     TestRecipeCoverage
     TestRepl
+    TestRequirements
     TestScoring
     TestUtil
 

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -42,6 +42,7 @@ import TestPedagogy (testPedagogy)
 import TestPretty (testPrettyConst)
 import TestRecipeCoverage (testDeviceRecipeCoverage)
 import TestRepl (testRepl)
+import TestRequirements (testRequirements)
 import TestScoring (testHighScores)
 import Witch (from)
 
@@ -65,6 +66,7 @@ tests s =
     , testHighScores
     , testEval (s ^. gameState)
     , testRepl
+    , testRequirements
     , testPedagogy (s ^. runtimeState)
     , testInventory
     , testNotification (s ^. gameState)

--- a/test/unit/TestRequirements.hs
+++ b/test/unit/TestRequirements.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Swarm requirements analysis tests
+module TestRequirements where
+
+import Control.Lens (view)
+import Data.Set qualified as S
+import Data.Text (Text)
+import Swarm.Language.Capability
+import Swarm.Language.Context qualified as Ctx
+import Swarm.Language.Pipeline
+import Swarm.Language.Requirement
+import Test.Tasty
+import Test.Tasty.HUnit
+import TestUtil (check)
+
+testRequirements :: TestTree
+testRequirements =
+  testGroup
+    "Requirements analysis"
+    [ testGroup
+        "Basic capabilities"
+        [ testCase "solar panel" $ "noop" `requiresCap` CPower
+        , testCase "move" $ "move" `requiresCap` CMove
+        , testCase "lambda" $ "\\x. x" `requiresCap` CLambda
+        , testCase "inl" $ "inl 3" `requiresCap` CSum
+        , testCase "cap from type" $ "inl () : rec t. Unit + t" `requiresCap` CRectype
+        ]
+    , testGroup
+        "Scope"
+        [ testCase "global var requirement does not apply to local var (#1914)" $
+            checkReqCtx
+              "def m = move end; def y = \\m. log (format m) end"
+              (maybe False ((CMove `S.notMember`) . capReqs) . Ctx.lookup "y")
+        ]
+    ]
+
+checkReqCtx :: Text -> (ReqCtx -> Bool) -> Assertion
+checkReqCtx code expect = check code (expect . view processedReqCtx)
+
+checkRequirements :: Text -> (Requirements -> Bool) -> Assertion
+checkRequirements code expect = check code (expect . view processedRequirements)
+
+requiresCap :: Text -> Capability -> Assertion
+requiresCap code cap = checkRequirements code ((cap `S.member`) . capReqs)

--- a/test/unit/TestUtil.hs
+++ b/test/unit/TestUtil.hs
@@ -26,6 +26,8 @@ import Swarm.Game.Step (gameTick, hypotheticalRobot, stepCESK)
 import Swarm.Language.Context
 import Swarm.Language.Pipeline (ProcessedTerm (..), processTerm)
 import Swarm.Language.Value
+import Test.Tasty.HUnit (Assertion, assertBool, assertFailure)
+import Witch (into)
 
 eval :: GameState -> Text -> IO (GameState, Robot, Either Text (Value, Int))
 eval g = either (return . (g,hypotheticalRobot undefined 0,) . Left) (evalPT g) . processTerm1
@@ -77,3 +79,8 @@ playUntilDone rid = do
       playUntilDone rid
     Just False -> return $ Right ()
     Nothing -> return $ Left . T.pack $ "The robot with ID " <> show rid <> " is nowhere to be found!"
+
+check :: Text -> (ProcessedTerm -> Bool) -> Assertion
+check code expect = case processTerm1 code of
+  Left err -> assertFailure $ "Term processing failed: " ++ into @String err
+  Right pt -> assertBool "Predicate was false!" (expect pt)


### PR DESCRIPTION
When I refactored requirements analysis during #1906 I didn't properly update the variable case: the code continued to look up the variable in `ctx` which used to be the name of the local context being passed around; after the refactoring, however, `ctx` was the name of the initial context passed to the top-level `requirements` function, and the local context was passed around as a `Reader` effect.  Thus, the lambda case (for example) was correctly deleting the bound variable from the context, but then when checking the variable inside the body of the lambda we looked up its requirements in the initial, global context instead of the modified local one.

This PR fixes the issue and also adds some test cases, one of which was failing before this fix.

Fixes #1914.