### PR TITLE
Support a generic "original" payload in structure recognizer

### DIFF
--- a/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
+++ b/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
@@ -73,7 +73,6 @@ import Witch (into)
 -- | A scenario item is either a specific scenario, or a collection of
 --   scenarios (/e.g./ the scenarios contained in a subdirectory).
 data ScenarioItem = SISingle ScenarioInfoPair | SICollection Text ScenarioCollection
-  deriving (Show)
 
 -- | Retrieve the name of a scenario item.
 scenarioItemName :: ScenarioItem -> Text
@@ -89,7 +88,6 @@ data ScenarioCollection = SC
   { scOrder :: Maybe [FilePath]
   , scMap :: Map FilePath ScenarioItem
   }
-  deriving (Show)
 
 -- | Access and modify 'ScenarioItem's in collection based on their path.
 scenarioItemByPath :: FilePath -> Traversal' ScenarioCollection ScenarioItem
@@ -114,7 +112,7 @@ tutorialsDirname = "Tutorials"
 getTutorials :: ScenarioCollection -> ScenarioCollection
 getTutorials sc = case M.lookup tutorialsDirname (scMap sc) of
   Just (SICollection _ c) -> c
-  _ -> error $ "No tutorials exist: " ++ show sc
+  _ -> error "No tutorials exist"
 
 -- | Canonicalize a scenario path, making it usable as a unique key.
 normalizeScenarioPath ::

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -12,9 +12,8 @@ module Swarm.Game.State.Initialize (
 import Control.Arrow (Arrow ((&&&)))
 import Control.Carrier.State.Lazy qualified as Fused
 import Control.Effect.Lens (view)
-import Control.Effect.Lift (Has)
-import Control.Effect.State (State)
-import Control.Lens hiding (Const, use, uses, view, (%=), (+=), (.=), (<+=), (<<.=))
+import Control.Lens hiding (view)
+import Data.Hashable (Hashable)
 import Data.IntMap qualified as IM
 import Data.List (partition)
 import Data.List.NonEmpty (NonEmpty)
@@ -24,6 +23,7 @@ import Data.Map qualified as M
 import Data.Maybe (isNothing)
 import Data.Set qualified as S
 import Data.Text (Text)
+import Data.Tuple.Extra (dupe)
 import Swarm.Game.CESK (finalValue, initMachine)
 import Swarm.Game.Device (getCapabilitySet, getMap)
 import Swarm.Game.Entity
@@ -38,12 +38,10 @@ import Swarm.Game.Robot.Concrete
 import Swarm.Game.Scenario
 import Swarm.Game.Scenario.Objective (initCompletion)
 import Swarm.Game.Scenario.Status
-import Swarm.Game.Scenario.Topography.Cell (Cell, cellToEntity)
 import Swarm.Game.Scenario.Topography.Structure.Recognition
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Log
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (emptyFoundStructures)
-import Swarm.Game.Scenario.Topography.Structure.Recognition.Static
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.State
 import Swarm.Game.State.Landscape (mkLandscape)
@@ -78,14 +76,19 @@ pureScenarioToGameState ::
   GameState
 pureScenarioToGameState scenario theSeed now toRun gsc =
   preliminaryGameState
-    & discovery . structureRecognition .~ recognizer
+    & discovery . structureRecognition .~ recognition
  where
   sLandscape = scenario ^. scenarioLandscape
 
-  recognizer =
-    runIdentity $
-      Fused.evalState preliminaryGameState $
-        mkRecognizer (sLandscape ^. scenarioStructures)
+  -- It may be possible at some point for the game seed to affect whether
+  -- initially-placed structures remain intact, by way of random placements.
+  -- Therefore we run this at 'GameState' initialization time, rather than
+  -- 'Scenario' parse time.
+  recognition =
+    runIdentity
+      . Fused.evalState preliminaryGameState
+      . adaptGameState
+      $ initializeRecognition mtlEntityAt (sLandscape ^. scenarioStructures)
 
   gs = initGameState gsc
   preliminaryGameState =
@@ -184,24 +187,23 @@ pureScenarioToGameState scenario theSeed now toRun gsc =
 -- we don't actually have to "search" for these structures since we are
 -- explicitly given their location; we only need to validate that each
 -- structure remains intact given other, potentially overlapping static placements.
-mkRecognizer ::
-  (Has (State GameState) sig m) =>
-  StaticStructureInfo Cell ->
-  m (StructureRecognizer (Maybe Cell) Entity)
-mkRecognizer structInfo@(StaticStructureInfo structDefs _) = do
+initializeRecognition ::
+  (Monad s, Hashable a, Eq b) =>
+  GenericEntLocator s a ->
+  StaticStructureInfo b a ->
+  s (RecognitionState b a)
+initializeRecognition entLoader structInfo = do
   foundIntact <- mapM checkIntactness allPlaced
 
   let fs = populateStaticFoundStructures . map fst . filter (null . snd) $ foundIntact
-  return
-    $ StructureRecognizer
-      (mkAutomatons cellToEntity structDefs)
-    $ RecognitionState
+  return $
+    RecognitionState
       fs
       [IntactStaticPlacement $ map mkLogEntry foundIntact]
  where
-  checkIntactness = sequenceA . (id &&& adaptGameState . ensureStructureIntact emptyFoundStructures mtlEntityAt)
+  checkIntactness = traverse (ensureStructureIntact emptyFoundStructures entLoader) . dupe
 
-  allPlaced = lookupStaticPlacements cellToEntity structInfo
+  allPlaced = lookupStaticPlacements structInfo
   mkLogEntry (x, intact) =
     IntactPlacementLog
       intact

--- a/src/swarm-engine/Swarm/Game/State/Substate.hs
+++ b/src/swarm-engine/Swarm/Game/State/Substate.hs
@@ -104,12 +104,10 @@ import Swarm.Game.Recipe (
   outRecipeMap,
  )
 import Swarm.Game.Robot
-import Swarm.Game.Scenario (GameStateInputs (..))
+import Swarm.Game.Scenario (GameStateInputs (..), RecognizableStructureContent)
 import Swarm.Game.Scenario.Objective
-import Swarm.Game.Scenario.Topography.Cell (Cell)
 import Swarm.Game.Scenario.Topography.Structure.Recognition
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (emptyFoundStructures)
-import Swarm.Game.Scenario.Topography.Structure.Recognition.Type (RecognizerAutomatons (..))
 import Swarm.Game.State.Config
 import Swarm.Game.Tick (TickNumber (..))
 import Swarm.Game.World.Gen (Seed)
@@ -342,7 +340,7 @@ data Discovery = Discovery
   , _availableCommands :: Notifications Const
   , _knownEntities :: S.Set EntityName
   , _gameAchievements :: Map GameplayAchievement Attainment
-  , _structureRecognition :: StructureRecognizer (Maybe Cell) Entity
+  , _structureRecognition :: RecognitionState RecognizableStructureContent Entity
   , _tagMembers :: Map Text (NonEmpty EntityName)
   }
 
