### PR TITLE
Refactor: move ResourceLoading to swarm-util

### DIFF
--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -17,7 +17,7 @@ import GitHash (GitInfo, giBranch, giHash, tGitInfoCwdTry)
 import Options.Applicative
 import Options.Applicative.Help hiding (color, fullDesc)
 import Swarm.App (appMain)
-import Swarm.Game.ResourceLoading (getSwarmConfigIniFile)
+import Swarm.ResourceLoading (getSwarmConfigIniFile)
 import Swarm.Language.Format
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Parser.Core (LanguageVersion (..))

--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -17,10 +17,10 @@ import GitHash (GitInfo, giBranch, giHash, tGitInfoCwdTry)
 import Options.Applicative
 import Options.Applicative.Help hiding (color, fullDesc)
 import Swarm.App (appMain)
-import Swarm.ResourceLoading (getSwarmConfigIniFile)
 import Swarm.Language.Format
 import Swarm.Language.LSP (lspMain)
 import Swarm.Language.Parser.Core (LanguageVersion (..))
+import Swarm.ResourceLoading (getSwarmConfigIniFile)
 import Swarm.TUI.Model (AppOpts (..), ColorMode (..))
 import Swarm.TUI.Model.DebugOption
 import Swarm.TUI.Model.KeyBindings (KeybindingPrint (..), showKeybindings)

--- a/src/swarm-engine/Swarm/Game/Achievement/Persistence.hs
+++ b/src/swarm-engine/Swarm/Game/Achievement/Persistence.hs
@@ -16,7 +16,7 @@ import Data.Yaml qualified as Y
 import Swarm.Failure
 import Swarm.Game.Achievement.Attainment
 import Swarm.Game.Achievement.Definitions
-import Swarm.Game.ResourceLoading (getSwarmAchievementsPath)
+import Swarm.ResourceLoading (getSwarmAchievementsPath)
 import Swarm.Util.Effect (forMW)
 import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
 import System.FilePath ((</>))

--- a/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
+++ b/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
@@ -57,10 +57,10 @@ import Data.Sequence qualified as Seq
 import Data.Text (Text)
 import Data.Yaml as Y
 import Swarm.Failure
-import Swarm.ResourceLoading (getDataDirSafe, getSwarmSavePath)
 import Swarm.Game.Scenario
 import Swarm.Game.Scenario.Scoring.CodeSize
 import Swarm.Game.Scenario.Status
+import Swarm.ResourceLoading (getDataDirSafe, getSwarmSavePath)
 import Swarm.Util.Effect (warn, withThrow)
 import System.Directory (canonicalizePath, doesDirectoryExist, doesFileExist, listDirectory)
 import System.FilePath (pathSeparator, splitDirectories, takeBaseName, takeExtensions, (-<.>), (</>))

--- a/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
+++ b/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
@@ -57,7 +57,7 @@ import Data.Sequence qualified as Seq
 import Data.Text (Text)
 import Data.Yaml as Y
 import Swarm.Failure
-import Swarm.Game.ResourceLoading (getDataDirSafe, getSwarmSavePath)
+import Swarm.ResourceLoading (getDataDirSafe, getSwarmSavePath)
 import Swarm.Game.Scenario
 import Swarm.Game.Scenario.Scoring.CodeSize
 import Swarm.Game.Scenario.Status

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -71,7 +71,7 @@ import Data.Tuple (swap)
 import GHC.Generics (Generic)
 import Swarm.Game.CESK (CESK (Waiting))
 import Swarm.Game.Location
-import Swarm.Game.ResourceLoading (NameGenerator)
+import Swarm.ResourceLoading (NameGenerator)
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.State.Config

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -71,12 +71,12 @@ import Data.Tuple (swap)
 import GHC.Generics (Generic)
 import Swarm.Game.CESK (CESK (Waiting))
 import Swarm.Game.Location
-import Swarm.ResourceLoading (NameGenerator)
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.State.Config
 import Swarm.Game.Tick
 import Swarm.Game.Universe as U
+import Swarm.ResourceLoading (NameGenerator)
 import Swarm.Util (binTuples, surfaceEmpty, (<+=), (<<.=))
 import Swarm.Util.Lens (makeLensesExcluding)
 

--- a/src/swarm-engine/Swarm/Game/State/Runtime.hs
+++ b/src/swarm-engine/Swarm/Game/State/Runtime.hs
@@ -35,12 +35,12 @@ import Data.Text (Text)
 import Swarm.Failure (SystemFailure)
 import Swarm.Game.Land
 import Swarm.Game.Recipe (loadRecipes)
