### PR TITLE
Remove grid overlay truncation behavior

### DIFF
--- a/data/scenarios/Testing/1780-structure-merge-expansion/nonoverlapping-structure-merge.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/nonoverlapping-structure-merge.yaml
@@ -37,10 +37,8 @@ world:
           xx
         placements:
           - src: vertical rectangle
-            truncate: false
             offset: [-7, 7]
           - src: horizontal rectangle
-            truncate: false
             offset: [7, -7]
   placements:
     - src: disjoint rectangles

--- a/data/scenarios/Testing/1780-structure-merge-expansion/root-map-expansion.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/root-map-expansion.yaml
@@ -24,7 +24,6 @@ world:
           x
   placements:
     - src: single tree
-      truncate: false
       offset: [-2, -4]
   map: |
     i.

--- a/data/scenarios/Testing/1780-structure-merge-expansion/structure-composition.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/structure-composition.yaml
@@ -45,9 +45,7 @@ world:
         map: ""
         placements:
           - src: vertical rectangle
-            truncate: false
           - src: horizontal rectangle
-            truncate: false
     - name: combined rectangles single cell base
       structure:
         palette:
@@ -56,9 +54,7 @@ world:
           x
         placements:
           - src: vertical rectangle
-            truncate: false
           - src: horizontal rectangle
-            truncate: false
     - name: multi overlap
       structure:
         palette:
@@ -68,19 +64,14 @@ world:
         placements:
           - src: vertical rectangle
             offset: [1, 0]
-            truncate: false
           - src: horizontal rectangle
-            truncate: false
             offset: [0, -2]
           - src: vertical rectangle
             offset: [3, -2]
-            truncate: false
           - src: horizontal rectangle
-            truncate: false
             offset: [3, -4]
           - src: vertical rectangle
             offset: [5, -4]
-            truncate: false
   placements:
     - src: vertical rectangle
       offset: [1, -1]
@@ -88,7 +79,6 @@ world:
       offset: [1, -1]
     - src: multi overlap
       offset: [1, -6]
-      truncate: false
     - src: combined rectangles blank base
       offset: [6, -1]
     - src: combined rectangles empty base

--- a/data/test/standalone-topography/checkerboard.yaml
+++ b/data/test/standalone-topography/checkerboard.yaml
@@ -15,10 +15,8 @@ structures:
       placements:
         - src: checker pair
           offset: [0, 0]
-          truncate: false
         - src: checker pair
           offset: [0, -4]
-          truncate: false
           orient:
             up: south
   - name: checker octo
@@ -27,27 +25,19 @@ structures:
       placements:
         - src: checker quad
           offset: [0, 0]
-          truncate: false
         - src: checker quad
           offset: [8, 0]
-          truncate: false
         - src: checker quad
           offset: [0, -8]
-          truncate: false
         - src: checker quad
           offset: [8, -8]
-          truncate: false
 placements:
   - src: checker octo
     offset: [0, 0]
-    truncate: false
   - src: checker octo
     offset: [16, 0]
-    truncate: false
   - src: checker octo
     offset: [0, -16]
-    truncate: false
   - src: checker octo
     offset: [16, -16]
-    truncate: false
 map: ""

--- a/data/test/standalone-topography/circle-and-crosses.yaml
+++ b/data/test/standalone-topography/circle-and-crosses.yaml
@@ -20,10 +20,8 @@ structures:
       placements:
         - src: beam
           offset: [0, 3]
-          truncate: false
         - src: beam
           offset: [-3, -3]
-          truncate: false
           orient:
             up: east
       map: ""
@@ -44,23 +42,18 @@ structures:
 placements:
   - src: cross
     offset: [0, -15]
-    truncate: false
   - src: cross
     offset: [0, 0]
-    truncate: false
     orient:
       up: east
   - src: cross
     offset: [15, 0]
-    truncate: false
     orient:
       up: south
   - src: cross
     offset: [15, -15]
-    truncate: false
     orient:
       up: west
   - src: disc
     offset: [8, -8]
-    truncate: false
 map: ""

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Placement.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Placement.hs
@@ -76,7 +76,6 @@ data Pose = Pose
 
 data Placement = Placement
   { src :: StructureName
-  , truncateOverlay :: Bool
   , structurePose :: Pose
   }
   deriving (Eq, Show)
@@ -84,7 +83,6 @@ data Placement = Placement
 instance FromJSON Placement where
   parseJSON = withObject "structure placement" $ \v -> do
     src <- v .: "src"
-    truncateOverlay <- v .:? "truncate" .!= True
     offset <- v .:? "offset" .!= origin
     orient <- v .:? "orient" .!= defaultOrientation
     let structurePose = Pose offset orient


### PR DESCRIPTION
In the implementation of #1826, I decided to preserve the old truncating behavior as the default.  But after some consideration, there's no real use case for the old behavior, so let's take it out to simplify the code.