### PR TITLE
Fix Mergify deprecation warnings

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,6 +1,11 @@
 queue_rules:
   - name: default
-    conditions:
+    merge_method: squash
+    commit_message_template: |
+      {{ title }} (#{{ number }})
+
+      {{ body }}
+    queue_conditions:
       - or:
         - and:
           - -files~=\.hs$
@@ -30,11 +35,6 @@ pull_request_rules:
 - actions:
     queue:
       name: default
-      method: squash
-      commit_message_template: |
-        {{ title }} (#{{ number }})
-
-        {{ body }}
 
   name: Automatically merge pull requests
   conditions:


### PR DESCRIPTION
* move `method` to `queue_rules`
* move `commit_message_template` to `queue_rules`
* rename `conditions` to `queue_conditions`
* closes #2136