### PR TITLE
More generic structure recognition

### DIFF
--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -182,9 +182,10 @@ mkRecognizer ::
 mkRecognizer structInfo@(StaticStructureInfo structDefs _) = do
   foundIntact <- mapM (sequenceA . (id &&& ensureStructureIntact)) allPlaced
   let fs = populateStaticFoundStructures . map fst . filter snd $ foundIntact
-  return $
-    StructureRecognizer
+  return
+    $ StructureRecognizer
       (mkAutomatons structDefs)
+    $ RecognitionState
       fs
       [IntactStaticPlacement $ map mkLogEntry foundIntact]
  where

--- a/src/swarm-engine/Swarm/Game/State/Substate.hs
+++ b/src/swarm-engine/Swarm/Game/State/Substate.hs
@@ -429,8 +429,9 @@ initDiscovery =
       -- since the master list of achievements is stored in UIState
       _gameAchievements = mempty
     , _structureRecognition =
-        StructureRecognizer (RecognizerAutomatons mempty mempty) $
-          RecognitionState emptyFoundStructures []
+        StructureRecognizer
+          (RecognizerAutomatons mempty mempty)
+          (RecognitionState emptyFoundStructures [])
     , _tagMembers = mempty
     }
 

--- a/src/swarm-engine/Swarm/Game/State/Substate.hs
+++ b/src/swarm-engine/Swarm/Game/State/Substate.hs
@@ -428,7 +428,9 @@ initDiscovery =
     , -- This does not need to be initialized with anything,
       -- since the master list of achievements is stored in UIState
       _gameAchievements = mempty
-    , _structureRecognition = StructureRecognizer (RecognizerAutomatons mempty mempty) emptyFoundStructures []
+    , _structureRecognition =
+        StructureRecognizer (RecognizerAutomatons mempty mempty) $
+          RecognitionState emptyFoundStructures []
     , _tagMembers = mempty
     }
 

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -64,7 +64,7 @@ import Swarm.Game.Scenario.Topography.Area (getAreaDimensions)
 import Swarm.Game.Scenario.Topography.Navigation.Portal (Navigation (..))
 import Swarm.Game.Scenario.Topography.Navigation.Util
 import Swarm.Game.Scenario.Topography.Navigation.Waypoint (WaypointName (..))
-import Swarm.Game.Scenario.Topography.Structure.Recognition (automatons, foundStructures)
+import Swarm.Game.Scenario.Topography.Structure.Recognition (automatons, foundStructures, recognitionState)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (foundByName)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.State
@@ -567,7 +567,7 @@ execConst runChildProg c vs s k = do
       _ -> badConst
     Structure -> case vs of
       [VText name, VInt idx] -> do
-        registry <- use $ discovery . structureRecognition . foundStructures
+        registry <- use $ discovery . structureRecognition . recognitionState . foundStructures
         let maybeFoundStructures = M.lookup name $ foundByName registry
             mkOutput mapNE = (NE.length xs, bottomLeftCorner)
              where

--- a/src/swarm-engine/Swarm/Game/Step/Path/Cache.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Cache.hs
@@ -44,6 +44,7 @@ import Swarm.Game.Entity
 import Swarm.Game.Location
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Walk
+import Swarm.Game.Scenario.Topography.Terraform
 import Swarm.Game.State
 import Swarm.Game.Step.Path.Cache.DistanceLimit
 import Swarm.Game.Step.Path.Type
@@ -51,7 +52,6 @@ import Swarm.Game.Step.Path.Walkability (checkUnwalkable)
 import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Step.Util.Inspect (robotWithID)
 import Swarm.Game.Universe (Cosmic (..), SubworldName)
