### PR TITLE
Split debug options

### DIFF
--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -138,17 +138,28 @@ cliParser =
   debug :: Parser (Set.Set DebugOption)
   debug = Set.unions <$> many debugOption
   debugOption :: Parser (Set.Set DebugOption)
-  debugOption = option debugOptionList (long "debug" <> short 'd' <> metavar "OPTS" <> hidden <> helpDoc debugOptionHelp)
+  debugOption =
+    option
+      debugOptionList
+      ( long "debug"
+          <> short 'd'
+          <> metavar "OPTS"
+          <> hidden
+          <> helpDoc debugOptionHelp
+          <> completeWith debugCompletions
+      )
+  allDebug = [minBound .. maxBound]
+  debugCompletions = "all" : map debugOptionName allDebug
   debugOptionList :: ReadM (Set.Set DebugOption)
   debugOptionList = eitherReader $ \case
-    "all" -> pure $ Set.fromAscList [minBound .. maxBound]
+    "all" -> pure $ Set.fromAscList allDebug
     opts -> Set.fromList <$> readDebugOptionList opts
   debugOptionHelp :: Maybe Doc
   debugOptionHelp =
     Just . nest 2 . vsep $
       "Use 'all' or a comma separated list of options:"
         : [ fillBreak 20 ("*" <+> pretty name) <+> pretty desc
-          | o <- [minBound .. maxBound]
+          | o <- allDebug
           , let name = debugOptionName o
           , let desc = debugOptionDescription o
           ]

--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -68,9 +68,10 @@ cliParser =
     autoPlay <- autoplay
     speed <- speedFactor
     debugOptions <- debug
+    cheatMode <- cheat
     colorMode <- color
     userWebPort <- webPort
-    return $ AppOpts {..}
+    return $ (\ao -> ao {debugOptions = Set.union cheatMode debugOptions}) $ AppOpts {..}
 
   input :: Parser FormatInput
   input =
@@ -135,7 +136,7 @@ cliParser =
       ]
 
   debug :: Parser (Set.Set DebugOption)
-  debug = Set.unions <$> (([Set.singleton ToggleCreative] <$ cheat) <|> many debugOption)
+  debug = Set.unions <$> many debugOption
   debugOption :: Parser (Set.Set DebugOption)
   debugOption = option debugOptionList (long "debug" <> short 'd' <> metavar "OPTS" <> hidden <> helpDoc debugOptionHelp)
   debugOptionList :: ReadM (Set.Set DebugOption)
@@ -151,8 +152,8 @@ cliParser =
           , let name = debugOptionName o
           , let desc = debugOptionDescription o
           ]
-  cheat :: Parser Bool
-  cheat = flag' True (long "cheat" <> short 'x' <> helpDoc (Just cheatHelp))
+  cheat :: Parser (Set.Set DebugOption)
+  cheat = flag mempty (Set.singleton ToggleCreative) (long "cheat" <> short 'x' <> helpDoc (Just cheatHelp))
   cheatHelp =
     "Enable cheat mode."
       <+> pretty ("This is an alias for --debug=" <> debugOptionName ToggleCreative)

--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -205,7 +205,7 @@ main :: IO ()
 main = do
   cli <- execParser cliInfo
   case cli of
-    Run opts -> print $ debugOptions opts
+    Run opts -> appMain opts
     ListKeybinding initialize p -> printKeybindings initialize p
     Format cfg -> formatSwarmIO cfg
     LSP -> lspMain

--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -10,15 +10,18 @@ module Main (main) where
 
 import Control.Monad (when)
 import Data.Foldable qualified
+import Data.Set qualified as Set
 import Data.Text.IO qualified as T
 import GitHash (GitInfo, giBranch, giHash, tGitInfoCwdTry)
 import Options.Applicative
+import Options.Applicative.Help hiding (color, fullDesc)
 import Swarm.App (appMain)
 import Swarm.Game.ResourceLoading (getSwarmConfigIniFile)
 import Swarm.Language.Format
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Parser.Core (LanguageVersion (..))
 import Swarm.TUI.Model (AppOpts (..), ColorMode (..))
