### PR TITLE
Add missing cases to var usage analysis

### DIFF
--- a/data/test/language-snippets/warnings/unused-vars/lambda-with-annot.sw
+++ b/data/test/language-snippets/warnings/unused-vars/lambda-with-annot.sw
@@ -1,0 +1,1 @@
+def put = \y. place (y : Text); end;

--- a/data/test/language-snippets/warnings/unused-vars/lambda-with-record-unused.sw
+++ b/data/test/language-snippets/warnings/unused-vars/lambda-with-record-unused.sw
@@ -1,0 +1,1 @@
+def put = \y. [x = 3, z = 7]; end;

--- a/data/test/language-snippets/warnings/unused-vars/lambda-with-record-used-abbrev.sw
+++ b/data/test/language-snippets/warnings/unused-vars/lambda-with-record-used-abbrev.sw
@@ -1,0 +1,1 @@
+def put = \y. [x = 3, y]; end;

--- a/data/test/language-snippets/warnings/unused-vars/lambda-with-record-used.sw
+++ b/data/test/language-snippets/warnings/unused-vars/lambda-with-record-used.sw
@@ -1,0 +1,1 @@
+def put = \y. [x = 3, z = y + 2]; end;

--- a/src/swarm-lang/Swarm/Language/LSP/VarUsage.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/VarUsage.hs
@@ -114,7 +114,6 @@ getUsage bindings (CSyntax _pos t _comments) = case t of
   SProj s _ -> getUsage bindings s
   SAnnotate s _ -> getUsage bindings s
   SSuspend s -> getUsage bindings s
-
   -- Explicitly enumerate the cases with no variables, instead of a
   -- catch-all, so that we get a warning when adding new constructors.
   TUnit {} -> mempty

--- a/src/swarm-lang/Swarm/Language/LSP/VarUsage.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/VarUsage.hs
@@ -110,4 +110,25 @@ getUsage bindings (CSyntax _pos t _comments) = case t of
     Just v -> checkOccurrences bindings v Bind [s1, s2]
     Nothing -> getUsage bindings s1 <> getUsage bindings s2
   SDelay s -> getUsage bindings s
-  _ -> mempty
+  SRcd m -> M.foldMapWithKey (\x -> maybe (getUsage bindings (STerm (TVar x))) (getUsage bindings)) m
+  SProj s _ -> getUsage bindings s
+  SAnnotate s _ -> getUsage bindings s
+  SSuspend s -> getUsage bindings s
+
+  -- Explicitly enumerate the cases with no variables, instead of a
+  -- catch-all, so that we get a warning when adding new constructors.
+  TUnit {} -> mempty
+  TConst {} -> mempty
+  TDir {} -> mempty
+  TInt {} -> mempty
+  TAntiInt {} -> mempty
+  TText {} -> mempty
+  TAntiText {} -> mempty
+  TBool {} -> mempty
+  TRobot {} -> mempty
+  TRef {} -> mempty
+  TRequireDevice {} -> mempty
+  TRequire {} -> mempty
+  SRequirements {} -> mempty
+  STydef {} -> mempty
+  TType {} -> mempty

--- a/test/unit/TestLSP.hs
+++ b/test/unit/TestLSP.hs
@@ -72,6 +72,22 @@ testLSP =
         checkFile
           "single-bind-used.sw"
           []
+    , testCase "lambda with var used inside annotation" $
+        checkFile
+          "lambda-with-annot.sw"
+          []
+    , testCase "record with used var" $
+        checkFile
+          "lambda-with-record-used.sw"
+          []
+    , testCase "record with used var abbrev" $
+        checkFile
+          "lambda-with-record-used-abbrev.sw"
+          []
+    , testCase "record with unused var" $
+        checkFile
+          "lambda-with-record-unused.sw"
+          [UnusedVar "y" VU.Lambda]
     ]
  where
   checkFile :: FilePath -> [UnusedVar] -> IO ()


### PR DESCRIPTION
Fixes #2250.  Some term constructors (records, type annotations) were missing, but no one ever realized since there was a catch-all `_ -> mempty` case at the end.  This PR:
- adds the missing cases
- adds some associated tests
- explicitly enumerates the other non-variable cases so that in the future, when we add a new term constructor we will get a warning.