### PR TITLE
Save current REPL input with down arrow

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/REPL.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/REPL.hs
@@ -57,8 +57,7 @@ togglePilotingMode = do
       if T.null uinput
         then uiState . uiGameplay . uiREPL . replControlMode .= Piloting
         else do
-          let err = REPLError "Please clear the REPL before engaging pilot mode."
-          uiState . uiGameplay . uiREPL . replHistory %= addREPLItem err
+          addREPLHistItem $ mkREPLError "Please clear the REPL before engaging pilot mode."
           invalidateCacheEntry REPLHistoryCache
 
 toggleCustomKeyHandling :: EventM Name AppState ()

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -100,7 +100,7 @@ updateUI = do
           let finalType = stripCmd (env ^. envTydefs) pty
               itName = fromString $ "it" ++ show itIx
               out = T.intercalate " " [itName, ":", prettyText finalType, "=", into (prettyValue v)]
-          uiState . uiGameplay . uiREPL . replHistory %= addREPLItem (REPLOutput out)
+          addREPLHistItem (mkREPLOutput out)
           invalidateCacheEntry REPLHistoryCache
           vScrollToEnd replScroll
           gameState . gameControls . replStatus .= REPLDone (Just (finalType, v))

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -34,6 +34,7 @@ import Swarm.Game.World.Coords
 import Swarm.Language.Capability (Capability (CDebug))
 import Swarm.Language.Syntax hiding (Key)
 import Swarm.TUI.Model
+import Swarm.TUI.Model.Repl (REPLHistItem, REPLPrompt, REPLState, addREPLItem, replHistory, replPromptText, replPromptType)
 import Swarm.TUI.Model.UI
 import Swarm.TUI.View.Util (generateModal)
 import System.Clock (Clock (..), getTime)
@@ -196,3 +197,15 @@ runBaseTerm = maybe (pure ()) startBaseProgram
     gameState . baseRobot . machine %= continue t
     -- Finally, be sure to activate the base robot.
     gameState %= execState (zoomRobots $ activateRobot 0)
+
+-- | Set the REPL to the given text and REPL prompt type.
+modifyResetREPL :: Text -> REPLPrompt -> REPLState -> REPLState
+modifyResetREPL t r = (replPromptText .~ t) . (replPromptType .~ r)
+
+-- | Reset the REPL state to the given text and REPL prompt type.
+resetREPL :: MonadState AppState m => Text -> REPLPrompt -> m ()
+resetREPL t p = uiState . uiGameplay . uiREPL %= modifyResetREPL t p
+
+-- | Add an item to the REPL history.
+addREPLHistItem :: MonadState AppState m => REPLHistItem -> m ()
+addREPLHistItem item = uiState . uiGameplay . uiREPL . replHistory %= addREPLItem item