+import Swarm.TUI.Model.DebugOption
 import Swarm.TUI.Model.KeyBindings (KeybindingPrint (..), showKeybindings)
 import Swarm.TUI.Model.UI (defaultInitLgTicksPerSecond)
 import Swarm.Version
@@ -64,7 +67,7 @@ cliParser =
     pausedAtStart <- paused
     autoPlay <- autoplay
     speed <- speedFactor
-    cheatMode <- cheat
+    debugOptions <- debug
     colorMode <- color
     userWebPort <- webPort
     return $ AppOpts {..}
@@ -130,8 +133,30 @@ cliParser =
       , "t/s."
       , "(Negative values are allowed, e.g. -3 means 1 tick per 8 sec.)"
       ]
+
+  debug :: Parser (Set.Set DebugOption)
+  debug = Set.unions <$> (([Set.singleton ToggleCreative] <$ cheat) <|> many debugOption)
+  debugOption :: Parser (Set.Set DebugOption)
+  debugOption = option debugOptionList (long "debug" <> short 'd' <> metavar "OPTS" <> hidden <> helpDoc debugOptionHelp)
+  debugOptionList :: ReadM (Set.Set DebugOption)
+  debugOptionList = eitherReader $ \case
+    "all" -> pure $ Set.fromAscList [minBound .. maxBound]
+    opts -> Set.fromList <$> readDebugOptionList opts
+  debugOptionHelp :: Maybe Doc
+  debugOptionHelp =
+    Just . nest 2 . vsep $
+      "Use 'all' or a comma separated list of options:"
+        : [ fillBreak 20 ("*" <+> pretty name) <+> pretty desc
+          | o <- [minBound .. maxBound]
+          , let name = debugOptionName o
+          , let desc = debugOptionDescription o
+          ]
   cheat :: Parser Bool
-  cheat = switch (long "cheat" <> short 'x' <> help "Enable cheat mode. This allows toggling Creative Mode with Ctrl+v and unlocks \"Testing\" scenarios in the menu.")
+  cheat = flag' True (long "cheat" <> short 'x' <> helpDoc (Just cheatHelp))
+  cheatHelp =
+    "Enable cheat mode."
+      <+> pretty ("This is an alias for --debug=" <> debugOptionName ToggleCreative)
+
   color :: Parser (Maybe ColorMode)
   color = optional $ option colorModeParser (long "color" <> short 'c' <> metavar "MODE" <> help "Use none/8/16/full color mode.")
   colorModeParser =
@@ -180,7 +205,7 @@ main :: IO ()
 main = do
   cli <- execParser cliInfo
   case cli of
-    Run opts -> appMain opts
+    Run opts -> print $ debugOptions opts
     ListKeybinding initialize p -> printKeybindings initialize p
     Format cfg -> formatSwarmIO cfg
     LSP -> lspMain

--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -71,7 +71,11 @@ cliParser =
     cheatMode <- cheat
     colorMode <- color
     userWebPort <- webPort
-    return $ (\ao -> ao {debugOptions = Set.union cheatMode debugOptions}) $ AppOpts {..}
+    -- ApplicativeDo does not give Monad powers, so cheat is added here
+    return $ addToDebug cheatMode $ AppOpts {..}
+
+  addToDebug :: Set.Set DebugOption -> AppOpts -> AppOpts
+  addToDebug cheatMode ao = ao {debugOptions = cheatMode `Set.union` debugOptions ao}
 
   input :: Parser FormatInput
   input =

--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -10,6 +10,7 @@ module Main (main) where
 
 import Control.Monad (when)
 import Data.Foldable qualified
+import Data.List.Extra (enumerate)
 import Data.Set qualified as Set
 import Data.Text.IO qualified as T
 import GitHash (GitInfo, giBranch, giHash, tGitInfoCwdTry)
