### PR TITLE
Fix release URL asset path in Haskell release action

### DIFF
--- a/.github/workflows/haskell-release.yml
+++ b/.github/workflows/haskell-release.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Get Release File Name & Upload URL
         id: get_release_info
         run: |
-          echo "upload_url=$(cat release_url/release_url.txt)" >> "$GITHUB_OUTPUT"
+          echo "upload_url=$(cat release_url.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Upload Release Asset
         id: upload-release-asset


### PR DESCRIPTION
The `create_release` job worked fine.  The `build_artifact` job, however, after downloading the `release_url` artifact, seemed to be looking for it in the wrong place --- it tried to access `release_url/release_url.txt`, but the corrsponding zip file contains only the file `release_url.txt` with no folder.

This PR fixes the job to look for the `release_url.txt` file in the correct (I hope) place.