### PR TITLE
Reset scroll position when switching modals

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -1470,23 +1470,27 @@ handleInventoryListEvent ev = do
 handleInventorySearchEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleInventorySearchEvent = \case
   -- Escape: stop filtering and go back to regular inventory mode
-  EscapeKey ->
+  EscapeKey -> do
+    resetViewport infoScroll
     Brick.zoom (uiState . uiGameplay . uiInventory) $ do
       uiInventoryShouldUpdate .= True
       uiInventorySearch .= Nothing
   -- Enter: return to regular inventory mode, and pop out the selected item
   Key V.KEnter -> do
+    resetViewport infoScroll
     Brick.zoom (uiState . uiGameplay . uiInventory) $ do
       uiInventoryShouldUpdate .= True
       uiInventorySearch .= Nothing
     gets focusedEntity >>= maybe continueWithoutRedraw descriptionModal
   -- Any old character: append to the current search string
-  CharKey c ->
+  CharKey c -> do
+    resetViewport infoScroll
     Brick.zoom (uiState . uiGameplay . uiInventory) $ do
       uiInventoryShouldUpdate .= True
       uiInventorySearch %= fmap (`snoc` c)
   -- Backspace: chop the last character off the end of the current search string
   BackspaceKey -> do
+    resetViewport infoScroll
     Brick.zoom (uiState . uiGameplay . uiInventory) $ do
       uiInventoryShouldUpdate .= True
       uiInventorySearch %= fmap (T.dropEnd 1)

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -1422,7 +1422,6 @@ adjustTPS (+/-) = uiState . uiGameplay . uiTiming . lgTicksPerSecond %~ (+/- 1)
 handleRobotPanelEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleRobotPanelEvent bev = do
   search <- use $ uiState . uiGameplay . uiInventory . uiInventorySearch
-  mapM_ resetViewport [infoScroll, modalScroll]
   case search of
     Just _ -> handleInventorySearchEvent bev
     Nothing -> case bev of
@@ -1459,6 +1458,7 @@ handleInventoryListEvent ev = do
   -- However, this does not work since we want to skip redrawing in the no-list case!
 
   mList <- preuse $ uiState . uiGameplay . uiInventory . uiInventoryList . _Just . _2
+  resetViewport infoScroll
   case mList of
     Nothing -> continueWithoutRedraw
     Just l -> do
@@ -1511,6 +1511,7 @@ makeEntity e = do
 descriptionModal :: Entity -> EventM Name AppState ()
 descriptionModal e = do
   s <- get
+  resetViewport modalScroll
   uiState . uiGameplay . uiModal ?= generateModal s (DescriptionModal e)
 
 ------------------------------------------------------------

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -1458,10 +1458,10 @@ handleInventoryListEvent ev = do
   -- However, this does not work since we want to skip redrawing in the no-list case!
 
   mList <- preuse $ uiState . uiGameplay . uiInventory . uiInventoryList . _Just . _2
-  resetViewport infoScroll
   case mList of
     Nothing -> continueWithoutRedraw
     Just l -> do
+      when (isValidListMovement ev) $ resetViewport infoScroll
       l' <- nestEventM' l (handleListEventWithSeparators ev (is _Separator))
       uiState . uiGameplay . uiInventory . uiInventoryList . _Just . _2 .= l'
 
@@ -1470,14 +1470,12 @@ handleInventoryListEvent ev = do
 handleInventorySearchEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleInventorySearchEvent = \case
   -- Escape: stop filtering and go back to regular inventory mode
-  EscapeKey -> do
-    resetViewport infoScroll
+  EscapeKey ->
     Brick.zoom (uiState . uiGameplay . uiInventory) $ do
       uiInventoryShouldUpdate .= True
       uiInventorySearch .= Nothing
   -- Enter: return to regular inventory mode, and pop out the selected item
   Key V.KEnter -> do
-    resetViewport infoScroll
     Brick.zoom (uiState . uiGameplay . uiInventory) $ do
       uiInventoryShouldUpdate .= True
       uiInventorySearch .= Nothing
@@ -1490,7 +1488,6 @@ handleInventorySearchEvent = \case
       uiInventorySearch %= fmap (`snoc` c)
   -- Backspace: chop the last character off the end of the current search string
   BackspaceKey -> do
-    resetViewport infoScroll
     Brick.zoom (uiState . uiGameplay . uiInventory) $ do
       uiInventoryShouldUpdate .= True
       uiInventorySearch %= fmap (T.dropEnd 1)

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -444,12 +444,12 @@ handleMainEvent ev = do
     _ev -> do
       fring <- use $ uiState . uiGameplay . uiFocusRing
       case focusGetCurrent fring of
-        Just (FocusablePanel x) -> ($ ev) $ case x of
-          REPLPanel -> handleREPLEvent
-          WorldPanel -> handleWorldEvent
-          WorldEditorPanel -> EC.handleWorldEditorPanelEvent
-          RobotPanel -> handleRobotPanelEvent
-          InfoPanel -> handleInfoPanelEvent infoScroll
+        Just (FocusablePanel x) -> case x of
+          REPLPanel -> handleREPLEvent ev
+          WorldPanel -> handleWorldEvent ev
+          WorldEditorPanel -> EC.handleWorldEditorPanelEvent ev
+          RobotPanel -> handleRobotPanelEvent ev
+          InfoPanel -> handleInfoPanelEvent infoScroll ev
         _ -> continueWithoutRedraw
 
 -- | Set the game to Running if it was (auto) paused otherwise to paused.