@@ -152,18 +153,17 @@ cliParser =
           <> helpDoc debugOptionHelp
           <> completeWith debugCompletions
       )
-  allDebug = [minBound .. maxBound]
-  debugCompletions = "all" : map debugOptionName allDebug
+  debugCompletions = "all" : map debugOptionName enumerate
   debugOptionList :: ReadM (Set.Set DebugOption)
   debugOptionList = eitherReader $ \case
-    "all" -> pure $ Set.fromAscList allDebug
+    "all" -> pure $ Set.fromAscList enumerate
     opts -> Set.fromList <$> readDebugOptionList opts
   debugOptionHelp :: Maybe Doc
   debugOptionHelp =
     Just . nest 2 . vsep $
       "Use 'all' or a comma separated list of options:"
         : [ fillBreak 20 ("*" <+> pretty name) <+> pretty desc
-          | o <- allDebug
+          | o <- enumerate
           , let name = debugOptionName o
           , let desc = debugOptionDescription o
           ]

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -172,12 +172,12 @@ handleMainMenuEvent menu = \case
       Nothing -> pure ()
       Just x0 -> case x0 of
         NewGame -> do
-          showTesting <- use $ uiState . uiDebugOptions . icontains ShowTestingScenarios
+          showTesting <- use $ uiState . uiDebugOptions . Lens.contains ShowTestingScenarios
           ss <- use $ runtimeState . scenarios
           uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList showTesting ss)
         Tutorial -> do
           -- Set up the menu stack as if the user had chosen "New Game > Tutorials"
-          showTesting <- use $ uiState . uiDebugOptions . icontains ShowTestingScenarios
+          showTesting <- use $ uiState . uiDebugOptions . Lens.contains ShowTestingScenarios
           ss <- use $ runtimeState . scenarios
           let tutorialCollection = getTutorials ss
               topMenu =
@@ -253,7 +253,7 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
       Nothing -> pure ()
       Just (SISingle siPair) -> invalidateCache >> startGame siPair Nothing
       Just (SICollection _ c) -> do
-        showTesting <- use $ uiState . uiDebugOptions . icontains ShowTestingScenarios
+        showTesting <- use $ uiState . uiDebugOptions . Lens.contains ShowTestingScenarios
         uiState . uiMenu .= NewGameMenu (NE.cons (mkScenarioList showTesting c) scenarioStack)
   CharKey 'o' -> showLaunchDialog
   CharKey 'O' -> showLaunchDialog

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -95,6 +95,7 @@ import Swarm.TUI.Launch.Model
 import Swarm.TUI.Launch.Prep (prepareLaunchDialog)
 import Swarm.TUI.List
 import Swarm.TUI.Model
+import Swarm.TUI.Model.DebugOption (DebugOption (..))
 import Swarm.TUI.Model.Goal
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.Popup (progressPopups)
@@ -171,19 +172,19 @@ handleMainMenuEvent menu = \case
       Nothing -> pure ()
       Just x0 -> case x0 of
         NewGame -> do
-          cheat <- use $ uiState . uiCheatMode
+          showTesting <- use $ uiState . uiDebugOptions . icontains ShowTestingScenarios
           ss <- use $ runtimeState . scenarios
-          uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList cheat ss)
+          uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList showTesting ss)
         Tutorial -> do
           -- Set up the menu stack as if the user had chosen "New Game > Tutorials"
-          cheat <- use $ uiState . uiCheatMode
+          showTesting <- use $ uiState . uiDebugOptions . icontains ShowTestingScenarios
           ss <- use $ runtimeState . scenarios
           let tutorialCollection = getTutorials ss
               topMenu =
                 BL.listFindBy
                   ((== tutorialsDirname) . T.unpack . scenarioItemName)
-                  (mkScenarioList cheat ss)
-              tutorialMenu = mkScenarioList cheat tutorialCollection
+                  (mkScenarioList showTesting ss)
+              tutorialMenu = mkScenarioList showTesting tutorialCollection
               menuStack = tutorialMenu :| pure topMenu
           uiState . uiMenu .= NewGameMenu menuStack
 
