### PR TITLE
Apply bindings before returning unification mismatch error

### DIFF
--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -482,7 +482,7 @@ testLanguagePipeline =
             "applying a pair"
             ( process
                 "(1,2) \"hi\""
-                "1:1: Type mismatch:\n  From context, expected `(1, 2)` to be a function,\n  but it is actually a pair"
+                "1:1: Type mismatch:\n  From context, expected `(1, 2)` to be a function,\n  but it actually has type `Int * Int`"
             )
         , testCase
             "providing a pair as an argument"
@@ -519,6 +519,12 @@ testLanguagePipeline =
             ( process
                 "1 + (\\x. \\y. 3)"
                 "1:5: Type mismatch:\n  From context, expected `\\x. \\y. 3` to have type `Int`,\n  but it is actually a function\n"
+            )
+        , testCase
+            "apply HOF to int - #1888"
+            ( process
+                "(\\f. f 3) 2"
+                "1:11: Type mismatch:\n  From context, expected `2` to have a type like `Int -> _`"
             )
         ]
     , testGroup
@@ -644,7 +650,7 @@ testLanguagePipeline =
             "def at non-cmd type"
             ( process
                 "def x = 3 end; x + 2"
-                "1:16: Type mismatch:\n  From context, expected `x + 2` to have a type like"
+                "1:16: Type mismatch:\n  From context, expected `x + 2` to be a command"
             )
         , testCase
             "def at cmd type"


### PR DESCRIPTION
Closes #1888.  When we discovered a type mismatch, we were not fully substituting everything we had learned about the types (via `applyBindings`) before reporting the error.  For example, in #1888 we had `2 : u1` and a unification constraint `u1 = Int -> u2`, but we were just reporting the type of `2` as `u1` rather than first substituting `Int -> u2` for `u1`.

I think we have had this problem for a while, but the recent rewrite of the unification engine possibly made the effects more noticeable.

This incidentally improved a couple more error messages in the test suite. =)