### PR TITLE
Fix shape recognition orientation edge case

### DIFF
--- a/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
+++ b/data/scenarios/Testing/1575-structure-recognizer/00-ORDER.txt
@@ -19,3 +19,4 @@
 2201-piecewise-lines.yaml
 2201-preclude-overlapping-recognition.yaml
 2201-initial-recognition-overlap.yaml
+2229-position-uniqueness-multiple-orientations.yaml

--- a/data/scenarios/Testing/1575-structure-recognizer/2229-position-uniqueness-multiple-orientations.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2229-position-uniqueness-multiple-orientations.yaml
@@ -1,0 +1,60 @@
+version: 1
+name: Structure recognition - rotated structures at same position
+description: |
+  A map keyed by (position, structure name) would not be sufficient to
+  account for multiple orientations of the same structure, sharing the
+  same top-left corner position.
+
+  This is why the found structure registry must include orientation
+  in its key.
+creative: false
+objectives:
+  - teaser: Recognize both structures
+    goal:
+      - |
+        Two `thingy`{=structure} structures should be recognized immediately.
+        Without distinguishing them by orientation in the registry, only
+        one would be recognized.
+    condition: |
+      foundStructure <- structure "thingy" 0;
+      return $ case foundStructure
+        (\_. false)
+        (\result. fst result == 2);
+robots:
+  - name: base
+    dir: north
+    devices:
+      - logger
+solution: |
+  noop;
+structures:
+  - name: thingy
+    recognize: [north, east]
+    structure:
+      palette:
+        'x': [stone, rock]
+        'y': [dirt]
+      mask: '.'
+      map: |
+        y.y
+        yxx
+known: [rock]
+world:
+  dsl: |
+    {blank}
+  placements:
+    - src: thingy
+    - src: thingy
+      offset: [0, 0]
+      orient:
+        up: east
+  palette:
+    '.': [grass, erase]
+    'B': [grass, erase, base]
+  upperleft: [-3, 3]
+  map: |
+    .........B.
+    ...........
+    ...........
+    ...........
+    ...........

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -554,7 +554,7 @@ execConst runChildProg c vs s k = do
             mkOutput mapNE = (NE.length xs, bottomLeftCorner)
              where
               xs = NEM.toList mapNE
-              (pos, struc) = indexWrapNonEmpty xs idx
+              ((pos, _), struc) = indexWrapNonEmpty xs idx
               topLeftCorner = pos ^. planar
               offsetHeight = V2 0 $ negate (rectHeight (getNEGridDimensions $ extractedGrid $ entityGrid struc) - 1)
               bottomLeftCorner :: Location

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Log.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Log.hs
@@ -17,6 +17,7 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Static (
  )
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.Universe (Cosmic)
+import Swarm.Language.Syntax.Direction (AbsoluteDir)
 
 renderSharedNames :: ConsolidatedRowReferences b a -> NonEmpty StructureName
 renderSharedNames =
@@ -81,7 +82,7 @@ searchLogOptions =
 instance ToSample (SearchLog e) where
   toSamples _ = SD.noSamples
 
-data StructureLocation = StructureLocation StructureName (Cosmic Location)
+data StructureLocation = StructureLocation StructureName (Cosmic Location, AbsoluteDir)
   deriving (Generic, ToJSON)
 
 instance ToSample StructureLocation where

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Log.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure/Recognition/Log.hs
@@ -57,6 +57,7 @@ data SearchLog e
   | StartSearchAt (Cosmic Location) InspectionOffsets
   | FoundParticipatingEntity (ParticipatingEntity e)
   | FoundCompleteStructureCandidates [(OrientedStructure, Cosmic Location)]
+  | RecognizedSingleStructure (OrientedStructure, Cosmic Location)
   | -- | this is actually internally used as a (Map (NonEmpty e) (NonEmpty Int)),
     -- but the requirements of Functor force us to invert the mapping
     FoundPiecewiseChunks [(NonEmpty Int, NonEmpty e)]

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -477,6 +477,7 @@ testScenarioSolutions rs ui key =
             , testSolution Default "Testing/1575-structure-recognizer/2201-piecewise-lines"
             , testSolution Default "Testing/1575-structure-recognizer/2201-preclude-overlapping-recognition"
             , testSolution Default "Testing/1575-structure-recognizer/2201-initial-recognition-overlap"
+            , testSolution Default "Testing/1575-structure-recognizer/2229-position-uniqueness-multiple-orientations"
             ]
         ]
     , testSolution' Default "Testing/1430-built-robot-ownership" CheckForBadErrors $ \g -> do


### PR DESCRIPTION
This PR augments the inner map key (from `Cosmic Location` to `(Cosmic Location, AbsoluteDir)`) for the `foundByName` field in the recognition registry to account for a shape that may have two non-overlapping orientations placed at the same coordinate.

## Testing
```
scripts/test/run-tests.sh --test-options '--pattern "structure"'
```
## Other changes and refactoring

* Enhanced logging: add a new constructor for logging that indicates which shape (if any) was recognized
* Extract the inner logic from `entityModified` into a function `entityModifiedLoggable` that does not dictate the logging structure
* Introduce a new `RecognitionActiveStatus` parameter that allows API users to temporarily disable recognition of "contained" structures while constructing larger structures
* Inline the `registerBestStructureMatch` function