### PR TITLE
Add an extra `ghcup set` step to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ unreleased features), read on.
 
            ghcup install ghc 9.8.2
 
+    1. Set the newly installed version of GHC as the current version
+       (if not already set):
+
+           ghcup set ghc 9.8.2
+
     1. Use `ghcup` to install `cabal`:
 
            ghcup install cabal

--- a/README.md
+++ b/README.md
@@ -52,13 +52,7 @@ unreleased features), read on.
        Haskell toolchain.
     1. Use `ghcup` to install a supported version of GHC:
 
-           ghcup install ghc 9.8.2
-
-    1. Set the newly installed version of GHC as the current version
-       (if not already set):
-
-           ghcup set ghc 9.8.2
-
+           ghcup install ghc 9.8.2 --set
     1. Use `ghcup` to install `cabal`:
 
            ghcup install cabal

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ unreleased features), read on.
     1. Use `ghcup` to install a supported version of GHC:
 
            ghcup install ghc 9.8.2 --set
+
     1. Use `ghcup` to install `cabal`:
 
            ghcup install cabal


### PR DESCRIPTION
As suggested on discord by ChucklesTheBeard, it may be necessary to do `ghcup set` after `ghcup install`.