-import Swarm.ResourceLoading (initNameGenerator, readAppData)
 import Swarm.Game.Scenario (GameStateInputs (..), ScenarioInputs (..))
 import Swarm.Game.ScenarioInfo (ScenarioCollection, loadScenarios)
 import Swarm.Game.State.Substate
 import Swarm.Game.World.Load (loadWorlds)
 import Swarm.Log
+import Swarm.ResourceLoading (initNameGenerator, readAppData)
 import Swarm.Util.Lens (makeLensesNoSigs)
 
 data RuntimeState = RuntimeState

--- a/src/swarm-engine/Swarm/Game/State/Runtime.hs
+++ b/src/swarm-engine/Swarm/Game/State/Runtime.hs
@@ -35,7 +35,7 @@ import Data.Text (Text)
 import Swarm.Failure (SystemFailure)
 import Swarm.Game.Land
 import Swarm.Game.Recipe (loadRecipes)
-import Swarm.Game.ResourceLoading (initNameGenerator, readAppData)
+import Swarm.ResourceLoading (initNameGenerator, readAppData)
 import Swarm.Game.Scenario (GameStateInputs (..), ScenarioInputs (..))
 import Swarm.Game.ScenarioInfo (ScenarioCollection, loadScenarios)
 import Swarm.Game.State.Substate

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -55,7 +55,7 @@ import Swarm.Game.Exception
 import Swarm.Game.Land
 import Swarm.Game.Location
 import Swarm.Game.Recipe
-import Swarm.Game.ResourceLoading (getDataFileNameSafe)
+import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Activity
 import Swarm.Game.Robot.Concrete

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -55,7 +55,6 @@ import Swarm.Game.Exception
 import Swarm.Game.Land
 import Swarm.Game.Location
 import Swarm.Game.Recipe
-import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Activity
 import Swarm.Game.Robot.Concrete
@@ -95,6 +94,7 @@ import Swarm.Language.Text.Markdown qualified as Markdown
 import Swarm.Language.Value
 import Swarm.Log
 import Swarm.Pretty (prettyText)
+import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Util hiding (both)
 import Swarm.Util.Effect (throwToMaybe)
 import Swarm.Util.Lens (inherit)

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -27,7 +27,6 @@ import Swarm.Game.Device
 import Swarm.Game.Entity hiding (empty, lookup, singleton, union)
 import Swarm.Game.Exception
 import Swarm.Game.Location
-import Swarm.ResourceLoading (NameGenerator (..))
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Tracking qualified as SRT
 import Swarm.Game.State
@@ -45,6 +44,7 @@ import Swarm.Language.Capability
 import Swarm.Language.Requirements.Type qualified as R
 import Swarm.Language.Syntax
 import Swarm.Language.Syntax.Direction (Direction)
+import Swarm.ResourceLoading (NameGenerator (..))
 import Swarm.Util hiding (both)
 import System.Random (UniformRange, uniformR)
 import Prelude hiding (Applicative (..), lookup)

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -27,7 +27,7 @@ import Swarm.Game.Device
 import Swarm.Game.Entity hiding (empty, lookup, singleton, union)
 import Swarm.Game.Exception
 import Swarm.Game.Location
-import Swarm.Game.ResourceLoading (NameGenerator (..))
+import Swarm.ResourceLoading (NameGenerator (..))
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Tracking qualified as SRT
 import Swarm.Game.State

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -126,11 +126,11 @@ import Swarm.Game.Entity.Cosmetic (WorldAttr (..))
 import Swarm.Game.Entity.Cosmetic.Assignment (worldAttributes)
 import Swarm.Game.Ingredients
 import Swarm.Game.Location
-import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Game.Terrain (TerrainType)
 import Swarm.Language.Capability
 import Swarm.Language.Syntax (Syntax)
 import Swarm.Language.Text.Markdown (Document, docToText)
+import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Util (binTuples, failT, findDup, plural, quote, (?))
 import Swarm.Util.Effect (withThrow)
 import Swarm.Util.Yaml

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -126,7 +126,7 @@ import Swarm.Game.Entity.Cosmetic (WorldAttr (..))
 import Swarm.Game.Entity.Cosmetic.Assignment (worldAttributes)
 import Swarm.Game.Ingredients
 import Swarm.Game.Location
-import Swarm.Game.ResourceLoading (getDataFileNameSafe)
+import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Game.Terrain (TerrainType)
 import Swarm.Language.Capability
 import Swarm.Language.Syntax (Syntax)

--- a/src/swarm-scenario/Swarm/Game/Recipe.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe.hs
@@ -70,7 +70,7 @@ import GHC.Generics (Generic)
 import Swarm.Failure
 import Swarm.Game.Entity as E
 import Swarm.Game.Ingredients
-import Swarm.Game.ResourceLoading (getDataFileNameSafe)
+import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Util.Effect (withThrow)
 import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Util.Yaml

