### PR TITLE
Focus REPL panel on click

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -428,13 +428,14 @@ handleMainEvent ev = do
           EC.activateWorldEditorFunction y
         _ -> return ()
       flip whenJust setFocus $ case n of
-        -- Adapt click event origin to their right panel.
-        -- For the REPL and the World view, using 'Brick.Widgets.Core.clickable' correctly set the origin.
-        -- However this does not seems to work for the robot and info panel.
-        -- Thus we force the destination focus here.
+        -- Adapt click event origin to the right panel.  For the world
+        -- view, we just use 'Brick.Widgets.Core.clickable'.  However,
+        -- the other panels all have a viewport, requiring us to
+        -- explicitly set their focus here.
         InventoryList -> Just RobotPanel
         InventoryListItem _ -> Just RobotPanel
         InfoViewport -> Just InfoPanel
+        REPLViewport -> Just REPLPanel
         REPLInput -> Just REPLPanel
         WorldEditorPanelControl _ -> Just WorldEditorPanel
         _ -> Nothing


### PR DESCRIPTION
Closes #1486.

I'm not entirely sure I understand why this is necessary but it seems like for anything with a brick `viewport` it's not enough to just rely on wrapping it in `clickable`.  We have to actually set their focus explicitly depending on the identity of the clicked viewport.