@@ -365,7 +363,7 @@ knownEntities :: Lens' Discovery (S.Set EntityName)
 gameAchievements :: Lens' Discovery (Map GameplayAchievement Attainment)
 
 -- | Recognizer for robot-constructed structures
-structureRecognition :: Lens' Discovery (StructureRecognizer (Maybe Cell) Entity)
+structureRecognition :: Lens' Discovery (RecognitionState RecognizableStructureContent Entity)
 
 -- | Map from tags to entities that possess that tag
 tagMembers :: Lens' Discovery (Map Text (NonEmpty EntityName))
@@ -446,10 +444,7 @@ initDiscovery =
     , -- This does not need to be initialized with anything,
       -- since the master list of achievements is stored in UIState
       _gameAchievements = mempty
-    , _structureRecognition =
-        StructureRecognizer
-          (RecognizerAutomatons mempty mempty)
-          (RecognitionState emptyFoundStructures [])
+    , _structureRecognition = RecognitionState emptyFoundStructures []
     , _tagMembers = mempty
     }
 

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -30,6 +30,7 @@ import Swarm.Game.Location
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Tracking qualified as SRT
 import Swarm.Game.State
+import Swarm.Game.State.Landscape (recognizerAutomatons)
 import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Step.Path.Cache
@@ -87,9 +88,10 @@ updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
     myID <- use robotID
     zoomRobots $ wakeWatchingRobots myID currentTick cLoc
 
-    oldRecognizer <- use $ discovery . structureRecognition
-    newRecognizer <- adaptGameState $ SRT.entityModified mtlEntityAt modType cLoc oldRecognizer
-    discovery . structureRecognition .= newRecognizer
+    structureRecognizer <- use $ landscape . recognizerAutomatons
+    oldRecognition <- use $ discovery . structureRecognition
+    newRecognition <- adaptGameState $ SRT.entityModified mtlEntityAt modType cLoc structureRecognizer oldRecognition
+    discovery . structureRecognition .= newRecognition
 
     pcr <- use $ pathCaching . pathCachingRobots
     mapM_ (revalidatePathCache cLoc modType) $ IM.toList pcr

