### PR TITLE
Remove warp dependency from engine

### DIFF
--- a/src/swarm-engine/Swarm/Game/State/Runtime.hs
+++ b/src/swarm-engine/Swarm/Game/State/Runtime.hs
@@ -109,7 +109,7 @@ initRuntimeState pause = do
 makeLensesNoSigs ''RuntimeState
 
 -- | The port on which the HTTP debug service is running.
-webPort :: Lens' RuntimeState (Maybe Port)
+webPort :: Lens' RuntimeState (Maybe Int)
 
 -- | The upstream release version.
 upstreamRelease :: Lens' RuntimeState (Either NewReleaseFailure String)

--- a/src/swarm-engine/Swarm/Game/State/Runtime.hs
+++ b/src/swarm-engine/Swarm/Game/State/Runtime.hs
@@ -29,7 +29,6 @@ import Control.Lens
 import Data.Map (Map)
 import Data.Sequence (Seq)
 import Data.Text (Text)
-import Network.Wai.Handler.Warp (Port)
 import Swarm.Game.Failure (SystemFailure)
 import Swarm.Game.Land
 import Swarm.Game.Recipe (loadRecipes)
@@ -43,7 +42,7 @@ import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Version (NewReleaseFailure (..))
 
 data RuntimeState = RuntimeState
-  { _webPort :: Maybe Port
+  { _webPort :: Maybe Int
   , _upstreamRelease :: Either NewReleaseFailure String
   , _eventLog :: Notifications LogEntry
   , _scenarios :: ScenarioCollection

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -450,7 +450,6 @@ library swarm-engine
     time >=1.9 && <1.15,
     transformers >=0.5 && <0.7,
     unordered-containers >=0.2.14 && <0.3,
-    warp,
     witch >=1.1.1.0 && <1.3,
     yaml >=0.11 && <0.11.12.0,
 


### PR DESCRIPTION
...just for one type-alias:
```Haskell
type Port = Int
```

* part of #2109