### PR TITLE
Add combustion delay parameter

### DIFF
--- a/data/scenarios/Testing/1355-combustion.yaml
+++ b/data/scenarios/Testing/1355-combustion.yaml
@@ -21,6 +21,7 @@ solution: |
   ignite forward;
   turn right;
   move; move; move;
+  ignite left;
   turn right;
   move;
   ignite left;
@@ -75,6 +76,18 @@ entities:
       duration: [8, 8]
       product: null
     properties: [known, pickable, combustible]
+  - name: slowfuse
+    display:
+      attr: silver
+      char: '~'
+    description:
+      - Reliably combustible, but burns more slowly
+    combustion:
+      ignition: 20
+      duration: [64, 64]
+      delay: 63
+      product: null
+    properties: [known, pickable, combustible]
   - name: dynamite
     display:
       attr: red
@@ -103,6 +116,7 @@ world:
     'b': [grass, board]
     'i': [grass, cotton]
     'F': [grass, fuse]
+    'f': [grass, slowfuse]
     'd': [grass, dynamite, judge]
     '.': [grass]
   upperleft: [0, 0]
@@ -123,11 +137,11 @@ world:
     ......iiiiiiii........F...F...F...F..
     iiiiiiiiiiiiiii..Ω.FFFF...FFFFF...d..
     ......iiiiiiii.......................
-    iiiiiiiiiiiii.....qqqqqqqqqqqqqqqq...
-    ......iiiiii......qqqqqqqqqqqqqqqq...
-    iiiiiiiiiii.......qqqqqqqqqqqqqqqq...
-    ..................qqqqqqqqqqqqqqqq...
-    ..................qqqqqqqqqqqqqqqq...
-    ..................qqqqqqqqqqqqqqqq...
-    ..................qqqqqqqqqqqqqqqq...
+    iiiiiiiiiiiii..f..qqqqqqqqqqqqqqqq...
+    ......iiiiii...f..qqqqqqqqqqqqqqqq...
+    iiiiiiiiiii....f..qqqqqqqqqqqqqqqq...
+    ...............f..qqqqqqqqqqqqqqqq...
+    ..ffff...ffff..f..qqqqqqqqqqqqqqqq...
+    ..f..f...f..f..f..qqqqqqqqqqqqqqqq...
+    ..f..fffff..ffff..qqqqqqqqqqqqqqqq...
     ..................qqqqqqqqqqqqqqqq...

--- a/data/schema/combustion.json
+++ b/data/schema/combustion.json
@@ -9,7 +9,7 @@
         "ignition": {
             "default": 0.5,
             "type": "number",
-            "description": "Rate of ignition by a neighbor, per tick."
+            "description": "Rate of ignition by a neighbor.  This is the rate parameter of a Poisson distribution, i.e. the expected number of times per tick that a combusting neighbor would tend to ignite this entity.  Typically a number between 0 and 1, but it can be any nonnegative real number (default: 0.5)."
         },
         "duration": {
             "type": "array",
@@ -17,10 +17,15 @@
             "$ref": "range.json",
             "description": "For combustible entities, a 2-tuple of integers specifying the minimum and maximum amount of time that the combustion shall persist."
         },
+        "delay": {
+            "type": "number",
+            "default": 0.0,
+            "description": "Warmup delay, i.e. the number of ticks combustion must persist until this entity will potentially start igniting its neighbors (default: 0)."
+        },
         "product": {
             "default": "ash",
             "type": ["string", "null"],
-            "description": "What entity, if any, is left over after combustion"
+            "description": "What entity, if any, is left over after combustion."
         }
     }
 }

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -102,7 +102,7 @@ import Control.Monad (forM_, unless, (<=<))
 import Data.Bifunctor (first)
 import Data.Char (toLower)
 import Data.Either.Extra (maybeToEither)
-import Data.Foldable (Foldable (..))
+import Data.Foldable (Foldable (elem, foldl', null))
 import Data.Function (on)
 import Data.Hashable
 import Data.IntMap (IntMap)
@@ -243,19 +243,30 @@ data Combustibility = Combustibility
   --   See <https://math.stackexchange.com/a/1243629>.
   , duration :: (Integer, Integer)
   -- ^ min and max tick counts for combustion to persist
+  , delay :: Integer
+  -- ^ Delay until this entity may start igniting its neighbors.
   , product :: Maybe EntityName
   -- ^ what entity, if any, is left over after combustion
   }
-  deriving (Eq, Ord, Show, Read, Generic, Hashable, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, Read, Generic, Hashable, ToJSON)
+
+instance FromJSON Combustibility where
+  parseJSON = withObject "Combustibility" $ \v -> do
+    ignition <- v .: "ignition"
+    duration <- v .: "duration"
+    delay <- v .:? "delay" .!= 0
+    product <- v .: "product"
+    pure Combustibility {..}
 
 -- | The default combustion specification for a combustible entity
 --   with no combustion specification:
 --
 --   * ignition rate 0.5
 --   * duration (100, 200)
+--   * delay of 0
 --   * product @ash@
 defaultCombustibility :: Combustibility
-defaultCombustibility = Combustibility 0.5 (100, 200) (Just "ash")
+defaultCombustibility = Combustibility 0.5 (100, 200) 0 (Just "ash")
 
 ------------------------------------------------------------
 -- Entity


### PR DESCRIPTION
The `delay` is the amount of time an entity must burn before it starts potentially affecting/igniting its neighbors.  Following the delay, combustion of neighbors is calculated exactly as before.