### PR TITLE
Improve type inference for record projection

### DIFF
--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -736,7 +736,7 @@ tcArity tydefs =
 -- Reducing types to WHNF
 ------------------------------------------------------------
 
--- | Reduce a type to weak head normal form, i.e. keep unfold type
+-- | Reduce a type to weak head normal form, i.e. keep unfolding type
 --   aliases and recursive types just until the top-level constructor
 --   of the type is neither @rec@ nor an application of a type alias.
 whnfType :: TDCtx -> Type -> Type

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -337,6 +337,12 @@ testLanguagePipeline =
                 "1:9: Type mismatch:\n  From context, expected `x` to have a record type,\n  but it actually has type `Int`"
             )
         , testCase
+            "inference failure with record projection"
+            ( process
+                "\\x. x.y"
+                "1:5: In the record projection `x.y`, can't infer whether the LHS has a record type.  Try adding a type annotation."
+            )
+        , testCase
             "infer record projection with tydef"
             (valid "tydef R = [x:Int] end; def f : R -> Int = \\r. r.x end")
         , testCase

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -330,6 +330,30 @@ testLanguagePipeline =
                 "(\\r:[x:Int, y:Int]. r.x) [x = 3, z = 5]"
                 "1:26: Field mismatch; record literal has:\n  - Extra field(s) `z`\n  - Missing field(s) `y`"
             )
+        , testCase
+            "type mismatch with record projection"
+            ( process
+                "\\x:Int. x.y"
+                "1:9: Type mismatch:\n  From context, expected `x` to have a record type,\n  but it actually has type `Int`"
+            )
+        , testCase
+            "infer record projection with tydef"
+            (valid "tydef R = [x:Int] end; def f : R -> Int = \\r. r.x end")
+        , testCase
+            "infer record projection with nested tydef"
+            (valid "tydef B = [x:Int] end; tydef A = B end; def f : A -> Int = \\r. r.x end")
+        , testCase
+            "infer record projection with tydef and recursive type"
+            (valid "tydef S = rec s. [hd:Int, tl:s] end; def two : S -> Int = \\s. s.tl.hd end")
+        , testCase
+            "infer record projection with tydef - RBTree"
+            (valid "tydef Color = Bool end; tydef RBTree k v = rec b. Unit + [c: Color, k: k, v: v, l: b, r: b] end; def balanceLR : RBTree k v -> RBTree k v = \\ln. case ln undefined (\\ne. ne.r) end")
+        , testCase
+            "infer record projection with tydef - RBTree, error"
+            ( process
+                "tydef Color = Bool end; tydef RBTree k v = rec b. Unit + [c: Color, k: k, v: v, l: b, r: b] end; def balanceLR : RBTree k v -> RBTree k v = \\ln. case ln.r undefined undefined end"
+                "1:151: Type mismatch:\n  From context, expected `ln` to have a record type,\n  but it actually has type `Unit +"
+            )
         ]
     , testGroup
         "type annotations"


### PR DESCRIPTION
When encountering a record projection `r.x`, we have to make sure that `r` has a record type.  Previously, if the type of `r` was not manifestly a record type, we simply emitted an error message like "Can't infer the type of a record projection: r.x".  This PR improves the situation in three related ways:

- First, we now expand the type of `r`, if it turns out to be a type alias or recursive type.  This was simply a bug: something like `tydef R = [x:Int] end; def f : R -> Int = \r. r.x` now works, as it should, but previously it was a type error.
- Second, if the type of `r` is provably *not* a record type, we generate an appropriate type mismatch error rather than an unhelpful "Can't infer" error.
- Finally, the "Can't infer" message itself is improved: it now says `In the record projection r.x, can't infer whether the LHS has a record type.  Try adding a type annotation.`.