### PR TITLE
Fix Lazy IO opening too many files in integration tests

### DIFF
--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -312,7 +312,6 @@ readFileMayT = catchIO . T.readFile
 
 -- | Recursively acquire all files in the given directory with the
 --   given extension, but does not read or open the file like 'acquireAllWithExt'.
---   To prevent lazy IO problems, open the file using e.g. 'System.IO.withFile'.
 findAllWithExt :: FilePath -> String -> IO [FilePath]
 findAllWithExt dir ext = do
   paths <- listDirectory dir <&> map (dir </>)

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -36,6 +36,7 @@ module Swarm.Util (
   -- * Directory utilities
   readFileMay,
   readFileMayT,
+  findAllWithExt,
   acquireAllWithExt,
 
   -- * Text utilities
@@ -310,18 +311,26 @@ readFileMayT :: FilePath -> IO (Maybe Text)
 readFileMayT = catchIO . T.readFile
 
 -- | Recursively acquire all files in the given directory with the
---   given extension, and their contents.
-acquireAllWithExt :: FilePath -> String -> IO [(FilePath, String)]
-acquireAllWithExt dir ext = do
+--   given extension, but does not read or open the file like 'acquireAllWithExt'.
+--   To prevent lazy IO problems, open the file using e.g. 'System.IO.withFile'.
+findAllWithExt :: FilePath -> String -> IO [FilePath]
+findAllWithExt dir ext = do
   paths <- listDirectory dir <&> map (dir </>)
   filePaths <- filterM (\path -> doesFileExist path <&> (&&) (hasExt path)) paths
-  children <- mapM (\path -> (,) path <$> readFile path) filePaths
   -- recurse
   sub <- filterM doesDirectoryExist paths
-  transChildren <- concat <$> mapM (`acquireAllWithExt` ext) sub
-  return $ children <> transChildren
+  transChildren <- concat <$> mapM (`findAllWithExt` ext) sub
+  return $ filePaths <> transChildren
  where
   hasExt path = takeExtension path == ("." ++ ext)
+
+-- | Recursively acquire all files in the given directory with the
+--   given extension, and their contents.
+acquireAllWithExt :: FilePath -> String -> IO [(FilePath, String)]
+acquireAllWithExt dir ext = findAllWithExt dir ext >>= mapM addContent
+ where
+  addContent :: FilePath -> IO (FilePath, String)
+  addContent path = (,) path <$> readFile path
 
 -- | Turns any IO error into Nothing.
 catchIO :: IO a -> IO (Maybe a)

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -82,11 +82,11 @@ import Swarm.Util (findAllWithExt)
 import Swarm.Util.RingBuffer qualified as RB
 import Swarm.Util.Yaml (decodeFileEitherE)
 import System.FilePath.Posix (splitDirectories)
+import System.IO (IOMode (ReadMode), withFile)
 import System.Timeout (timeout)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 import Witch (into)
-import System.IO (withFile, IOMode (ReadMode))
 
 isUnparseableTest :: FilePath -> Bool
 isUnparseableTest fp = "_Validation" `elem` splitDirectories fp

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -82,7 +82,6 @@ import Swarm.Util (findAllWithExt)
 import Swarm.Util.RingBuffer qualified as RB
 import Swarm.Util.Yaml (decodeFileEitherE)
 import System.FilePath.Posix (splitDirectories)
-import System.IO (IOMode (ReadMode), withFile)
 import System.Timeout (timeout)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
@@ -133,11 +132,9 @@ exampleTests inputs = testGroup "Test example" (map exampleTest inputs)
 
 exampleTest :: FilePath -> TestTree
 exampleTest path =
-  testCase ("processTerm for contents of " ++ show path) $
-    withFile path ReadMode $ \hnd -> do
-      fileContent <- T.hGetContents hnd
-      let value = processTerm fileContent
-      either (assertFailure . into @String) (\_ -> return ()) value
+  testCase ("processTerm for contents of " ++ show path) $ do
+    value <- processTerm <$> T.readFile path
+    either (assertFailure . into @String) (\_ -> return ()) value
 
 scenarioParseTests :: ScenarioInputs -> [FilePath] -> TestTree
 scenarioParseTests scenarioInputs inputs =

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -78,7 +78,7 @@ import Swarm.TUI.Model (
  )
 import Swarm.TUI.Model.StateUpdate (constructAppState, initPersistentState)
 import Swarm.TUI.Model.UI (UIState)
-import Swarm.Util (acquireAllWithExt)
+import Swarm.Util (findAllWithExt)
 import Swarm.Util.RingBuffer qualified as RB
 import Swarm.Util.Yaml (decodeFileEitherE)
 import System.FilePath.Posix (splitDirectories)
@@ -86,16 +86,17 @@ import System.Timeout (timeout)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 import Witch (into)
+import System.IO (withFile, IOMode (ReadMode))
 
-isUnparseableTest :: (FilePath, String) -> Bool
-isUnparseableTest (fp, _) = "_Validation" `elem` splitDirectories fp
+isUnparseableTest :: FilePath -> Bool
+isUnparseableTest fp = "_Validation" `elem` splitDirectories fp
 
 main :: IO ()
 main = do
-  examplePaths <- acquireAllWithExt "example" "sw"
-  scenarioPaths <- acquireAllWithExt "data/scenarios" "yaml"
+  examplePaths <- findAllWithExt "example" "sw"
+  scenarioPaths <- findAllWithExt "data/scenarios" "yaml"
   let (unparseableScenarios, parseableScenarios) = partition isUnparseableTest scenarioPaths
-  scenarioPrograms <- acquireAllWithExt "data/scenarios" "sw"
+  scenarioPrograms <- findAllWithExt "data/scenarios" "sw"
   (rs, ui) <- do
     out <- runM . runThrow @SystemFailure $ initPersistentState defaultAppOpts
     either (assertFailure . prettyString) return out
@@ -127,23 +128,24 @@ checkNoRuntimeErrors r =
 isError :: LogEntry -> Bool
 isError = (>= Warning) . view leSeverity
 
-exampleTests :: [(FilePath, String)] -> TestTree
+exampleTests :: [FilePath] -> TestTree
 exampleTests inputs = testGroup "Test example" (map exampleTest inputs)
 
-exampleTest :: (FilePath, String) -> TestTree
-exampleTest (path, fileContent) =
-  testCase ("processTerm for contents of " ++ show path) $ do
-    either (assertFailure . into @String) (const . return $ ()) value
- where
-  value = processTerm $ into @Text fileContent
+exampleTest :: FilePath -> TestTree
+exampleTest path =
+  testCase ("processTerm for contents of " ++ show path) $
+    withFile path ReadMode $ \hnd -> do
+      fileContent <- T.hGetContents hnd
+      let value = processTerm fileContent
+      either (assertFailure . into @String) (\_ -> return ()) value
 
-scenarioParseTests :: ScenarioInputs -> [(FilePath, String)] -> TestTree
+scenarioParseTests :: ScenarioInputs -> [FilePath] -> TestTree
 scenarioParseTests scenarioInputs inputs =
   testGroup
     "Test scenarios parse"
     (map (scenarioTest Parsed scenarioInputs) inputs)
 
-scenarioParseInvalidTests :: ScenarioInputs -> [(FilePath, String)] -> TestTree
+scenarioParseInvalidTests :: ScenarioInputs -> [FilePath] -> TestTree
 scenarioParseInvalidTests scenarioInputs inputs =
   testGroup
     "Test invalid scenarios fail to parse"
@@ -151,8 +153,8 @@ scenarioParseInvalidTests scenarioInputs inputs =
 
 data ParseResult = Parsed | Failed
 
-scenarioTest :: ParseResult -> ScenarioInputs -> (FilePath, String) -> TestTree
-scenarioTest expRes scenarioInputs (path, _) =
+scenarioTest :: ParseResult -> ScenarioInputs -> FilePath -> TestTree
+scenarioTest expRes scenarioInputs path =
   testCase ("parse scenario " ++ show path) (getScenario expRes scenarioInputs path)
 
 getScenario :: ParseResult -> ScenarioInputs -> FilePath -> IO ()


### PR DESCRIPTION
When running on macOS, the integration tests open too many file handles,
even when you do not need to run any swarm file tests.
```sh
> cabal run -O0 swarm-integration -- -p editors
swarm-integration: data/scenarios/Challenges/_bucket-brigade/hauler.sw: openFile: resource exhausted (Too many open files)
```
The solution is to get the file paths only and safely open them as needed.
Surprisingly, this even makes the integration test code simpler.

* discovered while fixing failing tests in #1895