### PR TITLE
On C-c, only cancel base CESK if it is currently running

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -1024,7 +1024,8 @@ handleREPLEvent x = do
     -- Handle Ctrl-c here so we can always cancel the currently running
     -- base program no matter what REPL control mode we are in.
     ControlChar 'c' -> do
-      gameState . baseRobot . machine %= cancel
+      working <- use $ gameState . gameControls . replWorking
+      when working $ gameState . baseRobot . machine %= cancel
       Brick.zoom (uiState . uiGameplay . uiREPL) $ do
         replPromptType .= CmdPrompt []
         replPromptText .= ""


### PR DESCRIPTION
Fixes #2007.  After #1928, we handle exceptions a little differently, so it no longer works to simply set the base's CESK machine to an `Up` (exception) state no matter what.  Instead we have to first check if the base is running, and if so set it to `Up` as before; if not, do nothing (except clear the REPL prompt).
