### PR TITLE
Put end on separate line when pretty printing definitions

### DIFF
--- a/src/swarm-lang/Swarm/Language/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Pretty.hs
@@ -316,7 +316,7 @@ instance PrettyPrec (Term' ty) where
         ]
     SLet LSDef _ (LV _ x) mty _ t1 t2 ->
       mconcat $
-        prettyDefinition "def" x mty t1 <+> "end"
+        sep [prettyDefinition "def" x mty t1, "end"]
           : case t2 of
             Syntax' _ (TConst Noop) _ _ -> []
             _ -> [hardline, hardline, ppr t2]


### PR DESCRIPTION
```diff
 def intersperse
   = \n. \f2. \f1.
-  if (n > 0) {f1; if (n > 1) {f2} {}; intersperse (n - 1) f2 f1} {} end
+  if (n > 0) {f1; if (n > 1) {f2} {}; intersperse (n - 1) f2 f1} {}
+ end
```

You can test it with:
```sh
swarm format -i data/scenarios/Challenges/_arbitrage/solution.sw
```

* caused by #1928 where def was made more similar to let