@@ -252,8 +253,8 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
       Nothing -> pure ()
       Just (SISingle siPair) -> invalidateCache >> startGame siPair Nothing
       Just (SICollection _ c) -> do
-        cheat <- use $ uiState . uiCheatMode
-        uiState . uiMenu .= NewGameMenu (NE.cons (mkScenarioList cheat c) scenarioStack)
+        showTesting <- use $ uiState . uiDebugOptions . icontains ShowTestingScenarios
+        uiState . uiMenu .= NewGameMenu (NE.cons (mkScenarioList showTesting c) scenarioStack)
   CharKey 'o' -> showLaunchDialog
   CharKey 'O' -> showLaunchDialog
   Key V.KEsc -> exitNewGameMenu scenarioStack

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -23,6 +23,7 @@ import Swarm.TUI.Controller.UpdateUI (updateUI)
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Editor.Model (isWorldEditorEnabled, worldOverdraw)
 import Swarm.TUI.Model
+import Swarm.TUI.Model.DebugOption (DebugOption (ToggleCreative, ToggleWorldEditor))
 import Swarm.TUI.Model.Event (MainEvent (..), SwarmEvent (..))
 import Swarm.TUI.Model.Goal
 import Swarm.TUI.Model.UI
@@ -51,8 +52,8 @@ mainEventHandlers = allHandlers Main $ \case
   FocusRobotEvent -> ("Set focus on the Robot panel", setFocus RobotPanel)
   FocusREPLEvent -> ("Set focus on the REPL panel", setFocus REPLPanel)
   FocusInfoEvent -> ("Set focus on the Info panel", setFocus InfoPanel)
-  ToggleCreativeModeEvent -> ("Toggle creative mode", whenCheating toggleCreativeMode)
-  ToggleWorldEditorEvent -> ("Toggle world editor mode", whenCheating toggleWorldEditor)
+  ToggleCreativeModeEvent -> ("Toggle creative mode", whenDebug ToggleCreative toggleCreativeMode)
+  ToggleWorldEditorEvent -> ("Toggle world editor mode", whenDebug ToggleWorldEditor toggleWorldEditor)
   ToggleREPLVisibilityEvent -> ("Collapse/Expand REPL panel", toggleREPLVisibility)
 
 toggleQuitGameDialog :: EventM Name AppState ()
@@ -149,7 +150,7 @@ isRunning = do
 whenRunning :: EventM Name AppState () -> EventM Name AppState ()
 whenRunning a = isRunning >>= \r -> when r a
 
-whenCheating :: EventM Name AppState () -> EventM Name AppState ()
-whenCheating a = do
-  s <- get
-  when (s ^. uiState . uiCheatMode) a
+whenDebug :: DebugOption -> EventM Name AppState () -> EventM Name AppState ()
+whenDebug d a = do
+  debug <- use $ uiState . uiDebugOptions . icontains d
+  when debug a

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -152,5 +152,5 @@ whenRunning a = isRunning >>= \r -> when r a
 
 whenDebug :: DebugOption -> EventM Name AppState () -> EventM Name AppState ()
 whenDebug d a = do
-  debug <- use $ uiState . uiDebugOptions . icontains d
+  debug <- use $ uiState . uiDebugOptions . contains d
   when debug a

--- a/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
@@ -118,5 +118,5 @@ saveScenarioInfoOnQuit =
         -- Now rebuild the NewGameMenu so it gets the updated ScenarioInfo,
         -- being sure to preserve the same focused scenario.
         sc <- use $ runtimeState . scenarios
