### PR TITLE
Add `imap` to world DSL, with examples

### DIFF
--- a/data/scenarios/00-ORDER.txt
+++ b/data/scenarios/00-ORDER.txt
@@ -8,3 +8,4 @@ Speedruns
 Testing
 Vignettes
 Mechanics
+World Examples

--- a/data/scenarios/Testing/1320-world-DSL/00-ORDER.txt
+++ b/data/scenarios/Testing/1320-world-DSL/00-ORDER.txt
@@ -2,3 +2,4 @@ constant.yaml
 erase.yaml
 override.yaml
 coords.yaml
+reflect.yaml

--- a/data/scenarios/Testing/1320-world-DSL/reflect.yaml
+++ b/data/scenarios/Testing/1320-world-DSL/reflect.yaml
@@ -1,0 +1,46 @@
+version: 1
+name: Reflection (imap) test
+description: |
+  A world with both horizontal and vertical reflection symmetry,
+  created with 'imap'.
+creative: false
+objectives:
+  - goal:
+      - Pick up four trees
+    condition: |
+      as base {n <- count "tree"; return (n >= 4)}
+robots:
+  - name: base
+    loc: [0, 0]
+    dir: north
+    devices:
+      - logger
+      - grabber
+      - treads
+      - branch predictor
+      - scanner
+      - ADT calculator
+      - comparator
+      - GPS receiver
+      - bitcoin
+solution: |
+  def x = \n. \c. if (n==0) {} {c; x (n-1) c} end
+  def ifC = \p. \t. \e. b <- p; if b t e end
+  def findTree = ifC (ishere "tree") {whereami} {move; findTree} end
+  def ell = \d. turn right; x (2*d) move; grab; return () end
+  def grabTrees = \loc. let x = fst loc in let y = snd loc in grab; ell y; ell x; ell y end
+  n <- random 10;
+  x (n+1) move; turn right; move;
+  loc <- findTree;
+  grabTrees loc
+known: [tree]
+world:
+  dsl: |
+    let trees = if (hash % 4 == 0) then {tree, dirt} else {stone}
+    in
+      overlay
+      [ mask (x >= 0 && y >= 0) trees
+      , mask (x >= 0 && y < 0) (imap x (-y) trees)
+      , mask (x < 0 && y >= 0) (imap (-x) y trees)
+      , mask (x < 0 && y < 0) (imap (-x) (-y) trees)
+      ]

--- a/data/scenarios/World Examples/00-ORDER.txt
+++ b/data/scenarios/World Examples/00-ORDER.txt
@@ -1,0 +1,3 @@
+clearing.yaml
+rorschach.yaml
+stretch.yaml

--- a/data/scenarios/World Examples/00-ORDER.txt
+++ b/data/scenarios/World Examples/00-ORDER.txt
@@ -1,3 +1,4 @@
 clearing.yaml
 rorschach.yaml
 stretch.yaml
+translate.yaml

--- a/data/scenarios/World Examples/clearing.yaml
+++ b/data/scenarios/World Examples/clearing.yaml
@@ -1,0 +1,22 @@
+version: 1
+name: Clearing
+description: |
+  The base is in a clearing in the forest: the area within a certain
+  radius of the base is completely clear of trees; then there are
+  random trees at increasing density up to another radius; outside of
+  the outer radius there are only trees.
+creative: true
+robots:
+  - name: base
+    display:
+      char: Ω
+    loc: [0, 0]
+    dir: north
+world:
+  dsl: |
+    overlay
+    [ {dirt}
+    , mask ((x*x + 4*y*y) >= (6*6) && (x*x + 4*y*y) <= (30*30))
+        (let h = hash % 24 in if (36 + h*h) <= (x*x + 4*y*y) then {tree,dirt} else {dirt} )
+    , mask ((x*x + 4*y*y) > (30*30)) {tree, dirt}
+    ]

--- a/data/scenarios/World Examples/rorschach.yaml
+++ b/data/scenarios/World Examples/rorschach.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Rorschach
 description: |
   A world with both horizontal and vertical reflection symmetry,
-  created with 'imap'.
+  created with `imap`{=snippet}.
 creative: true
 robots:
   - name: base

--- a/data/scenarios/World Examples/rorschach.yaml
+++ b/data/scenarios/World Examples/rorschach.yaml
@@ -1,0 +1,21 @@
+version: 1
+name: Rorschach
+description: |
+  A world with both horizontal and vertical reflection symmetry,
+  created with 'imap'.
+creative: true
+robots:
+  - name: base
+    dir: north
+    loc: [0, 0]
+known: [tree]
+world:
+  dsl: |
+    let trees = if (hash % 4 == 0) then {tree, dirt} else {stone}
+    in
+      overlay
+      [ mask (x >= 0 && y >= 0) trees
+      , mask (x >= 0 && y < 0) (imap x (-y) trees)
+      , mask (x < 0 && y >= 0) (imap (-x) y trees)
+      , mask (x < 0 && y < 0) (imap (-x) (-y) trees)
+      ]

