### PR TITLE
Get rid of memoizing delay + switch to a strict store

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Arithmetic.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Arithmetic.hs
@@ -72,9 +72,11 @@ compareValues v1 = case v1 of
   VBind {} -> incomparable v1
   VDelay {} -> incomparable v1
   VRef {} -> incomparable v1
+  VIndir {} -> incomparable v1
   VRequirements {} -> incomparable v1
   VSuspend {} -> incomparable v1
   VExc {} -> incomparable v1
+  VBlackhole {} -> incomparable v1
 
 -- | Values with different types were compared; this should not be
 --   possible since the type system should catch it.

--- a/src/swarm-lang/Swarm/Language/LSP/Hover.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/Hover.hs
@@ -114,7 +114,7 @@ narrowToPosition s0@(Syntax' _ t _ ty) pos = fromMaybe s0 $ case t of
   SLet _ _ lv _ _ s1@(Syntax' _ _ _ lty) s2 -> d (locVarToSyntax' lv lty) <|> d s1 <|> d s2
   SBind mlv _ _ _ s1@(Syntax' _ _ _ lty) s2 -> (mlv >>= d . flip locVarToSyntax' (getInnerType lty)) <|> d s1 <|> d s2
   SPair s1 s2 -> d s1 <|> d s2
-  SDelay _ s -> d s
+  SDelay s -> d s
   SRcd m -> asum . map d . catMaybes . M.elems $ m
   SProj s1 _ -> d s1
   SAnnotate s _ -> d s

--- a/src/swarm-lang/Swarm/Language/LSP/VarUsage.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/VarUsage.hs
@@ -109,5 +109,5 @@ getUsage bindings (CSyntax _pos t _comments) = case t of
   SBind maybeVar _ _ _ s1 s2 -> case maybeVar of
     Just v -> checkOccurrences bindings v Bind [s1, s2]
     Nothing -> getUsage bindings s1 <> getUsage bindings s2
-  SDelay _ s -> getUsage bindings s
+  SDelay s -> getUsage bindings s
   _ -> mempty

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -98,14 +98,8 @@ parseTermAtom2 =
         <|> SRcd <$> brackets (parseRecord (optional (symbol "=" *> parseTerm)))
         <|> parens (view sTerm . mkTuple <$> (parseTerm `sepBy` symbol ","))
     )
-    -- Potential syntax for explicitly requesting memoized delay.
-    -- Perhaps we will not need this in the end; see the discussion at
-    -- https://github.com/swarm-game/swarm/issues/150 .
-    -- <|> parseLoc (TDelay SimpleDelay (TConst Noop) <$ try (symbol "{{" *> symbol "}}"))
-    -- <|> parseLoc (SDelay MemoizedDelay <$> dbraces parseTerm)
-
-    <|> parseLoc (TDelay SimpleDelay (TConst Noop) <$ try (symbol "{" *> symbol "}"))
-    <|> parseLoc (SDelay SimpleDelay <$> braces parseTerm)
+    <|> parseLoc (TDelay (TConst Noop) <$ try (symbol "{" *> symbol "}"))
+    <|> parseLoc (SDelay <$> braces parseTerm)
     <|> parseLoc (view antiquoting >>= (guard . (== AllowAntiquoting)) >> parseAntiquotation)
 
 -- | Construct an 'SLet', automatically filling in the Boolean field