@@ -1422,6 +1422,7 @@ adjustTPS (+/-) = uiState . uiGameplay . uiTiming . lgTicksPerSecond %~ (+/- 1)
 handleRobotPanelEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()
 handleRobotPanelEvent bev = do
   search <- use $ uiState . uiGameplay . uiInventory . uiInventorySearch
+  mapM_ resetViewport [infoScroll, modalScroll]
   case search of
     Just _ -> handleInventorySearchEvent bev
     Nothing -> case bev of

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -52,6 +52,7 @@ pattern FKey c = VtyEvent (V.EvKey (V.KFun c) [])
 
 openModal :: ModalType -> EventM Name AppState ()
 openModal mt = do
+  resetViewport modalScroll
   newModal <- gets $ flip generateModal mt
   ensurePause
   uiState . uiGameplay . uiModal ?= newModal

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -111,3 +111,9 @@ hasDebugCapability :: Bool -> AppState -> Bool
 hasDebugCapability isCreative s =
   maybe isCreative (S.member CDebug . getCapabilitySet) $
     s ^? gameState . to focusedRobot . _Just . robotCapabilities
+
+-- | Resets the viewport scroll position
+resetViewport :: ViewportScroll Name -> EventM Name AppState ()
+resetViewport n = do
+  vScrollToBeginning n
+  hScrollToBeginning n

--- a/src/swarm-tui/Swarm/TUI/List.hs
+++ b/src/swarm-tui/Swarm/TUI/List.hs
@@ -3,7 +3,10 @@
 --
 -- A special modified version of 'Brick.Widgets.List.handleListEvent'
 -- to deal with skipping over separators.
-module Swarm.TUI.List (handleListEventWithSeparators) where
+module Swarm.TUI.List (
+  handleListEventWithSeparators,
+  isValidListMovement,
+) where
 
 import Brick (EventM)
 import Brick.Widgets.List qualified as BL
@@ -20,15 +23,21 @@ handleListEventWithSeparators ::
   (e -> Bool) ->
   EventM n (BL.GenericList n t e) ()
 handleListEventWithSeparators e isSep =
-  listSkip isSep movement
- where
-  movement = case e of
-    V.EvKey V.KUp [] -> Move One Bwd
-    V.EvKey (V.KChar 'k') [] -> Move One Bwd
-    V.EvKey V.KDown [] -> Move One Fwd
-    V.EvKey (V.KChar 'j') [] -> Move One Fwd
-    V.EvKey V.KHome [] -> Move Most Bwd
-    V.EvKey V.KEnd [] -> Move Most Fwd
-    V.EvKey V.KPageDown [] -> Move Page Fwd
-    V.EvKey V.KPageUp [] -> Move Page Bwd
-    _ -> NoMove
+  listSkip isSep (movement e)
+
+-- | A movement is considered legitimate when a key event
+-- results in @Move@ action.
+isValidListMovement :: V.Event -> Bool
+isValidListMovement e = movement e /= NoMove
+
+movement :: V.Event -> Move
+movement = \case
+  V.EvKey V.KUp [] -> Move One Bwd
+  V.EvKey (V.KChar 'k') [] -> Move One Bwd
+  V.EvKey V.KDown [] -> Move One Fwd
+  V.EvKey (V.KChar 'j') [] -> Move One Fwd
+  V.EvKey V.KHome [] -> Move Most Bwd
+  V.EvKey V.KEnd [] -> Move Most Fwd
+  V.EvKey V.KPageDown [] -> Move Page Fwd
+  V.EvKey V.KPageUp [] -> Move Page Bwd
+  _ -> NoMove

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -44,6 +44,7 @@ module Swarm.TUI.Model (
   infoScroll,
   modalScroll,
   replScroll,
+  resetViewport,
 
   -- ** Utility
   logEvent,
@@ -126,6 +127,12 @@ modalScroll = viewportScroll ModalViewport
 
 replScroll :: ViewportScroll Name
 replScroll = viewportScroll REPLViewport
+
+-- | Resets the viewport scroll position
+resetViewport :: ViewportScroll Name -> EventM Name AppState ()
+resetViewport n = do
+  vScrollToBeginning n
+  hScrollToBeginning n
 
 --------------------------------------------------
 -- Utility

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -44,7 +44,6 @@ module Swarm.TUI.Model (
   infoScroll,
   modalScroll,
   replScroll,
-  resetViewport,
 
   -- ** Utility
   logEvent,
@@ -127,12 +126,6 @@ modalScroll = viewportScroll ModalViewport
 
 replScroll :: ViewportScroll Name
 replScroll = viewportScroll REPLViewport
-
--- | Resets the viewport scroll position
-resetViewport :: ViewportScroll Name -> EventM Name AppState ()
-resetViewport n = do
-  vScrollToBeginning n
-  hScrollToBeginning n
 
 --------------------------------------------------
 -- Utility


### PR DESCRIPTION
Closes #1901 

When switching description modals or info panel in the bottom left corner, the viewport used to retail the scrolled state.
This PR attempts to reset the scroll position when we switch modals.