-        showTesting <- use $ uiState . uiDebugOptions . icontains ShowTestingScenarios
+        showTesting <- use $ uiState . uiDebugOptions . contains ShowTestingScenarios
         forM_ (mkNewGameMenu showTesting sc (fromMaybe p curPath)) (uiState . uiMenu .=)

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -34,6 +34,7 @@ import Swarm.Language.Value (Value (VExc, VUnit), envTydefs, prettyValue)
 import Swarm.TUI.Controller.SaveScenario (saveScenarioInfoOnFinishNocheat)
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Model
+import Swarm.TUI.Model.DebugOption (DebugOption (..))
 import Swarm.TUI.Model.Goal
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.Popup (Popup (..), addPopup)
@@ -174,7 +175,6 @@ updateUI = do
 doGoalUpdates :: EventM Name AppState Bool
 doGoalUpdates = do
   curGoal <- use (uiState . uiGameplay . uiGoal . goalsContent)
-  isCheating <- use (uiState . uiCheatMode)
   curWinCondition <- use (gameState . winCondition)
   announcementsSeq <- use (gameState . messageInfo . announcementQueue)
   let announcementsList = toList announcementsSeq
@@ -203,7 +203,8 @@ doGoalUpdates = do
       -- advance the menu at that point.
       return True
     WinConditions _ oc -> do
-      let newGoalTracking = GoalTracking announcementsList $ constructGoalMap isCheating oc
+      showHiddenGoals <- use $ uiState . uiDebugOptions . icontains ShowHiddenGoals
+      let newGoalTracking = GoalTracking announcementsList $ constructGoalMap showHiddenGoals oc
           -- The "uiGoal" field is initialized with empty members, so we know that
           -- this will be the first time showing it if it will be nonempty after previously
           -- being empty.
@@ -240,8 +241,9 @@ doGoalUpdates = do
         -- automatically popped up.
         gameState . messageInfo . announcementQueue .= mempty
 
-        hideGoals <- use $ uiState . uiGameplay . uiHideGoals
-        unless hideGoals $
+        isAutoPlay <- use $ uiState . uiGameplay . uiIsAutoPlay
+        showGoalsAnyway <- use $ uiState . uiDebugOptions . icontains ShowGoalDialogsInAutoPlay
+        unless (isAutoPlay && not showGoalsAnyway) $
           openModal GoalModal
 
       return goalWasUpdated

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -203,7 +203,7 @@ doGoalUpdates = do
       -- advance the menu at that point.
       return True
     WinConditions _ oc -> do
-      showHiddenGoals <- use $ uiState . uiDebugOptions . icontains ShowHiddenGoals
+      showHiddenGoals <- use $ uiState . uiDebugOptions . Lens.contains ShowHiddenGoals
       let newGoalTracking = GoalTracking announcementsList $ constructGoalMap showHiddenGoals oc
           -- The "uiGoal" field is initialized with empty members, so we know that
           -- this will be the first time showing it if it will be nonempty after previously
@@ -242,7 +242,7 @@ doGoalUpdates = do
         gameState . messageInfo . announcementQueue .= mempty
 
         isAutoPlay <- use $ uiState . uiGameplay . uiIsAutoPlay
-        showGoalsAnyway <- use $ uiState . uiDebugOptions . icontains ShowGoalDialogsInAutoPlay
+        showGoalsAnyway <- use $ uiState . uiDebugOptions . Lens.contains ShowGoalDialogsInAutoPlay
         unless (isAutoPlay && not showGoalsAnyway) $
           openModal GoalModal
 

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -82,6 +82,7 @@ import Control.Monad.State (MonadState)
 import Data.List (findIndex)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe)
+import Data.Set (Set)
 import Data.Text (Text)
 import Data.Vector qualified as V
 import GitHash (GitInfo)
@@ -99,6 +100,7 @@ import Swarm.Game.Tick (TickNumber (..))
 import Swarm.Game.World.Gen (Seed)
 import Swarm.Log
 import Swarm.TUI.Inventory.Sorting
+import Swarm.TUI.Model.DebugOption (DebugOption)
 import Swarm.TUI.Model.Event (SwarmEvent)
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
@@ -255,8 +257,8 @@ data AppOpts = AppOpts
   -- ^ Automatically run the solution defined in the scenario file
   , speed :: Int
   -- ^ Initial game speed (logarithm)
