### PR TITLE
Fix world DSL `hash` primitive to depend on seed

### DIFF
--- a/src/swarm-scenario/Swarm/Game/World/Compile.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Compile.hs
@@ -69,7 +69,7 @@ compileConst seed = \case
   CMask -> compileMask
   CSeed -> CConst (fromIntegral seed)
   CCoord ax -> CFun $ \(CConst (coordsToLoc -> Location x y)) -> CConst (fromIntegral (case ax of X -> x; Y -> y))
-  CHash -> compileHash
+  CHash -> compileHash seed
   CPerlin -> compilePerlin
   CReflect ax -> compileReflect ax
   CRot rot -> compileRot rot
@@ -94,10 +94,10 @@ compileMask = CFun $ \p -> CFun $ \a -> CFun $ \ix ->
   case p $$ ix of
     CConst b -> if b then a $$ ix else CConst empty
 
-compileHash :: CTerm (Coords -> Integer)
-compileHash = CFun $ \(CConst (Coords ix)) -> CConst (fromIntegral (h ix))
+compileHash :: Seed -> CTerm (Coords -> Integer)
+compileHash seed = CFun $ \(CConst (Coords ix)) -> CConst (fromIntegral (h ix))
  where
-  h = murmur3 0 . unTagged . from @String @(Encoding.UTF_8 ByteString) . show
+  h = murmur3 (fromIntegral seed) . unTagged . from @String @(Encoding.UTF_8 ByteString) . show
 
 compilePerlin :: CTerm (Integer -> Integer -> Double -> Double -> World Double)
 compilePerlin =

--- a/src/swarm-scenario/Swarm/Game/World/Interpret.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Interpret.hs
@@ -59,7 +59,7 @@ interpConst seed = \case
   CMask -> \b x c -> if b c then x c else empty
   CSeed -> fromIntegral seed
   CCoord ax -> \(coordsToLoc -> Location x y) -> fromIntegral (case ax of X -> x; Y -> y)
-  CHash -> \(Coords ix) -> fromIntegral . murmur3 0 . unTagged . from @String @(Encoding.UTF_8 ByteString) . show $ ix
+  CHash -> \(Coords ix) -> fromIntegral . murmur3 (fromIntegral seed) . unTagged . from @String @(Encoding.UTF_8 ByteString) . show $ ix
   CPerlin -> \s o k p ->
     let noise = perlin (fromIntegral s) (fromIntegral o) k p
         sample (i, j) = noiseValue noise (fromIntegral i / 2, fromIntegral j / 2, 0)


### PR DESCRIPTION
It turns out that the `hash` primitive was always computing the same deterministic hash of the coordinates regardless of the seed.  This meant that *e.g.* any world features placed in a way that depended on the hash were always in the same locations, and if you created a world that only relied on `hash` and not on, say, Perlin noise, it would always look the same regardless of the seed.  This does not seem desirable.

This PR fixes the DSL interpreter by passing the seed to the `murmur3` hash function (we used to always pass the constant seed 0).  In theory, this does mean that all the "classic" worlds are now slightly different than what they used to be (except for seed 0).  However, there's no way to tell the difference between one random placement and another.  The only scenario where we really depend on the particular locations of entities for a particular seed is the `world101` tutorial, but that used seed 0 anyway, which did not change.

Depends on merging #1988 first.