### PR TITLE
shape recognition with piecewise rows

### DIFF
--- a/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
+++ b/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
@@ -16,3 +16,4 @@
 1644-rotated-preplacement-recognition.yaml
 2115-encroaching-upon-exterior-transparent-cells.yaml
 2115-encroaching-upon-interior-transparent-cells.yaml
+9999-piecewise-lines.yaml

--- a/data/scenarios/Testing/1575-structure-recognizer/9999-piecewise-lines.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/9999-piecewise-lines.yaml
@@ -1,0 +1,74 @@
+version: 1
+name: Structure recognition - piecewise lines
+description: |
+  General solution for transparency
+creative: false
+objectives:
+  - teaser: Recognize structure
+    goal:
+      - |
+        `spaceship`{=structure} structure should be recognized upon completion,
+        even with an extraneous entity within its bounds.
+    condition: |
+      def isRight = \x. case x (\_. false) (\_. true); end;
+      foundStructure <- structure "spaceship" 0;
+      return $ isRight foundStructure;
+robots:
+  - name: base
+    dir: east
+    devices:
+      - ADT calculator
+      - blueprint
+      - fast grabber
+      - logger
+      - treads
+    inventory:
+      - [1, rock]
+solution: |
+  move; move; move;
+  swap "rock";
+structures:
+  - name: spaceship
+    recognize: [north]
+    structure:
+      palette:
+        'p': [stone, board]
+        'x': [stone, rock]
+        'y': [stone, mountain]
+      mask: '.'
+      map: |
+        xy.xy
+        .ppp.
+        xy.xy
+  - name: damage
+    description: A single-cell overwrite of the spaceship
+    structure:
+      palette:
+        't': [stone, tree]
+      map: |
+        t
+  - name: modified ship
+    description: A spaceship with a single cell replaced by a `tree`{=entity}
+    structure:
+      placements:
+        - src: spaceship
+        - src: damage
+      map: ""
+known: [board, mountain, rock, tree]
+world:
+  dsl: |
+    {blank}
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+    'p':
+      structure:
+        name: modified ship
+      cell: [grass]
+  upperleft: [0, 0]
+  map: |
+    ..........
+    B..p......
+    ..........
+    ..........
+    ..........

--- a/data/scenarios/Testing/1575-structure-recognizer/9999-piecewise-solid.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/9999-piecewise-solid.yaml
@@ -1,0 +1,73 @@
+version: 1
+name: Structure recognition - piecewise lines
+description: |
+  General solution for transparency
+creative: false
+objectives:
+  - teaser: Recognize structure
+    goal:
+      - |
+        `spaceship`{=structure} structure should be recognized upon completion,
+        even with an extraneous entity within its bounds.
+    condition: |
+      def isRight = \x. case x (\_. false) (\_. true); end;
+      foundStructure <- structure "spaceship" 0;
+      return $ isRight foundStructure;
+robots:
+  - name: base
+    dir: east
+    devices:
+      - ADT calculator
+      - blueprint
+      - fast grabber
+      - logger
+      - treads
+    inventory:
+      - [1, rock]
+solution: |
+  move; move; move;
+  swap "rock";
+structures:
+  - name: spaceship
+    recognize: [north]
+    structure:
+      palette:
+        'p': [stone, board]
+        'x': [stone, rock]
+      mask: '.'
+      map: |
+        xxx
+        ppp
+        xxx
+  - name: damage
+    description: A single-cell overwrite of the spaceship
+    structure:
+      palette:
+        't': [stone, tree]
+      map: |
+        t
+  - name: modified ship
+    description: A spaceship with a single cell replaced by a `tree`{=entity}
+    structure:
+      placements:
+        - src: spaceship
+        - src: damage
+      map: ""
+known: [board, mountain, rock, tree]
+world:
+  dsl: |
+    {blank}
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+    'p':
+      structure:
+        name: modified ship
+      cell: [grass]
+  upperleft: [0, 0]
+  map: |
+    .........
+    B..p.....
+    .........
+    .........
+    .........