-  , cheatMode :: Bool
-  -- ^ Should cheat mode be enabled?
+  , debugOptions :: Set DebugOption
+  -- ^ Debugging options, for example show creative switch.
   , colorMode :: Maybe ColorMode
   -- ^ What colour mode should be used?
   , userWebPort :: Maybe Port
@@ -275,7 +277,7 @@ defaultAppOpts =
     , pausedAtStart = False
     , autoPlay = False
     , speed = defaultInitLgTicksPerSecond
-    , cheatMode = False
+    , debugOptions = mempty
     , colorMode = Nothing
     , userWebPort = Nothing
     , repoGitInfo = Nothing

--- a/src/swarm-tui/Swarm/TUI/Model/DebugOption.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/DebugOption.hs
@@ -1,0 +1,58 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Sum type representing the Swarm debug options.
+module Swarm.TUI.Model.DebugOption (
+  DebugOption (..),
+  debugOptionName,
+  debugOptionDescription,
+  readDebugOption,
+  readDebugOptionList,
+) where
+
+import Data.Foldable (find, foldl')
+import Data.List.Extra (enumerate, splitOn, trim)
+
+data DebugOption
+  = ToggleCreative
+  | ToggleWorldEditor
+  | DebugCESK
+  | ListAllRobots
+  | ListRobotIDs
+  | ShowHiddenGoals
+  | ShowGoalDialogsInAutoPlay
+  | ShowTestingScenarios
+  deriving (Eq, Ord, Show, Enum, Bounded)
+
+debugOptionName :: DebugOption -> String
+debugOptionName = \case
+  ToggleCreative -> "creative"
+  ToggleWorldEditor -> "editor"
+  DebugCESK -> "cesk"
+  ListAllRobots -> "all_robots"
+  ListRobotIDs -> "robot_id"
+  ShowHiddenGoals -> "hidden_goals"
+  ShowGoalDialogsInAutoPlay -> "autoplay_goals"
+  ShowTestingScenarios -> "testing"
+
+debugOptionDescription :: DebugOption -> String
+debugOptionDescription = \case
+  ToggleCreative -> "allow toggling creative mode on/off"
+  ToggleWorldEditor -> "allow toggling the world editor mode on/off"
+  DebugCESK -> "allow toggling the CESK debug view on/off"
+  ListAllRobots -> "list all robots (including system robots) in the robot panel"
+  ListRobotIDs -> "list robot IDs in the robot panel"
+  ShowHiddenGoals -> "show hidden objectives in the goal dialog"
+  ShowGoalDialogsInAutoPlay -> "show goal dialogs when running in autoplay"
+  ShowTestingScenarios -> "show Testing folder in scenarios menu"
+
+readDebugOption :: String -> Maybe DebugOption
+readDebugOption name = find ((trim name ==) . debugOptionName) enumerate
+
+readDebugOptionList :: String -> Either String [DebugOption]
+readDebugOptionList = foldl' eitherRead (Right []) . splitOn ","
+ where
+  eitherRead s o = case (s, readDebugOption o) of
+    (Left e, _) -> Left e
+    (_, Nothing) -> Left $ "unknown option '" <> o <> "'"
+    (Right oss, Just os) -> Right $ os : oss

--- a/src/swarm-tui/Swarm/TUI/Model/Goal.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Goal.hs
@@ -102,7 +102,7 @@ hasMultipleGoals gt =
   goalCount = sum . M.elems . M.map NE.length . goals $ gt
 
 constructGoalMap :: Bool -> ObjectiveCompletion -> CategorizedGoals
-constructGoalMap isCheating oc =
+constructGoalMap showHidden oc =
   M.fromList $
     mapMaybe (traverse nonEmpty) categoryList
  where
@@ -118,7 +118,7 @@ constructGoalMap isCheating oc =
       filter (maybe False previewable . view objectivePrerequisite) inactiveGoals
 
   suppressHidden =
-    if isCheating
+    if showHidden
       then id
       else filter $ not . view objectiveHidden
 

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -102,15 +102,15 @@ makePrisms ''Menu
 
 -- | Create a brick 'BL.List' of scenario items from a 'ScenarioCollection'.
 mkScenarioList :: Bool -> ScenarioCollection -> BL.List Name ScenarioItem
-mkScenarioList cheat = flip (BL.list ScenarioList) 1 . V.fromList . filterTest . scenarioCollectionToList
+mkScenarioList showTesting = flip (BL.list ScenarioList) 1 . V.fromList . filterTest . scenarioCollectionToList
  where
-  filterTest = if cheat then id else filter (\case SICollection n _ -> n /= "Testing"; _ -> True)
+  filterTest = if showTesting then id else filter (\case SICollection n _ -> n /= "Testing"; _ -> True)
 
 -- | Given a 'ScenarioCollection' and a 'FilePath' which is the canonical
 --   path to some folder or scenario, construct a 'NewGameMenu' stack
 --   focused on the given item, if possible.
 mkNewGameMenu :: Bool -> ScenarioCollection -> FilePath -> Maybe Menu
-mkNewGameMenu cheat sc path = fmap NewGameMenu $ NE.nonEmpty =<< go (Just sc) (splitPath path) []
+mkNewGameMenu showTesting sc path = fmap NewGameMenu $ NE.nonEmpty =<< go (Just sc) (splitPath path) []
  where
   go ::
     Maybe ScenarioCollection ->
@@ -125,7 +125,7 @@ mkNewGameMenu cheat sc path = fmap NewGameMenu $ NE.nonEmpty =<< go (Just sc) (s
     hasName (SISingle (_, ScenarioInfo pth _)) = takeFileName pth == thing
     hasName (SICollection nm _) = nm == into @Text (dropTrailingPathSeparator thing)
 
-    lst = BL.listFindBy hasName (mkScenarioList cheat curSC)
+    lst = BL.listFindBy hasName (mkScenarioList showTesting curSC)
 
     nextSC = case M.lookup (dropTrailingPathSeparator thing) (scMap curSC) of
       Just (SICollection _ c) -> Just c

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -126,7 +126,7 @@ initPersistentState ::
 initPersistentState opts@(AppOpts {..}) = do
   (warnings :: Seq SystemFailure, (initRS, initUI, initKs)) <- runAccum mempty $ do
     rs <- initRuntimeState pausedAtStart
-    ui <- initUIState speed (not (skipMenu opts)) cheatMode
+    ui <- initUIState speed (not (skipMenu opts)) debugOptions
     ks <- initKeyHandlingState
     return (rs, ui, ks)
   let initRS' = addWarnings initRS (F.toList warnings)
@@ -249,7 +249,6 @@ scenarioToUIState isAutoplaying siPair@(scenario, _) gs u = do
   return $
     u
       & uiPlaying .~ True
-      & uiCheatMode ||~ isAutoplaying
       & uiAttrMap
         .~ applyAttrMappings
           ( map (first getWorldAttrName . toAttrPair) $
@@ -257,7 +256,7 @@ scenarioToUIState isAutoplaying siPair@(scenario, _) gs u = do
           )
           swarmAttrMap
       & uiGameplay . uiGoal .~ emptyGoalDisplay
-      & uiGameplay . uiHideGoals .~ (isAutoplaying && not (u ^. uiCheatMode))
+      & uiGameplay . uiIsAutoPlay .~ isAutoplaying
       & uiGameplay . uiFocusRing .~ initFocusRing
       & uiGameplay . uiInventory . uiInventorySearch .~ Nothing
       & uiGameplay . uiInventory . uiInventoryList .~ Nothing

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -787,8 +787,8 @@ robotsListWidget s = hCenter table
       . IM.elems
       $ g ^. robotInfo . robotMap
   creative = g ^. creativeMode
-  debugRID = s ^. uiState . uiDebugOptions . icontains ListRobotIDs
-  debugAllRobots = s ^. uiState . uiDebugOptions . icontains ListAllRobots
+  debugRID = s ^. uiState . uiDebugOptions . Lens.contains ListRobotIDs
+  debugAllRobots = s ^. uiState . uiDebugOptions . Lens.contains ListAllRobots
   g = s ^. gameState
 
 helpWidget :: Seed -> Maybe Port -> KeyEventHandlingState -> Widget Name
@@ -1015,8 +1015,8 @@ drawKeyMenu s =
   hasDebug = hasDebugCapability creative s
   viewingBase = (s ^. gameState . robotInfo . viewCenterRule) == VCRobot 0
   creative = s ^. gameState . creativeMode
-  showCreative = s ^. uiState . uiDebugOptions . icontains ToggleCreative
-  showEditor = s ^. uiState . uiDebugOptions . icontains ToggleWorldEditor
+  showCreative = s ^. uiState . uiDebugOptions . Lens.contains ToggleCreative
+  showEditor = s ^. uiState . uiDebugOptions . Lens.contains ToggleWorldEditor
   goal = hasAnythingToShow $ s ^. uiState . uiGameplay . uiGoal . goalsContent
   showZero = s ^. uiState . uiGameplay . uiInventory . uiShowZero
   inventorySort = s ^. uiState . uiGameplay . uiInventory . uiInventorySort

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -802,6 +802,7 @@ executable swarm
     base,
     brick,
     containers,
+    extra,
     fused-effects,
     githash >=0.1.6 && <0.2,
     lens,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -715,6 +715,7 @@ library swarm-tui
     Swarm.TUI.Model
     Swarm.TUI.Model.Achievements
     Swarm.TUI.Model.Event
+    Swarm.TUI.Model.DebugOption
     Swarm.TUI.Model.Goal
     Swarm.TUI.Model.KeyBindings
     Swarm.TUI.Model.Menu
@@ -800,6 +801,7 @@ executable swarm
     -- Imports shared with the library don't need bounds
     base,
     brick,
+    containers,
     fused-effects,
     githash >=0.1.6 && <0.2,
     lens,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -714,8 +714,8 @@ library swarm-tui
     Swarm.TUI.List
     Swarm.TUI.Model
     Swarm.TUI.Model.Achievements
-    Swarm.TUI.Model.Event
     Swarm.TUI.Model.DebugOption
+    Swarm.TUI.Model.Event
     Swarm.TUI.Model.Goal
     Swarm.TUI.Model.KeyBindings
     Swarm.TUI.Model.Menu


### PR DESCRIPTION
* replace `_uiCheatMode :: Bool` with `_uiDebugOptions :: (Set DebugOption)`
  * replace `uiHideGoals` with `uiIsAutoPlay` and debug option `ShowGoalDialogsInAutoPlay` 
* add command line flag `--debug` and make `--cheat` an alias for `--debug=creative` only 

```
  -x,--cheat               Enable cheat mode. This is an alias for --debug=creative
  -d,--debug OPTS          Use 'all' or a comma separated list of options:
                             * creative           allow toggling creative mode on/off
                             * editor             allow toggling the world editor mode on/off
                             * cesk               allow toggling the CESK debug view on/off
                             * all_robots         list all robots (including system robots) in the robot panel
                             * robot_id           list robot IDs in the robot panel
                             * hidden_goals       show hidden objectives in the goal dialog
                             * autoplay_goals     show goal dialogs when running in autoplay
                             * testing            show Testing folder in scenarios menu
```

It even has shell completions:
```bash
swarm --zsh-completion-script `which swarm` > ~/.oh-my-zsh/completions/_swarm
swarm --debug  # press Tab
# all  all_robots  autoplay_goals  cesk  creative  editor  hidden_goals  robot_id  testing
```

* closes #1324
