### PR TITLE
Fix type inference for recursive let bindings

### DIFF
--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -69,7 +69,7 @@ import Data.Set qualified as S
 import Data.Text (Text)
 import Data.Text qualified as T
 import Prettyprinter
-import Swarm.Effect.Unify (Unification, UnificationError, (=:=))
+import Swarm.Effect.Unify (Unification, UnificationError)
 import Swarm.Effect.Unify qualified as U
 import Swarm.Effect.Unify.Fast qualified as U
 import Swarm.Language.Context hiding (lookup)
@@ -342,7 +342,7 @@ unify ::
   TypeJoin ->
   m UType
 unify ms j = do
-  res <- expected =:= actual
+  res <- expected U.=:= actual
   case res of
     Left _ -> do
       j' <- traverse U.applyBindings j
@@ -1135,7 +1135,7 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
     traverse_ (adaptToTypeErr l KindErr . checkKind) mxTy
     case toU mxTy of
       Just xTy -> do
-        res <- argTy =:= xTy
+        res <- argTy U.=:= xTy
         case res of
           -- Generate a special error when the explicit type annotation
           -- on a lambda doesn't match the expected type,
@@ -1179,8 +1179,8 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
         xTy <- fresh
         t1' <- withBinding (lvVar x) (Forall [] xTy) $ infer t1
         let uty = t1' ^. sType
-        _ <- xTy =:= uty
-        upty <- generalize uty
+        uty' <- unify (Just t1) (joined xTy uty)
+        upty <- generalize uty'
         return ([], upty, t1')
       -- An explicit polytype annotation has been provided. Skolemize it and check
       -- definition and body under an extended context.

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -556,6 +556,12 @@ testLanguagePipeline =
                 "(\\f. f 3) 2"
                 "1:11: Type mismatch:\n  From context, expected `2` to have a type like `Int -> _`"
             )
+        , testCase
+            "inferring type of bad recursive function - #2186"
+            ( process
+                "def bad = \\acc.\\n. if (n <= 0) {fst acc} {bad (fst acc + 1) (n - 1)} end"
+                "1:1: Type mismatch:\n  From context, expected `\\acc. \\n. if (n <= 0) {fst acc} {\n    bad (fst acc + 1) (n - 1)\n  }` to have type `Int -> Int -> Int`,\n  but it actually has a type like `(Int * _) -> Int -> Int`"
+            )
         ]
     , testGroup
         "generalize top-level binds #351 #1501"


### PR DESCRIPTION
Fixes #2186.

When inferring the type of a recursive let binding with no provided type signature, we generate a unification variable to stand for its type, then infer the type of the body with the unification variable in the context.  Finally, we must unify the generated unification variable with the inferred type.  However, previously, we were doing this final unification with a direct call to `=:=` (which simply returns an `Either`) and discarding the result, which meant that we would simply ignore it when they failed to unify.

This PR replaces the bad call to `=:=` with a call to `unify`, and also makes the `=:=` import qualified to make it less likely that we will ever call `=:=` directly like this again.

This would only have ever caused a problem with (1) a recursive function definition (2) with no type annotation (3) with a type error (4) specifically in one of the recursive applications.  Apparently no one had ever done all of 1-4 at the same time before; @xsebek was the lucky winner. :smile: 