### PR TITLE
Unit tests for prettyTextWidth

### DIFF
--- a/test/unit/TestPretty.hs
+++ b/test/unit/TestPretty.hs
@@ -20,82 +20,82 @@ testPrettyConst =
     "Language - pretty"
     [ testCase
         "operators #8 - function application unchanged"
-        ( equalPretty "f say" $
+        ( equalPrettyLine "f say" $
             TApp (TVar "f") (TConst Say)
         )
     , testCase
         "operators #8 - double function application unchanged"
-        ( equalPretty "f () ()" $
+        ( equalPrettyLine "f () ()" $
             TApp (TApp (TVar "f") TUnit) TUnit
         )
     , testCase
         "operators #8 - embrace operator parameter"
-        ( equalPretty "f (==)" $
+        ( equalPrettyLine "f (==)" $
             TApp (TVar "f") (TConst Eq)
         )
     , testCase
         "operators #8 - unary negation"
-        ( equalPretty "-3" $
+        ( equalPrettyLine "-3" $
             TApp (TConst Neg) (TInt 3)
         )
     , testCase
         "operators #8 - double unary negation"
-        ( equalPretty "-(-1)" $
+        ( equalPrettyLine "-(-1)" $
             TApp (TConst Neg) $
               TApp (TConst Neg) (TInt 1)
         )
     , testCase
         "operators #8 - unary negation with strongly fixing binary operator"
-        ( equalPretty "-1 ^ (-2)"
+        ( equalPrettyLine "-1 ^ (-2)"
             . TApp (TConst Neg)
             . mkOp' Exp (TInt 1)
             $ TApp (TConst Neg) (TInt 2)
         )
     , testCase
         "operators #8 - unary negation with weakly fixing binary operator"
-        ( equalPretty "-(1 + -2)"
+        ( equalPrettyLine "-(1 + -2)"
             . TApp (TConst Neg)
             . mkOp' Add (TInt 1)
             $ TApp (TConst Neg) (TInt 2)
         )
     , testCase
         "operators #8 - simple infix operator"
-        ( equalPretty "1 == 2" $
+        ( equalPrettyLine "1 == 2" $
             mkOp' Eq (TInt 1) (TInt 2)
         )
     , testCase
         "operators #8 - infix operator with less fixing inner operator"
-        ( equalPretty "1 * (2 + 3)" $
+        ( equalPrettyLine "1 * (2 + 3)" $
             mkOp' Mul (TInt 1) (mkOp' Add (TInt 2) (TInt 3))
         )
     , testCase
         "operators #8 - infix operator with more fixing inner operator"
-        ( equalPretty "1 + 2 * 3" $
+        ( equalPrettyLine "1 + 2 * 3" $
             mkOp' Add (TInt 1) (mkOp' Mul (TInt 2) (TInt 3))
         )
     , testCase
         "operators #8 - infix operator right associativity"
-        ( equalPretty "2 ^ 4 ^ 8" $
+        ( equalPrettyLine "2 ^ 4 ^ 8" $
             mkOp' Exp (TInt 2) (mkOp' Exp (TInt 4) (TInt 8))
         )
     , testCase
         "operators #8 - infix operator right associativity not applied to left"
-        ( equalPretty "(2 ^ 4) ^ 8" $
+        ( equalPrettyLine "(2 ^ 4) ^ 8" $
             mkOp' Exp (mkOp' Exp (TInt 2) (TInt 4)) (TInt 8)
         )
     , testCase
         "pairs #225 - nested pairs are printed right-associative"
-        ( equalPretty "(1, 2, 3)" $
+        ( equalPrettyLine "(1, 2, 3)" $
             TPair (TInt 1) (TPair (TInt 2) (TInt 3))
         )
     , testCase
         "type ascription"
-        ( equalPretty "1 : Int" $
+        ( equalPrettyLine "1 : Int" $
             TAnnotate (TInt 1) (Forall [] TyInt)
         )
     , testCase
         "lambda precedence (#1468)"
-        ( equalPretty "\\m. case m (\\x. x + 1) (\\y. y * 2)" $
+        ( equalPrettyLine "\\m. case m (\\x. x + 1) (\\y. y * 2)" $
             TLam
               "m"
               Nothing
@@ -109,88 +109,125 @@ testPrettyConst =
         "types"
         [ testCase
             "Void type"
-            ( equalPretty "Void" TyVoid
+            ( equalPrettyLine "Void" TyVoid
             )
         , testCase
             "Unit type"
-            ( equalPretty "Unit" TyUnit
+            ( equalPrettyLine "Unit" TyUnit
             )
         , testCase
             "Function type"
-            ( equalPretty "Int -> Cmd Unit" $ TyInt :->: TyCmd TyUnit
+            ( equalPrettyLine "Int -> Cmd Unit" $ TyInt :->: TyCmd TyUnit
             )
         , testCase
             "Cmd type"
-            ( equalPretty "Cmd (Int -> Int)" $ TyCmd (TyInt :->: TyInt)
+            ( equalPrettyLine "Cmd (Int -> Int)" $ TyCmd (TyInt :->: TyInt)
             )
         , testCase
             "Cmd type"
-            ( equalPretty "Cmd (Int -> Int)" $ TyCmd (TyInt :->: TyInt)
+            ( equalPrettyLine "Cmd (Int -> Int)" $ TyCmd (TyInt :->: TyInt)
             )
         , testCase
             "Product type"
-            ( equalPretty "Int * Int" $ TyInt :*: TyInt
+            ( equalPrettyLine "Int * Int" $ TyInt :*: TyInt
             )
         , testCase
             "Sum type"
-            ( equalPretty "Int + Int" $ TyInt :+: TyInt
+            ( equalPrettyLine "Int + Int" $ TyInt :+: TyInt
             )
         , testCase
             "Sum of sum right"
-            ( equalPretty "Int + (Unit + Bool)" $ TyInt :+: (TyUnit :+: TyBool)
+            ( equalPrettyLine "Int + (Unit + Bool)" $ TyInt :+: (TyUnit :+: TyBool)
             )
         , testCase
             "Sum of sum left"
-            ( equalPretty "(Int + Unit) + Bool" $ (TyInt :+: TyUnit) :+: TyBool
+            ( equalPrettyLine "(Int + Unit) + Bool" $ (TyInt :+: TyUnit) :+: TyBool
             )
         , testCase
             "Product of product right"
-            ( equalPretty "Int * (Unit * Bool)" $ TyInt :*: (TyUnit :*: TyBool)
+            ( equalPrettyLine "Int * (Unit * Bool)" $ TyInt :*: (TyUnit :*: TyBool)
             )
         , testCase
             "Product of product left"
-            ( equalPretty "(Int * Unit) * Bool" $ (TyInt :*: TyUnit) :*: TyBool
+            ( equalPrettyLine "(Int * Unit) * Bool" $ (TyInt :*: TyUnit) :*: TyBool
             )
         , testCase
             "Product of sum"
-            ( equalPretty "Int * (Unit + Bool)" $ TyInt :*: (TyUnit :+: TyBool)
+            ( equalPrettyLine "Int * (Unit + Bool)" $ TyInt :*: (TyUnit :+: TyBool)
             )
         , testCase
             "Sum of product"
-            ( equalPretty "Int + (Unit * Bool)" $ TyInt :+: (TyUnit :*: TyBool)
+            ( equalPrettyLine "Int + (Unit * Bool)" $ TyInt :+: (TyUnit :*: TyBool)
             )
         , testCase
             "Product of function"
-            ( equalPretty "Int * (Unit -> Bool)" $ TyInt :*: (TyUnit :->: TyBool)
+            ( equalPrettyLine "Int * (Unit -> Bool)" $ TyInt :*: (TyUnit :->: TyBool)
             )
         , testCase
             "Function of product"
-            ( equalPretty "Int -> (Unit * Bool)" $ TyInt :->: (TyUnit :*: TyBool)
+            ( equalPrettyLine "Int -> (Unit * Bool)" $ TyInt :->: (TyUnit :*: TyBool)
             )
         , testCase
             "Function of function right"
-            ( equalPretty "Int -> Unit -> Bool" $ TyInt :->: (TyUnit :->: TyBool)
+            ( equalPrettyLine "Int -> Unit -> Bool" $ TyInt :->: (TyUnit :->: TyBool)
             )
         , testCase
             "Function of function left"
-            ( equalPretty "(Int -> Unit) -> Bool" $ (TyInt :->: TyUnit) :->: TyBool
+            ( equalPrettyLine "(Int -> Unit) -> Bool" $ (TyInt :->: TyUnit) :->: TyBool
             )
         , testCase
             "density (two nested products)"
-            ( equalPretty "((Int * Int) * (Int * Int)) -> Cmd Int" $
+            ( equalPrettyLine "((Int * Int) * (Int * Int)) -> Cmd Int" $
                 ((TyInt :*: TyInt) :*: (TyInt :*: TyInt)) :->: TyCmd TyInt
+            )
+        ]
+    , testGroup
+        "types but with limited width for pretty printing"
+        [ testCase
+            "Void type"
+            ( equalPrettyWidth 10 "Void" TyVoid
+            )
+        , testCase
+            "Function type"
+            ( equalPrettyWidth 20 "Int -> Cmd Unit" $ TyInt :->: TyCmd TyUnit
+            )
+        , testCase
+            "Cmd type"
+            ( equalPrettyWidth 20 "Cmd (Int -> Int)" $ TyCmd (TyInt :->: TyInt)
+            )
+        , testCase
+            "Product type"
+            ( equalPrettyWidth 20 "Int * Int" $ TyInt :*: TyInt
+            )
+        , testCase
+            "Function of function right"
+            ( equalPrettyWidth 10 "Int ->\nUnit ->\nBool" $ TyInt :->: (TyUnit :->: TyBool)
+            )
+        , testCase
+            "Function of function left"
+            ( equalPrettyWidth 20 "(Int -> Unit) ->\nBool" $ (TyInt :->: TyUnit) :->: TyBool
+            )
+        , testCase
+            "density (two nested products) with  neted indentation"
+            ( equalPrettyWidth 20 "(\n  (Int * Int) * (\n    Int * Int\n  )\n) -> Cmd Int" $
+                ((TyInt :*: TyInt) :*: (TyInt :*: TyInt)) :->: TyCmd TyInt
+            )
+        , testCase
+            "Resonate"
+            ( equalPrettyWidth 40 "Text -> ((Int * Int) * (Int * Int)) ->\nCmd (Unit + (Int * Int))" $
+                TyText :->: ((TyInt :*: TyInt) :*: (TyInt :*: TyInt)) :->: TyCmd (TyUnit :+: (TyInt :*: TyInt))
             )
         ]
     , testGroup
         "tydef"
         [ testCase "tydef alias" $
-            equalPretty "tydef X = Int end" $
+            equalPrettyLine "tydef X = Int end" $
               TTydef (LV NoLoc "X") (Forall [] TyInt)
         , testCase "tydef Maybe" $
-            equalPretty "tydef Maybe a = Unit + a end" $
+            equalPrettyLine "tydef Maybe a = Unit + a end" $
               TTydef (LV NoLoc "Maybe") (Forall ["a"] (TyUnit :+: TyVar "a"))
         , testCase "tydef multi-arg" $
-            equalPretty "tydef Foo a b c d = Unit + ((a * b) + ((c -> d) * a)) end" $
+            equalPrettyLine "tydef Foo a b c d = Unit + ((a * b) + ((c -> d) * a)) end" $
               TTydef
                 (LV NoLoc "Foo")
                 ( Forall
@@ -201,16 +238,19 @@ testPrettyConst =
     , testGroup
         "recursive types"
         [ testCase "nat" $
-            equalPretty "rec n. Unit + n" $
+            equalPrettyLine "rec n. Unit + n" $
               TyRec "n" (TyUnit :+: Fix (TyRecVarF NZ))
         , testCase "list" $
-            equalPretty "rec list. Unit + (a * list)" $
+            equalPrettyLine "rec list. Unit + (a * list)" $
               TyRec "list" (TyUnit :+: (TyVar "a" :*: Fix (TyRecVarF NZ)))
         , testCase "rose" $
-            equalPretty "rec r. a * (rec l. Unit + (r * l))" $
+            equalPrettyLine "rec r. a * (rec l. Unit + (r * l))" $
               TyRec "r" (TyVar "a" :*: TyRec "l" (TyUnit :+: (Fix (TyRecVarF (NS NZ)) :*: Fix (TyRecVarF NZ))))
         ]
     ]
  where
-  equalPretty :: PrettyPrec a => String -> a -> Assertion
-  equalPretty expected = assertEqual "" expected . into @String . prettyTextLine
+  equalPrettyLine :: PrettyPrec a => String -> a -> Assertion
+  equalPrettyLine expected = assertEqual "" expected . into @String . prettyTextLine
+
+  equalPrettyWidth :: PrettyPrec a => Int -> String -> a -> Assertion
+  equalPrettyWidth width expected doc = assertEqual "" expected . into @String $ prettyTextWidth doc width

--- a/test/unit/TestPretty.hs
+++ b/test/unit/TestPretty.hs
@@ -204,7 +204,7 @@ testPrettyConst =
             ( equalPrettyWidth 20 "(Int -> Unit) ->\nBool" $ (TyInt :->: TyUnit) :->: TyBool
             )
         , testCase
-            "density (two nested products) with  neted indentation"
+            "density (two nested products) with  nested indentation"
             ( equalPrettyWidth 20 "(\n  (Int * Int) * (\n    Int * Int\n  )\n) -> Cmd Int" $
                 ((TyInt :*: TyInt) :*: (TyInt :*: TyInt)) :->: TyCmd TyInt
             )


### PR DESCRIPTION
Includes tests for `prettyTextWidth` on type signatures. It should verify that line breaks are
introduced appropriately given number of allowed characters in a line.