### PR TITLE
ensure no overlaps in initial placement of recognized structures

### DIFF
--- a/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
+++ b/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
@@ -18,3 +18,4 @@
 2115-encroaching-upon-interior-transparent-cells.yaml
 2201-piecewise-lines.yaml
 2201-preclude-overlapping-recognition.yaml
+2201-initial-recognition-overlap.yaml

--- a/data/scenarios/Testing/1575-structure-recognizer/2201-initial-recognition-overlap.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2201-initial-recognition-overlap.yaml
@@ -1,0 +1,52 @@
+version: 1
+name: Structure recognition - precluding overlaps
+description: |
+  A cell may be a member of at most one structure.
+creative: false
+objectives:
+  - teaser: Recognize exactly one structure
+    goal:
+      - |
+        `square`{=structure} structure should be recognized upon scenario start.
+      - |
+        Although two of these structures were initially placed, only one should be recognized.
+    condition: |
+      foundStructure <- structure "square" 0;
+      return $ case foundStructure (\_. false) (\pair. fst pair == 1);
+robots:
+  - name: base
+    dir: north
+    devices:
+      - ADT calculator
+      - blueprint
+      - fast grabber
+      - logger
+      - treads
+solution: |
+  noop;
+structures:
+  - name: square
+    recognize: [north]
+    structure:
+      palette:
+        'x': [stone, rock]
+      mask: '.'
+      map: |
+        xx
+        xx
+known: [rock]
+world:
+  dsl: |
+    {blank}
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+    's':
+      structure:
+        name: square
+      cell: [grass]
+  upperleft: [0, 0]
+  map: |
+    ...s...
+    ....s..
+    .B.....

--- a/data/scenarios/Testing/1575-structure-recognizer/2201-initial-recognition-overlap.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2201-initial-recognition-overlap.yaml
@@ -1,7 +1,13 @@
 version: 1
-name: Structure recognition - precluding overlaps
+name: Structure recognition - precluding initial overlaps
 description: |
   A cell may be a member of at most one structure.
+
+  Since recognition of pre-placed structures bypasses
+  the regular "search" process, we need to ensure that
+  overlaps are properly excluded by this alternate mechanism.
+  In this scenario, only the upper-left structure should be recognized,
+  based on the precedence criteria (structure size, then grid location)
 creative: false
 objectives:
   - teaser: Recognize exactly one structure
@@ -9,7 +15,8 @@ objectives:
       - |
         `square`{=structure} structure should be recognized upon scenario start.
       - |
-        Although two of these structures were initially placed, only one should be recognized.
+        Although two of these structures were initially placed, only
+        the upper-left one should be recognized.
     condition: |
       foundStructure <- structure "square" 0;
       return $ case foundStructure (\_. false) (\pair. fst pair == 1);

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -200,8 +200,7 @@ mkRecognizer structInfo@(StaticStructureInfo structDefs _) = do
   mkLogEntry (x, intact) =
     IntactPlacementLog
       intact
-      ((getName . originalDefinition . structureWithGrid) x)
-      (upperLeftCorner x)
+      $ FoundStructure (upperLeftCorner x) ((distillLabel . structureWithGrid) x)
 
 buildTagMap :: EntityMap -> Map Text (NonEmpty EntityName)
 buildTagMap em =

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -178,7 +178,7 @@ pureScenarioToGameState scenario theSeed now toRun gsc =
   addRecipesWith f = IM.unionWith (<>) (f $ scenario ^. scenarioOperation . scenarioRecipes)
 
 -- |
--- As part of initilizing the recognizer, we also pre-populate the
+-- As part of initializing the recognizer, we also pre-populate the
 -- list of "found" structures with those statically placed by the scenario definition.
 -- Note that this bypasses the regular "online" recognition machinery;
 -- we don't actually have to "search" for these structures since we are

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -184,7 +184,6 @@ pureScenarioToGameState scenario theSeed now toRun gsc =
 -- we don't actually have to "search" for these structures since we are
 -- explicitly given their location; we only need to validate that each
 -- structure remains intact given other, potentially overlapping static placements.
---
 mkRecognizer ::
   (Has (State GameState) sig m) =>
   StaticStructureInfo Cell ->
@@ -206,7 +205,7 @@ mkRecognizer structInfo@(StaticStructureInfo structDefs _) = do
   mkLogEntry (x, intact) =
     IntactPlacementLog
       intact
-      $ FoundStructure (upperLeftCorner x) ((distillLabel . structureWithGrid) x)
+      $ PositionedStructure (upperLeftCorner x) ((distillLabel . structureWithGrid) x)
 
 buildTagMap :: EntityMap -> Map Text (NonEmpty EntityName)
 buildTagMap em =

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -177,6 +177,14 @@ pureScenarioToGameState scenario theSeed now toRun gsc =
 
   addRecipesWith f = IM.unionWith (<>) (f $ scenario ^. scenarioOperation . scenarioRecipes)
 
+-- |
+-- As part of initilizing the recognizer, we also pre-populate the
+-- list of "found" structures with those statically placed by the scenario definition.
+-- Note that this bypasses the regular "online" recognition machinery;
+-- we don't actually have to "search" for these structures since we are
+-- explicitly given their location; we only need to validate that each
+-- structure remains intact given other, potentially overlapping static placements.
+--
 mkRecognizer ::
   (Has (State GameState) sig m) =>
   StaticStructureInfo Cell ->
@@ -192,8 +200,6 @@ mkRecognizer structInfo@(StaticStructureInfo structDefs _) = do
       fs
       [IntactStaticPlacement $ map mkLogEntry foundIntact]
  where
-  -- NOTE: We assume that all static scenario placements are carefully arranged
-  -- so that overlapping structures are not simultaneously recognized.
   checkIntactness = sequenceA . (id &&& adaptGameState . ensureStructureIntact emptyFoundStructures mtlEntityAt)
 
   allPlaced = lookupStaticPlacements cellToEntity structInfo

--- a/src/swarm-scenario/Swarm/Game/State/Landscape.hs
+++ b/src/swarm-scenario/Swarm/Game/State/Landscape.hs
@@ -166,7 +166,7 @@ buildWorld tem WorldDescription {..} =
   -- Get all the robots described in cells and set their locations appropriately
   robots :: SubworldName -> [IndexedTRobot]
   robots swName =
