### PR TITLE
Fix Semigroup EntityMap instance to update Capabilities map properly when there are overridden devices

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -71,3 +71,4 @@ Achievements
 2085-toplevel-mask.yaml
 2086-structure-palette.yaml
 2239-custom-entity.yaml
+2240-overridden-entity-capabilities.yaml

--- a/data/scenarios/Testing/2240-overridden-entity-capabilities.yaml
+++ b/data/scenarios/Testing/2240-overridden-entity-capabilities.yaml
@@ -1,0 +1,49 @@
+version: 1
+name: Overridden entity capabilities
+description: |
+  Overridden standard entity should not still be suggested for its
+  capabilities. The error message should suggest "- tank treads", not
+  "- treads or tank treads".
+creative: false
+objectives:
+  - goal:
+      - Place a rock
+    condition: |
+      as base {
+        isHere "rock"
+      };
+entities:
+  - name: treads
+    display:
+      char: '#'
+      attr: red
+    description:
+      - Broken treads
+    properties: [known, pickable]
+robots:
+  - name: base
+    dir: east
+    devices:
+      - logger
+      - clock
+      - grabber
+    inventory:
+      - [1, rock]
+  - name: crasher
+    dir: east
+    devices:
+      - logger
+      - treads
+    program: |
+      move
+solution: |
+  wait 5; place "rock"
+world:
+  dsl: |
+    {grass}
+  palette:
+    'C': [grass, null, crasher]
+    'B': [grass, null, base]
+  upperleft: [0, 0]
+  map: |
+    BC

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -104,7 +104,6 @@ import Data.Char (toLower)
 import Data.Either.Extra (maybeToEither)
 import Data.Foldable (Foldable (..))
 import Data.Function (on)
-import Data.Functor.Identity
 import Data.Hashable
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IM
@@ -448,17 +447,7 @@ instance Semigroup EntityMap where
     notOverridden = (`M.notMember` n2) . view entityName
     removeOverriddenDevices (Capabilities m) =
       Capabilities
-        . runIdentity
-        -- traverseMaybeWithKey allows us in one operation to filter
-        -- the NonEmpty list of devices for each capability, turn the
-        -- resulting lists into Maybe NonEmpty, and then remove from
-        -- the map any that became Nothing.  However, it is more
-        -- general than we need: it gives us access to the key which
-        -- we don't need (this explains the call to 'const'), and runs
-        -- in an arbitrary Applicative which we also don't need (this
-        -- explains the Identity).
-        . M.traverseMaybeWithKey
-          (const (Identity . NE.nonEmpty . NE.filter (notOverridden . device)))
+        . M.mapMaybe (NE.nonEmpty . NE.filter (notOverridden . device))
         $ m
 
 instance Monoid EntityMap where

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -500,6 +500,12 @@ testScenarioSolutions rs ui key =
           assertEqual "Incorrect step count." 62 $ view lifetimeStepCount counters
     , expectFailBecause "Awaiting fix for #231" $
         testSolution Default "Testing/231-requirements/231-command-transformer-reqs"
+    , testSolution Default "Testing/2239-custom-entity"
+    , testSolution' Default "Testing/2240-overridden-entity-capabilities" CheckForBadErrors $ \g -> do
+        let msgs = g ^.. robotInfo . robotMap . traverse . robotLog . to logToText . traverse
+        assertBool "Error message should mention tank treads but not treads" $
+          not (any ("- treads" `T.isInfixOf`) msgs)
+          && (any ("- tank treads" `T.isInfixOf`) msgs)
     ]
  where
   -- expectFailIf :: Bool -> String -> TestTree -> TestTree

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -505,7 +505,7 @@ testScenarioSolutions rs ui key =
         let msgs = g ^.. robotInfo . robotMap . traverse . robotLog . to logToText . traverse
         assertBool "Error message should mention tank treads but not treads" $
           not (any ("- treads" `T.isInfixOf`) msgs)
-          && (any ("- tank treads" `T.isInfixOf`) msgs)
+            && any ("- tank treads" `T.isInfixOf`) msgs
     ]
  where
   -- expectFailIf :: Bool -> String -> TestTree -> TestTree


### PR DESCRIPTION
Fixes #2240.  Fixes the `Semigroup EntityMap` instance so that devices which are overridden are removed from the lists of devices providing certain capabilities.

- Also adds a test scenario which generated an incorrect error message before this fix.
- Also adds the test scenario from #2241 to the test suite which was missed previously.