### PR TITLE
Only check for escaped skolem variables among those just generated

### DIFF
--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -656,6 +656,15 @@ testLanguagePipeline =
             "def at cmd type"
             (valid "def x = 3 end; move; return (x+2)")
         ]
+    , testGroup
+        "nested let/def/annot #2101"
+        [ testCase
+            "nested polymorphic def/let"
+            (valid "def id : a -> a = \\y. let x = 3 in y end")
+        , testCase
+            "nested polymorphic def/annot"
+            (valid "def id : a -> a * Int = \\y. (y, 3 : Int) end")
+        ]
     ]
  where
   valid = flip process ""


### PR DESCRIPTION
Fixes #2101.

- Modifies `skolemize` to return the list of generated variable names along with the substituted type (and remove an unnecessary call to `error`!)
- Then in `noSkolems` only check for relevant, recently-generated skolem variables instead of for any skolem variables at all.