### PR TITLE
remove pandoc dependency from main game

### DIFF
--- a/app/doc/Main.hs
+++ b/app/doc/Main.hs
@@ -19,6 +19,7 @@ cliParser =
       , command "editors" (info (EditorKeywords <$> editor <**> helper) $ progDesc "Output editor keywords")
       , command "keys" (info (pure SpecialKeyNames) $ progDesc "Output list of recognized special key names")
       , command "cheatsheet" (info (CheatSheet <$> address <*> cheatsheet <**> helper) $ progDesc "Output nice Wiki tables")
+      , command "commands" (info (pure CommandsData <**> helper) $ progDesc "Output JSON data for commands matrix")
       , command "pedagogy" (info (pure TutorialCoverage) $ progDesc "Output tutorial coverage")
       ]
  where

--- a/scripts/gen/commands-matrix-data.sh
+++ b/scripts/gen/commands-matrix-data.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/../..
+
+cabal run -j -O0 -- swarm-docs commands | jq . > web/data/commands.json

--- a/src/swarm-doc/Swarm/Doc/Gen.hs
+++ b/src/swarm-doc/Swarm/Doc/Gen.hs
@@ -24,6 +24,7 @@ module Swarm.Doc.Gen (
 
 import Control.Lens (view, (^.))
 import Control.Monad (zipWithM, zipWithM_)
+import Data.Aeson.Text (encodeToLazyText)
 import Data.Containers.ListUtils (nubOrd)
 import Data.Foldable (toList)
 import Data.List qualified as List
@@ -36,7 +37,9 @@ import Data.Set qualified as Set
 import Data.Text (Text, unpack)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
+import Data.Text.Lazy.IO qualified as TL
 import Data.Tuple (swap)
+import Swarm.Doc.Command (getCatalog)
 import Swarm.Doc.Keyword
 import Swarm.Doc.Pedagogy
 import Swarm.Doc.Util
@@ -73,6 +76,8 @@ data GenerateDocs where
   SpecialKeyNames :: GenerateDocs
   -- | Cheat sheets for inclusion on the Swarm wiki.
   CheatSheet :: PageAddress -> SheetType -> GenerateDocs
+  -- | JSON representation of commands metadata matrix
+  CommandsData :: GenerateDocs
   -- | List command introductions by tutorial
   TutorialCoverage :: GenerateDocs
   deriving (Eq, Show)
@@ -94,6 +99,7 @@ generateDocs = \case
         mapM_ editorGen enumerate
   SpecialKeyNames -> generateSpecialKeyNames
   CheatSheet address s -> makeWikiPage address s
+  CommandsData -> TL.putStrLn $ encodeToLazyText getCatalog
   TutorialCoverage -> renderTutorialProgression >>= putStrLn . T.unpack
 
 -- ----------------------------------------------------------------------------

--- a/src/swarm-web/Swarm/Web.hs
+++ b/src/swarm-web/Swarm/Web.hs
@@ -63,7 +63,6 @@ import Servant
 import Servant.Docs (ToCapture)
 import Servant.Docs qualified as SD
 import Servant.Docs.Internal qualified as SD (renderCurlBasePath)
-import Swarm.Doc.Command
 import Swarm.Game.Entity (EntityName, entityName)
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Objective
@@ -110,7 +109,6 @@ type SwarmAPI =
     :<|> "code" :> "render" :> ReqBody '[PlainText] T.Text :> Post '[PlainText] T.Text
     :<|> "code" :> "run" :> ReqBody '[PlainText] T.Text :> Post '[PlainText] T.Text
     :<|> "paths" :> "log" :> Get '[JSON] (RingBuffer CacheLogEntry)
-    :<|> "commands" :> Get '[JSON] CommandCatalog
     :<|> "repl" :> "history" :> "full" :> Get '[JSON] [REPLHistItem]
     :<|> "map" :> Capture "size" AreaDimensions :> Get '[JSON] GridResponse
 
@@ -166,7 +164,6 @@ mkApp state events =
     :<|> codeRenderHandler
     :<|> codeRunHandler events
     :<|> pathsLogHandler state
-    :<|> cmdMatrixHandler state
     :<|> replHistHandler state
     :<|> mapViewHandler state
 
@@ -245,9 +242,6 @@ pathsLogHandler :: ReadableIORef AppState -> Handler (RingBuffer CacheLogEntry)
 pathsLogHandler appStateRef = do
   appState <- liftIO (readIORef appStateRef)
   pure $ appState ^. gameState . pathCaching . pathCachingLog
-
-cmdMatrixHandler :: ReadableIORef AppState -> Handler CommandCatalog
-cmdMatrixHandler _ = pure getCatalog
 
 replHistHandler :: ReadableIORef AppState -> Handler [REPLHistItem]
 replHistHandler appStateRef = do

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -499,7 +499,6 @@ library swarm-web
     witch,
 
   build-depends:
-    swarm:swarm-doc,
     swarm:swarm-engine,
     swarm:swarm-lang,
     swarm:swarm-scenario,

--- a/web/data/README.md
+++ b/web/data/README.md
@@ -1,0 +1,4 @@
+Regenerate this data with:
+```
+scripts/gen/commands-matrix-data.sh
+```

--- a/web/data/commands.json
+++ b/web/data/commands.json
@@ -1,0 +1,4189 @@
+{
+  "entries": [
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Noop",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": true,
+        "returnsValue": false
+      },
+      "effects": []
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BInt"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Wait",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Selfdestruct",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "ExistenceChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Move",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": true,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "PositionChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Backup",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": true,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "PositionChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BInt"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Volume",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF (TCBase BInt) [])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCSum": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCSum": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BText"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCProd": []
+                        },
+                        [
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BDir"
+                              },
+                              []
+                            ]
+                          },
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BInt"
+                              },
+                              []
+                            ]
+                          }
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Path",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF TCProd [Fix (TyConF (TCBase BDir) []),Fix (TyConF (TCBase BInt) [])])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Push",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": true,
+        "movesRobot": true,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "PositionChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BInt"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Stride",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": true,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "PositionChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BDir"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Turn",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": true,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "PositionChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BText"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Grab",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BText) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BText"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Harvest",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BText) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Sow",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BDir"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Ignite",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Place",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BActor"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCProd": []
+                        },
+                        [
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BInt"
+                              },
+                              []
+                            ]
+                          },
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BInt"
+                              },
+                              []
+                            ]
+                          }
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Ping",
+      "derivedAttrs": {
+        "hasActorTarget": true,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF (TCBase BInt) [])])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BActor"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Give",
+      "derivedAttrs": {
+        "hasActorTarget": true,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Equip",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Unequip",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Make",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BBool"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Has",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BBool) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BBool"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Equipped",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BBool) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Count",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BInt) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BDir"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BText"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Drill",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF (TCBase BText) [])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCBase": "BDir"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BText"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Use",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF (TCBase BText) [])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCDelay": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCCmd": []
+                  },
+                  [
+                    {
+                      "TyVarF": "a"
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BActor"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Build",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BActor) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "ExistenceChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Salvage",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "ExistenceChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BActor"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCDelay": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCCmd": []
+                  },
+                  [
+                    {
+                      "TyVarF": "a"
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Reprogram",
+      "derivedAttrs": {
+        "hasActorTarget": true,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Say",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BText"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Listen",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BText) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Log",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "LogEmission"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BActor"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "View",
+      "derivedAttrs": {
+        "hasActorTarget": true,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCSum": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BText"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Appear",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "Cosmetic"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Create",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BActor"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Halt",
+      "derivedAttrs": {
+        "hasActorTarget": true,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Time",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BInt) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "WorldCondition",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BDir"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BBool"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Scout",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BBool) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Whereami",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF (TCBase BInt) [])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCBase": "BInt"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCProd": []
+                        },
+                        [
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BInt"
+                              },
+                              []
+                            ]
+                          },
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BInt"
+                              },
+                              []
+                            ]
+                          }
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Waypoint",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF (TCBase BInt) [])])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "APriori"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCBase": "BInt"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCProd": []
+                        },
+                        [
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BInt"
+                              },
+                              []
+                            ]
+                          },
+                          {
+                            "TyConF": [
+                              {
+                                "TCProd": []
+                              },
+                              [
+                                {
+                                  "TyConF": [
+                                    {
+                                      "TCBase": "BInt"
+                                    },
+                                    []
+                                  ]
+                                },
+                                {
+                                  "TyConF": [
+                                    {
+                                      "TCBase": "BInt"
+                                    },
+                                    []
+                                  ]
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Structure",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF (TCBase BInt) [])])])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Floorplan",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF (TCBase BInt) [])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "APriori"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BBool"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "HasTag",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BBool) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "APriori"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCBase": "BInt"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BText"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "TagMembers",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF (TCBase BText) [])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "APriori"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCProd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCProd": []
+                        },
+                        [
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BInt"
+                              },
+                              []
+                            ]
+                          },
+                          {
+                            "TyConF": [
+                              {
+                                "TCBase": "BInt"
+                              },
+                              []
+                            ]
+                          }
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Detect",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF TCProd [Fix (TyConF (TCBase BInt) []),Fix (TyConF (TCBase BInt) [])])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCProd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Resonate",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BInt) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCProd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCProd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BInt"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Density",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BInt) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Sniff",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BInt) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BDir"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Chirp",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BDir) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BDir"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Watch",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCProd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Surveil",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BDir"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Heading",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BDir) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BBool"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Blocked",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BBool) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BDir"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BText"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Scan",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF (TCBase BText) [])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BActor"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Upload",
+      "derivedAttrs": {
+        "hasActorTarget": true,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BBool"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Ishere",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BBool) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BBool"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Isempty",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BBool) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "EntitySensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCSum": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    },
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BActor"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Meet",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF (TCBase BActor) [])])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyRecF": [
+                  "l",
+                  {
+                    "TyConF": [
+                      {
+                        "TCSum": []
+                      },
+                      [
+                        {
+                          "TyConF": [
+                            {
+                              "TCBase": "BUnit"
+                            },
+                            []
+                          ]
+                        },
+                        {
+                          "TyConF": [
+                            {
+                              "TCProd": []
+                            },
+                            [
+                              {
+                                "TyConF": [
+                                  {
+                                    "TCBase": "BActor"
+                                  },
+                                  []
+                                ]
+                              },
+                              {
+                                "TyRecVarF": {
+                                  "tag": "NZ"
+                                }
+                              }
+                            ]
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "MeetAll",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyRecF \"l\" (Fix (TyConF TCSum [Fix (TyConF (TCBase BUnit) []),Fix (TyConF TCProd [Fix (TyConF (TCBase BActor) []),Fix (TyRecVarF NZ)])])))])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BText"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Whoami",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BText) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Setname",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BInt"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Random",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BInt) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "PRNG"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Run",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyVarF": "a"
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyVarF": "a"
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Return",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyVarF \"a\")])",
+        "pureComputation": true,
+        "returnsValue": true
+      },
+      "effects": []
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCDelay": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCCmd": []
+                  },
+                  [
+                    {
+                      "TyVarF": "a"
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCDelay": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCCmd": []
+                  },
+                  [
+                    {
+                      "TyVarF": "a"
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyVarF": "a"
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Try",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyVarF \"a\")])",
+        "pureComputation": true,
+        "returnsValue": true
+      },
+      "effects": []
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BText"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Swap",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": true,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BText) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "tag": "EntityChange"
+          },
+          "tag": "Mutation"
+        },
+        {
+          "contents": {
+            "contents": "InventoryChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyVarF": "a"
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyVarF": "a"
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Atomic",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyVarF \"a\")])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "tag": "MetaEffect"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyVarF": "a"
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyVarF": "a"
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Instant",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyVarF \"a\")])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "tag": "MetaEffect"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCFun": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BKey"
+                  },
+                  []
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCCmd": []
+                  },
+                  [
+                    {
+                      "TyConF": [
+                        {
+                          "TCBase": "BUnit"
+                        },
+                        []
+                      ]
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "InstallKeyHandler",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BActor"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCProd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              },
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BInt"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BUnit"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Teleport",
+      "derivedAttrs": {
+        "hasActorTarget": true,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": true,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BUnit) [])])",
+        "pureComputation": false,
+        "returnsValue": false
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "PositionChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BActor"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCDelay": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCCmd": []
+                  },
+                  [
+                    {
+                      "TyVarF": "a"
+                    }
+                  ]
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyVarF": "a"
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "As",
+      "derivedAttrs": {
+        "hasActorTarget": true,
+        "modifiesEnvironment": false,
+        "modifiesRobot": true,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyVarF \"a\")])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "BehaviorChange",
+            "tag": "RobotChange"
+          },
+          "tag": "Mutation"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BActor"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "RobotNamed",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BActor) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BInt"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BActor"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "RobotNumbered",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BActor) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    },
+    {
+      "argTypes": [
+        {
+          "TyConF": [
+            {
+              "TCBase": "BText"
+            },
+            []
+          ]
+        },
+        {
+          "TyConF": [
+            {
+              "TCCmd": []
+            },
+            [
+              {
+                "TyConF": [
+                  {
+                    "TCBase": "BBool"
+                  },
+                  []
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "cmd": "Knows",
+      "derivedAttrs": {
+        "hasActorTarget": false,
+        "modifiesEnvironment": false,
+        "modifiesRobot": false,
+        "movesRobot": false,
+        "outputType": "Fix (TyConF TCCmd [Fix (TyConF (TCBase BBool) [])])",
+        "pureComputation": false,
+        "returnsValue": true
+      },
+      "effects": [
+        {
+          "contents": {
+            "contents": "RobotSensing",
+            "tag": "Sensing"
+          },
+          "tag": "Query"
+        }
+      ]
+    }
+  ]
+}

--- a/web/index.html
+++ b/web/index.html
@@ -7,5 +7,6 @@
     <h1>Hello Swarm player!</h1>
     <p>Looking for the <a href="api">Web API docs</a>?</p>
     <p>Or an <a href="play.html">experimental web frontend</a> for the game?</p>
+    <p>Or the <a href="command-matrix.html">Command attributes matrix?</p>
   </body>
 </html>

--- a/web/script/command-matrix.js
+++ b/web/script/command-matrix.js
@@ -42,7 +42,7 @@ function insertTableRows(myTableBody, entries) {
 }
 
 function doFetch(myTable) {
-    fetch("commands")
+    fetch("data/commands.json")
     .then((response) => {
     if (!response.ok) {
         throw new Error(`HTTP error, status = ${response.status}`);


### PR DESCRIPTION
Closes #2083

Rendering a matrix of command attributes was originally implemented in #1658.  But this generated the data to drive the table at runtime, which pulled in an unfortunate Pandoc dependency.

To work around this, let's just pre-generate the data offline.

# Demo

1. `scripts/play.sh`
2. Visit http://localhost:5357/command-matrix.html