--- a/data/scenarios/World Examples/stretch.yaml
+++ b/data/scenarios/World Examples/stretch.yaml
@@ -1,0 +1,16 @@
+version: 1
+name: Stretch
+description: |
+  A world created by stretching a random pattern of trees, with the
+  amount of stretching determined by the distance from the origin.
+creative: true
+robots:
+  - name: base
+    dir: north
+    loc: [0, 0]
+known: [tree]
+world:
+  dsl: |
+    let trees = if (hash % 4 == 0) then {tree, dirt} else {stone}
+    in
+      imap (if (y == 0) then 0 else (x/abs(y))) (if (abs x <= 1) then 0 else (y/abs(x/2))) trees

--- a/data/scenarios/World Examples/translate.yaml
+++ b/data/scenarios/World Examples/translate.yaml
@@ -1,0 +1,24 @@
+version: 1
+name: Translate
+description: |
+  An illustration of how to use `imap`{=snippet} to translate.  A basic patch is
+  created and then overlaid at various translations.  Note that since
+  `imap`{=snippet} works by mapping a function over the coordinates, translation
+  is "backwards": for example, `imap (x+4)`{=snippet} translates 4 units to the
+  *left*.
+creative: true
+robots:
+  - name: base
+    dir: north
+    loc: [0, 0]
+known: [rock]
+world:
+  dsl: |
+    let patch = mask (abs(x) <= 4 && abs(y) <= 4) (if ((x + y) % 2 == 0) then {rock, dirt} else {dirt})
+    in
+      overlay
+      [ patch
+      , imap (x+6) (y+3) patch
+      , imap (x-10) (y-7) patch
+      , imap (x-14) (y+5) patch
+      ]

--- a/data/worlds/README.md
+++ b/data/worlds/README.md
@@ -81,6 +81,7 @@ repetitions of `S` separated by `,`.
   | 'let' (<ident> '=' <exp>)*, 'in' <exp>
   | 'overlay' '[' <exp>+, ']'
   | 'mask' <atom> <atom>
+  | 'imap' <atom> <atom> <atom>
   | '"' <nonquote>+ '"'
   | '(' <exp> ')'
 
@@ -186,4 +187,9 @@ entities but also some empty cells.
    https://libnoise.sourceforge.net/glossary/index.html#perlinnoise
 - `mask b e` takes the value of `e` where `b` is true, and is empty
   elsewhere.
+- `imap` has type `World int -> World int -> World a -> World a`, and
+  creates a new world from a reference world using the given index
+  lookup functions.  That is, `imap wx wy wa` yields the world
+  `\c -> wa (wx c, wy c)`.  For example, `imap (-x) y w` reflects the
+  world `w` across the line `y = 0`.
 - `"foo"` imports the DSL term in `worlds/foo.world`.

--- a/src/swarm-scenario/Swarm/Game/World/Compile.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Compile.hs
@@ -24,10 +24,9 @@ import Data.Tagged (Tagged (unTagged))
 import Numeric.Noise.Perlin (noiseValue, perlin)
 import Swarm.Game.Location (pattern Location)
 import Swarm.Game.World.Abstract (BTerm (..))
-import Swarm.Game.World.Coords (Coords (..), coordsToLoc)
+import Swarm.Game.World.Coords (Coords (..), coordsToLoc, locToCoords)
 import Swarm.Game.World.Gen (Seed)
-import Swarm.Game.World.Interpret (interpReflect, interpRot)
-import Swarm.Game.World.Syntax (Axis (..), Rot, World)
+import Swarm.Game.World.Syntax (Axis (..), World)
 import Swarm.Game.World.Typecheck (Applicable (..), Const (..), Empty (..), NotFun, Over (..))
 import Witch (from)
 import Witch.Encoding qualified as Encoding
@@ -71,9 +70,8 @@ compileConst seed = \case
   CCoord ax -> CFun $ \(CConst (coordsToLoc -> Location x y)) -> CConst (fromIntegral (case ax of X -> x; Y -> y))
   CHash -> compileHash seed
   CPerlin -> compilePerlin
-  CReflect ax -> compileReflect ax
-  CRot rot -> compileRot rot
   COver -> binary (<!>)
+  CIMap -> compileIMap
   K -> CFun $ \x -> CFun $ const x
   S -> CFun $ \f -> CFun $ \g -> CFun $ \x -> f $$ x $$ (g $$ x)
   I -> CFun id
@@ -110,11 +108,15 @@ compilePerlin =
  where
   sample (i, j) noise = noiseValue noise (fromIntegral i / 2, fromIntegral j / 2, 0)
 