-    concat $ mapIndexedMembers extractRobots g
+    concat $ mapWithCoords extractRobots g
    where
     extractRobots (Coords coordsTuple) maybeCell =
       let robotWithLoc = trobotLocation ?~ Cosmic swName (coordsToLoc (coords `addTuple` coordsTuple))

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Area.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Area.hs
@@ -4,10 +4,14 @@
 -- SPDX-License-Identifier: BSD-3-Clause
 module Swarm.Game.Scenario.Topography.Area where
 
+import Data.Aeson (ToJSON)
+import Data.Function (on)
 import Data.Int (Int32)
 import Data.List qualified as L
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (listToMaybe)
 import Data.Semigroup
+import GHC.Generics (Generic)
 import Linear (V2 (..))
 import Swarm.Game.Location
 import Swarm.Game.Scenario.Topography.Grid
@@ -18,10 +22,18 @@ data AreaDimensions = AreaDimensions
   { rectWidth :: Int32
   , rectHeight :: Int32
   }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic, ToJSON)
 
 getGridDimensions :: Grid a -> AreaDimensions
 getGridDimensions g = getAreaDimensions $ getRows g
+
+getNEGridDimensions :: NonEmptyGrid a -> AreaDimensions
+getNEGridDimensions (NonEmptyGrid xs) =
+  (AreaDimensions `on` fromIntegral)
+    (NE.length firstRow)
+    (NE.length xs)
+ where
+  firstRow = NE.head xs
 
 asTuple :: AreaDimensions -> (Int32, Int32)
 asTuple (AreaDimensions x y) = (x, y)
@@ -76,6 +88,7 @@ fillGrid (AreaDimensions 0 _) _ = EmptyGrid
 fillGrid (AreaDimensions _ 0) _ = EmptyGrid
 fillGrid (AreaDimensions w h) x =
   Grid
+    . NonEmptyGrid
     . stimes h
     . pure
     . stimes w

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Grid.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Grid.hs
@@ -2,63 +2,84 @@
 -- SPDX-License-Identifier: BSD-3-Clause
 module Swarm.Game.Scenario.Topography.Grid (
   Grid (..),
+  NonEmptyGrid (..),
   gridToVec,
-  mapIndexedMembers,
+  zipNumberedNE,
+  mapWithCoordsNE,
+  mapWithCoords,
   allMembers,
-  mapRows,
+  mapRowsNE,
   getRows,
   mkGrid,
 )
 where
 
 import Data.Aeson (ToJSON (..))
+import Data.Foldable qualified as F
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
 import Data.Semigroup
 import Data.Vector qualified as V
+import GHC.Generics (Generic)
 import Swarm.Game.World.Coords
 import Prelude hiding (zipWith)
 
+newtype NonEmptyGrid c = NonEmptyGrid (NonEmpty (NonEmpty c))
+  deriving (Generic, Show, Eq, Functor, Foldable, Traversable, ToJSON)
+
 data Grid c
   = EmptyGrid
-  | Grid (NonEmpty (NonEmpty c))
+  | Grid (NonEmptyGrid c)
   deriving (Show, Eq, Functor, Foldable, Traversable)
 
 mkGrid :: [[a]] -> Grid a
 mkGrid rows = fromMaybe EmptyGrid $ do
   rowsNE <- NE.nonEmpty =<< mapM NE.nonEmpty rows
-  return $ Grid rowsNE
+  return $ Grid $ NonEmptyGrid rowsNE
 
 getRows :: Grid a -> [[a]]
 getRows EmptyGrid = []
-getRows (Grid g) = NE.toList . NE.map NE.toList $ g
+getRows (Grid (NonEmptyGrid g)) = NE.toList . NE.map NE.toList $ g
 
 -- | Since the derived 'Functor' instance applies to the
 -- type parameter that is nested within lists, we define
 -- an explicit function for mapping over the enclosing lists.
-mapRows :: (NonEmpty (NonEmpty a) -> NonEmpty (NonEmpty b)) -> Grid a -> Grid b
-mapRows _ EmptyGrid = EmptyGrid
-mapRows f (Grid rows) = Grid $ f rows
+mapRowsNE ::
+  (NonEmpty (NonEmpty a) -> NonEmpty (NonEmpty b)) ->
+  NonEmptyGrid a ->
+  NonEmptyGrid b
+mapRowsNE f (NonEmptyGrid rows) = NonEmptyGrid $ f rows
 
 allMembers :: Grid a -> [a]
 allMembers EmptyGrid = []
-allMembers g = concat . getRows $ g
+allMembers g = F.toList g
 
-mapIndexedMembers :: (Coords -> a -> b) -> Grid a -> [b]
-mapIndexedMembers _ EmptyGrid = []
-mapIndexedMembers f (Grid g) =
-  NE.toList $
-    sconcat $
-      NE.zipWith (\i -> NE.zipWith (\j -> f (Coords (i, j))) nonemptyCount) nonemptyCount g
+nonemptyCount :: (Integral i) => NonEmpty i
+nonemptyCount = NE.iterate succ 0
+
+zipNumberedNE ::
+  Integral i =>
+  (i -> a -> b) ->
+  NonEmpty a ->
+  NonEmpty b
+zipNumberedNE f = NE.zipWith f nonemptyCount
+
+mapWithCoordsNE :: (Coords -> a -> b) -> NonEmptyGrid a -> NonEmpty b
+mapWithCoordsNE f (NonEmptyGrid g) =
+  sconcat $ NE.zipWith outer nonemptyCount g
  where
-  nonemptyCount = NE.iterate succ 0
+  outer i = zipNumberedNE $ \j -> f (Coords (i, j))
+
+mapWithCoords :: (Coords -> a -> b) -> Grid a -> [b]
+mapWithCoords _ EmptyGrid = []
+mapWithCoords f (Grid g) = NE.toList $ mapWithCoordsNE f g
 
 -- | Converts linked lists to vectors to facilitate
 -- random access when assembling the image
 gridToVec :: Grid a -> V.Vector (V.Vector a)
 gridToVec EmptyGrid = V.empty
-gridToVec (Grid g) = V.fromList . map (V.fromList . NE.toList) $ NE.toList g
+gridToVec (Grid (NonEmptyGrid g)) = V.fromList . map (V.fromList . NE.toList) $ NE.toList g
 
 instance (ToJSON a) => ToJSON (Grid a) where
   toJSON EmptyGrid = toJSON ([] :: [a])

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Placement.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Placement.hs
@@ -9,20 +9,17 @@
 module Swarm.Game.Scenario.Topography.Placement where
 
 import Data.List.NonEmpty qualified as NE
