### PR TITLE
Update to allow GHC 9.10 and drop GHC 9.2

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,10 +25,10 @@ queue_rules:
           - or:
             - check-success=HLint
             - -files~=\.hs$
+          - check-success=Haskell-CI - Linux - ghc-9.10.1
           - check-success=Haskell-CI - Linux - ghc-9.8.2
-          - check-success=Haskell-CI - Linux - ghc-9.6.5
+          - check-success=Haskell-CI - Linux - ghc-9.6.6
           - check-success=Haskell-CI - Linux - ghc-9.4.8
-          - check-success=Haskell-CI - Linux - ghc-9.2.8
           - check-success=Haskell-CI - windows-latest - ghc-9.8.2
 
 pull_request_rules:
@@ -57,10 +57,10 @@ pull_request_rules:
       - or:
         - check-success=HLint
         - -files~=\.hs$
+      - check-success=Haskell-CI - Linux - ghc-9.10.1
       - check-success=Haskell-CI - Linux - ghc-9.8.2
-      - check-success=Haskell-CI - Linux - ghc-9.6.5
+      - check-success=Haskell-CI - Linux - ghc-9.6.6
       - check-success=Haskell-CI - Linux - ghc-9.4.8
-      - check-success=Haskell-CI - Linux - ghc-9.2.8
       - check-success=Haskell-CI - windows-latest - ghc-9.8.2
   - label=merge me
   - ! '#approved-reviews-by>=1'

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -4,7 +4,7 @@
 ##                                                                  #
 ## WARNING:                                                         #
 ## Hand-edited to add filter in on.push and on.pull_request.        #
-## Also hand-edited to add 'weeder' step to GHC 9.6.5.              #
+## Also hand-edited to add 'weeder' step to GHC 9.6.6.              #
 ## If possible do not manually edit beside the above.               #
 #####################################################################
 #
@@ -18,9 +18,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240708
+# version: 0.19.20241202
 #
-# REGENDATA ("0.19.20240708",["github","--config=.github/workflows/cabal.haskell-ci","--copy-fields=all","swarm.cabal"])
+# REGENDATA ("0.19.20241202",["github","--config=.github/workflows/cabal.haskell-ci","--copy-fields=all","swarm.cabal"])
 #
 name: Haskell-CI
 on:
@@ -58,14 +58,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.1
+            compilerKind: ghc
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.8.2
             compilerKind: ghc
             compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.5
+          - compiler: ghc-9.6.6
             compilerKind: ghc
-            compilerVersion: 9.6.5
+            compilerVersion: 9.6.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -73,22 +78,31 @@ jobs:
             compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.8
-            compilerKind: ghc
-            compilerVersion: 9.2.8
-            setup-method: ghcup
-            allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+      - name: Install cabal-install
+        run: |
           "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -99,21 +113,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -222,7 +227,7 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: weeder
-        if: matrix.compilerVersion == '9.6.5'
+        if: matrix.compilerVersion == '9.6.6'
         uses: freckle/weeder-action@v2
         with:
           ghc-version: ${{ matrix.compilerVersion }}