--- a/src/swarm-tui/Swarm/TUI/Model/Repl.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Repl.hs
@@ -8,9 +8,16 @@
 -- SPDX-License-Identifier: BSD-3-Clause
 module Swarm.TUI.Model.Repl (
   -- ** REPL
+  REPLEntryType (..),
+  REPLHistItemType (..),
   REPLHistItem (..),
-  replItemText,
+  mkREPLSubmission,
+  mkREPLSaved,
+  mkREPLOutput,
+  mkREPLError,
   isREPLEntry,
+  getREPLSubmitted,
+  isREPLSaved,
   getREPLEntry,
   REPLHistory,
   replIndex,
@@ -73,47 +80,86 @@ import Prelude hiding (Applicative (..))
 -- REPL History
 ------------------------------------------------------------
 
--- | An item in the REPL history.
-data REPLHistItem
-  = -- | Something entered by the user.
-    REPLEntry Text
-  | -- | A response printed by the system.
-    REPLOutput Text
-  | -- | An error printed by the system.
-    REPLError Text
+-- | Whether a user REPL entry was submitted or merely saved.
+data REPLEntryType
+  = -- | The entry was submitted (with Enter) and should thus be shown
+    --   in the REPL scrollback.
+    REPLEntrySubmitted
+  | -- | The entry was merely saved (e.g. by hitting down
+    --   arrow) and should thus be available in the history but not
+    --   shown in the scrollback.
+    REPLEntrySaved
   deriving (Eq, Ord, Show, Read)
+
+-- | Various types of REPL history items (user input, output, error).
+data REPLHistItemType
+  = -- | Something entered by the user.
+    REPLEntry REPLEntryType
+  | -- | A response printed by the system.
+    REPLOutput
+  | -- | An error printed by the system.
+    REPLError
+  deriving (Eq, Ord, Show, Read)
+
+-- | An item in the REPL history.
+data REPLHistItem = REPLHistItem {replItemType :: REPLHistItemType, replItemText :: Text}
+  deriving (Eq, Ord, Show, Read)
+
+mkREPLSubmission :: Text -> REPLHistItem
+mkREPLSubmission = REPLHistItem (REPLEntry REPLEntrySubmitted)
+
+mkREPLSaved :: Text -> REPLHistItem
+mkREPLSaved = REPLHistItem (REPLEntry REPLEntrySaved)
+
+mkREPLOutput :: Text -> REPLHistItem
+mkREPLOutput = REPLHistItem REPLOutput
+
+mkREPLError :: Text -> REPLHistItem
+mkREPLError = REPLHistItem REPLError
 
 instance ToSample REPLHistItem where
   toSamples _ =
     SD.samples
-      [ REPLEntry "grab"
-      , REPLOutput "it0 : text = \"tree\""
-      , REPLEntry "place tree"
-      , REPLError "1:7: Unbound variable tree"
+      [ REPLHistItem (REPLEntry REPLEntrySubmitted) "grab"
+      , REPLHistItem REPLOutput "it0 : text = \"tree\""
+      , REPLHistItem (REPLEntry REPLEntrySaved) "place"
+      , REPLHistItem (REPLEntry REPLEntrySubmitted) "place tree"
+      , REPLHistItem REPLError "1:7: Unbound variable tree"
       ]
 
 instance ToJSON REPLHistItem where
-  toJSON e = case e of
-    REPLEntry x -> object ["in" .= x]
-    REPLOutput x -> object ["out" .= x]
-    REPLError x -> object ["err" .= x]
+  toJSON (REPLHistItem itemType x) = object [label .= x]
+   where
+    label = case itemType of
+      REPLEntry REPLEntrySubmitted -> "in"
+      REPLEntry REPLEntrySaved -> "save"
+      REPLOutput -> "out"
+      REPLError -> "err"
 
--- | Useful helper function to only get user input text.
+-- | Useful helper function to only get user input text.  Gets all
+--   user input, including both submitted and saved history items.
 getREPLEntry :: REPLHistItem -> Maybe Text
 getREPLEntry = \case
-  REPLEntry t -> Just t
+  REPLHistItem (REPLEntry {}) t -> Just t
   _ -> Nothing
 
--- | Useful helper function to filter out REPL output.
+-- | Useful helper function to filter out REPL output.  Returns True
+--   for all user input, including both submitted and saved history
+--   items.
 isREPLEntry :: REPLHistItem -> Bool
 isREPLEntry = isJust . getREPLEntry
 
--- | Get the text of REPL input/output.
-replItemText :: REPLHistItem -> Text
-replItemText = \case
-  REPLEntry t -> t
-  REPLOutput t -> t
-  REPLError t -> t
+-- | Helper function to get only submitted user input text.
+getREPLSubmitted :: REPLHistItem -> Maybe Text
+getREPLSubmitted = \case
+  REPLHistItem (REPLEntry REPLEntrySubmitted) t -> Just t
+  _ -> Nothing
+
+-- | Useful helper function to filter out saved REPL entries (which
+--   should not be shown in the scrollback).
+isREPLSaved :: REPLHistItem -> Bool
+isREPLSaved (REPLHistItem (REPLEntry REPLEntrySaved) _) = True
+isREPLSaved _ = False
 
 -- | History of the REPL with indices (0 is first entry) to the current
 --   line and to the first entry since loading saved history.
@@ -216,7 +262,7 @@ moveReplHistIndex d lastEntered history = history & replIndex .~ newIndex
   (olderP, newer) = Seq.splitAt curIndex entries
   -- find first different entry in direction
   notSameEntry = \case
-    REPLEntry t -> t /= curText
+    REPLHistItem (REPLEntry {}) t -> t /= curText
     _ -> False
   newIndex = case d of
     Newer -> maybe historyLen (curIndex +) $ Seq.findIndexL notSameEntry newer
@@ -229,11 +275,11 @@ replIndexIsAtInput :: REPLHistory -> Bool
 replIndexIsAtInput repl = repl ^. replIndex == replLength repl
 
 -- | Given some text,  removes the 'REPLEntry' within 'REPLHistory' which is equal to that.
---   This is used when the user enters in search mode and want to traverse the history.
+--   This is used when the user enters search mode and wants to traverse the history.
 --   If a command has been used many times, the history will be populated with it causing
 --   the effect that search command always finds the same command.
 removeEntry :: Text -> REPLHistory -> REPLHistory
-removeEntry foundtext hist = hist & replSeq %~ Seq.filter (/= REPLEntry foundtext)
+removeEntry foundtext hist = hist & replSeq %~ Seq.filter ((/= Just foundtext) . getREPLEntry)
 
 -- | Get the last 'REPLEntry' in 'REPLHistory' matching the given text
 lastEntry :: Text -> REPLHistory -> Maybe Text

--- a/src/swarm-tui/Swarm/TUI/Model/UI.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI.hs
@@ -341,7 +341,7 @@ initUIState ::
   m UIState
 initUIState speedFactor showMainMenu cheatMode = do
   historyT <- sendIO $ readFileMayT =<< getSwarmHistoryPath False
-  let history = maybe [] (map REPLEntry . T.lines) historyT
+  let history = maybe [] (map mkREPLSubmission . T.lines) historyT
   startTime <- sendIO $ getTime Monotonic
   achievements <- loadAchievementsInfo
   launchConfigPanel <- sendIO initConfigPanel

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -1601,7 +1601,7 @@ drawREPL s =
  where
   -- rendered history lines fitting above REPL prompt
   history :: [Widget n]
-  history = map fmt . toList . getSessionREPLHistoryItems $ theRepl ^. replHistory
+  history = map fmt . filter (not . isREPLSaved) . toList . getSessionREPLHistoryItems $ theRepl ^. replHistory
   currentPrompt :: Widget Name
   currentPrompt = case (isActive <$> base, theRepl ^. replControlMode) of
     (_, Handling) -> padRight Max $ txt "[key handler running, M-k to toggle]"
@@ -1613,9 +1613,10 @@ drawREPL s =
   -- indexing that may be an alternative to this:
   base = s ^. gameState . robotInfo . robotMap . at 0
 
-  fmt (REPLEntry e) = txt $ "> " <> e
-  fmt (REPLOutput t) = txt t
-  fmt (REPLError t) = txtWrapWith indent2 {preserveIndentation = True} t
+  fmt (REPLHistItem itemType t) = case itemType of
+    REPLEntry {} -> txt $ "> " <> t
+    REPLOutput -> txt t
+    REPLError -> txtWrapWith indent2 {preserveIndentation = True} t
   mayDebug = [drawRobotMachine s True | s ^. uiState . uiGameplay . uiShowDebug]
 
 ------------------------------------------------------------

--- a/test/unit/TestRepl.hs
+++ b/test/unit/TestRepl.hs
@@ -27,21 +27,21 @@ testRepl =
         "latest repl lines after one input"
         ( assertEqual
             "get 5 history [0|()] --> [()]"
-            [REPLEntry "()"]
-            (getLatestREPLHistoryItems 5 (addREPLItem (REPLEntry "()") history0))
+            [mkREPLSubmission "()"]
+            (getLatestREPLHistoryItems 5 (addREPLItem (mkREPLSubmission "()") history0))
         )
     , testCase
         "latest repl lines after one input and output"
         ( assertEqual
             "get 5 history [0|1,1:Int] --> [1,1:Int]"
-            [REPLEntry "1", REPLOutput "1:Int"]
+            [mkREPLSubmission "1", mkREPLOutput "1:Int"]
             (getLatestREPLHistoryItems 5 (addInOutInt 1 history0))
         )
     , testCase
         "latest repl lines after nine inputs and outputs"
         ( assertEqual
             "get 6 history [0|1,1:Int .. 9,9:Int] --> [7,7:Int..9,9:Int]"
-            (concat [[REPLEntry (toT x), REPLOutput (toT x <> ":Int")] | x <- [7 .. 9]])
+            (concat [[mkREPLSubmission (toT x), mkREPLOutput (toT x <> ":Int")] | x <- [7 .. 9]])
             (getLatestREPLHistoryItems 6 (foldl (flip addInOutInt) history0 [1 .. 9]))
         )
     , testCase
@@ -49,7 +49,7 @@ testRepl =
         ( assertEqual
             "get 5 history (restart [0|()]) --> []"
             []
-            (getLatestREPLHistoryItems 5 (restartREPLHistory $ addREPLItem (REPLEntry "()") history0))
+            (getLatestREPLHistoryItems 5 (restartREPLHistory $ addREPLItem (mkREPLSubmission "()") history0))
         )
     , testCase
         "current item at start"
@@ -84,8 +84,8 @@ testRepl =
         )
     ]
  where
-  history0 = newREPLHistory [REPLEntry "0"]
+  history0 = newREPLHistory [mkREPLSubmission "0"]
   toT :: Int -> Text
   toT = fromString . show
   addInOutInt :: Int -> REPLHistory -> REPLHistory
-  addInOutInt i = addREPLItem (REPLOutput $ toT i <> ":Int") . addREPLItem (REPLEntry $ toT i)
+  addInOutInt i = addREPLItem (mkREPLOutput $ toT i <> ":Int") . addREPLItem (mkREPLSubmission $ toT i)


### PR DESCRIPTION
Closes #713.

Also does a bit of refactoring:
- Decompose `REPLHistItem` into a `REPLHistItemType` and some `Text` instead of having multiple constructors all containing a `Text`
- Add some helpers in `Controller.Util` to cut down on duplicated code