### PR TITLE
Add `TCAppL` and `TCAppR` typechecking stack frames, and remove `TCBind{L,R}`

### DIFF
--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -668,19 +668,28 @@ testLanguagePipeline =
                 "1:1: Undefined type U"
             )
         ]
-    , testCase
-        "Stop printing context after a definition. - #1336"
-        ( processCompare
-            (==)
-            "move; def x = move; say 3 end; move;"
-            "1:25: Type mismatch:\n  From context, expected `3` to have type `Text`,\n  but it actually has type `Int`\n\n  - While checking the argument to a function: say _\n  - While checking the definition of x"
-        )
-    , testCase
-        "Error inside function application + argument #2220"
-        ( process
-            "id 3 3"
-            "1:1: Unbound variable id\n\n  - While checking a function applied to an argument: _ 3\n  - While checking a function applied to an argument: _ 3"
-        )
+    , testGroup
+        "typechecking context stack"
+        [ testCase
+            "Stop printing context after a definition. - #1336"
+            ( processCompare
+                (==)
+                "move; def x = move; say 3 end; move;"
+                "1:25: Type mismatch:\n  From context, expected `3` to have type `Text`,\n  but it actually has type `Int`\n\n  - While checking the argument to a function: say _\n  - While checking the definition of x"
+            )
+        , testCase
+            "Error inside function application + argument #2220"
+            ( process
+                "id 3 3"
+                "1:1: Unbound variable id\n\n  - While checking a function applied to an argument: _ 3\n  - While checking a function applied to an argument: _ 3"
+            )
+        , testCase
+            "Error inside function application + argument #2220"
+            ( process
+                "(\\x. x) 7 8"
+                "1:1: Type mismatch:\n  From context, expected `(\\x. x) 7` to be a function,\n  but it actually has type `Int`\n\n  - While checking a function applied to an argument: _ 8"
+            )
+        ]
     , testGroup
         "let and def types"
         [ testCase

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -689,6 +689,12 @@ testLanguagePipeline =
                 "(\\x. x) 7 8"
                 "1:1: Type mismatch:\n  From context, expected `(\\x. x) 7` to be a function,\n  but it actually has type `Int`\n\n  - While checking a function applied to an argument: _ 8"
             )
+        , testCase
+            "Nested error #2220"
+            ( process
+                "\"hi\" + 2"
+                "1:1: Type mismatch:\n  From context, expected `\"hi\"` to have type `Int`,\n  but it actually has type `Text`\n\n  - While checking the argument to a function: (+) _\n  - While checking a function applied to an argument: _ 2"
+            )
         ]
     , testGroup
         "let and def types"

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -675,6 +675,12 @@ testLanguagePipeline =
             "move; def x = move; say 3 end; move;"
             "1:25: Type mismatch:\n  From context, expected `3` to have type `Text`,\n  but it actually has type `Int`\n\n  - While checking the right-hand side of a function application: say _\n  - While checking the definition of x"
         )
+    , testCase
+        "Error inside function application + argument #2220"
+        ( process
+            "id 3 3"
+            "foo"
+        )
     , testGroup
         "let and def types"
         [ testCase

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -673,13 +673,13 @@ testLanguagePipeline =
         ( processCompare
             (==)
             "move; def x = move; say 3 end; move;"
-            "1:25: Type mismatch:\n  From context, expected `3` to have type `Text`,\n  but it actually has type `Int`\n\n  - While checking the right-hand side of a function application: say _\n  - While checking the definition of x"
+            "1:25: Type mismatch:\n  From context, expected `3` to have type `Text`,\n  but it actually has type `Int`\n\n  - While checking the argument to a function: say _\n  - While checking the definition of x"
         )
     , testCase
         "Error inside function application + argument #2220"
         ( process
             "id 3 3"
-            "foo"
+            "1:1: Unbound variable id\n\n  - While checking a function applied to an argument: _ 3\n  - While checking a function applied to an argument: _ 3"
         )
     , testGroup
         "let and def types"

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -673,7 +673,7 @@ testLanguagePipeline =
         ( processCompare
             (==)
             "move; def x = move; say 3 end; move;"
-            "1:25: Type mismatch:\n  From context, expected `3` to have type `Text`,\n  but it actually has type `Int`\n\n  - While checking the right-hand side of a semicolon\n  - While checking the definition of x"
+            "1:25: Type mismatch:\n  From context, expected `3` to have type `Text`,\n  but it actually has type `Int`\n\n  - While checking the right-hand side of a function application: say _\n  - While checking the definition of x"
         )
     , testGroup
         "let and def types"


### PR DESCRIPTION
Towards #1314.

- It seems like it could be helpful to report that we were checking the left- or right-hand side of a function application when reporting type errors, to help give context.
- On the other hand the "checking the LHS/RHS of a semicolon" never seemed very useful, since it would always come in a big chain and didn't really help localize the error, so I removed it.
- I'm open to suggestions for other context we could provide.  There is definitely a balance here between providing helpful context and providing too much.  For example, should we add something that says "while checking the LHS/RHS of a pair"?