### PR TITLE
test and schema update for toplevel mask

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -67,3 +67,4 @@ Achievements
 1533-sow-command.yaml
 1533-sow-seed-maturation.yaml
 231-requirements
+2085-toplevel-mask.yaml

--- a/data/scenarios/Testing/2085-toplevel-mask.yaml
+++ b/data/scenarios/Testing/2085-toplevel-mask.yaml
@@ -1,0 +1,45 @@
+version: 1
+name: Toplevel palette mask
+description: |
+  Demo equivalence of 'blank' terrain and
+  the 'mask' property for producing transparent cells.
+seed: 0
+objectives:
+  - goal:
+      - |
+        `grab` a `flower`{=entity}.
+    condition: |
+      as base {has "flower"};
+solution: |
+  move; move; grab;
+robots:
+  - name: base
+    dir: east
+    devices:
+      - treads
+      - logger
+      - grabber
+known: [water, flower]
+world:
+  dsl: |
+    overlay [
+      {grass},
+      mask ((x + y) % 2 == 0) {flower}
+    ]
+  upperleft: [-4, 4]
+  offset: false
+  mask: x
+  palette:
+    'B': [stone, erase, base]
+    '.': [stone, erase]
+    'y': [blank]
+  map: |-
+    yyy...xxx
+    y.......x
+    y.......x
+    .........
+    ....Bxxxx
+    .........
+    x.......y
+    x.......y
+    xxx...yyy

--- a/data/schema/world.json
+++ b/data/schema/world.json
@@ -56,6 +56,10 @@
             "type": "boolean",
             "description": "Whether players are allowed to scroll the world map."
         },
+        "mask": {
+            "type": "string",
+            "description": "A special palette character that indicates that map cell should be transparent"
+        },
         "palette": {
             "type": "object",
             "examples": [{"T": ["grass", "tree"]}],

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -371,6 +371,7 @@ testScenarioSolutions rs ui key =
         , testSolution Default "Testing/1642-biomes"
         , testSolution (Sec 10) "Testing/1533-sow-command"
         , testSolution Default "Testing/1533-sow-seed-maturation"
+        , testSolution Default "Testing/2085-toplevel-mask"
         , testGroup
             -- Note that the description of the classic world in
             -- data/worlds/classic.yaml (automatically tested to some


### PR DESCRIPTION
Also updated the schema to reflect availability of the `mask` property at the toplevel (since #2071).

The `mask` property for indicating transparency in structure overlays has existed since #1332.  In structure overlays, the `mask` is semantically different than a `blank` terrain cell.
```
scripts/play.sh -i data/scenarios/Testing/2085-toplevel-mask.yaml --autoplay
```

![Screenshot from 2024-07-28 17-39-15](https://github.com/user-attachments/assets/feac8c75-25a3-44dc-b49c-a061d09c78af)