--- a/data/schema/placement.json
+++ b/data/schema/placement.json
@@ -10,10 +10,6 @@
             "type": "string",
             "description": "Name of structure definition"
         },
-        "truncate": {
-            "type": "boolean",
-            "description": "Overlay should be truncated if it exceeds bounds of target structure"
-        },
         "offset": {
             "$ref": "planar-loc.json"
         },

--- a/data/schema/structure.json
+++ b/data/schema/structure.json
@@ -26,7 +26,7 @@
             }
         },
         "placements": {
-            "description": "Structure placements. Earlier members may occlude later members of the list.",
+            "description": "Structure placements. Later members may occlude earlier members of the list.",
             "type": "array",
             "items": {
                 "$ref": "placement.json"

--- a/data/schema/world.json
+++ b/data/schema/world.json
@@ -28,7 +28,7 @@
             }
         },
         "placements": {
-            "description": "Structure placements. Earlier members may occlude later members of the list.",
+            "description": "Structure placements. Later members may occlude earlier members of the list.",
             "type": "array",
             "items": {
                 "$ref": "placement.json"

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -206,7 +206,7 @@ ensureStructureIntact ::
   (Has (State GameState) sig m) =>
   FoundStructure (Maybe Cell) Entity ->
   m Bool
-ensureStructureIntact (FoundStructure (StructureWithGrid _ _ grid) upperLeft) =
+ensureStructureIntact (FoundStructure (StructureWithGrid _ _ _ grid) upperLeft) =
   allM outer $ zip [0 ..] grid
  where
   outer (y, row) = allM (inner y) $ zip [0 ..] row

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Log.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Log.hs
@@ -65,7 +65,7 @@ data EntityKeyedFinder e = EntityKeyedFinder
 
 data ParticipatingEntity e = ParticipatingEntity
   { entity :: e
-  , entityKeyedFinders :: NonEmpty (EntityKeyedFinder e)
+  , entityKeyedFinders :: EntityKeyedFinder e
   }
   deriving (Functor, Generic, ToJSON)
 

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Precompute.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Precompute.hs
@@ -45,6 +45,7 @@ import Data.Hashable (Hashable)
 import Data.Map qualified as M
 import Data.Maybe (catMaybes, mapMaybe)
 import Data.Set qualified as Set
+import Swarm.Game.Scenario.Topography.Area (getGridDimensions, rectWidth)
 import Swarm.Game.Scenario.Topography.Grid (getRows)
 import Swarm.Game.Scenario.Topography.Placement (Orientation (..), applyOrientationTransform, getStructureName)
 import Swarm.Game.Scenario.Topography.Structure.Named
@@ -92,8 +93,9 @@ extractOrientedGrid ::
   AbsoluteDir ->
   StructureWithGrid (Maybe b) a
 extractOrientedGrid extractor x d =
-  StructureWithGrid wrapped d $ getEntityGrid extractor g
+  StructureWithGrid wrapped d w $ getEntityGrid extractor g
  where
+  w = RowWidth . rectWidth . getGridDimensions $ structure g
   wrapped = NamedOriginal (getStructureName $ name x) x
   g = applyOrientationTransform (Orientation d False) <$> x
 

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Prep.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Prep.hs
@@ -15,6 +15,7 @@ import Data.Semigroup (sconcat)
 import Data.Tuple (swap)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Text.AhoCorasick (makeStateMachine)
+import Data.List.Split (wordsBy)
 
 -- | Given all candidate structures, explode them into annotated rows.
 -- These annotations entail both the row index with the original structure
@@ -75,13 +76,6 @@ mkEntityLookup ::
 mkEntityLookup grids =
   HM.map mkRowAutomatons rowsByEntityParticipation
  where
-  -- The input here are all rows across all structures
-  -- that share the same entity sequence.
-  mkSmValue ksms singleRows =
-    StructureSearcher sm2D ksms singleRows
-   where
-    structureRowsNE = NE.map myRow singleRows
-    sm2D = mkRowLookup structureRowsNE
 
   -- Produces a list of automatons to evaluate whenever a given entity
   -- is encountered.
@@ -89,9 +83,20 @@ mkEntityLookup grids =
    where
     searchPatternsAndSubAutomatons = NE.map (\(a, b) -> (a, mkSmValue a b)) groupedByUniqueRow
      where
+
+      zz = map catMaybes $ wordsBy null a
+
       groupedByUniqueRow =
         binTuplesHMasListNE $
           NE.map (rowContent . myRow &&& id) neList
+
+      -- The input here are all rows across all structures
+      -- that share the same entity sequence.
+      mkSmValue ksms singleRows =
+        StructureSearcher sm2D ksms singleRows
+       where
+        structureRowsNE = NE.map myRow singleRows
+        sm2D = mkRowLookup structureRowsNE
 
     bounds = sconcat $ NE.map expandedOffsets neList
     sm = makeStateMachine $ NE.toList searchPatternsAndSubAutomatons

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
@@ -68,8 +68,8 @@ entityModified entLoader modification cLoc recognizer =
       Just finder -> do
         let logFinder f =
               EntityKeyedFinder
-                (f ^. inspectionOffsets)
-                (NE.map fst $ f ^. searchPairs)
+                (f ^. inspectionOffsets2)
+                (NE.map fst $ f ^. searchPairs2)
                 mempty
             msg =
               FoundParticipatingEntity $
@@ -165,10 +165,10 @@ registerRowMatches ::
   (Monad s, Hashable a, Eq b) =>
   GenericEntLocator s a ->
   Cosmic Location ->
-  AutomatonInfo a (AtomicKeySymbol a) (StructureSearcher b a) ->
+  AutomatonNewInfo a (StructureSearcher b a) ->
   RecognitionState b a ->
   s (RecognitionState b a)
-registerRowMatches entLoader cLoc (AutomatonInfo horizontalOffsets sm _) rState = do
+registerRowMatches entLoader cLoc (AutomatonNewInfo horizontalOffsets sm _ _) rState = do
   maskChoices <- attemptSearchWithEntityMask
 
   let logEntry = uncurry logRowCandidates maskChoices

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
@@ -169,7 +169,6 @@ registerRowMatches ::
   RecognitionState b a ->
   s (RecognitionState b a)
 registerRowMatches entLoader cLoc (AutomatonNewInfo horizontalOffsets sm _ pwMatcher) rState = do
-
   entitiesRow <-
     getWorldRow
       entLoader
@@ -185,7 +184,6 @@ registerRowMatches entLoader cLoc (AutomatonNewInfo horizontalOffsets sm _ pwMat
   let logEntry = uncurry logRowCandidates maskChoices
       rState2 = rState & recognitionLog %~ (logEntry :)
       candidates = snd maskChoices
-
 
   let PiecewiseRecognition pwSM pwMap = pwMatcher
   let candidatesChunked = findAll pwSM entitiesRow

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -23,6 +23,7 @@ import Control.Lens (makeLenses)
 import Data.Aeson (ToJSON)
 import Data.Function (on)
 import Data.HashMap.Strict (HashMap)
+import Data.HashSet (HashSet)
 import Data.Int (Int32)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
@@ -37,7 +38,6 @@ import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.Structure.Named (NamedGrid)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Static
 import Swarm.Game.Universe (Cosmic, offsetBy)
-import Data.HashSet (HashSet)
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
 import Text.AhoCorasick (StateMachine)
 
@@ -94,14 +94,13 @@ data PositionWithinRow b a = PositionWithinRow
   , structureRow :: StructureRow b a
   }
 
-
-data PiecewiseRecognition a = PiecewiseRecognition {
-    piecewiseSM :: StateMachine (AtomicKeySymbol a) (NonEmpty a)
+data PiecewiseRecognition a = PiecewiseRecognition
+  { piecewiseSM :: StateMachine (AtomicKeySymbol a) (NonEmpty a)
   , picewiseLookup :: HashMap (HashSet (NonEmpty a)) (HashMap (NonEmpty a) (NonEmpty Int))
   }
 
-data PositionedChunk a = PositionedChunk {
-    chunkStartPos :: Int
+data PositionedChunk a = PositionedChunk
+  { chunkStartPos :: Int
   , chunkContents :: NonEmpty a
   }
 

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -37,6 +37,7 @@ import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.Structure.Named (NamedGrid)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Static
 import Swarm.Game.Universe (Cosmic, offsetBy)
+import Data.HashSet (HashSet)
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
 import Text.AhoCorasick (StateMachine)
 
@@ -95,8 +96,8 @@ data PositionWithinRow b a = PositionWithinRow
 
 
 data PiecewiseRecognition a = PiecewiseRecognition {
-    piecewiseSM :: StateMachine (NonEmpty a) [NonEmpty a]
-  , picewiseLookup :: Int
+    piecewiseSM :: StateMachine (AtomicKeySymbol a) (NonEmpty a)
+  , picewiseLookup :: HashMap (HashSet (NonEmpty a)) (HashMap (NonEmpty a) (NonEmpty Int))
   }
 
 data PositionedChunk a = PositionedChunk {

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -112,6 +112,9 @@ data SingleRowEntityOccurrences b a = SingleRowEntityOccurrences
   , expandedOffsets :: InspectionOffsets
   }
 
+newtype RowWidth = RowWidth Int32
+  deriving (Eq)
+
 -- | A a specific row within a particular structure.
 --
 -- === Example
@@ -152,6 +155,7 @@ data NamedOriginal b = NamedOriginal
 data StructureWithGrid b a = StructureWithGrid
   { originalDefinition :: NamedOriginal b
   , rotatedTo :: AbsoluteDir
+  , gridWidth :: RowWidth
   , entityGrid :: [SymbolSequence a]
   }
   deriving (Eq)

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -23,7 +23,6 @@ import Control.Lens (makeLenses)
 import Data.Aeson (ToJSON)
 import Data.Function (on)
 import Data.HashMap.Strict (HashMap)
-import Data.HashSet (HashSet)
 import Data.Int (Int32)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
@@ -198,8 +197,7 @@ instance Semigroup InspectionOffsets where
 -- a certain subset of structure rows, that may either
 -- all be within one structure, or span multiple structures.
 data AutomatonInfo en k v = AutomatonInfo
-  { _participatingEntities :: HashSet en
-  , _inspectionOffsets :: InspectionOffsets
+  { _inspectionOffsets :: InspectionOffsets
   , _automaton :: StateMachine k v
   , _searchPairs :: NonEmpty ([k], v)
   -- ^ these are the tuples input to the 'makeStateMachine' function,
@@ -215,7 +213,7 @@ data RecognizerAutomatons b a = RecognizerAutomatons
   { _originalStructureDefinitions :: Map OriginalName (StructureInfo b a)
   -- ^ all of the structures that shall participate in automatic recognition.
   -- This list is used only by the UI and by the 'Floorplan' command.
-  , _automatonsByEntity :: HashMap a (NonEmpty (AutomatonInfo a (AtomicKeySymbol a) (StructureSearcher b a)))
+  , _automatonsByEntity :: HashMap a (AutomatonInfo a (AtomicKeySymbol a) (StructureSearcher b a))
   }
   deriving (Generic)
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -505,6 +505,7 @@ library swarm-topography
     linear,
     nonempty-containers,
     servant-docs,
+    split,
     text,
     transformers,
     unordered-containers,


### PR DESCRIPTION
Certain hacks were employed to better handle "transparency" when recognizing shapes.  However, these approaches were still limited in capability.

The "right" way to use Aho-Corasick with transparency is to break rows up into contiguous segments, separated by transparent cells.  The individual segments recognized by the automaton can then be matched against their expected position.