--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -280,8 +280,8 @@ instance PrettyPrec (Term' ty) where
     TRequire n e -> pparens (p > 10) $ "require" <+> pretty n <+> ppr @Term (TText e)
     SRequirements _ e -> pparens (p > 10) $ "requirements" <+> ppr e
     TVar s -> pretty s
-    SDelay _ (Syntax' _ (TConst Noop) _ _) -> "{}"
-    SDelay _ t -> group . encloseWithIndent 2 lbrace rbrace $ ppr t
+    SDelay (Syntax' _ (TConst Noop) _ _) -> "{}"
+    SDelay t -> group . encloseWithIndent 2 lbrace rbrace $ ppr t
     t@SPair {} -> prettyTuple t
     t@SLam {} ->
       pparens (p > 9) $

--- a/src/swarm-lang/Swarm/Language/Requirements/Analysis.hs
+++ b/src/swarm-lang/Swarm/Language/Requirements/Analysis.hs
@@ -148,7 +148,7 @@ requirements tdCtx ctx =
       local @ReqCtx (maybe id Ctx.delete mx) $ go t2
     -- Everything else is straightforward.
     TPair t1 t2 -> add (singletonCap CProd) *> go t1 *> go t2
-    TDelay _ t -> go t
+    TDelay t -> go t
     TRcd m -> add (singletonCap CRecord) *> forM_ (M.assocs m) (go . expandEq)
      where
       expandEq (x, Nothing) = TVar x

--- a/src/swarm-lang/Swarm/Language/Syntax/AST.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/AST.hs
@@ -125,7 +125,7 @@ data Term' ty
     --   Note that 'Force' is just a constant, whereas 'SDelay' has to
     --   be a special syntactic form so its argument can get special
     --   treatment during evaluation.
-    SDelay DelayType (Syntax' ty)
+    SDelay (Syntax' ty)
   | -- | Record literals @[x1 = e1, x2 = e2, x3, ...]@ Names @x@
     --   without an accompanying definition are sugar for writing
     --   @x=x@.

--- a/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
@@ -122,8 +122,8 @@ pattern TBind mv mty mreq t1 t2 <- SBind (fmap lvVar -> mv) _ mty mreq (STerm t1
     TBind mv mty mreq t1 t2 = SBind (LV NoLoc <$> mv) Nothing mty mreq (STerm t1) (STerm t2)
 
 -- | Match a TDelay without annotations.
-pattern TDelay :: DelayType -> Term -> Term
-pattern TDelay m t = SDelay m (STerm t)
+pattern TDelay :: Term -> Term
+pattern TDelay t = SDelay (STerm t)
 
 -- | Match a TRcd without annotations.
 pattern TRcd :: Map Var (Maybe Term) -> Term

--- a/src/swarm-lang/Swarm/Language/Syntax/Util.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Util.hs
@@ -140,7 +140,7 @@ freeVarsS f = go S.empty
     STydef x xdef tdInfo t1 -> rewrap $ STydef x xdef tdInfo <$> go bound t1
     SPair s1 s2 -> rewrap $ SPair <$> go bound s1 <*> go bound s2
     SBind mx mty mpty mreq s1 s2 -> rewrap $ SBind mx mty mpty mreq <$> go bound s1 <*> go (maybe id (S.insert . lvVar) mx bound) s2
-    SDelay m s1 -> rewrap $ SDelay m <$> go bound s1
+    SDelay s1 -> rewrap $ SDelay <$> go bound s1
     SRcd m -> rewrap $ SRcd <$> (traverse . traverse) (go bound) m
     SProj s1 x -> rewrap $ SProj <$> go bound s1 <*> pure x
     SAnnotate s1 pty -> rewrap $ SAnnotate <$> go bound s1 <*> pure pty

--- a/test/unit/TestScoring.hs
+++ b/test/unit/TestScoring.hs
@@ -33,8 +33,8 @@ testHighScores =
         , compareAstSize 5 "double-move-let-with-invocation.sw"
         , compareAstSize 3 "single-move-def-with-invocation.sw"
         , compareAstSize 5 "double-move-def-with-invocation.sw"
-        , compareAstSize 27 "single-def-two-args-recursive.sw"
-        , compareAstSize 34 "single-def-two-args-recursive-with-invocation.sw"
+        , compareAstSize 25 "single-def-two-args-recursive.sw"
+        , compareAstSize 30 "single-def-two-args-recursive-with-invocation.sw"
         ]
     , testGroup
         "Precedence"


### PR DESCRIPTION
Closes #1948; see that issue for a much more in-depth discussion.

Depends on merging #1928 first.

A lot of this PR consists in deleting code that is either (1) ugly or (2) overly clever! :partying_face: 

The short version is that the `Store` used to incorporate some laziness + memoization: when a cell was first allocated, it was an unevaluated thunk; it then got evaluated the first time it was referenced.  However, this wasn't really needed to handle recursive definitions (which is the only thing we were using it for).  Getting rid of it means we can get rid of a lot of weird ugly code needed to wrap free variables in extra calls to `force` and so on.

The new and improved `Store` just stores `Value`s, period.  A special `VBlackhole` value was added, to be used while evaluating a recursive `let`.

Note that `VRef` is no longer really used, but I left it there for use in implementing #1660 .  Once we have mutable references we can use them + delay/force to implement lazy cells.