-import Swarm.Game.World.Modify
 import Swarm.Util (prependList, tails1)
 import Swarm.Util.RingBuffer qualified as RB
 

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -16,6 +16,7 @@ import Control.Effect.Lens
 import Control.Monad (forM_, guard, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Control.Monad.Trans.State.Strict qualified as TS
 import Data.Array (bounds, (!))
 import Data.IntMap qualified as IM
 import Data.Set qualified as S
@@ -76,7 +77,15 @@ updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
     currentTick <- use $ temporal . ticks
     myID <- use robotID
     zoomRobots $ wakeWatchingRobots myID currentTick cLoc
-    SRT.entityModified modType cLoc
+    oldRecognizer <- use $ discovery . structureRecognition
+
+    oldGS <- get @GameState
+    let (newRecognizer, newGS) =
+          flip TS.runState oldGS $
+            SRT.entityModified mtlEntityAt modType cLoc oldRecognizer
+    put newGS
+
+    discovery . structureRecognition .= newRecognizer
 
     pcr <- use $ pathCaching . pathCachingRobots
     mapM_ (revalidatePathCache cLoc modType) $ IM.toList pcr

--- a/src/swarm-scenario/Swarm/Game/World/Modify.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Modify.hs
@@ -9,6 +9,7 @@ module Swarm.Game.World.Modify where
 import Control.Lens (view)
 import Data.Function (on)
 import Swarm.Game.Entity (Entity, entityHash)
+import Swarm.Game.Scenario.Topography.Terraform
 
 -- | Compare to 'WorldUpdate' in "Swarm.Game.World"
 data CellUpdate e
@@ -18,13 +19,6 @@ data CellUpdate e
 getModification :: CellUpdate e -> Maybe (CellModification e)
 getModification (NoChange _) = Nothing
 getModification (Modified x) = Just x
-
-data CellModification e
-  = -- | Fields represent what existed in the cell "before" and "after", in that order.
-    -- The values are guaranteed to be different.
-    Swap e e
-  | Remove e
-  | Add e
 
 classifyModification ::
   -- | before

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition.hs
@@ -12,14 +12,24 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Log
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 
+-- | State of the structure recognizer that is intended
+-- to be modifiable.
+data RecognitionState b a = RecognitionState
+  { _foundStructures :: FoundRegistry b a
+  -- ^ Records the top-left corner of the found structure
+  , _recognitionLog :: [SearchLog a]
+  }
+
+makeLenses ''RecognitionState
+
 -- |
 -- The type parameters, `b`, and `a`, correspond
 -- to 'StructureCells' and 'Entity', respectively.
 data StructureRecognizer b a = StructureRecognizer
   { _automatons :: RecognizerAutomatons b a
-  , _foundStructures :: FoundRegistry b a
-  -- ^ Records the top-left corner of the found structure
-  , _recognitionLog :: [SearchLog a]
+  -- ^ read-only
+  , _recognitionState :: RecognitionState b a
+  -- ^ mutatable
   }
   deriving (Generic)
 

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
@@ -72,8 +72,9 @@ removeStructure fs (FoundRegistry byName byLoc) =
   -- Swarm.Game.State.removeRobotFromLocationMap
   tidyDelete = NEM.nonEmptyMap . NEM.delete upperLeft
 
-addFound :: FoundStructure b a -> FoundRegistry b a -> FoundRegistry b a
-addFound fs@(FoundStructure swg loc) (FoundRegistry byName byLoc) =
+addFound :: Maybe (FoundStructure b a) -> FoundRegistry b a -> FoundRegistry b a
+addFound Nothing x = x
+addFound (Just fs@(FoundStructure swg loc)) (FoundRegistry byName byLoc) =
   FoundRegistry
     (M.insertWith (<>) k (NEM.singleton loc swg) byName)
     (M.union occupationMap byLoc)

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
@@ -72,9 +72,8 @@ removeStructure fs (FoundRegistry byName byLoc) =
   -- Swarm.Game.State.removeRobotFromLocationMap
   tidyDelete = NEM.nonEmptyMap . NEM.delete upperLeft
 
-addFound :: Maybe (FoundStructure b a) -> FoundRegistry b a -> FoundRegistry b a
-addFound Nothing x = x
-addFound (Just fs@(FoundStructure swg loc)) (FoundRegistry byName byLoc) =
+addFound :: FoundStructure b a -> FoundRegistry b a -> FoundRegistry b a
+addFound fs@(FoundStructure swg loc) (FoundRegistry byName byLoc) =
   FoundRegistry
     (M.insertWith (<>) k (NEM.singleton loc swg) byName)
     (M.union occupationMap byLoc)

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
@@ -244,7 +244,7 @@ registerStructureMatches ::
 registerStructureMatches unrankedCandidates oldState =
   oldState
     & (recognitionLog %~ (newMsg :))
-    & foundStructures %~ addFound (listToMaybe rankedCandidates)
+    & foundStructures %~ maybe id addFound (listToMaybe rankedCandidates)
  where
   -- Sorted by decreasing order of preference.
   rankedCandidates = sortOn Down unrankedCandidates

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Terraform.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Terraform.hs
@@ -1,0 +1,10 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+module Swarm.Game.Scenario.Topography.Terraform where
+
+data CellModification e
+  = -- | Fields represent what existed in the cell "before" and "after", in that order.
+    -- The values are guaranteed to be different.
+    Swap e e
+  | Remove e
+  | Add e

--- a/src/swarm-tui/Swarm/TUI/View/CellDisplay.hs
+++ b/src/swarm-tui/Swarm/TUI/View/CellDisplay.hs
@@ -33,7 +33,7 @@ import Swarm.Game.Entity
 import Swarm.Game.Land
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Topography.EntityFacade
-import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures)
+import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures, recognitionState)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (foundByLocation)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
@@ -71,7 +71,7 @@ drawLoc ui g cCoords@(Cosmic _ coords) =
 
   boldStructure = applyWhen isStructure $ modifyDefAttr (`V.withStyle` V.bold)
    where