--- a/src/swarm-scenario/Swarm/Game/Scenario.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario.hs
@@ -80,7 +80,7 @@ import Swarm.Game.Entity.Cosmetic.Assignment (worldAttributes)
 import Swarm.Game.Land
 import Swarm.Game.Location (Location)
 import Swarm.Game.Recipe
-import Swarm.Game.ResourceLoading (getDataFileNameSafe)
+import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Game.Robot (TRobot, trobotLocation, trobotName)
 import Swarm.Game.Scenario.Objective (Objective)
 import Swarm.Game.Scenario.Objective.Validation

--- a/src/swarm-scenario/Swarm/Game/Scenario.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario.hs
@@ -80,7 +80,6 @@ import Swarm.Game.Entity.Cosmetic.Assignment (worldAttributes)
 import Swarm.Game.Land
 import Swarm.Game.Location (Location)
 import Swarm.Game.Recipe
-import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Game.Robot (TRobot, trobotLocation, trobotName)
 import Swarm.Game.Scenario.Objective (Objective)
 import Swarm.Game.Scenario.Objective.Validation
@@ -104,6 +103,7 @@ import Swarm.Game.World.Typecheck (WorldMap)
 import Swarm.Language.Syntax (Syntax, TSyntax)
 import Swarm.Language.Text.Markdown (Document)
 import Swarm.Pretty (prettyText)
+import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Util (binTuples, commaList, failT, quote)
 import Swarm.Util.Effect (ignoreWarnings, throwToMaybe, withThrow)
 import Swarm.Util.Lens (makeLensesNoSigs)

--- a/src/swarm-scenario/Swarm/Game/State/Config.hs
+++ b/src/swarm-scenario/Swarm/Game/State/Config.hs
@@ -7,7 +7,7 @@ module Swarm.Game.State.Config where
 
 import Data.Map (Map)
 import Data.Text (Text)
-import Swarm.Game.ResourceLoading (NameGenerator)
+import Swarm.ResourceLoading (NameGenerator)
 import Swarm.Game.Scenario (GameStateInputs)
 
 -- | Record to pass information needed to create an initial

--- a/src/swarm-scenario/Swarm/Game/State/Config.hs
+++ b/src/swarm-scenario/Swarm/Game/State/Config.hs
@@ -7,8 +7,8 @@ module Swarm.Game.State.Config where
 
 import Data.Map (Map)
 import Data.Text (Text)
-import Swarm.ResourceLoading (NameGenerator)
 import Swarm.Game.Scenario (GameStateInputs)
+import Swarm.ResourceLoading (NameGenerator)
 
 -- | Record to pass information needed to create an initial
 --   'GameState' record when starting a scenario.

--- a/src/swarm-scenario/Swarm/Game/Terrain.hs
+++ b/src/swarm-scenario/Swarm/Game/Terrain.hs
@@ -38,7 +38,7 @@ import GHC.Generics (Generic)
 import Swarm.Failure
 import Swarm.Game.Display
 import Swarm.Game.Entity.Cosmetic (WorldAttr (..))
-import Swarm.Game.ResourceLoading (getDataFileNameSafe)
+import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Util (enumeratedMap, quote)
 import Swarm.Util.Effect (withThrow)
 

--- a/src/swarm-scenario/Swarm/Game/World/Load.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Load.hs
@@ -18,7 +18,7 @@ import Data.Sequence (Seq)
 import Data.Text (Text)
 import Swarm.Failure (Asset (..), AssetData (..), LoadingFailure (..), SystemFailure (..))
 import Swarm.Game.Land
-import Swarm.Game.ResourceLoading (getDataDirSafe)
+import Swarm.ResourceLoading (getDataDirSafe)
 import Swarm.Game.World.Parse (parseWExp, runParser)
 import Swarm.Game.World.Typecheck
 import Swarm.Pretty (prettyText)

--- a/src/swarm-scenario/Swarm/Game/World/Load.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Load.hs
@@ -18,10 +18,10 @@ import Data.Sequence (Seq)
 import Data.Text (Text)
 import Swarm.Failure (Asset (..), AssetData (..), LoadingFailure (..), SystemFailure (..))
 import Swarm.Game.Land
-import Swarm.ResourceLoading (getDataDirSafe)
 import Swarm.Game.World.Parse (parseWExp, runParser)
 import Swarm.Game.World.Typecheck
 import Swarm.Pretty (prettyText)
