### PR TITLE
better transparency handling for structure recognizer

### DIFF
--- a/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
+++ b/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
@@ -14,3 +14,5 @@
 1575-bounding-box-overlap.yaml
 1644-rotated-recognition.yaml
 1644-rotated-preplacement-recognition.yaml
+2115-encroaching-upon-exterior-transparent-cells.yaml
+2115-encroaching-upon-interior-transparent-cells.yaml

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-interior-entity-placement.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-interior-entity-placement.yaml
@@ -9,10 +9,6 @@ description: |
   Additionally, recognition of statically-placed
   structures at scenario initialization is also
   unaffected by interior entities.
-
-  However, any such "contaminating" entities
-  will prevent the recognition of a structure
-  when constructed by a robot.
 creative: false
 objectives:
   - teaser: Replace rock

--- a/data/scenarios/Testing/1575-structure-recognizer/2115-encroaching-upon-exterior-transparent-cells.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2115-encroaching-upon-exterior-transparent-cells.yaml
@@ -1,0 +1,77 @@
+version: 1
+name: Structure recognition - exterior transparency
+description: |
+  Incursion of an entity of a foreign type
+  upon a "transparent" cell within the bounding box
+  of a recognizable structure shall not prevent
+  the structure from being recognized.
+
+  If the incurring entity is the *same* type as
+  a participating entity in that structure, however,
+  it will prevent recognition.
+creative: false
+objectives:
+  - teaser: Recognize structure
+    goal:
+      - |
+        `chevron`{=structure} structure should be recognized upon completion,
+        even with an extraneous entity within its bounds.
+    condition: |
+      def isRight = \x. case x (\_. false) (\_. true); end;
+
+      foundBox <- structure "chevron" 0;
+      return $ isRight foundBox;
+robots:
+  - name: base
+    dir: east
+    devices:
+      - ADT calculator
+      - blueprint
+      - fast grabber
+      - logger
+      - treads
+    inventory:
+      - [1, board]
+  - name: judge
+    dir: east
+    system: true
+    display:
+      invisible: true
+solution: |
+  move; move; move;
+  swap "board";
+structures:
+  - name: chevron
+    recognize: [north]
+    structure:
+      palette:
+        'b': [stone, board]
+      mask: '.'
+      map: |
+        .b
+        bb
+  - name: stripe
+    recognize: [north]
+    structure:
+      palette:
+        't': [grass, tree]
+        'b': [grass, board]
+      map: |
+        btb
+known: [board, mountain, tree]
+world:
+  dsl: |
+    {blank}
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+    'j': [grass, erase, judge]
+    't': [grass, tree]
+    'b': [grass, board]
+  upperleft: [-7, 3]
+  map: |
+    j.....
+    ......
+    .B.ttt
+    ...bb.
+    ......

--- a/data/scenarios/Testing/1575-structure-recognizer/2115-encroaching-upon-interior-transparent-cells.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2115-encroaching-upon-interior-transparent-cells.yaml
@@ -1,0 +1,85 @@
+version: 1
+name: Structure recognition - interior transparency
+description: |
+  Incursion of an entity of a foreign type
+  upon a "transparent" cell within the bounding box
+  of a recognizable structure shall not prevent
+  the structure from being recognized.
+
+  If the incurring entity is the *same* type as
+  a participating entity in that structure, however,
+  it will prevent recognition.
+creative: false
+objectives:
+  - teaser: Recognize structure
+    goal:
+      - |
+        `pigpen`{=structure} structure should be recognized upon completion,
+        even with an extraneous entity within its bounds.
+    condition: |
+      def isRight = \x. case x (\_. false) (\_. true); end;
+      foundBox <- structure "pigpen" 0;
+      return $ isRight foundBox;
+robots:
+  - name: base
+    dir: east
+    devices:
+      - ADT calculator
+      - blueprint
+      - fast grabber
+      - logger
+      - treads
+    inventory:
+      - [1, board]
+  - name: judge
+    dir: east
+    system: true
+    display:
+      invisible: true
+solution: |
+  move; move; move; move;
+  swap "board";
+structures:
+  - name: pigpen
+    recognize: [north]
+    structure:
+      palette:
+        'b': [stone, board]
+      mask: '.'
+      map: |
+        bbbb
+        b..b
+        b..b
+        bbbb
+  - name: obstruction
+    recognize: [north]
+    structure:
+      palette:
+        't': [grass, tree]
+        'b': [grass, board]
+      map: |
+        tttb
+known: [board, mountain, tree]
+world:
+  dsl: |
+    {blank}
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+    'r': [grass, mountain]
+    'j': [grass, erase, judge]
+    'p':
+      structure:
+        name: pigpen
+      cell: [grass]
+    'b':
+      structure:
+        name: obstruction
+      cell: [grass]
+  upperleft: [-7, 3]
+  map: |
+    j.....
+    .p....
+    ...r..
+    B..b..
+    ......

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -25,7 +25,7 @@ import Data.Function (on)
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
 import Data.Int (Int32)
-import Data.List.NonEmpty qualified as NE
+import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import Data.Maybe (catMaybes)
 import Data.Ord (Down (Down))
