### PR TITLE
Make custom entities override built-in entities

### DIFF
--- a/data/scenarios/Challenges/Ranching/pied-piper.yaml
+++ b/data/scenarios/Challenges/Ranching/pied-piper.yaml
@@ -164,7 +164,7 @@ entities:
       char: 'k'
     description:
       - Used by an `unlocker`{=entity} to open a a `locked door`{=entity}
-    properties: [known]
+    properties: [known, pickable]
   - name: unlocker
     display:
       char: 'u'
@@ -190,7 +190,7 @@ entities:
       attr: wood
     description:
       - wall
-    properties: [known, unwalkable]
+    properties: [known, unwalkable, boundary]
   - name: oats
     display:
       attr: oats

--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -70,3 +70,4 @@ Achievements
 231-requirements
 2085-toplevel-mask.yaml
 2086-structure-palette.yaml
+2239-custom-entity.yaml

--- a/data/scenarios/Testing/2239-custom-entity.yaml
+++ b/data/scenarios/Testing/2239-custom-entity.yaml
@@ -1,0 +1,42 @@
+version: 1
+name: Custom entity
+description: |
+  Custom entity overriding standard entity
+creative: false
+objectives:
+  - goal:
+      - Move to (1,0)
+    condition: |
+      as base {
+        loc <- whereami;
+        return $ loc == (1,0)
+      };
+entities:
+  - name: rock
+    display:
+      char: '$'
+      attr: gold
+    description:
+      - Not your average rock!
+    properties: [pickable]
+    capabilities: [move]
+robots:
+  - name: base
+    dir: east
+    devices:
+      - logger
+      - grabber
+      - welder
+solution: |
+  grab;
+  equip "rock";
+  move
+known: [rock]
+world:
+  dsl: |
+    {grass}
+  palette:
+    'B': [grass, rock, base]
+  upperleft: [0, 0]
+  map: |
+    B

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -424,15 +424,15 @@ data EntityMap = EntityMap
   }
   deriving (Eq, Show, Generic, ToJSON)
 
--- |
--- Note that duplicates in a single 'EntityMap' are precluded by the
--- 'buildEntityMap' function.
--- But it is possible for the latter 'EntityMap' to override
--- members of the former with the same name.
--- This replacement happens automatically with 'Map', but needs
--- to be explicitly handled for the list concatenation
--- of 'entityDefinitionOrder' (overridden entries are removed
--- from the former 'EntityMap').
+-- | Right-biased union of 'EntityMap's.
+--
+--   Note that duplicates in a single 'EntityMap' are precluded by the
+--   'buildEntityMap' function.  But it is possible for the right-hand
+--   'EntityMap' to override members of the left-hand with the same name.
+--   This replacement happens automatically with 'Map', but needs to
+--   be explicitly handled for the list concatenation of
+--   'entityDefinitionOrder' (overridden entries are removed from the
+--   former 'EntityMap').
 instance Semigroup EntityMap where
   EntityMap n1 c1 d1 <> EntityMap n2 c2 d2 =
     EntityMap

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -436,7 +436,7 @@ data EntityMap = EntityMap
 instance Semigroup EntityMap where
   EntityMap n1 c1 d1 <> EntityMap n2 c2 d2 =
     EntityMap
-      (n1 <> n2)
+      (n2 <> n1)
       (c1 <> c2)
       (filter ((`M.notMember` n2) . view entityName) d1 <> d2)
 


### PR DESCRIPTION
Fixes #2239.  The comments on the `Semigroup` instance for `EntityMap` *say* "it is possible for the latter 'EntityMap' to override members of the former with the same name.  This replacement happens automatically with 'Map'...", however, this was not correct.  The `Semigroup` instance for `Map` calls `Map.union`, which is *left*-biased (https://hackage.haskell.org/package/containers-0.7/docs/Data-Map-Lazy.html#t:Map).  So we want `n2 <> n1` here instead of `n1 <> n2`, so that the second `EntityMap` properly overrides the first.

Note that `c1 <> c2` is not correct either, for a more subtle reason.  In the case of overrides it needs to be manually adjusted, in a similar way to what is already done for `d1`; see #2240.  I will address that in a separate PR.

The attached scenario will succeed only if the `rock` entity is properly overridden so that it can provide the `move` capability.

Also had to apply a couple minor fixes to the `pied-piper` scenario, which it turns out tried to define custom entities named `key` and `wall` which were silently being ignored in preference to the standard entities of the same name; but then the solution inadvertently ended up depending on a property of the standard `key` (namely `pickable`) which the custom one did not have.