### PR TITLE
ensure non-overlapping mask char

### DIFF
--- a/data/scenarios/Testing/_Validation/2077-mask-char.yaml
+++ b/data/scenarios/Testing/_Validation/2077-mask-char.yaml
@@ -1,0 +1,14 @@
+version: 1
+name: Mask char palette overlap
+description: |
+  Ensure mask char is not used as a palette key
+robots: []
+world:
+  mask: q
+  palette:
+    '.': [grass]
+    'q': [dirt]
+  upperleft: [0, 0]
+  map: |
+    ..
+    ..


### PR DESCRIPTION
We want to ensure that the character used for the `mask` does not also occur as an entry in the `palette`.

# Testing
Added new test:
```
scripts/play.sh -i data/scenarios/Testing/_Validation/2077-mask-char.yaml
```
# Also in this PR

To simplify the test, we make use of the fact that `mask` is now also supported at the toplevel in addition to within a `structure` definition.