-import Data.Text (Text)
 import Data.Yaml as Y
-import GHC.Generics (Generic)
 import Swarm.Game.Location
-import Swarm.Game.Scenario.Topography.Area
+import Swarm.Game.Scenario.Topography.Area (
+  AreaDimensions (..),
+ )
 import Swarm.Game.Scenario.Topography.Grid
+import Swarm.Game.Scenario.Topography.Structure.Named (
+  StructureName,
+ )
 import Swarm.Language.Syntax.Direction (AbsoluteDir (..))
 import Swarm.Util (applyWhen)
-
-newtype StructureName = StructureName Text
-  deriving (Eq, Ord, Show, Generic, FromJSON, ToJSON)
-
-getStructureName :: StructureName -> Text
-getStructureName (StructureName sn) = sn
 
 -- | Orientation transformations are applied before translation.
 data Orientation = Orientation
@@ -57,10 +54,17 @@ reorientLandmark (Orientation upDir shouldFlip) (AreaDimensions width height) =
     DEast -> transposeLoc . flipV
     DWest -> transposeLoc . flipH
 
+applyOrientationTransform ::
+  Orientation ->
+  Grid a ->
+  Grid a
+applyOrientationTransform _ EmptyGrid = EmptyGrid
+applyOrientationTransform f (Grid g) = Grid $ applyOrientationTransformNE f g
+
 -- | affine transformation
-applyOrientationTransform :: Orientation -> Grid a -> Grid a
-applyOrientationTransform (Orientation upDir shouldFlip) =
-  mapRows f
+applyOrientationTransformNE :: Orientation -> NonEmptyGrid a -> NonEmptyGrid a
+applyOrientationTransformNE (Orientation upDir shouldFlip) =
+  mapRowsNE f
  where
   f = rotational . flipping
   flipV = NE.reverse

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/ProtoCell.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/ProtoCell.hs
@@ -19,6 +19,7 @@ import Data.Yaml as Y
 import GHC.Generics (Generic)
 import Swarm.Game.Scenario.Topography.Navigation.Waypoint (WaypointConfig)
 import Swarm.Game.Scenario.Topography.Placement
+import Swarm.Game.Scenario.Topography.Structure.Named (StructureName)
 import Swarm.Util (quote)
 import Swarm.Util.Yaml
 

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure.hs
@@ -118,10 +118,10 @@ paintMap maskChar pal g = do
         ]
 
   let cells = fmap standardCell <$> nestedLists
-      wps = catMaybes $ mapIndexedMembers getWp nestedLists
+      wps = catMaybes $ mapWithCoords getWp nestedLists
 
   let extraPlacements =
-        catMaybes $ mapIndexedMembers getStructureMarker nestedLists
+        catMaybes $ mapWithCoords getStructureMarker nestedLists
 
   return (cells, wps, extraPlacements)
  where

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Assembly.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Assembly.hs
@@ -117,8 +117,7 @@ foldLayer structureMap origArea overlays originatedWaypoints =
 
   wrapPlacement (Placed z ns) =
     LocatedStructure
-      (name ns)
-      (up $ orient structPose)
+      (OrientedStructure (name ns) (up $ orient structPose))
       (offset structPose)
    where
     structPose = structurePose z

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Named.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Named.hs
@@ -4,9 +4,16 @@ module Swarm.Game.Scenario.Topography.Structure.Named where
 
 import Data.Set (Set)
 import Data.Text (Text)
+import Data.Yaml
+import GHC.Generics (Generic)
 import Swarm.Game.Scenario.Topography.Grid (Grid)