-    sMap = foundByLocation $ g ^. discovery . structureRecognition . foundStructures
+    sMap = foundByLocation $ g ^. discovery . structureRecognition . recognitionState . foundStructures
     isStructure = M.member (coordsToLoc <$> cCoords) sMap
 
 -- | Subset of the game state needed to render the world

--- a/src/swarm-tui/Swarm/TUI/View/Structure.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Structure.hs
@@ -24,7 +24,7 @@ import Swarm.Game.Scenario (StructureCells)
 import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.Placement (getStructureName)
 import Swarm.Game.Scenario.Topography.Structure qualified as Structure
-import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures)
+import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures, recognitionState)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute (getEntityGrid)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (foundByName)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
@@ -92,7 +92,7 @@ structureWidget gs s =
       Structure.description . namedGrid . annotatedGrid $
         s
 
-  registry = gs ^. discovery . structureRecognition . foundStructures
+  registry = gs ^. discovery . structureRecognition . recognitionState . foundStructures
   occurrenceCountSuffix = case M.lookup theName $ foundByName registry of
     Nothing -> emptyWidget
     Just inner -> padLeft (Pad 2) . headerItem "Count" . T.pack . show $ NEM.size inner

--- a/src/swarm-web/Swarm/Web.hs
+++ b/src/swarm-web/Swarm/Web.hs
@@ -212,12 +212,12 @@ recogLogHandler appStateRef = do
   appState <- liftIO appStateRef
   return $
     map (fmap (view entityName)) $
-      appState ^. gameState . discovery . structureRecognition . recognitionLog
+      appState ^. gameState . discovery . structureRecognition . recognitionState . recognitionLog
 
 recogFoundHandler :: IO AppState -> Handler [StructureLocation]
 recogFoundHandler appStateRef = do
   appState <- liftIO appStateRef
-  let registry = appState ^. gameState . discovery . structureRecognition . foundStructures
+  let registry = appState ^. gameState . discovery . structureRecognition . recognitionState . foundStructures
   return
     . map (uncurry StructureLocation)
     . concatMap (\(x, ys) -> map (x,) $ NE.toList ys)

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -227,7 +227,9 @@ library swarm-topography
     Swarm.Game.Scenario.Topography.Structure.Recognition.Prep
     Swarm.Game.Scenario.Topography.Structure.Recognition.Registry
     Swarm.Game.Scenario.Topography.Structure.Recognition.Symmetry
+    Swarm.Game.Scenario.Topography.Structure.Recognition.Tracking
     Swarm.Game.Scenario.Topography.Structure.Recognition.Type
+    Swarm.Game.Scenario.Topography.Terraform
     Swarm.Game.Universe
     Swarm.Game.World.Coords
 
@@ -247,6 +249,7 @@ library swarm-topography
     nonempty-containers >=0.3.4 && <0.3.5,
     servant-docs >=0.12 && <0.14,
     text >=1.2.4 && <2.2,
+    transformers,
     unordered-containers,
     vector >=0.12 && <0.14,
     yaml >=0.11 && <0.11.12.0,
@@ -386,7 +389,6 @@ library swarm-engine
     Swarm.Game.Scenario.Scoring.GenericMetrics
     Swarm.Game.Scenario.Status
     Swarm.Game.Scenario.Topography.Navigation.Util
-    Swarm.Game.Scenario.Topography.Structure.Recognition.Tracking
     Swarm.Game.ScenarioInfo
     Swarm.Game.State
     Swarm.Game.State.Initialize
@@ -416,7 +418,6 @@ library swarm-engine
   other-modules: Paths_swarm
   autogen-modules: Paths_swarm
   build-depends:
-    AhoCorasick >=0.0.4 && <0.0.5,
     SHA >=1.6.4 && <1.6.5,
     aeson >=2.2 && <2.3,
     array >=0.5.4 && <0.6,
@@ -432,7 +433,6 @@ library swarm-engine
     fused-effects >=1.1.1.1 && <1.2,
     fused-effects-lens >=1.2.0.1 && <1.3,
     githash,
-    hashable >=1.3.4 && <1.5,
     http-client >=0.7 && <0.8,
     http-client-tls >=0.3 && <0.4,
     http-types >=0.12 && <0.13,


### PR DESCRIPTION
Builds upon #1836.

Most importantly in this PR, the `Swarm.Game.Scenario.Topography.Structure.Recognition.Tracking` module is made generic in its `Entity` parameter, and is now able to be moved from the `swarm-engine` sublibrary to the `swarm-topology` sublibrary.

I've also introduced an intermediate `RecognitionState` record inside `StructureRecognizer` to distinguish between the stateful and read-only elements.

The `AhoCorasick` dependency is now reduced to only one sublibrary.