### PR TITLE
cache scenario preview widget

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Model/Name.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Name.hs
@@ -92,6 +92,8 @@ data Name
     InventoryList
   | -- | The inventory item position in the InventoryList.
     InventoryListItem Int
+  | -- | Cacheable scenario preview
+    ScenarioPreview FilePath
   | -- | The list of main menu choices.
     MenuList
   | -- | The list of achievements.

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -17,9 +17,6 @@ module Swarm.TUI.View (
   drawModalMenu,
   drawKeyCmd,
 
-  -- * World
-  drawWorldPane,
-
   -- * Robot panel
   drawRobotPanel,
   drawItem,
@@ -255,7 +252,9 @@ drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
   drawDescription (SISingle (s, si)) =
     vBox
       [ drawMarkdown (nonBlank (s ^. scenarioOperation . scenarioDescription))
-      , hCenter . padTop (Pad 1) . vLimit 6 $ hLimitPercent 60 worldPeek
+      , cached (ScenarioPreview $ si ^. scenarioPath) $
+          hCenter . padTop (Pad 1) . vLimit 6 $
+            hLimitPercent 60 worldPeek
       , padTop (Pad 1) table
       ]
    where


### PR DESCRIPTION
Fixes the lag issue noted in #1515.

# Demo

1. First, launch a toplevel scenario:
    ```
    scripts/play.sh -i data/scenarios/blank.yaml
    ```
2. Then use <kbd>Ctrl</kbd>+<kbd>q</kbd> to quit to the scenario selection menu.
3. Notice when using up-arrow to select the "Classic" and "Creative" scenarios, there is a delay as the preview is computed for the first time.
4. Finally, when subsequently selecting back and forth between the two again, notice that the lag is gone, as the cache is being used.