-compileReflect :: Axis -> CTerm (World a -> World a)
-compileReflect ax = CFun $ \w -> CFun $ \(CConst c) -> w $$ CConst (interpReflect ax c)
-
-compileRot :: Rot -> CTerm (World a -> World a)
-compileRot rot = CFun $ \w -> CFun $ \(CConst c) -> w $$ CConst (interpRot rot c)
+compileIMap :: NotFun a => CTerm (World Integer -> World Integer -> World a -> World a)
+compileIMap =
+  CFun $ \wx ->
+    CFun $ \wy ->
+      CFun $ \wa ->
+        CFun $ \c ->
+          let mkCoords :: CTerm Integer -> CTerm Integer -> CTerm Coords
+              mkCoords (CConst x) (CConst y) = CConst (locToCoords (Location (fromIntegral x) (fromIntegral y)))
+           in wa $$ mkCoords (wx $$ c) (wy $$ c)
 
 type family NoFunParams a :: Constraint where
   NoFunParams (a -> b) = (NotFun a, NoFunParams b)

--- a/src/swarm-scenario/Swarm/Game/World/Parse.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Parse.hs
@@ -52,6 +52,7 @@ reservedWords =
   , "mask"
   , "empty"
   , "abs"
+  , "imap"
   ]
 
 -- | Skip spaces and comments.
@@ -139,6 +140,7 @@ parseWExpAtom =
     <|> parseOverlay
     <|> parseMask
     <|> parseImport
+    <|> parseIMap
     -- <|> parseCat
     -- <|> parseStruct
     <|> parens parseWExp
@@ -237,6 +239,14 @@ parseMask = do
 
 parseImport :: Parser WExp
 parseImport = WImport . into @Text <$> between (symbol "\"") (symbol "\"") (some (satisfy (/= '"')))
+
+parseIMap :: Parser WExp
+parseIMap = do
+  reserved "imap"
+  wx <- parseWExpAtom
+  wy <- parseWExpAtom
+  wa <- parseWExpAtom
+  return $ WOp IMap [wx, wy, wa]
 
 -- parseCat :: Parser WExp
 -- parseCat =

--- a/src/swarm-scenario/Swarm/Game/World/Syntax.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Syntax.hs
@@ -10,7 +10,6 @@ module Swarm.Game.World.Syntax (
   RawCellVal,
   CellTag (..),
   CellVal (..),
-  Rot (..),
   Var,
   Axis (..),
   Op (..),
@@ -65,16 +64,6 @@ instance PrettyPrec CellVal where
         ++ [(Just CellEntity, e ^. entityName) | EJust (Last e) <- [ent]]
         ++ map ((Just CellRobot,) . view trobotName) rs
 
-data Rot = Rot0 | Rot90 | Rot180 | Rot270
-  deriving (Eq, Ord, Show, Bounded, Enum)
-
-instance PrettyPrec Rot where
-  prettyPrec _ = \case
-    Rot0 -> "rot0"
-    Rot90 -> "rot90"
-    Rot180 -> "rot180"
-    Rot270 -> "rot270"
-
 type Var = Text
 
 data Axis = X | Y
@@ -83,7 +72,7 @@ data Axis = X | Y
 instance PrettyPrec Axis where
   prettyPrec _ = \case X -> "x"; Y -> "y"
 
-data Op = Not | Neg | And | Or | Add | Sub | Mul | Div | Mod | Eq | Neq | Lt | Leq | Gt | Geq | If | Perlin | Reflect Axis | Rot Rot | Mask | Overlay | Abs
+data Op = Not | Neg | And | Or | Add | Sub | Mul | Div | Mod | Eq | Neq | Lt | Leq | Gt | Geq | If | Perlin | Mask | Overlay | Abs | IMap
   deriving (Eq, Ord, Show)
 
 ------------------------------------------------------------


### PR DESCRIPTION
Adds a new primitive `imap`, aka index map, primitive to the world DSL.  `imap` has type `World int -> World int -> World a -> World a`.  Think of it like `(Coords -> Coords) -> World a -> World a`, i.e. given a coordinate mapping, it creates a new world by looking up the cell at the transformed coordinates in the given base world.  However, since there are no lambdas we cannot directly give it that type; instead, the first `World int` represents a function `Coords -> int` which gives an x coordinate, and the second gives the y coordinate.  All told, `imap wx wy wa` is like `\c -> wa (wx c, wy c)`.  For example, `imap (-x) y w` is a reflection of `w` across the y-axis.

Adds a description of `imap` to the language reference, as well as adding a few examples.

Also removes the `rot` and `reflect` primitives, since they can now be simply implemented in terms of `imap`.

Depends on merging #1989 first.  Closes #1584.