--- a/src/swarm-scenario/Swarm/Game/Scenario.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario.hs
@@ -17,8 +17,8 @@ module Swarm.Game.Scenario (
   Scenario (..),
   ScenarioLandscape (..),
   ScenarioMetadata (ScenarioMetadata),
+  RecognizableStructureContent,
   staticPlacements,
-  structureDefs,
 
   -- ** Fields
   scenarioMetadata,
@@ -86,14 +86,16 @@ import Swarm.Game.Scenario.Objective.Validation
 import Swarm.Game.Scenario.RobotLookup
 import Swarm.Game.Scenario.Style
 import Swarm.Game.Scenario.Topography.Cell
+import Swarm.Game.Scenario.Topography.Grid
 import Swarm.Game.Scenario.Topography.Navigation.Portal
 import Swarm.Game.Scenario.Topography.Navigation.Waypoint (Parentage (..))
 import Swarm.Game.Scenario.Topography.Structure qualified as Structure
 import Swarm.Game.Scenario.Topography.Structure.Assembly qualified as Assembly
 import Swarm.Game.Scenario.Topography.Structure.Named qualified as Structure
 import Swarm.Game.Scenario.Topography.Structure.Overlay
-import Swarm.Game.Scenario.Topography.Structure.Recognition.Static
-import Swarm.Game.Scenario.Topography.Structure.Recognition.Symmetry
+import Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute
+import Swarm.Game.Scenario.Topography.Structure.Recognition.Symmetry (renderRedundancy)
+import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.Scenario.Topography.WorldDescription
 import Swarm.Game.Terrain
 import Swarm.Game.Universe
@@ -181,6 +183,8 @@ scenarioSolution :: Lens' ScenarioOperation (Maybe TSyntax)
 --   take during a single tick.
 scenarioStepsPerTick :: Lens' ScenarioOperation (Maybe Int)
 
+type RecognizableStructureContent = NonEmptyGrid (Maybe Cell)
+
 -- | All cosmetic and structural content of the scenario.
 data ScenarioLandscape = ScenarioLandscape
   { _scenarioSeed :: Maybe Int
@@ -190,10 +194,9 @@ data ScenarioLandscape = ScenarioLandscape
   , _scenarioKnown :: Set EntityName
   , _scenarioWorlds :: NonEmpty WorldDescription
   , _scenarioNavigation :: Navigation (M.Map SubworldName) Location
-  , _scenarioStructures :: StaticStructureInfo Cell
+  , _scenarioStructures :: StaticStructureInfo RecognizableStructureContent Entity
   , _scenarioRobots :: [TRobot]
   }
-  deriving (Show)
 
 makeLensesNoSigs ''ScenarioLandscape
 
@@ -220,7 +223,7 @@ scenarioKnown :: Lens' ScenarioLandscape (Set EntityName)
 scenarioWorlds :: Lens' ScenarioLandscape (NonEmpty WorldDescription)
 
 -- | Information required for structure recognition
-scenarioStructures :: Lens' ScenarioLandscape (StaticStructureInfo Cell)
+scenarioStructures :: Lens' ScenarioLandscape (StaticStructureInfo RecognizableStructureContent Entity)
 
 -- | Waypoints and inter-world portals
 scenarioNavigation :: Lens' ScenarioLandscape (Navigation (M.Map SubworldName) Location)
@@ -236,7 +239,6 @@ data Scenario = Scenario
   , _scenarioOperation :: ScenarioOperation
   , _scenarioLandscape :: ScenarioLandscape
   }
-  deriving (Show)
 
 makeLensesNoSigs ''Scenario
 
@@ -355,10 +357,15 @@ instance FromJSONE ScenarioInputs Scenario where
           namedGrids = map stuffGrid mergedStructures
           recognizableGrids = filter Structure.isRecognizable namedGrids
 
-      symmetryAnnotatedGrids <- mapM checkSymmetry recognizableGrids
+          -- We exclude empty grids from the recognition engine.
+          nonEmptyRecognizableGrids = mapMaybe (traverse getNonEmptyGrid) recognizableGrids
+
+      myAutomatons <-
+        either (fail . T.unpack . renderRedundancy) return $
+          mkAutomatons (fmap cellToEntity) nonEmptyRecognizableGrids
 
       let structureInfo =
-            StaticStructureInfo symmetryAnnotatedGrids
+            StaticStructureInfo myAutomatons
               . M.fromList
               . NE.toList
               $ NE.map (worldName &&& placedStructures) allWorlds