+import Swarm.ResourceLoading (getDataDirSafe)
 import Swarm.Util (acquireAllWithExt)
 import Swarm.Util.Effect (throwToWarning, withThrow)
 import System.FilePath (dropExtension, joinPath, splitPath)

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -60,7 +60,6 @@ import Swarm.Game.Achievement.Definitions
 import Swarm.Game.CESK (CESK (Out), Frame (FApp, FExec, FSuspend))
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Land
-import Swarm.ResourceLoading (getSwarmHistoryPath)
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.State
@@ -85,6 +84,7 @@ import Swarm.Language.Typecheck (
  )
 import Swarm.Language.Value (Value (VKey), envTypes)
 import Swarm.Log
+import Swarm.ResourceLoading (getSwarmHistoryPath)
 import Swarm.TUI.Controller.EventHandlers
 import Swarm.TUI.Controller.SaveScenario (saveScenarioInfoOnQuit)
 import Swarm.TUI.Controller.UpdateUI

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -60,7 +60,7 @@ import Swarm.Game.Achievement.Definitions
 import Swarm.Game.CESK (CESK (Out), Frame (FApp, FExec, FSuspend))
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Land
-import Swarm.Game.ResourceLoading (getSwarmHistoryPath)
+import Swarm.ResourceLoading (getSwarmHistoryPath)
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.State

--- a/src/swarm-tui/Swarm/TUI/Model/KeyBindings.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/KeyBindings.hs
@@ -23,8 +23,8 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Failure (Asset (..), LoadingFailure (..), SystemFailure (..))
-import Swarm.ResourceLoading (getSwarmConfigIniFile)
 import Swarm.Pretty (prettyText)
+import Swarm.ResourceLoading (getSwarmConfigIniFile)
 import Swarm.TUI.Controller.EventHandlers
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Event (SwarmEvent, defaultSwarmBindings, swarmEvents)

--- a/src/swarm-tui/Swarm/TUI/Model/KeyBindings.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/KeyBindings.hs
@@ -23,7 +23,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Failure (Asset (..), LoadingFailure (..), SystemFailure (..))
-import Swarm.Game.ResourceLoading (getSwarmConfigIniFile)
+import Swarm.ResourceLoading (getSwarmConfigIniFile)
 import Swarm.Pretty (prettyText)
 import Swarm.TUI.Controller.EventHandlers
 import Swarm.TUI.Model

--- a/src/swarm-tui/Swarm/TUI/Model/UI.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI.hs
@@ -40,7 +40,7 @@ import Swarm.Failure (SystemFailure)
 import Swarm.Game.Achievement.Attainment
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
-import Swarm.Game.ResourceLoading (getSwarmHistoryPath)
+import Swarm.ResourceLoading (getSwarmHistoryPath)
 import Swarm.TUI.Editor.Model
 import Swarm.TUI.Inventory.Sorting
 import Swarm.TUI.Launch.Model

--- a/src/swarm-util/Swarm/ResourceLoading.hs
+++ b/src/swarm-util/Swarm/ResourceLoading.hs
@@ -5,7 +5,7 @@
 -- Description: Fetching game data
 --
 -- Various utilities related to loading game data files.
-module Swarm.Game.ResourceLoading (
+module Swarm.ResourceLoading (
   -- * Generic data access
   getDataDirSafe,
   getDataFileNameSafe,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -596,7 +596,6 @@ library swarm-scenario
     Swarm.Game.Ingredients
     Swarm.Game.Land
     Swarm.Game.Recipe
-    Swarm.Game.ResourceLoading
     Swarm.Game.Robot
     Swarm.Game.Robot.Walk
     Swarm.Game.Scenario
@@ -848,6 +847,7 @@ library swarm-util
   import:
     stan-config, common, ghc2021-extensions,
     aeson,
+    array,
     base,
     boolexpr,
     clock,
@@ -882,6 +882,7 @@ library swarm-util
     Swarm.Failure
     Swarm.Language.Syntax.Direction
     Swarm.Pretty
+    Swarm.ResourceLoading
     Swarm.Util
     Swarm.Util.Effect
     Swarm.Util.Erasable
@@ -1103,7 +1104,6 @@ executable swarm
   build-depends:
     swarm:swarm-engine,
     swarm:swarm-lang,
-    swarm:swarm-scenario,
     swarm:swarm-tui,
     swarm:swarm-util,
     swarm:swarm-web,


### PR DESCRIPTION
Now that `Failure` is moved to `swarm-util` (#2155), that was the last remaining dependency of `Swarm.Game.ResourceLoading` which prevented it from moving as well.  The `ResourceLoading` code is not specific to Swarm scenarios; this PR moves it to `swarm-util` to make it more generally applicable.

In fact, the `ResourceLoading` code is already being used to load `.sw` files when executing the `Run` command; in order to implement #495 we will need to do that loading in order to resolve `import` expressions, but that code will live in `swarm-lang`, which cannot import `swarm-scenario`.