### PR TITLE
Scoped type variables

### DIFF
--- a/src/swarm-doc/Swarm/Doc/Command.hs
+++ b/src/swarm-doc/Swarm/Doc/Command.hs
@@ -62,7 +62,7 @@ mkEntry c =
   cmdInfo = constInfo c
   cmdEffects = effectInfo $ constDoc cmdInfo
 
-  getArgs ((Forall _ t)) = unchainFun t
+  getArgs = unchainFun . ptBody
 
   rawArgs = getArgs $ inferConst c
 

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -640,10 +640,10 @@ stepCESK cesk = case cesk of
     _ -> badMachineState s "FProj frame with non-record value"
   -- To evaluate non-recursive let expressions, we start by focusing on the
   -- let-bound expression.
-  In (TLet _ False x mty mreq t1 t2) e s k ->
+  In (TLet _ False x _ mty mreq t1 t2) e s k ->
     return $ In t1 e s (FLet x ((,) <$> mty <*> mreq) t2 e : k)
   -- To evaluate a recursive let binding:
-  In (TLet _ True x mty mreq t1 t2) e s k -> do
+  In (TLet _ True x _ mty mreq t1 t2) e s k -> do
     -- First, allocate a cell for it in the store with the initial
     -- value of Blackhole.
     let (loc, s') = allocate VBlackhole s

--- a/src/swarm-lang/Swarm/Language/Context.hs
+++ b/src/swarm-lang/Swarm/Language/Context.hs
@@ -18,6 +18,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import Data.Data (Data)
 import Data.Map (Map)
 import Data.Map qualified as M
+import Data.Maybe (isJust)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Prettyprinter (brackets, emptyDoc, hsep, punctuate)
@@ -69,6 +70,10 @@ singleton x t = Ctx (M.singleton x t)
 lookup :: Var -> Ctx t -> Maybe t
 lookup x (Ctx c) = M.lookup x c
 
+-- | Check whether a context contains a certain variable as a key.
+member :: Var -> Ctx t -> Bool
+member x = isJust . lookup x
+
 -- | Look up a variable in a context in an ambient Reader effect.
 lookupR :: Has (Reader (Ctx t)) sig m => Var -> m (Maybe t)
 lookupR x = lookup x <$> ask
@@ -80,6 +85,10 @@ delete x (Ctx c) = Ctx (M.delete x c)
 -- | Get the list of key-value associations from a context.
 assocs :: Ctx t -> [(Var, t)]
 assocs = M.assocs . unCtx
+
+-- | Get the list of bound variables from a context.
+vars :: Ctx t -> [Var]
+vars = M.keys . unCtx
 
 -- | Add a key-value binding to a context (overwriting the old one if
 --   the key is already present).

--- a/src/swarm-lang/Swarm/Language/Context.hs
+++ b/src/swarm-lang/Swarm/Language/Context.hs
@@ -18,7 +18,6 @@ import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import Data.Data (Data)
 import Data.Map (Map)
 import Data.Map qualified as M
-import Data.Maybe (isJust)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Prettyprinter (brackets, emptyDoc, hsep, punctuate)
@@ -69,10 +68,6 @@ singleton x t = Ctx (M.singleton x t)
 -- | Look up a variable in a context.
 lookup :: Var -> Ctx t -> Maybe t
 lookup x (Ctx c) = M.lookup x c
-
--- | Check whether a context contains a certain variable as a key.
-member :: Var -> Ctx t -> Bool
-member x = isJust . lookup x
 
 -- | Look up a variable in a context in an ambient Reader effect.
 lookupR :: Has (Reader (Ctx t)) sig m => Var -> m (Maybe t)

--- a/src/swarm-lang/Swarm/Language/Kindcheck.hs
+++ b/src/swarm-lang/Swarm/Language/Kindcheck.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
@@ -65,7 +66,7 @@ instance PrettyPrec KindError where
 
 -- | Check that a polytype is well-kinded.
 checkPolytypeKind :: (Has (Reader TDCtx) sig m, Has (Throw KindError) sig m) => Polytype -> m TydefInfo
-checkPolytypeKind pty@(Forall xs t) = TydefInfo pty (Arity $ length xs) <$ checkKind t
+checkPolytypeKind pty@(unPoly -> (xs, t)) = TydefInfo pty (Arity $ length xs) <$ checkKind t
 
 -- | Check that a type is well-kinded. For now, we don't allow
 --   higher-kinded types, *i.e.* all kinds will be of the form @Type

--- a/src/swarm-lang/Swarm/Language/LSP/Hover.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/Hover.hs
@@ -162,7 +162,7 @@ class Show t => ExplainableType t where
   -- and get the type of the bound variable.
   getInnerType :: t -> t
 
-  -- | Check if this type is same as the given 'RawPolytype'.
+  -- | Check if this type is same as the given 'Polytype'.
   --
   -- We use it to not print same type twice (e.g. inferred and generic).
   eq :: t -> Polytype -> Bool

--- a/src/swarm-lang/Swarm/Language/LSP/Hover.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/Hover.hs
@@ -23,7 +23,7 @@ import Data.Foldable (asum)
 import Data.Graph
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map qualified as M
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, isNothing)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lines qualified as R
@@ -111,7 +111,7 @@ narrowToPosition ::
 narrowToPosition s0@(Syntax' _ t _ ty) pos = fromMaybe s0 $ case t of
   SLam lv _ s -> d (locVarToSyntax' lv $ getInnerType ty) <|> d s
   SApp s1 s2 -> d s1 <|> d s2
-  SLet _ _ lv _ _ s1@(Syntax' _ _ _ lty) s2 -> d (locVarToSyntax' lv lty) <|> d s1 <|> d s2
+  SLet _ _ lv _ _ _ s1@(Syntax' _ _ _ lty) s2 -> d (locVarToSyntax' lv lty) <|> d s1 <|> d s2
   SBind mlv _ _ _ s1@(Syntax' _ _ _ lty) s2 -> (mlv >>= d . flip locVarToSyntax' (getInnerType lty)) <|> d s1 <|> d s2
   STydef typ typBody _ti s1 -> d s1 <|> Just (locVarToSyntax' typ $ fromPoly typBody)
   SPair s1 s2 -> d s1 <|> d s2
@@ -162,7 +162,7 @@ class Show t => ExplainableType t where
   -- and get the type of the bound variable.
   getInnerType :: t -> t
 
-  -- | Check if this type is same as the given 'Polytype'.
+  -- | Check if this type is same as the given 'RawPolytype'.
   --
   -- We use it to not print same type twice (e.g. inferred and generic).
   eq :: t -> Polytype -> Bool
@@ -181,6 +181,15 @@ instance ExplainableType Polytype where
     (TyCmd t) -> t
     t -> t
   eq = (==)
+
+instance ExplainableType RawPolytype where
+  fromPoly = forgetQ
+  prettyType = prettyTextLine
+  getInnerType = fmap $ \case
+    (l :->: _r) -> l
+    (TyCmd t) -> t
+    t -> t
+  eq r t = r == forgetQ t
 
 explain :: ExplainableType ty => Syntax' ty -> Tree Text
 explain trm = case trm ^. sTerm of
@@ -205,7 +214,7 @@ explain trm = case trm ^. sTerm of
   TRequire {} -> pure "Require a certain number of an entity."
   SRequirements {} -> pure "Query the requirements of a term."
   -- definition or bindings
-  SLet ls isRecursive var mTypeAnn _ rhs _b -> pure $ explainDefinition ls isRecursive var (rhs ^. sType) mTypeAnn
+  SLet ls isRecursive var mTypeAnn _ _ rhs _b -> pure $ explainDefinition ls isRecursive var (rhs ^. sType) mTypeAnn
   SLam (LV _s v) _mType _syn ->
     pure $
       typeSignature v ty $
@@ -264,7 +273,7 @@ explainFunction s =
           (map explain params)
       ]
 
-explainDefinition :: ExplainableType ty => LetSyntax -> Bool -> LocVar -> ty -> Maybe Polytype -> Text
+explainDefinition :: ExplainableType ty => LetSyntax -> Bool -> LocVar -> ty -> Maybe RawPolytype -> Text
 explainDefinition ls isRecursive (LV _s var) ty maybeTypeAnnotation =
   typeSignature var ty $
     T.unwords
@@ -272,7 +281,7 @@ explainDefinition ls isRecursive (LV _s var) ty maybeTypeAnnotation =
       , (if isRecursive then "" else "non-") <> "recursive"
       , if ls == LSDef then "definition" else "let"
       , "expression"
-      , if null maybeTypeAnnotation then "without" else "with"
+      , if isNothing maybeTypeAnnotation then "without" else "with"
       , "a type annotation on the variable."
       ]
 

--- a/src/swarm-lang/Swarm/Language/LSP/VarUsage.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/VarUsage.hs
@@ -101,10 +101,10 @@ getUsage bindings (CSyntax _pos t _comments) = case t of
   SLam v _ s -> checkOccurrences bindings v Lambda [s]
   SApp s1 s2 -> getUsage bindings s1 <> getUsage bindings s2
   -- Warn on unused 'let' bindings...
-  SLet LSLet _ v _ _ s1 s2 -> getUsage bindings s1 <> checkOccurrences bindings v Let [s2]
+  SLet LSLet _ v _ _ _ s1 s2 -> getUsage bindings s1 <> checkOccurrences bindings v Let [s2]
   -- But don't warn on unused 'def' bindings, because they may be
   -- intended to be used at a later REPL input.
-  SLet LSDef _ _ _ _ s1 s2 -> getUsage bindings s1 <> getUsage bindings s2
+  SLet LSDef _ _ _ _ _ s1 s2 -> getUsage bindings s1 <> getUsage bindings s2
   SPair s1 s2 -> getUsage bindings s1 <> getUsage bindings s2
   SBind maybeVar _ _ _ s1 s2 -> case maybeVar of
     Just v -> checkOccurrences bindings v Bind [s1, s2]

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -104,8 +104,8 @@ parseTermAtom2 =
 
 -- | Construct an 'SLet', automatically filling in the Boolean field
 --   indicating whether it is recursive.
-sLet :: LetSyntax -> LocVar -> Maybe Polytype -> Syntax -> Syntax -> Term
-sLet ls x ty t1 = SLet ls (lvVar x `S.member` setOf freeVarsV t1) x ty mempty t1
+sLet :: LetSyntax -> LocVar -> Maybe RawPolytype -> Syntax -> Syntax -> Term
+sLet ls x ty t1 = SLet ls (lvVar x `S.member` setOf freeVarsV t1) x ty Nothing mempty t1
 
 sNoop :: Syntax
 sNoop = STerm (TConst Noop)
@@ -121,7 +121,7 @@ bindTydef xs ty
   | not (S.null free) =
       failT $
         "Undefined type variable(s) on right-hand side of tydef:" : S.toList free
-  | otherwise = return $ Forall xs ty
+  | otherwise = return . absQuantify $ mkPoly xs ty
  where
   free = tyVars ty `S.difference` S.fromList xs
 
@@ -160,7 +160,7 @@ parseExpr :: Parser Syntax
 parseExpr =
   parseLoc $ ascribe <$> parseExpr' <*> optional (symbol ":" *> parsePolytype)
  where
-  ascribe :: Syntax -> Maybe Polytype -> Term
+  ascribe :: Syntax -> Maybe RawPolytype -> Term
   ascribe s Nothing = s ^. sTerm
   ascribe s (Just ty) = SAnnotate s ty
 

--- a/src/swarm-lang/Swarm/Language/Parser/Type.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Type.hs
@@ -42,26 +42,9 @@ import Witch (from)
 --   'parseType' is also accepted by 'parsePolytype'.
 parsePolytype :: Parser Polytype
 parsePolytype =
-  join $
-    ( quantify . fromMaybe []
-        <$> optional ((reserved "forall" <|> reserved "∀") *> some tyVar <* symbol ".")
-    )
-      <*> parseType
- where
-  quantify :: [Var] -> Type -> Parser Polytype
-  quantify xs ty
-    -- Iplicitly quantify over free type variables if the user didn't write a forall
-    | null xs = return $ Forall (S.toList free) ty
-    -- Otherwise, require all variables to be explicitly quantified
-    | S.null free = return $ Forall xs ty
-    | otherwise =
-        fail $
-          unlines
-            [ "  Type contains free variable(s): " ++ unwords (map from (S.toList free))
-            , "  Try adding them to the 'forall'."
-            ]
-   where
-    free = tyVars ty `S.difference` S.fromList xs
+  Forall . fromMaybe []
+    <$> optional ((reserved "forall" <|> reserved "∀") *> some tyVar <* symbol ".")
+    <*> parseType
 
 -- | Parse a Swarm language (mono)type.
 parseType :: Parser Type

--- a/src/swarm-lang/Swarm/Language/Parser/Type.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Type.hs
@@ -38,7 +38,7 @@ import Text.Megaparsec (choice, optional, some, (<|>))
 --   quanitifation (@forall@ followed by one or more variables and a
 --   period) followed by a type.  Note that anything accepted by
 --   'parseType' is also accepted by 'parsePolytype'.
-parsePolytype :: Parser (Poly Unquantified Type)
+parsePolytype :: Parser RawPolytype
 parsePolytype =
   mkPoly . fromMaybe []
     <$> optional ((reserved "forall" <|> reserved "∀") *> some tyVar <* symbol ".")

--- a/src/swarm-lang/Swarm/Language/Parser/Type.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Type.hs
@@ -13,13 +13,11 @@ module Swarm.Language.Parser.Type (
 ) where
 
 import Control.Lens (view)
-import Control.Monad (join)
 import Control.Monad.Combinators (many)
 import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
 import Data.Fix (Fix (..), foldFix)
 import Data.List.Extra (enumerate)
 import Data.Maybe (fromMaybe)
-import Data.Set qualified as S
 import Swarm.Language.Parser.Core (LanguageVersion (..), Parser, languageVersion)
 import Swarm.Language.Parser.Lex (
   braces,
@@ -34,7 +32,6 @@ import Swarm.Language.Parser.Lex (
 import Swarm.Language.Parser.Record (parseRecord)
 import Swarm.Language.Types
 import Text.Megaparsec (choice, optional, some, (<|>))
-import Witch (from)
 
 -- | Parse a Swarm language polytype, which starts with an optional
 --   quanitifation (@forall@ followed by one or more variables and a

--- a/src/swarm-lang/Swarm/Language/Parser/Type.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
@@ -37,9 +38,9 @@ import Text.Megaparsec (choice, optional, some, (<|>))
 --   quanitifation (@forall@ followed by one or more variables and a
 --   period) followed by a type.  Note that anything accepted by
 --   'parseType' is also accepted by 'parsePolytype'.
-parsePolytype :: Parser Polytype
+parsePolytype :: Parser (Poly Unquantified Type)
 parsePolytype =
-  Forall . fromMaybe []
+  mkPoly . fromMaybe []
     <$> optional ((reserved "forall" <|> reserved "∀") *> some tyVar <* symbol ".")
     <*> parseType
 

--- a/src/swarm-lang/Swarm/Language/Pipeline.hs
+++ b/src/swarm-lang/Swarm/Language/Pipeline.hs
@@ -77,7 +77,7 @@ extractTCtx :: Syntax' ty -> TCtx
 extractTCtx (Syntax' _ t _ _) = extractTCtxTerm t
  where
   extractTCtxTerm = \case
-    SLet _ _ (LV _ x) mty _ _ t2 -> maybe id (Ctx.addBinding x) mty (extractTCtx t2)
+    SLet _ _ (LV _ x) _ mty _ _ t2 -> maybe id (Ctx.addBinding x) mty (extractTCtx t2)
     SBind mx _ mty _ c1 c2 ->
       maybe
         id
@@ -94,7 +94,7 @@ extractReqCtx :: Syntax' ty -> ReqCtx
 extractReqCtx (Syntax' _ t _ _) = extractReqCtxTerm t
  where
   extractReqCtxTerm = \case
-    SLet _ _ (LV _ x) _ mreq _ t2 -> maybe id (Ctx.addBinding x) mreq (extractReqCtx t2)
+    SLet _ _ (LV _ x) _ _ mreq _ t2 -> maybe id (Ctx.addBinding x) mreq (extractReqCtx t2)
     SBind mx _ _ mreq c1 c2 ->
       maybe
         id

--- a/src/swarm-lang/Swarm/Language/Requirements/Analysis.hs
+++ b/src/swarm-lang/Swarm/Language/Requirements/Analysis.hs
@@ -108,7 +108,7 @@ requirements tdCtx ctx =
     -- will be used at least once in the body. We delete the let-bound
     -- name from the context when recursing for the same reason as
     -- lambda.
-    TLet LSLet r x mty _ t1 t2 -> do
+    TLet LSLet r x mty _ _ t1 t2 -> do
       when r $ add (singletonCap CRecursion)
       add (singletonCap CEnv)
       mapM_ polytypeRequirements mty
@@ -116,7 +116,7 @@ requirements tdCtx ctx =
     -- However, for def, we do NOT assume that the defined expression
     -- will be used at least once in the body; it may not be executed
     -- until later on, when the base robot has more capabilities.
-    TLet LSDef r x mty _ t1 t2 -> do
+    TLet LSDef r x mty _ _ t1 t2 -> do
       add (singletonCap CEnv)
       mapM_ polytypeRequirements mty
       localReqCtx <- ask @ReqCtx
@@ -159,9 +159,9 @@ requirements tdCtx ctx =
 
 polytypeRequirements ::
   (Has (Accum Requirements) sig m, Has (Reader TDCtx) sig m) =>
-  Polytype ->
+  Poly q Type ->
   m ()
-polytypeRequirements (Forall _ ty) = typeRequirements ty
+polytypeRequirements = typeRequirements . ptBody
 
 typeRequirements ::
   (Has (Accum Requirements) sig m, Has (Reader TDCtx) sig m) =>

--- a/src/swarm-lang/Swarm/Language/Syntax/AST.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/AST.hs
@@ -100,10 +100,11 @@ data Term' ty
     --   annotation on the variable. The @Bool@ indicates whether
     --   it is known to be recursive.
     --
-    --   The @Maybe Requirements@ field is only for annotating the
-    --   requirements of a definition after typechecking; there is no
-    --   way to annotate requirements in the surface syntax.
-    SLet LetSyntax Bool LocVar (Maybe Polytype) (Maybe Requirements) (Syntax' ty) (Syntax' ty)
+    --   The @Maybe Polytype@ and @Maybe Requirements@ fields are only
+    --   for annotating the requirements of a definition after
+    --   typechecking; there is no way to annotate requirements in the
+    --   surface syntax.
+    SLet LetSyntax Bool LocVar (Maybe RawPolytype) (Maybe Polytype) (Maybe Requirements) (Syntax' ty) (Syntax' ty)
   | -- | A type synonym definition.  Note that this acts like a @let@
     --   (just like @def@), /i.e./ the @Syntax' ty@ field is the local
     --   context over which the type definition is in scope.
@@ -136,7 +137,7 @@ data Term' ty
   | -- | Record projection @e.x@
     SProj (Syntax' ty) Var
   | -- | Annotate a term with a type
-    SAnnotate (Syntax' ty) Polytype
+    SAnnotate (Syntax' ty) RawPolytype
   | -- | Run the given command, then suspend and wait for a new REPL
     --   input.
     SSuspend (Syntax' ty)

--- a/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
@@ -104,10 +104,10 @@ pattern (:$:) :: Term -> Syntax -> Term
 pattern (:$:) t1 s2 = SApp (STerm t1) s2
 
 -- | Match a TLet without annotations.
-pattern TLet :: LetSyntax -> Bool -> Var -> Maybe Polytype -> Maybe Requirements -> Term -> Term -> Term
-pattern TLet ls r v mty mreq t1 t2 <- SLet ls r (lvVar -> v) mty mreq (STerm t1) (STerm t2)
+pattern TLet :: LetSyntax -> Bool -> Var -> Maybe RawPolytype -> Maybe Polytype -> Maybe Requirements -> Term -> Term -> Term
+pattern TLet ls r v mty mpty mreq t1 t2 <- SLet ls r (lvVar -> v) mty mpty mreq (STerm t1) (STerm t2)
   where
-    TLet ls r v mty mreq t1 t2 = SLet ls r (LV NoLoc v) mty mreq (STerm t1) (STerm t2)
+    TLet ls r v mty mpty mreq t1 t2 = SLet ls r (LV NoLoc v) mty mpty mreq (STerm t1) (STerm t2)
 
 -- | Match a STydef without annotations.
 pattern TTydef :: Var -> Polytype -> Maybe TydefInfo -> Term -> Term
@@ -135,7 +135,7 @@ pattern TProj :: Term -> Var -> Term
 pattern TProj t x = SProj (STerm t) x
 
 -- | Match a TAnnotate without annotations.
-pattern TAnnotate :: Term -> Polytype -> Term
+pattern TAnnotate :: Term -> RawPolytype -> Term
 pattern TAnnotate t pt = SAnnotate (STerm t) pt
 
 -- | Match a TSuspend without annotations.

--- a/src/swarm-lang/Swarm/Language/Syntax/Util.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Util.hs
@@ -134,9 +134,9 @@ freeVarsS f = go S.empty
       | otherwise -> f s
     SLam x xty s1 -> rewrap $ SLam x xty <$> go (S.insert (lvVar x) bound) s1
     SApp s1 s2 -> rewrap $ SApp <$> go bound s1 <*> go bound s2
-    SLet ls r x xty xreq s1 s2 ->
+    SLet ls r x xty xpty xreq s1 s2 ->
       let bound' = S.insert (lvVar x) bound
-       in rewrap $ SLet ls r x xty xreq <$> go bound' s1 <*> go bound' s2
+       in rewrap $ SLet ls r x xty xpty xreq <$> go bound' s1 <*> go bound' s2
     STydef x xdef tdInfo t1 -> rewrap $ STydef x xdef tdInfo <$> go bound t1
     SPair s1 s2 -> rewrap $ SPair <$> go bound s1 <*> go bound s2
     SBind mx mty mpty mreq s1 s2 -> rewrap $ SBind mx mty mpty mreq <$> go bound s1 <*> go (maybe id (S.insert . lvVar) mx bound) s2

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -1193,7 +1193,8 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
 
   -- Checking the type of a let- or def-expression.
   SLet ls r x mxTy _ t1 t2 -> withFrame l (TCLet (lvVar x)) $ do
-    (skolems, upty, t1') <- case mxTy of
+    mqxTy <- traverse quantify mxTy
+    (skolems, upty, t1') <- case mqxTy of
       -- No type annotation was provided for the let binding, so infer its type.
       Nothing -> do
         -- The let could be recursive, so we must generate a fresh
@@ -1267,7 +1268,7 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
           LSLet -> Nothing
 
     -- Return the annotated let.
-    return $ Syntax' l (SLet ls r x mxTy mreqs t1' t2') cs expected
+    return $ Syntax' l (SLet ls r x mqxTy mreqs t1' t2') cs expected
 
   -- Kind-check a type definition and then check the body under an
   -- extended context.

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -512,12 +512,20 @@ unPoly (Forall xs t) = (xs, t)
 ptVars :: Poly 'Quantified t -> [Var]
 ptVars (Forall xs _) = xs
 
+-- | Forget that a polytype has been properly quantified.
 forgetQ :: Poly 'Quantified t -> Poly 'Unquantified t
 forgetQ (Forall xs t) = Forall xs t
 
--- | A polytype without unification variables.
+-- | A regular polytype (without unification variables).  A @Polytype@
+--   (as opposed to a @RawPolytype@) is guaranteed to have implicit
+--   quantification properly applied, so that all type variables bound
+--   by the forall are explicitly listed.
 type Polytype = Poly 'Quantified Type
 
+-- | A raw polytype (without unification variables), which corresponds
+--   exactly to the way a polytype was written in source code.  In
+--   particular there may be type variables which are used in the type
+--   but not listed explicitly, which are to be implicitly quantified.
 type RawPolytype = Poly 'Unquantified Type
 
 instance PrettyPrec (Poly q Type) where

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -742,13 +742,13 @@ quantify ::
   Poly 'Unquantified ty ->
   m (Poly 'Quantified ty)
 quantify (Forall xs ty) = do
-  -- Look at all variables which occur in the type but are not explicitly bound by the forall...
-  let unbound = tyVars ty `S.difference` S.fromList xs
-  -- ...and filter out those that are not bound in the context and
-  -- should therefore be implicitly quantified
   inScope <- ask @TVCtx
-  let implicit = S.filter (not . (`Ctx.member` inScope)) unbound
-
+  -- Look at all variables which occur in the type but are not
+  -- explicitly bound by the forall, and and are not bound in the
+  -- context.  Such variables must be implicitly quantified.
+  let implicit =
+        (tyVars ty `S.difference` S.fromList xs)
+          `S.difference` M.keysSet (Ctx.unCtx inScope)
   pure $ Forall (xs ++ S.toList implicit) ty
 
 -- | Absolute implicit quantification, i.e. assume there are no type

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -488,7 +488,7 @@ data Poly (q :: ImplicitQuantification) t = Forall {_ptVars :: [Var], ptBody :: 
   deriving (Show, Eq, Functor, Foldable, Traversable, Data, Generic, FromJSON, ToJSON)
 
 -- | Create a raw, unquantified @Poly@ value.
-mkPoly :: [Var] -> t -> Poly Unquantified t
+mkPoly :: [Var] -> t -> Poly 'Unquantified t
 mkPoly = Forall
 
 -- | Create a polytype while performing implicit quantification.

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -83,10 +84,21 @@ module Swarm.Language.Types (
   UnchainableFun (..),
 
   -- * Polytypes
-  Poly (..),
+  ImplicitQuantification (..),
+  Poly,
+  mkPoly,
+  mkQPoly,
+  mkTrivPoly,
+  unPoly,
+  ptVars,
+  ptBody,
   Polytype,
+  RawPolytype,
   pattern PolyUnit,
   UPolytype,
+  quantify,
+  absQuantify,
+  forgetQ,
 
   -- * Contexts
   TCtx,
@@ -281,10 +293,6 @@ instance FromJSON1 TypeF where
 --   with 'Type' as if it were defined in a directly recursive way.
 type Type = Fix TypeF
 
--- | Get all the type variables contained in a 'Type'.
-tyVars :: Type -> Set Var
-tyVars = foldFix (\case TyVarF x -> S.singleton x; f -> fold f)
-
 newtype IntVar = IntVar Int
   deriving (Show, Data, Eq, Ord)
 
@@ -424,41 +432,102 @@ instance (UnchainableFun t, PrettyPrec t, SubstRec t) => PrettyPrec (TypeF t) wh
 ------------------------------------------------------------
 
 class Typical t where
-  foldT :: (TypeF t -> t) -> t -> t
+  -- Fold a type into a summary value of some type @a@, given an
+  -- "empty" value of type @a@ (for use at e.g. Pure nodes in a UType)
+  foldT :: a -> (TypeF a -> a) -> t -> a
+
+  -- Refold a type into another type
+  refoldT :: (TypeF t -> t) -> t -> t
   rollT :: TypeF t -> t
   fromType :: Type -> t
 
 instance Typical Type where
-  foldT = foldFix
+  foldT _ = foldFix
+  refoldT = foldFix
   rollT = Fix
   fromType = id
 
 instance Typical UType where
-  foldT = ucata Pure
+  foldT e = ucata (const e)
+  refoldT = ucata Pure
   rollT = Free
   fromType = toU
+
+-- | Get all the type variables (/not/ unification variables)
+--   contained in a 'Type' or 'UType'.
+tyVars :: Typical t => t -> Set Var
+tyVars = foldT S.empty (\case TyVarF x -> S.singleton x; f -> fold f)
 
 ------------------------------------------------------------
 -- Polytypes
 ------------------------------------------------------------
 
--- | A @Poly t@ is a universally quantified @t@.  The variables in the
---   list are bound inside the @t@.  For example, the type @forall
---   a. a -> a@ would be represented as @Forall ["a"] (TyFun "a" "a")@.
-data Poly t = Forall {ptVars :: [Var], ptBody :: t}
+data ImplicitQuantification = Unquantified | Quantified
+  deriving (Eq, Ord, Read, Show)
+
+-- | A @Poly q t@ is a universally quantified @t@.  The variables in
+--   the list are bound inside the @t@.  For example, the type @forall
+--   a. a -> a@ would be represented as @Forall ["a"] (TyFun "a"
+--   "a")@.
+--
+--   The type index @q@ is a phantom type index indicating whether the
+--   type has been implicitly quantified.  Immediately after a
+--   polytype is parsed it is 'Unquantified' and unsafe to use.  For
+--   example, the type @a -> a@ would parse literally as @Forall []
+--   (TyFun "a" "a") :: Poly Unquantified Type@, where the type
+--   variable @a@ is not in the list of bound variables.  Later, after
+--   running through 'quantify', it would become a @Poly Quantified
+--   Type@, either @Forall ["a"] (TyFun "a" "a")@ if the type variable
+--   is implicitly quantified, or unchanged if the type variable @a@
+--   was already in scope.
+--
+--   The @Poly@ constructor intentionally unexported, so that the
+--   only way to create a @Poly Quantified@ is through the 'quantify'
+--   function.
+data Poly (q :: ImplicitQuantification) t = Forall {_ptVars :: [Var], ptBody :: t}
   deriving (Show, Eq, Functor, Foldable, Traversable, Data, Generic, FromJSON, ToJSON)
 
--- | A polytype without unification variables.
-type Polytype = Poly Type
+-- | Create a raw, unquantified @Poly@ value.
+mkPoly :: [Var] -> t -> Poly Unquantified t
+mkPoly = Forall
 
-instance PrettyPrec Polytype where
+-- | Create a polytype while performing implicit quantification.
+mkQPoly :: Typical t => t -> Poly Quantified t
+mkQPoly = absQuantify . Forall []
+
+-- | Create a trivial "polytype" with no bound variables.  This is
+--   somewhat unsafe --- only use this if you are sure that the polytype
+--   you want has no type variables.
+mkTrivPoly :: t -> Poly q t
+mkTrivPoly = Forall []
+
+-- | Project out the variables and body of a 'Poly' value.  It's only
+--   possible to project from a 'Poly Quantified' since the list of
+--   variables might be meaningless for a type that has not had
+--   implicit quantification applied.
+unPoly :: Poly Quantified t -> ([Var], t)
+unPoly (Forall xs t) = (xs, t)
+
+-- | Project out the variables of a 'Poly Quantified' value.
+ptVars :: Poly Quantified t -> [Var]
+ptVars (Forall xs _) = xs
+
+forgetQ :: Poly Quantified t -> Poly Unquantified t
+forgetQ (Forall xs t) = Forall xs t
+
+-- | A polytype without unification variables.
+type Polytype = Poly Quantified Type
+
+type RawPolytype = Poly Unquantified Type
+
+instance PrettyPrec (Poly q Type) where
   prettyPrec _ (Forall [] t) = ppr t
   prettyPrec _ (Forall xs t) = hsep ("∀" : map pretty xs) <> "." <+> ppr t
 
 -- | A polytype with unification variables.
-type UPolytype = Poly UType
+type UPolytype = Poly Quantified UType
 
-instance PrettyPrec UPolytype where
+instance PrettyPrec (Poly q UType) where
   prettyPrec _ (Forall [] t) = ppr t
   prettyPrec _ (Forall xs t) = hsep ("∀" : map pretty xs) <> "." <+> ppr t
 
@@ -656,6 +725,30 @@ type UCtx = Ctx UPolytype
 type TVCtx = Ctx UType
 
 ------------------------------------------------------------
+-- Implicit quantification of polytypes
+------------------------------------------------------------
+
+-- | Implicitly quantify any otherwise unbound type variables.
+quantify ::
+  (Has (Reader TVCtx) sig m, Typical ty) =>
+  Poly Unquantified ty ->
+  m (Poly Quantified ty)
+quantify (Forall xs ty) = do
+  -- Look at all variables which occur in the type but are not explicitly bound by the forall...
+  let unbound = tyVars ty `S.difference` S.fromList xs
+  -- ...and filter out those that are not bound in the context and
+  -- should therefore be implicitly quantified
+  inScope <- ask @TVCtx
+  let implicit = S.filter (not . (`Ctx.member` inScope)) unbound
+
+  pure $ Forall (xs ++ S.toList implicit) ty
+
+-- | Absolute implicit quantification, i.e. assume there are no type
+--   variables in scope.
+absQuantify :: Typical t => Poly Unquantified t -> Poly Quantified t
+absQuantify = run . runReader @TVCtx Ctx.empty . quantify
+
+------------------------------------------------------------
 -- Type definitions
 ------------------------------------------------------------
 
@@ -698,7 +791,7 @@ expandTydef userTyCon tys = do
 -- | Given the definition of a type alias, substitute the given
 --   arguments into its body and return the resulting type.
 substTydef :: forall t. Typical t => TydefInfo -> [t] -> t
-substTydef (TydefInfo (Forall as ty) _) tys = foldT @t substF (fromType ty)
+substTydef (TydefInfo (Forall as ty) _) tys = refoldT @t substF (fromType ty)
  where
   argMap = M.fromList $ zip as tys
 
@@ -712,7 +805,7 @@ substTydef (TydefInfo (Forall as ty) _) tys = foldT @t substF (fromType ty)
 --   a term containing a local tydef: since the tydef is local we
 --   can't use it in the reported type.
 elimTydef :: forall t. Typical t => Var -> TydefInfo -> t -> t
-elimTydef x tdInfo = foldT substF
+elimTydef x tdInfo = refoldT substF
  where
   substF = \case
     TyConF (TCUser u) tys | u == x -> substTydef tdInfo tys

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -91,6 +91,7 @@ module Swarm.Language.Types (
   -- * Contexts
   TCtx,
   UCtx,
+  TVCtx,
 
   -- * User type definitions
   TydefInfo (..),
@@ -649,6 +650,10 @@ type TCtx = Ctx Polytype
 --   unification variables.  We generally have one of these while we
 --   are in the midst of the type inference process.
 type UCtx = Ctx UPolytype
+
+-- | A @TVCtx@ tracks which type variables are in scope, and what
+--   skolem variables were assigned to them.
+type TVCtx = Ctx UType
 
 ------------------------------------------------------------
 -- Type definitions

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -431,14 +431,27 @@ instance (UnchainableFun t, PrettyPrec t, SubstRec t) => PrettyPrec (TypeF t) wh
 -- Generic folding over type representations
 ------------------------------------------------------------
 
+-- | Type class for various type representations (e.g. 'Type',
+--   'UType') and generic operations we can perform on them.  This
+--   helps us avoid code duplication in some cases, by writing a
+--   single generic function which works for any 'Typical' instance.
 class Typical t where
-  -- Fold a type into a summary value of some type @a@, given an
-  -- "empty" value of type @a@ (for use at e.g. Pure nodes in a UType)
+  -- | Fold a type into a summary value of some type @a@, given an
+  --   "empty" value of type @a@ (for use at e.g. Pure nodes in a
+  --   UType)
   foldT :: a -> (TypeF a -> a) -> t -> a
 
-  -- Refold a type into another type
+  -- | Refold a type into another type.  This is a special case of
+  --   'foldT' when we want to produce another type, since then we can
+  --   do something more sensible with 'Pure' nodes in a 'UType'
+  --   (i.e. preserve them instead of replacing them with a default
+  --   value).
   refoldT :: (TypeF t -> t) -> t -> t
+
+  -- | Roll up one level of structure.
   rollT :: TypeF t -> t
+
+  -- | It should be possible to convert 'Type' to any type-ish thing.
   fromType :: Type -> t
 
 instance Typical Type where

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -492,7 +492,7 @@ mkPoly :: [Var] -> t -> Poly Unquantified t
 mkPoly = Forall
 
 -- | Create a polytype while performing implicit quantification.
-mkQPoly :: Typical t => t -> Poly Quantified t
+mkQPoly :: Typical t => t -> Poly 'Quantified t
 mkQPoly = absQuantify . Forall []
 
 -- | Create a trivial "polytype" with no bound variables.  This is
@@ -505,27 +505,27 @@ mkTrivPoly = Forall []
 --   possible to project from a 'Poly Quantified' since the list of
 --   variables might be meaningless for a type that has not had
 --   implicit quantification applied.
-unPoly :: Poly Quantified t -> ([Var], t)
+unPoly :: Poly 'Quantified t -> ([Var], t)
 unPoly (Forall xs t) = (xs, t)
 
 -- | Project out the variables of a 'Poly Quantified' value.
-ptVars :: Poly Quantified t -> [Var]
+ptVars :: Poly 'Quantified t -> [Var]
 ptVars (Forall xs _) = xs
 
-forgetQ :: Poly Quantified t -> Poly Unquantified t
+forgetQ :: Poly 'Quantified t -> Poly 'Unquantified t
 forgetQ (Forall xs t) = Forall xs t
 
 -- | A polytype without unification variables.
-type Polytype = Poly Quantified Type
+type Polytype = Poly 'Quantified Type
 
-type RawPolytype = Poly Unquantified Type
+type RawPolytype = Poly 'Unquantified Type
 
 instance PrettyPrec (Poly q Type) where
   prettyPrec _ (Forall [] t) = ppr t
   prettyPrec _ (Forall xs t) = hsep ("∀" : map pretty xs) <> "." <+> ppr t
 
 -- | A polytype with unification variables.
-type UPolytype = Poly Quantified UType
+type UPolytype = Poly 'Quantified UType
 
 instance PrettyPrec (Poly q UType) where
   prettyPrec _ (Forall [] t) = ppr t
@@ -731,8 +731,8 @@ type TVCtx = Ctx UType
 -- | Implicitly quantify any otherwise unbound type variables.
 quantify ::
   (Has (Reader TVCtx) sig m, Typical ty) =>
-  Poly Unquantified ty ->
-  m (Poly Quantified ty)
+  Poly 'Unquantified ty ->
+  m (Poly 'Quantified ty)
 quantify (Forall xs ty) = do
   -- Look at all variables which occur in the type but are not explicitly bound by the forall...
   let unbound = tyVars ty `S.difference` S.fromList xs
@@ -745,7 +745,7 @@ quantify (Forall xs ty) = do
 
 -- | Absolute implicit quantification, i.e. assume there are no type
 --   variables in scope.
-absQuantify :: Typical t => Poly Unquantified t -> Poly Quantified t
+absQuantify :: Typical t => Poly 'Unquantified t -> Poly 'Quantified t
 absQuantify = run . runReader @TVCtx Ctx.empty . quantify
 
 ------------------------------------------------------------

--- a/src/swarm-lang/Swarm/Language/Value.hs
+++ b/src/swarm-lang/Swarm/Language/Value.hs
@@ -225,7 +225,7 @@ valueToTerm = \case
     M.foldrWithKey
       ( \y v -> case v of
           VIndir {} -> id
-          _ -> TLet LSLet False y Nothing Nothing (valueToTerm v)
+          _ -> TLet LSLet False y Nothing Nothing Nothing (valueToTerm v)
       )
       (TLam x Nothing t)
       (M.restrictKeys (Ctx.unCtx (e ^. envVals)) (S.delete x (setOf freeVarsV (Syntax' NoLoc t Empty ()))))

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -326,6 +326,6 @@ generateNotificationPopups = do
 -- | Strips the top-level @Cmd@ from a type, if any (to compute the
 --   result type of a REPL command evaluation).
 stripCmd :: TDCtx -> Polytype -> Polytype
-stripCmd tdCtx (Forall xs ty) = case whnfType tdCtx ty of
-  TyCmd resTy -> Forall xs resTy
-  _ -> Forall xs ty
+stripCmd tdCtx = fmap $ \ty -> case whnfType tdCtx ty of
+  TyCmd resTy -> resTy
+  _ -> ty

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -51,7 +51,7 @@ testLanguagePipeline =
           "type variable scope #2178 - shadowing"
           ( process
             "def f : a -> (a * Int) = \\x. let g : forall a. a * Int = (x, 3) in g end"
-            ""
+            "1:59: Type mismatch:\n  From context, expected `x` to have type `s2`,\n  but it actually has type `s1`"
           )
         ]
     , testCase
@@ -403,7 +403,7 @@ testLanguagePipeline =
             "type ascription doesn't allow rank 2 types"
             ( process
                 "\\f. (f:forall a. a->a) 3"
-                "1:5: Skolem variable s3 would escape its scope"
+                "1:24: Type mismatch:\n  From context, expected `3` to have type `s3`,\n  but it actually has type `Int`"
             )
         , testCase
             "checking a lambda with the wrong argument type"

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -36,23 +36,23 @@ testLanguagePipeline =
     , testGroup
         "quantification + scope"
         [ testCase
-          "quantification #148 - implicit"
-          (valid "def id : a -> a = \\x. x end; id move")
+            "quantification #148 - implicit"
+            (valid "def id : a -> a = \\x. x end; id move")
         , testCase
-          "quantification #148 - explicit"
-          (valid "def id : forall a. a -> a = \\x. x end; id move")
+            "quantification #148 - explicit"
+            (valid "def id : forall a. a -> a = \\x. x end; id move")
         , testCase
-          "quantification #148 - explicit with free tyvars"
-          (valid "def id : forall a. b -> b = \\x. x end; id move")
+            "quantification #148 - explicit with free tyvars"
+            (valid "def id : forall a. b -> b = \\x. x end; id move")
         , testCase
-          "type variable scope #2178"
-          (valid "def f : a -> (a * Int) = \\x. let g : a * Int = (x, 3) in g end")
+            "type variable scope #2178"
+            (valid "def f : a -> (a * Int) = \\x. let g : a * Int = (x, 3) in g end")
         , testCase
-          "type variable scope #2178 - shadowing"
-          ( process
-            "def f : a -> (a * Int) = \\x. let g : forall a. a * Int = (x, 3) in g end"
-            "1:59: Type mismatch:\n  From context, expected `x` to have type `s2`,\n  but it actually has type `s1`"
-          )
+            "type variable scope #2178 - shadowing"
+            ( process
+                "def f : a -> (a * Int) = \\x. let g : forall a. a * Int = (x, 3) in g end"
+                "1:59: Type mismatch:\n  From context, expected `x` to have type `s2`,\n  but it actually has type `s1`"
+            )
         ]
     , testCase
         "parsing operators #188 - parse valid operator (!=)"

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -33,15 +33,27 @@ testLanguagePipeline =
   testGroup
     "Language - pipeline"
     [ testCase "end semicolon #79" (valid "def a = 41 end def b = a + 1 end def c = b + 2 end")
-    , testCase
-        "quantification #148 - implicit"
-        (valid "def id : a -> a = \\x. x end; id move")
-    , testCase
-        "quantification #148 - explicit"
-        (valid "def id : forall a. a -> a = \\x. x end; id move")
-    , testCase
-        "quantification #148 - explicit with free tyvars"
-        (valid "def id : forall a. b -> b = \\x. x end; id move")
+    , testGroup
+        "quantification + scope"
+        [ testCase
+          "quantification #148 - implicit"
+          (valid "def id : a -> a = \\x. x end; id move")
+        , testCase
+          "quantification #148 - explicit"
+          (valid "def id : forall a. a -> a = \\x. x end; id move")
+        , testCase
+          "quantification #148 - explicit with free tyvars"
+          (valid "def id : forall a. b -> b = \\x. x end; id move")
+        , testCase
+          "type variable scope #2178"
+          (valid "def f : a -> (a * Int) = \\x. let g : a * Int = (x, 3) in g end")
+        , testCase
+          "type variable scope #2178 - shadowing"
+          ( process
+            "def f : a -> (a * Int) = \\x. let g : forall a. a * Int = (x, 3) in g end"
+            ""
+          )
+        ]
     , testCase
         "parsing operators #188 - parse valid operator (!=)"
         (valid "1!=(2)")

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -41,19 +41,7 @@ testLanguagePipeline =
         (valid "def id : forall a. a -> a = \\x. x end; id move")
     , testCase
         "quantification #148 - explicit with free tyvars"
-        ( process
-            "def id : forall a. b -> b = \\x. x end; id move"
-            ( T.unlines
-                [ "1:27:"
-                , "  |"
-                , "1 | def id : forall a. b -> b = \\x. x end; id move"
-                , "  |                           ^"
-                , "  Type contains free variable(s): b"
-                , "  Try adding them to the 'forall'."
-                , ""
-                ]
-            )
-        )
+        (valid "def id : forall a. b -> b = \\x. x end; id move")
     , testCase
         "parsing operators #188 - parse valid operator (!=)"
         (valid "1!=(2)")

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -376,6 +376,7 @@ testLanguagePipeline =
 
                   isVar (TVar {}) = True
                   isVar _ = False
+                  getVars :: TSyntax -> [(Term' Polytype, Polytype)]
                   getVars = map (_sTerm &&& _sType) . filter (isVar . _sTerm) . universe
                in assertEqual
                     "variable types"

--- a/test/unit/TestPretty.hs
+++ b/test/unit/TestPretty.hs
@@ -91,7 +91,7 @@ testPrettyConst =
     , testCase
         "type ascription"
         ( equalPrettyLine "1 : Int" $
-            TAnnotate (TInt 1) (Forall [] TyInt)
+            TAnnotate (TInt 1) (mkTrivPoly TyInt)
         )
     , testCase
         "lambda precedence (#1468)"
@@ -218,23 +218,22 @@ testPrettyConst =
         "tydef"
         [ testCase "tydef alias" $
             equalPrettyLine "tydef X = Int end" $
-              TTydef "X" (Forall [] TyInt) Nothing (TConst Noop)
+              TTydef "X" (mkTrivPoly TyInt) Nothing (TConst Noop)
         , testCase "tydef Maybe" $
             equalPrettyLine "tydef Maybe a = Unit + a end" $
-              TTydef "Maybe" (Forall ["a"] (TyUnit :+: TyVar "a")) Nothing (TConst Noop)
+              TTydef "Maybe" (mkQPoly (TyUnit :+: TyVar "a")) Nothing (TConst Noop)
         , testCase "tydef multi-arg" $
             equalPrettyLine "tydef Foo a b c d = Unit + ((a * b) + ((c -> d) * a)) end" $
               TTydef
                 "Foo"
-                ( Forall
-                    ["a", "b", "c", "d"]
+                ( mkQPoly
                     (TyUnit :+: (TyVar "a" :*: TyVar "b") :+: ((TyVar "c" :->: TyVar "d") :*: TyVar "a"))
                 )
                 Nothing
                 (TConst Noop)
         , testCase "consecutive tydef" $
             equalPrettyLine "tydef X = Int end\n\ntydef Y = Bool end" $
-              TTydef "X" (Forall [] TyInt) Nothing (TTydef "Y" (Forall [] TyBool) Nothing (TConst Noop))
+              TTydef "X" (mkTrivPoly TyInt) Nothing (TTydef "Y" (mkTrivPoly TyBool) Nothing (TConst Noop))
         ]
     , testGroup
         "recursive types"


### PR DESCRIPTION
Type variables in polymorphic types now scope over any nested local type signatures by default. Closes #2168.

- Any polymorphic type, whether written with an explicit `forall` or not, brings all its variables into scope in the body of its definition.
- Any type variables declared with an explicit `forall` are introduced as new variables, and in particular they will shadow any type variables already in scope with the same names.
- Any type variables not bound by an explicit `forall` *which are not already in scope* will be implicitly quantified.  Any such type variable names which are in scope will simply refer to the name in the enclosing scope.

So, for example, this will work:
```
def balance : RBNode k v -> RBTree k v = \t.
  let baseCase : RBTree k v = inr t in
  let balanceRR : RBNode k v -> RBTree k v = ...
  in undefined
end
```
The type signature on `balance` will bring `k` and `v` into scope in its body (even though there is not an explicit `forall` written); then the `k` and `v` in the type signatures on `baseCase` and `balanceRR` will both refer to the `k` and `v` bound in the type of `balance`.  In particular, this means that `inr t` is a valid definition for `baseCase` since their types match.  On the other hand, if one were to write
```
def balance : RBNode k v -> RBTree k v = \t.
  let baseCase : forall k v. RBTree k v = inr t in
  undefined
end
```
then the `k` and `v` in the type of `baseCase` would be *new* type variables which are different than the `k` and `v` in the type of `balance` (which would now be shadowed within the definition of `baseCase`).  This would now be a type error (which is what happens currently), since `baseCase` is required to be an `RBTree k v` for *any* types `k` and `v`, but `inr t` only has the specific type that was given as an input to `balance`.

Finally, if one wrote 
```
def balance : RBNode k v -> RBTree k v = \t.
  let baseCase : forall k. RBTree k v = inr t in
  undefined
end
```
then only `k` would be a new type variable, whereas `v` would refer to the `v` from the type of `balance`. (This would still be a type error, of course.)

In addition, what used to be `Polytype` is now two separate types: `RawPolytype` is what we get out of the parser, before implicit quantification has been carried out.  A `Polytype` is guaranteed to be properly quantified, i.e. variables bound by the forall are explicitly listed.  We carefully do not export the constructor so we can be sure that the typechecker is making sure that we never accidentally use a `RawPolytype` before we implicitly quantify over it.