@@ -243,8 +248,8 @@ jobs:
         run: |
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/src/swarm-doc/Swarm/Doc/Pedagogy.hs
+++ b/src/swarm-doc/Swarm/Doc/Pedagogy.hs
@@ -20,7 +20,8 @@ module Swarm.Doc.Pedagogy (
 
 import Control.Lens (universe, view, (^.))
 import Control.Monad (guard)
-import Data.List (foldl', intercalate, sort, sortOn)
+import Data.Foldable (Foldable (..))
+import Data.List (intercalate, sort, sortOn)
 import Data.List.Extra (zipFrom)
 import Data.Map (Map)
 import Data.Map qualified as M
@@ -58,6 +59,7 @@ import Swarm.Language.Syntax
 import Swarm.Language.Text.Markdown (docToText, findCode)
 import Swarm.Language.Types (Polytype)
 import Swarm.Util.Effect (ignoreWarnings)
+import Prelude hiding (Foldable (..))
 
 -- * Constants
 

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -9,9 +9,8 @@ module Swarm.Language.Parser.Term where
 import Control.Lens (view, (^.))
 import Control.Monad (guard, join)
 import Control.Monad.Combinators.Expr
-import Data.Foldable (asum)
+import Data.Foldable (asum, Foldable (..))
 import Data.Functor (($>))
-import Data.List (foldl')
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (mapMaybe)
@@ -27,6 +26,7 @@ import Swarm.Language.Types
 import Swarm.Util (failT, findDup)
 import Text.Megaparsec hiding (runParser)
 import Text.Megaparsec.Char
+import Prelude hiding (Foldable (..))
 
 -- Imports for doctests (cabal-docspec needs this)
 

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -9,7 +9,7 @@ module Swarm.Language.Parser.Term where
 import Control.Lens (view, (^.))
 import Control.Monad (guard, join)
 import Control.Monad.Combinators.Expr
-import Data.Foldable (asum, Foldable (..))
+import Data.Foldable (Foldable (..), asum)
 import Data.Functor (($>))
 import Data.Map (Map)
 import Data.Map qualified as M

--- a/src/swarm-lang/Swarm/Language/Value.hs
+++ b/src/swarm-lang/Swarm/Language/Value.hs
@@ -29,8 +29,8 @@ module Swarm.Language.Value (
 
 import Control.Lens hiding (Const)
 import Data.Bool (bool)
+import Data.Foldable (Foldable (..))
 import Data.Hashable (Hashable)
-import Data.List (foldl')
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Set qualified as S
@@ -46,6 +46,7 @@ import Swarm.Language.Syntax.Direction
 import Swarm.Language.Typed
 import Swarm.Language.Types (Polytype, TCtx, TDCtx, TydefInfo, Type)
 import Swarm.Pretty (prettyText)
+import Prelude hiding (Foldable (..))
 
 -- | A /value/ is a term that cannot (or does not) take any more
 --   evaluation steps on its own.

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -102,13 +102,13 @@ import Control.Monad (forM_, unless, (<=<))
 import Data.Bifunctor (first)
 import Data.Char (toLower)
 import Data.Either.Extra (maybeToEither)
+import Data.Foldable (Foldable (..))
 import Data.Function (on)
 import Data.Hashable
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IM
 import Data.IntSet (IntSet)
 import Data.IntSet qualified as IS
-import Data.List (foldl')
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
@@ -136,7 +136,7 @@ import Swarm.Util.Effect (withThrow)
 import Swarm.Util.Yaml
 import Text.Read (readMaybe)
 import Witch
-import Prelude hiding (lookup)
+import Prelude hiding (lookup, Foldable (..))
 
 ------------------------------------------------------------
 -- Properties

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -136,7 +136,7 @@ import Swarm.Util.Effect (withThrow)
 import Swarm.Util.Yaml
 import Text.Read (readMaybe)
 import Witch
-import Prelude hiding (lookup, Foldable (..))
+import Prelude hiding (Foldable (..), lookup)
 
 ------------------------------------------------------------
 -- Properties

--- a/src/swarm-scenario/Swarm/Game/Recipe.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe.hs
@@ -59,9 +59,9 @@ import Control.Lens hiding (from, (.=))
 import Control.Monad ((<=<))
 import Data.Bifunctor (second)
 import Data.Either.Validation
+import Data.Foldable (Foldable (..))
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IM
-import Data.List (foldl')
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -75,6 +75,7 @@ import Swarm.Util.Effect (withThrow)
 import Swarm.Util.Lens (makeLensesNoSigs)
 import Swarm.Util.Yaml
 import Witch
+import Prelude hiding (Foldable (..))
 
 -- | A recipe represents some kind of process where inputs are
 --   transformed into outputs.

--- a/src/swarm-scenario/Swarm/Game/World.hs
+++ b/src/swarm-scenario/Swarm/Game/World.hs
@@ -71,7 +71,7 @@ import Swarm.Game.World.Coords
 import Swarm.Game.World.Modify
 import Swarm.Util ((?))
 import Swarm.Util.Erasable
-import Prelude hiding (lookup, Foldable (..))
+import Prelude hiding (Foldable (..), lookup)
 
 ------------------------------------------------------------
 -- World function

--- a/src/swarm-scenario/Swarm/Game/World.hs
+++ b/src/swarm-scenario/Swarm/Game/World.hs
@@ -71,7 +71,7 @@ import Swarm.Game.World.Coords
 import Swarm.Game.World.Modify
 import Swarm.Util ((?))
 import Swarm.Util.Erasable
-import Prelude hiding (lookup)
+import Prelude hiding (lookup, Foldable (..))
 
 ------------------------------------------------------------
 -- World function

--- a/src/swarm-scenario/Swarm/Game/World/Typecheck.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Typecheck.hs
@@ -23,10 +23,10 @@ module Swarm.Game.World.Typecheck where
 import Control.Algebra (Has)
 import Control.Effect.Reader (Reader, ask)
 import Control.Effect.Throw (Throw, throwError)
+import Data.Foldable (Foldable (..))
 import Data.Foldable qualified as F
 import Data.Functor.Const qualified as F
 import Data.Kind (Type)
-import Data.List (foldl')
 import Data.List.Extra (enumerate)
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
@@ -42,7 +42,7 @@ import Swarm.Game.World.Syntax
 import Swarm.Pretty (PrettyPrec (..), pparens, ppr)
 import Swarm.Util (showT)
 import Swarm.Util.Erasable
-import Prelude hiding (lookup)
+import Prelude hiding (lookup, Foldable (..))
 
 ------------------------------------------------------------
 -- Type classes for monoidal world values

--- a/src/swarm-scenario/Swarm/Game/World/Typecheck.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Typecheck.hs
@@ -42,7 +42,7 @@ import Swarm.Game.World.Syntax
 import Swarm.Pretty (PrettyPrec (..), pparens, ppr)
 import Swarm.Util (showT)
 import Swarm.Util.Erasable
-import Prelude hiding (lookup, Foldable (..))
+import Prelude hiding (Foldable (..), lookup)
 
 ------------------------------------------------------------
 -- Type classes for monoidal world values

--- a/src/swarm-tui/Swarm/TUI/Model/DebugOption.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/DebugOption.hs
@@ -12,6 +12,7 @@ module Swarm.TUI.Model.DebugOption (
 
 import Data.Foldable (find, foldl')
 import Data.List.Extra (enumerate, splitOn, trim)
+import Prelude hiding (Foldable (..))
 
 data DebugOption
   = ToggleCreative

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -121,7 +121,7 @@ import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
 import System.FilePath (takeExtension, (</>))
 import System.IO.Error (catchIOError)
 import Witch (from)
-import Prelude hiding (Foldable(..))
+import Prelude hiding (Foldable (..))
 
 infixr 1 ?
 infix 4 %%=, <+=, <%=, <<.=, <>=

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -92,10 +92,11 @@ import Control.Monad.Trans.Maybe (MaybeT (..))
 import Data.Bifunctor (Bifunctor (bimap), first)
 import Data.Char (isAlphaNum, toLower)
 import Data.Either.Validation
+import Data.Foldable (Foldable (..))
 import Data.Foldable qualified as Foldable
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IM
-import Data.List (foldl', maximumBy, partition)
+import Data.List (maximumBy, partition)
 import Data.List qualified as List
 import Data.List.Extra (enumerate)
 import Data.List.NonEmpty (NonEmpty ((:|)))
@@ -120,6 +121,7 @@ import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
 import System.FilePath (takeExtension, (</>))
 import System.IO.Error (catchIOError)
 import Witch (from)
+import Prelude hiding (Foldable(..))
 
 infixr 1 ?
 infix 4 %%=, <+=, <%=, <<.=, <>=

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -120,7 +120,7 @@ common ghc2021-extensions
     TypeOperators
 
 common base
-  build-depends: base >=4.14 && <4.20
+  build-depends: base >=4.14 && <4.21
 
 common AhoCorasick
   build-depends: AhoCorasick >=0.0.4 && <0.0.5
@@ -339,7 +339,7 @@ common tasty-quickcheck
   build-depends: tasty-quickcheck >=0.10 && <0.11
 
 common template-haskell
-  build-depends: template-haskell >=2.16 && <2.22
+  build-depends: template-haskell >=2.16 && <2.23
 
 common terminal-size
   build-depends: terminal-size >=0.3 && <1.0

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -198,7 +198,7 @@ common extra
   build-depends: extra >=1.7 && <1.8
 
 common filepath
-  build-depends: filepath >=1.4 && <1.5
+  build-depends: filepath >=1.4 && <1.6
 
 common free
   build-depends: free >=5.2 && <5.3

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -38,7 +38,7 @@ maintainer: byorgey@gmail.com
 bug-reports: https://github.com/swarm-game/swarm/issues
 copyright: Brent Yorgey 2021
 category: Game
-tested-with: ghc ==9.2.8 || ==9.4.8 || ==9.6.5 || ==9.8.2
+tested-with: ghc ==9.4.8 || ==9.6.6 || ==9.8.2 || ==9.10.1
 extra-doc-files:
   CHANGELOG.md
 


### PR DESCRIPTION
- Allow `base-4.21` and `template-haskell-2.22`
- Update CI + mergify config
- Update imports of `foldl'`: closes #1421 
- Update to testing with GHC-9.6.6 instead of 9.6.5, but stay with 9.8.2 instead of 9.8.4 since it's supported by HLS