--- a/src/swarm-scenario/Swarm/Game/State/Landscape.hs
+++ b/src/swarm-scenario/Swarm/Game/State/Landscape.hs
@@ -13,6 +13,7 @@ module Swarm.Game.State.Landscape (
   multiWorld,
   worldScrollable,
   terrainAndEntities,
+  recognizerAutomatons,
 
   -- ** Utilities
   initLandscape,
@@ -45,6 +46,7 @@ import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.Grid
 import Swarm.Game.Scenario.Topography.Navigation.Portal (Navigation (..))
 import Swarm.Game.Scenario.Topography.Structure.Overlay
+import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.Scenario.Topography.WorldDescription
 import Swarm.Game.State.Config
 import Swarm.Game.Terrain (TerrainType (..), terrainIndexByName)
@@ -63,6 +65,7 @@ data Landscape = Landscape
   { _worldNavigation :: Navigation (M.Map SubworldName) Location
   , _multiWorld :: MultiWorld Int Entity
   , _terrainAndEntities :: TerrainEntityMaps
+  , _recognizerAutomatons :: RecognizerAutomatons RecognizableStructureContent Entity
   , _worldScrollable :: Bool
   }
 
@@ -81,6 +84,9 @@ multiWorld :: Lens' Landscape (MultiWorld Int Entity)
 -- | The catalogs of all terrain and entities that the game knows about.
 terrainAndEntities :: Lens' Landscape TerrainEntityMaps
 
+-- | Recognition engine for predefined structures
+recognizerAutomatons :: Lens' Landscape (RecognizerAutomatons RecognizableStructureContent Entity)
+
 -- | Whether the world map is supposed to be scrollable or not.
 worldScrollable :: Lens' Landscape Bool
 
@@ -92,6 +98,7 @@ initLandscape gsc =
     { _worldNavigation = Navigation mempty mempty
     , _multiWorld = mempty
     , _terrainAndEntities = initEntityTerrain $ gsiScenarioInputs $ initState gsc
+    , _recognizerAutomatons = RecognizerAutomatons mempty mempty
     , _worldScrollable = True
     }
 
@@ -101,6 +108,7 @@ mkLandscape sLandscape worldTuples theSeed =
     { _worldNavigation = sLandscape ^. scenarioNavigation
     , _multiWorld = genMultiWorld worldTuples theSeed
     , _terrainAndEntities = sLandscape ^. scenarioTerrainAndEntities
+    , _recognizerAutomatons = sLandscape ^. scenarioStructures . staticAutomatons
     , -- TODO (#1370): Should we allow subworlds to have their own scrollability?
       -- Leaning toward no, but for now just adopt the root world scrollability
       -- as being universal.

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Grid.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Grid.hs
@@ -4,12 +4,14 @@ module Swarm.Game.Scenario.Topography.Grid (
   Grid (..),
   NonEmptyGrid (..),
   gridToVec,
-  mapWithCoordsNE,
   mapWithCoords,
+  mapWithCoordsNE,
   allMembers,
+  allMembersNE,
   mapRowsNE,
   getRows,
   mkGrid,
+  getNonEmptyGrid,
 )
 where
 
@@ -43,6 +45,11 @@ mkGrid :: [[a]] -> Grid a
 mkGrid rows = fromMaybe EmptyGrid $ do
   rowsNE <- NE.nonEmpty =<< mapM NE.nonEmpty rows
   return $ Grid $ NonEmptyGrid rowsNE
+
+getNonEmptyGrid :: Grid a -> Maybe (NonEmptyGrid a)
+getNonEmptyGrid = \case
+  EmptyGrid -> Nothing
+  Grid x -> Just x
 
 getRows :: Grid a -> [[a]]
 getRows EmptyGrid = []

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Named.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Named.hs
@@ -6,7 +6,6 @@ import Data.Set (Set)
 import Data.Text (Text)
 import Data.Yaml
 import GHC.Generics (Generic)
-import Swarm.Game.Scenario.Topography.Grid (Grid)
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
 
 newtype StructureName = StructureName Text
@@ -27,9 +26,7 @@ data NamedArea a = NamedArea
   -- ^ will be UI-facing only if this is a recognizable structure
   , structure :: a
   }
-  deriving (Eq, Show, Functor)
+  deriving (Eq, Show, Functor, Foldable, Traversable)
 
 isRecognizable :: NamedArea a -> Bool
 isRecognizable = not . null . recognize
-
-type NamedGrid c = NamedArea (Grid c)

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition.hs
@@ -13,27 +13,15 @@ import Control.Lens
 import GHC.Generics (Generic)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Log
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry
-import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 
--- | State of the structure recognizer that is intended
--- to be modifiable.
+-- |
+-- The type parameters, `b`, and `a`, correspond
+-- to 'Cell' and 'Entity', respectively.
 data RecognitionState b a = RecognitionState
   { _foundStructures :: FoundRegistry b a
   -- ^ Records the top-left corner of the found structure
   , _recognitionLog :: [SearchLog a]
   }
-
-makeLenses ''RecognitionState
-
--- |
--- The type parameters, `b`, and `a`, correspond
--- to 'Cell' and 'Entity', respectively.
-data StructureRecognizer b a = StructureRecognizer
-  { _automatons :: RecognizerAutomatons b a
-  -- ^ read-only
-  , _recognitionState :: RecognitionState b a
-  -- ^ mutatable
-  }
   deriving (Generic)
 
-makeLenses ''StructureRecognizer
+makeLenses ''RecognitionState

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Log.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Log.hs
@@ -6,12 +6,12 @@ module Swarm.Game.Scenario.Topography.Structure.Recognition.Log where
 
 import Data.Aeson
 import Data.List.NonEmpty (NonEmpty)
-import Data.List.NonEmpty qualified as NE
+import Data.List.NonEmpty.Extra qualified as NE
 import GHC.Generics (Generic)
 import Servant.Docs (ToSample)
 import Servant.Docs qualified as SD
 import Swarm.Game.Location (Location)
-import Swarm.Game.Scenario.Topography.Structure.Named (StructureName)
+import Swarm.Game.Scenario.Topography.Structure.Named (StructureName, name)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Static (
   OrientedStructure,
  )
@@ -20,7 +20,7 @@ import Swarm.Game.Universe (Cosmic)
 
 renderSharedNames :: ConsolidatedRowReferences b a -> NonEmpty StructureName
 renderSharedNames =
-  NE.nub . NE.map (getName . originalDefinition . wholeStructure) . referencingRows
+  NE.nubOrd . NE.map (name . originalItem . entityGrid . wholeStructure) . referencingRows
 
 data ParticipatingEntity e = ParticipatingEntity
   { entity :: e

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Prep.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Prep.hs
@@ -34,7 +34,7 @@ allStructureRows =
  where
   transformRows g = imap (StructureRow g . fromIntegral) rows
    where
-    NonEmptyGrid rows = entityGrid g
+    NonEmptyGrid rows = extractedGrid $ entityGrid g
 
 -- | If this entity is encountered in the world,
 -- how far left of it and how far right of it do we need to

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Registry.hs
@@ -32,7 +32,7 @@ import Data.Maybe (listToMaybe, maybeToList)
 import Data.Ord (Down (Down))
 import Data.Set qualified as Set
 import Swarm.Game.Location
-import Swarm.Game.Scenario.Topography.Structure.Named (StructureName)
+import Swarm.Game.Scenario.Topography.Structure.Named (StructureName, name)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.Universe (Cosmic (..))
 import Swarm.Util (binTuples, deleteKeys)
@@ -70,7 +70,7 @@ removeStructure fs (FoundRegistry byName byLoc) =
     (deleteKeys allOccupiedCoords byLoc)
  where
   allOccupiedCoords = genOccupiedCoords fs
-  structureName = getName $ originalDefinition $ structureWithGrid fs
+  structureName = name . originalItem . entityGrid $ structureWithGrid fs
   upperLeft = upperLeftCorner fs
 
   -- NOTE: Observe similarities to
@@ -83,12 +83,12 @@ addFound fs@(PositionedStructure loc swg) (FoundRegistry byName byLoc) =
     (M.insertWith (<>) k (NEM.singleton loc swg) byName)
     (M.union occupationMap byLoc)
  where
-  k = getName $ originalDefinition swg
+  k = name . originalItem $ entityGrid swg
   occupationMap = M.fromList $ map (,fs) $ genOccupiedCoords fs
 
 -- | Bulk insertion of structures statically placed in the scenario definition.
 --
--- See the docs for 'Swarm.Game.State.Initialize.mkRecognizer' for more context.
+-- See the docs for 'Swarm.Game.State.Initialize.initializeRecognition' for more context.
 --
 -- Note that if any of these pre-placed structures overlap, we can't be sure of
 -- the author's intent as to which member of the overlap should take precedence,
@@ -117,7 +117,7 @@ populateStaticFoundStructures allFound =
   byName =
     M.map (NEM.fromList . NE.map (upperLeftCorner &&& structureWithGrid)) $
       binTuples $
-        map (getName . originalDefinition . structureWithGrid &&& id) resolvedCollisions
+        map (name . originalItem . entityGrid . structureWithGrid &&& id) resolvedCollisions
 
   resolvePreplacementCollisions foundList =
     nonOverlappingFound <> maybeToList (listToMaybe overlapsByDecreasingPreference)

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Static.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Static.hs
@@ -1,18 +1,12 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 module Swarm.Game.Scenario.Topography.Structure.Recognition.Static where
 
-import Control.Lens (Lens')
 import Data.Aeson (ToJSON)
-import Data.Map (Map)
 import GHC.Generics (Generic)
 import Swarm.Game.Location
 import Swarm.Game.Scenario.Topography.Structure.Named
-import Swarm.Game.Universe (SubworldName)
 import Swarm.Language.Syntax.Direction (AbsoluteDir)
-import Swarm.Util.Lens (makeLensesNoSigs)
 
 data RotationalSymmetry
   = -- | Aka 1-fold symmetry
@@ -24,10 +18,10 @@ data RotationalSymmetry
   deriving (Show, Eq)
 
 data SymmetryAnnotatedGrid a = SymmetryAnnotatedGrid
-  { namedGrid :: NamedGrid a
-  , symmetry :: RotationalSymmetry
+  { symmetry :: RotationalSymmetry
+  , grid :: a
   }
-  deriving (Show)
+  deriving (Show, Functor, Foldable, Traversable)
 
 data OrientedStructure = OrientedStructure
   { oName :: StructureName
@@ -48,19 +42,3 @@ data LocatedStructure = LocatedStructure
 instance HasLocation LocatedStructure where
   modifyLoc f (LocatedStructure x originalLoc) =
     LocatedStructure x $ f originalLoc
-
-data StaticStructureInfo b = StaticStructureInfo
-  { _structureDefs :: [SymmetryAnnotatedGrid (Maybe b)]
-  , _staticPlacements :: Map SubworldName [LocatedStructure]
-  }
-  deriving (Show)
-
-makeLensesNoSigs ''StaticStructureInfo
-
--- | Structure templates that may be auto-recognized when constructed
--- by a robot
-structureDefs :: Lens' (StaticStructureInfo b) [SymmetryAnnotatedGrid (Maybe b)]
-
--- | A record of the static placements of structures, so that they can be
--- added to the "recognized" list upon scenario initialization
-staticPlacements :: Lens' (StaticStructureInfo b) (Map SubworldName [LocatedStructure])

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -13,9 +13,9 @@ import Brick.Keybindings
 import Control.Lens as Lens
 import Control.Monad (unless, void, when)
 import Control.Monad.IO.Class (liftIO)
-import Swarm.Game.Scenario.Topography.Structure.Recognition (automatons)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type (originalStructureDefinitions)
 import Swarm.Game.State
+import Swarm.Game.State.Landscape
 import Swarm.Game.State.Substate
 import Swarm.Game.Step (finishGameTick)
 import Swarm.TUI.Controller.EventHandlers.Frame (runGameTickUI)
@@ -41,7 +41,7 @@ mainEventHandlers = allHandlers Main $ \case
   ViewRecipesEvent -> ("View Recipes screen", toggleDiscoveryNotificationModal RecipesModal availableRecipes)
   ViewCommandsEvent -> ("View Commands screen", toggleDiscoveryNotificationModal CommandsModal availableCommands)
   ViewMessagesEvent -> ("View Messages screen", toggleMessagesModal)
-  ViewStructuresEvent -> ("View Structures screen", toggleDiscoveryModal StructuresModal (structureRecognition . automatons . originalStructureDefinitions))
+  ViewStructuresEvent -> ("View Structures screen", toggleStructuresModal StructuresModal (recognizerAutomatons . originalStructureDefinitions))
   ViewGoalEvent -> ("View scenario goal description", viewGoal)
   HideRobotsEvent -> ("Hide robots for a few ticks", hideRobots)
   ShowCESKDebugEvent -> ("Show active robot CESK machine debugging line", showCESKDebug)
@@ -72,8 +72,8 @@ toggleGameModal m l = do
   unless nothingToShow $ toggleModal m
   return nothingToShow
 
-toggleDiscoveryModal :: Foldable t => ModalType -> Lens' Discovery (t a) -> EventM Name AppState ()
-toggleDiscoveryModal m l = void $ toggleGameModal m (discovery . l)
+toggleStructuresModal :: Foldable t => ModalType -> Lens' Landscape (t a) -> EventM Name AppState ()
+toggleStructuresModal m l = void $ toggleGameModal m (landscape . l)
 
 toggleDiscoveryNotificationModal :: ModalType -> Lens' Discovery (Notifications a) -> EventM Name AppState ()
 toggleDiscoveryNotificationModal m l = do

--- a/src/swarm-tui/Swarm/TUI/Model/Dialog/Structure.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Dialog/Structure.hs
@@ -12,12 +12,12 @@ import Brick.Widgets.List qualified as BL
 import Control.Lens (makeLenses)
 import Data.List.Extra (enumerate)
 import Swarm.Game.Entity (Entity)
-import Swarm.Game.Scenario.Topography.Cell (Cell)
+import Swarm.Game.Scenario (RecognizableStructureContent)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.TUI.Model.Name
 
 data StructureDisplay = StructureDisplay
-  { _structurePanelListWidget :: BL.List Name (StructureInfo (Maybe Cell) Entity)
+  { _structurePanelListWidget :: BL.List Name (StructureInfo RecognizableStructureContent Entity)
   -- ^ required for maintaining the selection/navigation
   -- state among list items
   , _structurePanelFocus :: FocusRing Name

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -59,7 +59,6 @@ import Swarm.Game.Scenario.Scoring.Best
 import Swarm.Game.Scenario.Scoring.ConcreteMetrics
 import Swarm.Game.Scenario.Scoring.GenericMetrics
 import Swarm.Game.Scenario.Status
-import Swarm.Game.Scenario.Topography.Structure.Recognition (automatons)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type (originalStructureDefinitions)
 import Swarm.Game.ScenarioInfo (
   loadScenarioInfo,
@@ -280,7 +279,7 @@ scenarioToUIState isAutoplaying siPair@(scenario, _) gs u = do
       & uiGameplay . uiWorldEditor . EM.editingBounds . EM.boundsRect %~ setNewBounds
       & uiGameplay . uiDialogs . uiStructure
         .~ StructureDisplay
-          (SR.makeListWidget . M.elems $ gs ^. discovery . structureRecognition . automatons . originalStructureDefinitions)
+          (SR.makeListWidget . M.elems $ gs ^. landscape . recognizerAutomatons . originalStructureDefinitions)
           (focusSetCurrent (StructureWidgets StructuresList) $ focusRing $ map StructureWidgets enumerate)
  where
   entityList = EU.getEntitiesForList $ gs ^. landscape . terrainAndEntities . entityMap

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -95,7 +95,6 @@ import Swarm.Game.Scenario.Scoring.ConcreteMetrics
 import Swarm.Game.Scenario.Scoring.GenericMetrics
 import Swarm.Game.Scenario.Status
 import Swarm.Game.Scenario.Topography.Center
-import Swarm.Game.Scenario.Topography.Structure.Recognition (automatons)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.ScenarioInfo (
   ScenarioItem (..),
@@ -830,7 +829,7 @@ drawModalMenu s = vLimit 1 . hBox $ map (padLeftRight 1 . drawKeyCmd) globalKeyC
 
   -- Hides this key if the recognizable structure list is empty
   structuresKey =
-    if null $ s ^. gameState . discovery . structureRecognition . automatons . originalStructureDefinitions
+    if null $ s ^. gameState . landscape . recognizerAutomatons . originalStructureDefinitions
       then Nothing
       else Just (NoHighlight, keyM SE.ViewStructuresEvent, "Structures")
 

--- a/src/swarm-tui/Swarm/TUI/View/CellDisplay.hs
+++ b/src/swarm-tui/Swarm/TUI/View/CellDisplay.hs
@@ -36,7 +36,7 @@ import Swarm.Game.Land
 import Swarm.Game.Location (Point (..), toHeading)
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Topography.EntityFacade
-import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures, recognitionState)
+import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (foundByLocation)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
@@ -76,7 +76,7 @@ drawLoc ui g cCoords@(Cosmic _ coords) =
 
   boldStructure = applyWhen isStructure $ modifyDefAttr (`V.withStyle` V.bold)
    where
-    sMap = foundByLocation $ g ^. discovery . structureRecognition . recognitionState . foundStructures
+    sMap = foundByLocation $ g ^. discovery . structureRecognition . foundStructures
     isStructure = M.member (coordsToLoc <$> cCoords) sMap
 
 -- | Subset of the game state needed to render the world

--- a/src/swarm-tui/Swarm/TUI/View/Structure.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Structure.hs
@@ -21,10 +21,9 @@ import Data.Text qualified as T
 import Data.Vector qualified as V
 import Swarm.Game.Entity (Entity, entityDisplay)
 import Swarm.Game.Scenario.Topography.Area
-import Swarm.Game.Scenario.Topography.Cell (Cell, cellToEntity)
+import Swarm.Game.Scenario.Topography.Grid
 import Swarm.Game.Scenario.Topography.Structure.Named qualified as Structure
-import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures, recognitionState)
-import Swarm.Game.Scenario.Topography.Structure.Recognition.Precompute (getEntityGrid)
+import Swarm.Game.Scenario.Topography.Structure.Recognition (foundStructures)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (foundByName)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Static
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
@@ -41,7 +40,7 @@ import Swarm.Util (commaList)
 
 -- | Render a two-pane widget with structure selection on the left
 -- and single-structure details on the right.
-structureWidget :: GameState -> StructureInfo (Maybe Cell) Entity -> Widget n
+structureWidget :: GameState -> StructureInfo b Entity -> Widget n
 structureWidget gs s =
   vBox
     [ hBox
@@ -50,7 +49,7 @@ structureWidget gs s =
             . headerItem "Size"
             . T.pack
             . renderRectDimensions
-            . getAreaDimensions
+            . getNEGridDimensions
             $ entityProcessedGrid s
         , occurrenceCountSuffix
         ]
@@ -70,8 +69,8 @@ structureWidget gs s =
       ]
 
   annotatedStructureGrid = annotatedGrid s
-
-  supportedOrientations = Set.toList . Structure.recognize . namedGrid $ annotatedStructureGrid
+  theNamedGrid = originalItem $ grid annotatedStructureGrid
+  supportedOrientations = Set.toList . Structure.recognize $ theNamedGrid
 
   renderSymmetry = \case
     NoSymmetry -> "no"
@@ -90,16 +89,14 @@ structureWidget gs s =
 
   maybeDescriptionWidget =
     maybe emptyWidget (padTop (Pad 1) . withAttr italicAttr . txtWrap) $
-      Structure.description . namedGrid . annotatedGrid $
-        s
+      Structure.description theNamedGrid
 
-  registry = gs ^. discovery . structureRecognition . recognitionState . foundStructures
+  registry = gs ^. discovery . structureRecognition . foundStructures
   occurrenceCountSuffix = case M.lookup theName $ foundByName registry of
     Nothing -> emptyWidget
     Just inner -> padLeft (Pad 2) . headerItem "Count" . T.pack . show $ NEM.size inner
 
   structureIllustration = vBox $ map (hBox . map renderOneCell) cells
-  d = namedGrid $ annotatedGrid s
 
   ingredientsBox =
     vBox
@@ -118,15 +115,19 @@ structureWidget gs s =
             ]
       ]
 
-  theName = Structure.name d
-  cells = getEntityGrid cellToEntity d
+  theName = Structure.name theNamedGrid
+  cells = getRows $ Grid $ entityProcessedGrid s
+
   renderOneCell = maybe (txt " ") (renderDisplay . view entityDisplay)
 
-makeListWidget :: [StructureInfo (Maybe Cell) Entity] -> BL.List Name (StructureInfo (Maybe Cell) Entity)
+makeListWidget :: [StructureInfo b a] -> BL.List Name (StructureInfo b a)
 makeListWidget structureDefinitions =
   BL.listMoveTo 0 $ BL.list (StructureWidgets StructuresList) (V.fromList structureDefinitions) 1
 
-renderStructuresDisplay :: GameState -> StructureDisplay -> Widget Name
+renderStructuresDisplay ::
+  GameState ->
+  StructureDisplay ->
+  Widget Name
 renderStructuresDisplay gs structureDisplay =
   vBox
     [ hBox
@@ -163,7 +164,7 @@ renderStructuresDisplay gs structureDisplay =
 
 drawSidebarListItem ::
   Bool ->
-  StructureInfo (Maybe Cell) Entity ->
+  StructureInfo b a ->
   Widget Name
 drawSidebarListItem _isSelected (StructureInfo annotated _ _) =
-  txt . Structure.getStructureName . Structure.name $ namedGrid annotated
+  txt . Structure.getStructureName . Structure.name $ originalItem $ grid annotated

--- a/src/swarm-util/Swarm/Language/Syntax/Direction.hs
+++ b/src/swarm-util/Swarm/Language/Syntax/Direction.hs
@@ -10,6 +10,7 @@
 module Swarm.Language.Syntax.Direction (
   -- * Directions
   Direction (..),
+  CoordinateOrientation (..),
   AbsoluteDir (..),
   RelativeDir (..),
   PlanarRelativeDir (..),

--- a/src/swarm-web/Swarm/Web.hs
+++ b/src/swarm-web/Swarm/Web.hs
@@ -231,12 +231,12 @@ recogLogHandler appStateRef = do
   appState <- liftIO appStateRef
   return $
     map (fmap (view entityName)) $
-      appState ^. gameState . discovery . structureRecognition . recognitionState . recognitionLog
+      appState ^. gameState . discovery . structureRecognition . recognitionLog
 
 recogFoundHandler :: IO AppState -> Handler [StructureLocation]
 recogFoundHandler appStateRef = do
   appState <- liftIO appStateRef
-  let registry = appState ^. gameState . discovery . structureRecognition . recognitionState . foundStructures
+  let registry = appState ^. gameState . discovery . structureRecognition . foundStructures
   return
     . map (uncurry StructureLocation)
     . concatMap (\(x, ys) -> map (x,) $ NE.toList ys)

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -685,6 +685,7 @@ library swarm-engine
     servant-docs,
     text,
     time,
+    hashable,
     transformers,
     unordered-containers,
     witch,


### PR DESCRIPTION
The recognizer algorithm operates on a `NonEmptyGrid` of `Maybe` elements.  However, there may exist some progenitor object with auxiliary metadata payload that is independent of the algorithm but should be presented along with the final recognized structure.

So long as an "extraction" function is provided that derives the nonempty grid of `a`s from the original object `b`, we can send `b` along for the ride through the algorithm without concern to `b`'s internals.

# Changes

Overall this refactoring makes the code more generic and simpler.

* Build the recognizer automata at scenario parse time
* Enforce grid no emptiness earlier in recognizer construction
* Subsume redundant `_structureDefs` member of `StaticStructureInfo` record with `_staticAutomatons` field
* Make some type signatures in the UI more generic
* Push the conversion from `Cell` to `Entity `further up the pipeline
* Remove some derived `Show` instances (`show`-ing a Scenario is not likely to be useful due to sheer volume of content)