### PR TITLE
set required cabal-version to 3.6

### DIFF
--- a/swarm.cabal
+++ b/swarm.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.8
+cabal-version: 3.6
 name: swarm
 version: 0.6.0.0
 synopsis: 2D resource gathering game with programmable robots


### PR DESCRIPTION
Hackage does not like `cabal-version: 3.8`, it requires at most 3.6.  I don't know if there was a specific reason we were using 3.8, but it seems to work fine with 3.6 specified.