-import Swarm.Game.Scenario.Topography.Placement (StructureName)
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
+
+newtype StructureName = StructureName Text
+  deriving (Eq, Ord, Show, Generic, FromJSON, ToJSON)
+
+getStructureName :: StructureName -> Text
+getStructureName (StructureName sn) = sn
 
 data NamedArea a = NamedArea
   { name :: StructureName

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Precompute.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Precompute.hs
@@ -157,7 +157,7 @@ lookupStaticPlacements extractor (StaticStructureInfo structDefs thePlacements) 
     g (LocatedStructure (OrientedStructure theName d) loc) = do
       sGrid <- M.lookup theName definitionMap
       x <- extractOrientedGrid extractor sGrid d
-      return $ FoundStructure (Cosmic subworldName loc) x
+      return $ PositionedStructure (Cosmic subworldName loc) x
 
 -- | Matches definitions against the placements.
 -- Fails fast (short-circuits) if a non-matching
@@ -171,7 +171,7 @@ ensureStructureIntact ::
   GenericEntLocator s a ->
   FoundStructure b a ->
   s (Maybe (StructureIntactnessFailure a))
-ensureStructureIntact registry entLoader (FoundStructure upperLeft (StructureWithGrid _ _ _ grid)) = do
+ensureStructureIntact registry entLoader (PositionedStructure upperLeft (StructureWithGrid _ _ _ grid)) = do
   fmap leftToMaybe . runExceptT $ mapM checkLoc allLocPairs
  where
   gridArea = getNEGridDimensions grid

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Precompute.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Precompute.hs
@@ -43,6 +43,7 @@ module Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute (
 ) where
 
 import Control.Arrow ((&&&))
+import Control.Lens ((^.))
 import Control.Monad (forM_, unless)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (except, runExceptT)
@@ -53,9 +54,9 @@ import Data.Maybe (catMaybes, mapMaybe)
 import Data.Set qualified as Set
 import Data.Tuple (swap)
 import Swarm.Game.Location (Location, asVector)
-import Swarm.Game.Scenario.Topography.Area (getGridDimensions, rectWidth)
-import Swarm.Game.Scenario.Topography.Grid (getRows, mapIndexedMembers, mkGrid)
-import Swarm.Game.Scenario.Topography.Placement (Orientation (..), applyOrientationTransform, getStructureName)
+import Swarm.Game.Scenario.Topography.Area (getNEGridDimensions, rectWidth)
+import Swarm.Game.Scenario.Topography.Grid
+import Swarm.Game.Scenario.Topography.Placement (Orientation (..), applyOrientationTransformNE)
 import Swarm.Game.Scenario.Topography.Structure.Named
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Prep (
   mkEntityLookup,
@@ -67,7 +68,7 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (
  )
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Static
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
-import Swarm.Game.Universe (Cosmic (..), offsetBy)
+import Swarm.Game.Universe (Cosmic (..), offsetBy, planar)
 import Swarm.Game.World.Coords (coordsToLoc)
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
 import Swarm.Util (histogram)
@@ -104,29 +105,40 @@ mkAutomatons extractor xs =
 
   infos =
     M.fromList $
-      map (getStructureName . name . namedGrid &&& process) xs
+      map (name . namedGrid &&& process) xs
 
+-- | Returns 'Nothing' if the grid is empty, since we want
+-- to exclude them from the recognition engine.
 extractOrientedGrid ::
   (Maybe b -> Maybe a) ->
   NamedGrid (Maybe b) ->
   AbsoluteDir ->
-  StructureWithGrid (Maybe b) a
+  Maybe (StructureWithGrid (Maybe b) a)
 extractOrientedGrid extractor x d =
-  StructureWithGrid wrapped d w $ getEntityGrid extractor g
+  case extractor <$> structure x of
+    EmptyGrid -> Nothing
+    Grid neGrid ->
+      let w = RowWidth . rectWidth . getNEGridDimensions $ neGrid
+       in Just $
+            StructureWithGrid wrapped d w $
+              applyOrientationTransformNE (Orientation d False) neGrid
  where
-  w = RowWidth . rectWidth . getGridDimensions $ structure g
-  wrapped = NamedOriginal (getStructureName $ name x) x
-  g = applyOrientationTransform (Orientation d False) <$> x
+  wrapped = NamedOriginal (name x) x
 
--- | At this point, we have already ensured that orientations
+-- |
+-- At this point, we have already ensured that orientations
 -- redundant by rotational symmetry have been excluded
 -- (i.e. at Scenario validation time).
+--
+-- Excludes empty grids.
 extractGrids ::
   (Maybe b -> Maybe a) ->
   NamedGrid (Maybe b) ->
   [StructureWithGrid (Maybe b) a]
 extractGrids extractor x =
-  map (extractOrientedGrid extractor x) $ Set.toList $ recognize x
+  mapMaybe (extractOrientedGrid extractor x) orientations
+ where
+  orientations = Set.toList $ recognize x
 
 -- | The output list of 'FoundStructure' records is not yet
 -- vetted; the 'ensureStructureIntact' function will subsequently
@@ -142,9 +154,10 @@ lookupStaticPlacements extractor (StaticStructureInfo structDefs thePlacements) 
 
   f (subworldName, locatedList) = mapMaybe g locatedList
    where
-    g (LocatedStructure theName d loc) = do
+    g (LocatedStructure (OrientedStructure theName d) loc) = do
       sGrid <- M.lookup theName definitionMap
-      return $ FoundStructure (extractOrientedGrid extractor sGrid d) $ Cosmic subworldName loc
+      x <- extractOrientedGrid extractor sGrid d
+      return $ FoundStructure (Cosmic subworldName loc) x
 
 -- | Matches definitions against the placements.
 -- Fails fast (short-circuits) if a non-matching
@@ -158,24 +171,29 @@ ensureStructureIntact ::
   GenericEntLocator s a ->
   FoundStructure b a ->
   s (Maybe (StructureIntactnessFailure a))
-ensureStructureIntact registry entLoader (FoundStructure (StructureWithGrid _ _ (RowWidth w) grid) upperLeft) = do
-  fmap leftToMaybe . runExceptT . mapM checkLoc $ zip [0 ..] allLocPairs
+ensureStructureIntact registry entLoader (FoundStructure upperLeft (StructureWithGrid _ _ _ grid)) = do
+  fmap leftToMaybe . runExceptT $ mapM checkLoc allLocPairs
  where
-  checkLoc (idx, (maybeTemplateEntity, loc)) =
+  gridArea = getNEGridDimensions grid
+  checkLoc (maybeTemplateEntity, loc) =
     forM_ maybeTemplateEntity $ \x -> do
       e <- lift $ entLoader loc
 
       forM_ (M.lookup loc $ foundByLocation registry) $ \s ->
-        except
-          . Left
-          . StructureIntactnessFailure (AlreadyUsedBy $ distillLabel $ structureWithGrid s) idx
-          $ fromIntegral w * length grid
+        errorPrefix
+          . AlreadyUsedBy
+          . distillLabel
+          $ structureWithGrid s
 
       unless (e == Just x)
-        . except
+        . errorPrefix
+        $ DiscrepantEntity
+        $ EntityDiscrepancy x e
+   where
+    errorPrefix =
+      except
         . Left
-        . StructureIntactnessFailure (DiscrepantEntity $ EntityDiscrepancy x e) idx
-        $ fromIntegral w * length grid
+        . StructureIntactnessFailure (loc ^. planar) gridArea
 
   f = fmap ((upperLeft `offsetBy`) . asVector . coordsToLoc) . swap
-  allLocPairs = mapIndexedMembers (curry f) $ mkGrid grid
+  allLocPairs = mapWithCoordsNE (curry f) grid

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Prep.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Prep.hs
@@ -6,6 +6,7 @@ module Swarm.Game.Scenario.Topography.Structure.Recognition.Prep (
 ) where
 
 import Control.Arrow ((&&&))
+import Control.Lens.Indexed (imap)
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
 import Data.Hashable (Hashable)
@@ -31,7 +32,7 @@ allStructureRows :: [StructureWithGrid b a] -> [StructureRow b a]
 allStructureRows =
   concatMap $ NE.toList . transformRows
  where
-  transformRows g = zipNumberedNE (StructureRow g) rows
+  transformRows g = imap (StructureRow g . fromIntegral) rows
    where
     NonEmptyGrid rows = entityGrid g
 
@@ -150,7 +151,7 @@ explodeRowEntities annotatedRow@(ConsolidatedRowReferences rowMembers _ width) =
     map swap
       . catMaybes
       . NE.toList
-      $ zipNumberedNE (\idx -> fmap (PositionWithinRow idx annotatedRow,)) rowMembers
+      $ imap (\idx -> fmap (PositionWithinRow (fromIntegral idx) annotatedRow,)) rowMembers
 
   deriveEntityOffsets :: PositionWithinRow b a -> InspectionOffsets
   deriveEntityOffsets (PositionWithinRow pos _) = mkOffsets pos width

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Prep.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Prep.hs
@@ -16,6 +16,7 @@ import Data.List.Split (wordsBy)
 import Data.Maybe (catMaybes, mapMaybe)
 import Data.Semigroup (sconcat)
 import Data.Tuple (swap)
+import Swarm.Game.Scenario.Topography.Grid
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Text.AhoCorasick (makeStateMachine)
 
@@ -28,9 +29,11 @@ import Text.AhoCorasick (makeStateMachine)
 -- in multiple rows within the same structure, or occur across structures.
 allStructureRows :: [StructureWithGrid b a] -> [StructureRow b a]
 allStructureRows =
-  concatMap transformRows
+  concatMap $ NE.toList . transformRows
  where
-  transformRows g = zipWith (StructureRow g) [0 ..] $ entityGrid g
+  transformRows g = zipNumberedNE (StructureRow g) rows
+   where
+    NonEmptyGrid rows = entityGrid g
 
 -- | If this entity is encountered in the world,
 -- how far left of it and how far right of it do we need to
@@ -133,7 +136,7 @@ explodeRowEntities ::
 explodeRowEntities annotatedRow@(ConsolidatedRowReferences rowMembers _ width) =
   map f $ HM.toList $ binTuplesHM unconsolidatedEntityOccurrences
  where
-  chunks = getContiguousChunks rowMembers
+  chunks = getContiguousChunks $ NE.toList rowMembers
 
   f (e, occurrences) =
     SingleRowEntityOccurrences annotatedRow e chunks $
@@ -144,9 +147,10 @@ explodeRowEntities annotatedRow@(ConsolidatedRowReferences rowMembers _ width) =
   -- Only row members for which an entity exists (is not Nothing)
   -- are retained here.
   unconsolidatedEntityOccurrences =
-    map swap $
-      catMaybes $
-        zipWith (\idx -> fmap (PositionWithinRow idx annotatedRow,)) [0 ..] rowMembers
+    map swap
+      . catMaybes
+      . NE.toList
+      $ zipNumberedNE (\idx -> fmap (PositionWithinRow idx annotatedRow,)) rowMembers
 
   deriveEntityOffsets :: PositionWithinRow b a -> InspectionOffsets
   deriveEntityOffsets (PositionWithinRow pos _) = mkOffsets pos width

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
@@ -22,14 +22,19 @@ module Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (
 where
 
 import Control.Arrow ((&&&))
+import Data.List (partition, sortOn)
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Map.NonEmpty (NEMap)
 import Data.Map.NonEmpty qualified as NEM
-import Swarm.Game.Location (Location)
+import Data.Maybe (listToMaybe, maybeToList)
+import Data.Ord (Down (Down))
+import Data.Set qualified as Set
+import Swarm.Game.Location
+import Swarm.Game.Scenario.Topography.Structure.Named (StructureName)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
-import Swarm.Game.Universe (Cosmic)
+import Swarm.Game.Universe (Cosmic (..))
 import Swarm.Util (binTuples, deleteKeys)
 
 -- | The authoritative source of which built structures currently exist.
@@ -37,7 +42,7 @@ import Swarm.Util (binTuples, deleteKeys)
 -- The two type parameters, `b` and `a`, correspond
 -- to 'Cell' and 'Entity', respectively.
 data FoundRegistry b a = FoundRegistry
-  { _foundByName :: Map OriginalName (NEMap (Cosmic Location) (StructureWithGrid b a))
+  { _foundByName :: Map StructureName (NEMap (Cosmic Location) (StructureWithGrid b a))
   , _foundByLocation :: Map (Cosmic Location) (FoundStructure b a)
   }
 
@@ -47,7 +52,7 @@ emptyFoundStructures = FoundRegistry mempty mempty
 -- | We use a 'NEMap' here so that we can use the
 -- safe-indexing function 'indexWrapNonEmpty' in the implementation
 -- of the @structure@ command.
-foundByName :: FoundRegistry b a -> Map OriginalName (NEMap (Cosmic Location) (StructureWithGrid b a))
+foundByName :: FoundRegistry b a -> Map StructureName (NEMap (Cosmic Location) (StructureWithGrid b a))
 foundByName = _foundByName
 
 -- | This is a worldwide "mask" that prevents members of placed
@@ -73,7 +78,7 @@ removeStructure fs (FoundRegistry byName byLoc) =
   tidyDelete = NEM.nonEmptyMap . NEM.delete upperLeft
 
 addFound :: FoundStructure b a -> FoundRegistry b a -> FoundRegistry b a
-addFound fs@(FoundStructure swg loc) (FoundRegistry byName byLoc) =
+addFound fs@(FoundStructure loc swg) (FoundRegistry byName byLoc) =
   FoundRegistry
     (M.insertWith (<>) k (NEM.singleton loc swg) byName)
     (M.union occupationMap byLoc)
@@ -83,16 +88,51 @@ addFound fs@(FoundStructure swg loc) (FoundRegistry byName byLoc) =
 
 -- | Bulk insertion of found structures.
 --
--- Each of these shall have been re-checked in case
--- a subsequent placement occludes them.
-populateStaticFoundStructures :: [FoundStructure b a] -> FoundRegistry b a
+-- If any of these overlap, we can't be sure of the author's
+-- intent as to which member of the overlap should take precedence,
+-- so perhaps it would be ideal to throw an error at scenario parse time.
+--
+-- However, determining whether a structure is all three of:
+-- 1. placed
+-- 2. still recognizable
+-- 3. overlapping with another recognized structure
+-- occurs at a later phase than scenario parse; it requires access to the 'GameState'.
+--
+-- So we just use the same sorting criteria as the one used to resolve recognition
+-- conflicts at entity placement time.
+populateStaticFoundStructures ::
+  (Eq a, Eq b) =>
+  [FoundStructure b a] ->
+  FoundRegistry b a
 populateStaticFoundStructures allFound =
   FoundRegistry byName byLocation
  where
+  resolvedCollisions = resolvePreplacementCollisions allFound
+
   mkOccupationMap fs = M.fromList $ map (,fs) $ genOccupiedCoords fs
-  byLocation = M.unions $ map mkOccupationMap allFound
+  byLocation = M.unions $ map mkOccupationMap resolvedCollisions
 
   byName =
     M.map (NEM.fromList . NE.map (upperLeftCorner &&& structureWithGrid)) $
       binTuples $
-        map (getName . originalDefinition . structureWithGrid &&& id) allFound
+        map (getName . originalDefinition . structureWithGrid &&& id) resolvedCollisions
+
+  resolvePreplacementCollisions foundList =
+    nonOverlappingFound <> maybeToList (listToMaybe overlapsByDecreasingPreference)
+   where
+    overlapsByDecreasingPreference = sortOn Down overlappingFound
+
+    (overlappingFound, nonOverlappingFound) =
+      partition ((`Set.member` overlappingPlacements) . fmap distillLabel) foundList
+
+    -- We convert the full-fledged FoundStructure record
+    -- to a less-expensive identity-preserving form
+    -- for the purpose of set membership
+    overlappingPlacements =
+      Set.fromList
+        . map (fmap distillLabel)
+        . concatMap NE.toList
+        . M.elems
+        . M.filter ((> 1) . NE.length)
+        . M.unionsWith (<>)
+        $ map (M.map pure . mkOccupationMap) foundList

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
@@ -78,7 +78,7 @@ removeStructure fs (FoundRegistry byName byLoc) =
   tidyDelete = NEM.nonEmptyMap . NEM.delete upperLeft
 
 addFound :: FoundStructure b a -> FoundRegistry b a -> FoundRegistry b a
-addFound fs@(FoundStructure loc swg) (FoundRegistry byName byLoc) =
+addFound fs@(PositionedStructure loc swg) (FoundRegistry byName byLoc) =
   FoundRegistry
     (M.insertWith (<>) k (NEM.singleton loc swg) byName)
     (M.union occupationMap byLoc)

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
@@ -86,10 +86,12 @@ addFound fs@(FoundStructure loc swg) (FoundRegistry byName byLoc) =
   k = getName $ originalDefinition swg
   occupationMap = M.fromList $ map (,fs) $ genOccupiedCoords fs
 
--- | Bulk insertion of found structures.
+-- | Bulk insertion of structures statically placed in the scenario definition.
 --
--- If any of these overlap, we can't be sure of the author's
--- intent as to which member of the overlap should take precedence,
+-- See the docs for 'Swarm.Game.State.Initialize.mkRecognizer' for more context.
+--
+-- Note that if any of these pre-placed structures overlap, we can't be sure of
+-- the author's intent as to which member of the overlap should take precedence,
 -- so perhaps it would be ideal to throw an error at scenario parse time.
 --
 -- However, determining whether a structure is all three of:
@@ -99,7 +101,7 @@ addFound fs@(FoundStructure loc swg) (FoundRegistry byName byLoc) =
 -- occurs at a later phase than scenario parse; it requires access to the 'GameState'.
 --
 -- So we just use the same sorting criteria as the one used to resolve recognition
--- conflicts at entity placement time.
+-- conflicts at entity placement time (see [STRUCTURE RECOGNIZER CONFLICT RESOLUTION]).
 populateStaticFoundStructures ::
   (Eq a, Eq b) =>
   [FoundStructure b a] ->

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Static.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Static.hs
@@ -5,9 +5,10 @@
 module Swarm.Game.Scenario.Topography.Structure.Recognition.Static where
 
 import Control.Lens (Lens')
+import Data.Aeson (ToJSON)
 import Data.Map (Map)
+import GHC.Generics (Generic)
 import Swarm.Game.Location
-import Swarm.Game.Scenario.Topography.Placement (StructureName)
 import Swarm.Game.Scenario.Topography.Structure.Named
 import Swarm.Game.Universe (SubworldName)
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
@@ -28,17 +29,25 @@ data SymmetryAnnotatedGrid a = SymmetryAnnotatedGrid
   }
   deriving (Show)
 
--- | For use in registering recognizable pre-placed structures
+data OrientedStructure = OrientedStructure
+  { oName :: StructureName
+  , oDir :: AbsoluteDir
+  }
+  deriving (Show, Eq, Ord, Generic, ToJSON)
+
+-- | For use in registering recognizable pre-placed structures.
+--
+-- Compare to
+-- 'Swarm.Game.Scenario.Topography.Structure.Recognition.Type.PositionedStructure'.
 data LocatedStructure = LocatedStructure
-  { placedName :: StructureName
-  , upDirection :: AbsoluteDir
+  { placedStruct :: OrientedStructure
   , cornerLoc :: Location
   }
   deriving (Show)
 
 instance HasLocation LocatedStructure where
-  modifyLoc f (LocatedStructure x y originalLoc) =
-    LocatedStructure x y $ f originalLoc
+  modifyLoc f (LocatedStructure x originalLoc) =
+    LocatedStructure x $ f originalLoc
 
 data StaticStructureInfo b = StaticStructureInfo
   { _structureDefs :: [SymmetryAnnotatedGrid (Maybe b)]

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
@@ -173,7 +173,7 @@ checkChunksCombination
       NE.toList $ NE.map mkFoundStructure . referencingRows . chunkStructure $ foundChunkRow x
      where
       mkFoundStructure r =
-        FoundStructure
+        PositionedStructure
           (cLoc `offsetBy` theOffset)
           (wholeStructure r)
        where
@@ -279,14 +279,14 @@ registerRowMatches entLoader cLoc (AutomatonInfo horizontalOffsets pwMatcher) rS
   registry = rState ^. foundStructures
   PiecewiseRecognition pwSM rowChunkReferences = pwMatcher
 
-  getStructInfo (FoundStructure loc swg) = (distillLabel swg, loc)
+  getStructInfo (PositionedStructure loc swg) = (distillLabel swg, loc)
 
   validateIntactness2d fs = do
     maybeIntactnessFailure <- lift $ ensureStructureIntact (rState ^. foundStructures) entLoader fs
     tell . pure . ChunkIntactnessVerification
       $ IntactPlacementLog
         maybeIntactnessFailure
-      $ FoundStructure (upperLeftCorner fs) (distillLabel . structureWithGrid $ fs)
+      $ PositionedStructure (upperLeftCorner fs) (distillLabel . structureWithGrid $ fs)
 
     return $ null maybeIntactnessFailure
 

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
@@ -259,10 +259,12 @@ registerRowMatches entLoader cLoc (AutomatonInfo horizontalOffsets pwMatcher) rS
   let candidatesChunked = findAll pwSM entitiesRow
   unrankedCandidateStructures <- checkCombo candidatesChunked
 
+  -- [STRUCTURE RECOGNIZER CONFLICT RESOLUTION]
   -- We only allow an entity to participate in one structure at a time,
   -- so multiple matches require a tie-breaker.
   -- The largest structure (by area) shall win.
-  -- Sort by decreasing order of preference.
+  -- Sort by decreasing order of preference
+  -- (see the Ord instance of 'FoundStructure').
   let rankedCandidates = sortOn Down unrankedCandidateStructures
   tell . pure . FoundCompleteStructureCandidates $
     map getStructInfo rankedCandidates

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Tracking.hs
@@ -174,8 +174,8 @@ checkChunksCombination
      where
       mkFoundStructure r =
         FoundStructure
-          (wholeStructure r)
           (cLoc `offsetBy` theOffset)
+          (wholeStructure r)
        where
         theOffset = V2 (horizontalStructPos $ foundChunkRow x) (rowIndex r)
 
@@ -277,15 +277,15 @@ registerRowMatches entLoader cLoc (AutomatonInfo horizontalOffsets pwMatcher) rS
   registry = rState ^. foundStructures
   PiecewiseRecognition pwSM rowChunkReferences = pwMatcher
 
-  getStructInfo (FoundStructure swg loc) = (distillLabel swg, loc)
+  getStructInfo (FoundStructure loc swg) = (distillLabel swg, loc)
 
   validateIntactness2d fs = do
     maybeIntactnessFailure <- lift $ ensureStructureIntact (rState ^. foundStructures) entLoader fs
-    tell . pure . ChunkIntactnessVerification $
-      IntactPlacementLog
+    tell . pure . ChunkIntactnessVerification
+      $ IntactPlacementLog
         maybeIntactnessFailure
-        (getName . originalDefinition . structureWithGrid $ fs)
-        (upperLeftCorner fs)
+      $ FoundStructure (upperLeftCorner fs) (distillLabel . structureWithGrid $ fs)
+
     return $ null maybeIntactnessFailure
 
   checkCombo = checkChunksCombination cLoc horizontalOffsets rowChunkReferences

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -247,7 +247,7 @@ type FoundStructure b a = PositionedStructure (StructureWithGrid b a)
 --
 -- Compare "PositionedStructure OrientedStructure" to:
 -- "Swarm.Game.Scenario.Topography.Structure.Recognition.Static.LocatedStructure"
-data PositionedStructure s = FoundStructure
+data PositionedStructure s = PositionedStructure
   { upperLeftCorner :: Cosmic Location
   , structureWithGrid :: s
   }
@@ -323,7 +323,7 @@ instance (Eq b, Eq a) => Ord (FoundStructure b a) where
 -- Cells within the rectangular bounds of the structure that are unoccupied
 -- are not included.
 genOccupiedCoords :: FoundStructure b a -> [Cosmic Location]
-genOccupiedCoords (FoundStructure loc swg) =
+genOccupiedCoords (PositionedStructure loc swg) =
   catMaybes . NE.toList . mapWithCoordsNE f $ entityGrid swg
  where
   -- replaces an "occupied" grid cell with its location

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -301,7 +301,9 @@ data StructureIntactnessFailure e = StructureIntactnessFailure
   }
   deriving (Functor, Generic, ToJSON)
 
--- | Ordering is by increasing preference between simultaneously
+-- |
+-- [STRUCTURE RECOGNIZER CONFLICT RESOLUTION]
+-- Ordering is by increasing preference between simultaneously
 -- completed structures.
 -- The preference heuristic is for:
 --

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Type.hs
@@ -26,25 +26,21 @@ import Data.HashMap.Strict (HashMap)
 import Data.Int (Int32)
 import Data.IntSet.NonEmpty (NEIntSet)
 import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Maybe (catMaybes)
 import Data.Ord (Down (Down))
 import Data.Semigroup (Max, Min)
-import Data.Text (Text)
 import GHC.Generics (Generic)
-import Linear (V2 (..))
-import Swarm.Game.Location (Location)
+import Swarm.Game.Location (Location, asVector)
 import Swarm.Game.Scenario.Topography.Area
-import Swarm.Game.Scenario.Topography.Structure.Named (NamedGrid)
+import Swarm.Game.Scenario.Topography.Grid
+import Swarm.Game.Scenario.Topography.Structure.Named (NamedGrid, StructureName)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Static
 import Swarm.Game.Universe (Cosmic, offsetBy)
+import Swarm.Game.World.Coords (coordsToLoc)
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
 import Text.AhoCorasick (StateMachine)
-
--- | A 'NamedStructure' has its own newtype name ('StructureName'), but we
--- standardize on 'Text' here to avoid parameterizing our 'NamedOriginal'
--- datatype on bespoke name types.
-type OriginalName = Text
 
 -- | A "needle" consisting of a single cell within
 -- the haystack (a row of cells) to be searched.
@@ -147,13 +143,13 @@ data StructureRow b a = StructureRow
   { wholeStructure :: StructureWithGrid b a
   , rowIndex :: Int32
   -- ^ vertical index of the row within the structure
-  , rowContent :: SymbolSequence a
+  , rowContent :: NonEmpty (AtomicKeySymbol a)
   }
 
 -- | Represents all rows across all structures that share
 -- a particular row content
 data ConsolidatedRowReferences b a = ConsolidatedRowReferences
-  { sharedRowContent :: SymbolSequence a
+  { sharedRowContent :: NonEmpty (AtomicKeySymbol a)
   , referencingRows :: NonEmpty (StructureRow b a)
   , theRowWidth :: RowWidth
   }
@@ -163,7 +159,7 @@ data ConsolidatedRowReferences b a = ConsolidatedRowReferences
 -- for the purpose of both UI display and internal uniqueness,
 -- while remaining agnostic to its internals.
 data NamedOriginal b = NamedOriginal
-  { getName :: OriginalName
+  { getName :: StructureName
   , orig :: NamedGrid b
   }
   deriving (Show, Eq)
@@ -177,7 +173,7 @@ data StructureWithGrid b a = StructureWithGrid
   { originalDefinition :: NamedOriginal b
   , rotatedTo :: AbsoluteDir
   , gridWidth :: RowWidth
-  , entityGrid :: [SymbolSequence a]
+  , entityGrid :: NonEmptyGrid (AtomicKeySymbol a)
   }
   deriving (Eq)
 
@@ -226,7 +222,7 @@ makeLenses ''AutomatonInfo
 -- | The complete set of data needed to identify applicable
 -- structures, based on a just-placed entity.
 data RecognizerAutomatons b a = RecognizerAutomatons
-  { _originalStructureDefinitions :: Map OriginalName (StructureInfo b a)
+  { _originalStructureDefinitions :: Map StructureName (StructureInfo b a)
   -- ^ all of the structures that shall participate in automatic recognition.
   -- This list is used only by the UI and by the 'Floorplan' command.
   , _automatonsByEntity :: HashMap a (AutomatonInfo b a)
@@ -240,11 +236,24 @@ makeLenses ''RecognizerAutomatons
 --
 -- The two type parameters, `b` and `a`, correspond
 -- to 'Cell' and 'Entity', respectively.
-data FoundStructure b a = FoundStructure
-  { structureWithGrid :: StructureWithGrid b a
-  , upperLeftCorner :: Cosmic Location
+type FoundStructure b a = PositionedStructure (StructureWithGrid b a)
+
+-- | NOTE: A structure's name + orientation + position will uniquely
+-- identify it in the world.  Note that position alone is not sufficient;
+-- due to transparency, a completely intact smaller structure can co-exist
+-- within a larger structure, both sharing the same upper-left coordinate.
+-- However, two identical structures (with identical orientation) cannot
+-- occupy the same space.
+--
+-- Compare "PositionedStructure OrientedStructure" to:
+-- "Swarm.Game.Scenario.Topography.Structure.Recognition.Static.LocatedStructure"
+data PositionedStructure s = FoundStructure
+  { upperLeftCorner :: Cosmic Location
+  , structureWithGrid :: s
   }
-  deriving (Eq)
+  deriving (Eq, Functor, Generic, ToJSON)
+
+deriving instance (Ord (PositionedStructure OrientedStructure))
 
 data FoundRowFromChunk a = FoundRowFromChunk
   { chunkOffsetFromSearchBorder :: Int
@@ -277,12 +286,6 @@ data EntityDiscrepancy e = EntityDiscrepancy
   }
   deriving (Functor, Generic, ToJSON)
 
-data OrientedStructure = OrientedStructure
-  { oName :: OriginalName
-  , oDir :: AbsoluteDir
-  }
-  deriving (Generic, ToJSON)
-
 distillLabel :: StructureWithGrid b a -> OrientedStructure
 distillLabel swg = OrientedStructure (getName $ originalDefinition swg) (rotatedTo swg)
 
@@ -292,9 +295,9 @@ data IntactnessFailureReason e
   deriving (Functor, Generic, ToJSON)
 
 data StructureIntactnessFailure e = StructureIntactnessFailure
-  { reason :: IntactnessFailureReason e
-  , failedOnIndex :: Int
-  , totalSize :: Int
+  { failedOnIndex :: Location
+  , totalSize :: AreaDimensions
+  , reason :: IntactnessFailureReason e
   }
   deriving (Functor, Generic, ToJSON)
 
@@ -311,15 +314,15 @@ data StructureIntactnessFailure e = StructureIntactnessFailure
 instance (Eq b, Eq a) => Ord (FoundStructure b a) where
   compare = compare `on` (f1 &&& f2)
    where
-    f1 = computeArea . getAreaDimensions . entityGrid . structureWithGrid
+    f1 = computeArea . getNEGridDimensions . entityGrid . structureWithGrid
     f2 = Down . upperLeftCorner
 
 -- | Yields coordinates that are occupied by an entity of a placed structure.
 -- Cells within the rectangular bounds of the structure that are unoccupied
 -- are not included.
 genOccupiedCoords :: FoundStructure b a -> [Cosmic Location]
-genOccupiedCoords (FoundStructure swg loc) =
-  concatMap catMaybes . zipWith mkRow [0 ..] $ entityGrid swg
+genOccupiedCoords (FoundStructure loc swg) =
+  catMaybes . NE.toList . mapWithCoordsNE f $ entityGrid swg
  where
-  mkCol y x ent = loc `offsetBy` V2 x (negate y) <$ ent
-  mkRow rowIdx = zipWith (mkCol rowIdx) [0 ..]
+  -- replaces an "occupied" grid cell with its location
+  f cellLoc maybeEnt = ((loc `offsetBy`) . asVector . coordsToLoc $ cellLoc) <$ maybeEnt

--- a/src/swarm-tui/Swarm/TUI/View/Structure.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Structure.hs
@@ -22,7 +22,6 @@ import Data.Vector qualified as V
 import Swarm.Game.Entity (Entity, entityDisplay)
 import Swarm.Game.Scenario.Topography.Area
 import Swarm.Game.Scenario.Topography.Cell (Cell, cellToEntity)
-import Swarm.Game.Scenario.Topography.Placement (getStructureName)
 import Swarm.Game.Scenario.Topography.Structure.Named qualified as Structure
 import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures, recognitionState)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute (getEntityGrid)
@@ -46,7 +45,7 @@ structureWidget :: GameState -> StructureInfo (Maybe Cell) Entity -> Widget n
 structureWidget gs s =
   vBox
     [ hBox
-        [ headerItem "Name" theName
+        [ headerItem "Name" $ Structure.getStructureName theName
         , padLeft (Pad 2)
             . headerItem "Size"
             . T.pack
@@ -119,7 +118,7 @@ structureWidget gs s =
             ]
       ]
 
-  theName = getStructureName $ Structure.name d
+  theName = Structure.name d
   cells = getEntityGrid cellToEntity d
   renderOneCell = maybe (txt " ") (renderDisplay . view entityDisplay)
 
@@ -167,4 +166,4 @@ drawSidebarListItem ::
   StructureInfo (Maybe Cell) Entity ->
   Widget Name
 drawSidebarListItem _isSelected (StructureInfo annotated _ _) =
-  txt . getStructureName . Structure.name $ namedGrid annotated
+  txt . Structure.getStructureName . Structure.name $ namedGrid annotated

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -476,6 +476,7 @@ testScenarioSolutions rs ui key =
             , testSolution Default "Testing/1575-structure-recognizer/2115-encroaching-upon-exterior-transparent-cells"
             , testSolution Default "Testing/1575-structure-recognizer/2201-piecewise-lines"
             , testSolution Default "Testing/1575-structure-recognizer/2201-preclude-overlapping-recognition"
+            , testSolution Default "Testing/1575-structure-recognizer/2201-initial-recognition-overlap"
             ]
         ]
     , testSolution' Default "Testing/1430-built-robot-ownership" CheckForBadErrors $ \g -> do


### PR DESCRIPTION
Implements overlap resolution for pre-placed recognized structures.

Also introduces a `NonEmptyGrid` type, towards #2004.

## Testing
```
scripts/play.sh --scenario data/scenarios/Testing/1575-structure-recognizer/2201-initial-recognition-overlap.yaml --autoplay
```
## Other changes

* Enrich structure logging (e.g. `OriginalName` -> `OrientedStructure`)
* Consolidate record fields (e.g. in `LocatedStructure`)
* Introduce `zipNumberedNE` function
* Rename some functions (e.g. `mapIndexedMembers` -> `mapWithCoords`)
* Use `StructureName`, remove `OriginalName`