@@ -74,7 +74,7 @@ type SymbolSequence a = [AtomicKeySymbol a]
 data StructureSearcher b a = StructureSearcher
   { automaton2D :: AutomatonInfo a (SymbolSequence a) (StructureWithGrid b a)
   , needleContent :: SymbolSequence a
-  , singleRowItems :: NE.NonEmpty (SingleRowEntityOccurrences b a)
+  , singleRowItems :: NonEmpty (SingleRowEntityOccurrences b a)
   }
 
 -- |
@@ -108,7 +108,7 @@ data PositionWithinRow b a = PositionWithinRow
 data SingleRowEntityOccurrences b a = SingleRowEntityOccurrences
   { myRow :: StructureRow b a
   , myEntity :: a
-  , entityOccurrences :: NE.NonEmpty (PositionWithinRow b a)
+  , entityOccurrences :: NonEmpty (PositionWithinRow b a)
   , expandedOffsets :: InspectionOffsets
   }
 
@@ -197,6 +197,9 @@ data AutomatonInfo en k v = AutomatonInfo
   { _participatingEntities :: HashSet en
   , _inspectionOffsets :: InspectionOffsets
   , _automaton :: StateMachine k v
+  , _searchPairs :: NonEmpty ([k], v)
+  -- ^ these are the tuples input to the 'makeStateMachine' function,
+  -- for debugging purposes.
   }
   deriving (Generic)
 
@@ -208,7 +211,7 @@ data RecognizerAutomatons b a = RecognizerAutomatons
   { _originalStructureDefinitions :: Map OriginalName (StructureInfo b a)
   -- ^ all of the structures that shall participate in automatic recognition.
   -- This list is used only by the UI and by the 'Floorplan' command.
-  , _automatonsByEntity :: HashMap a (AutomatonInfo a (AtomicKeySymbol a) (StructureSearcher b a))
+  , _automatonsByEntity :: HashMap a (NonEmpty (AutomatonInfo a (AtomicKeySymbol a) (StructureSearcher b a)))
   }
   deriving (Generic)
 

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -454,6 +454,8 @@ testScenarioSolutions rs ui key =
             , testSolution Default "Testing/1575-structure-recognizer/1575-bounding-box-overlap"
             , testSolution Default "Testing/1575-structure-recognizer/1644-rotated-recognition"
             , testSolution Default "Testing/1575-structure-recognizer/1644-rotated-preplacement-recognition"
+            , testSolution Default "Testing/1575-structure-recognizer/2115-encroaching-upon-interior-transparent-cells"
+            , testSolution Default "Testing/1575-structure-recognizer/2115-encroaching-upon-exterior-transparent-cells"
             ]
         ]
     , testSolution' Default "Testing/1430-built-robot-ownership" CheckForBadErrors $ \g -> do

--- a/weeder.toml
+++ b/weeder.toml
@@ -40,9 +40,9 @@ roots = [
     "^Swarm.Language.Syntax.Pattern.UTerm$",
     "^Swarm.Language.Syntax.Util.asTree$",
     "^Swarm.Language.Syntax.Util.mapFreeS$",
+    "^Swarm.Util.isSuccessOr$",
     "^Swarm.Util.replaceLast$",
     "^Swarm.Util.reflow$",
-    "^Swarm.Util.isSuccessOr$",
     "^Swarm.Util._NonEmpty$",
 
     # True positives (unused lenses):


### PR DESCRIPTION
Some recognizable structures have "transparent" cells.  However, the Aho-Corasick algorithm doesn't support "wildcards", which is essentially what transparent cells are, for the purpose of matching.  So, for a structure template that contains transparent cells to be recognized, the cells of the world must also have "empty" cells in the same place.

Despite this, we can accommodate certain instances of structure recognition when the transparent cells are "overlapped" (or "incurred upon") by some other entity.  We do this by "masking out" entities from the world that don't participate in the set of structures we're trying to match against.

This often works well, except when the set of structures to be recognized contains:
* one structure `S1` with transparent cells
* another structure `S2` with some additional type of entity `E` not participating in `S1`
* The entity `E` occupies a transparent cell of `S1`.

`E` can't be masked out since we're trying to simultaneously recognize structures of type `S2` in the same Aho-Corasick pass.  So a legitimate instance of `S1` will fail to be recognized.

## Workaround

We can make multiple Aho-Corasick passes: one pass for each distinct set of "masked entities".  Notably:
* If no structures have transparent cells, we don't need to mask at all
* If all of the structures that contain transparent cells have an identical set of participating entities, they can all be handled in the same pass
* **Not implemented:** A structure with no transparency (i.e. with an empty "mask set") can be handled in the same pass as a a transparent structure, if they have an identical participating entity set.

## Caveats

Note that this fundamental limitation of Aho-Corasick still exists for "incurring entities" of the **same type** as the entity participants in the structure to be recognized.

E.g., if we have a structure defined as:
```
 X
XX
```
then, depending on the order of entity placement, the following occurrence in the world will **not** be recognized:
```
XX
XX
```

## Testing
```
scripts/test/run-tests.sh --test-options '--pattern "structure-recognizer"'
```

## Also in this PR
* improved docs/logging
