### PR TITLE
Make `halt`ed robots immediately wake up

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -72,3 +72,4 @@ Achievements
 2086-structure-palette.yaml
 2239-custom-entity.yaml
 2240-overridden-entity-capabilities.yaml
+2253-halt-waiting.yaml

--- a/data/scenarios/Testing/2253-halt-waiting.yaml
+++ b/data/scenarios/Testing/2253-halt-waiting.yaml
@@ -1,0 +1,27 @@
+version: 1
+name: Halt a waiting robot
+description: |
+  Calling `halt` on a waiting robot should make it immediately idle,
+  so it can e.g. be `reprogram`med
+creative: true
+objectives:
+  - goal:
+      - Get some gold
+    condition: |
+      as base { has "gold" };
+robots:
+  - name: base
+    dir: north
+    devices:
+      - logger
+solution: |
+  r <- build {move; wait 10000};
+  wait 2;
+  halt r; wait 1; reprogram r {create "gold"; give base "gold"}
+world:
+  dsl: |
+    {grass}
+  palette:
+    'B': [grass, null, base]
+  map: |
+    B

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -893,9 +893,10 @@ execConst runChildProg c vs s k = do
             omni <- isPrivilegedBot
             case omni || not (target ^. systemRobot) of
               True -> zoomRobots $ do
-                -- Cancel its CESK machine, and put it to sleep.
+                -- Cancel its CESK machine, and wake it up to ensure
+                -- it can do cleanup + run to completion.
                 robotMap . at targetID . _Just . machine %= cancel
-                sleepForever targetID
+                activateRobot targetID
                 return $ mkReturn ()
               False -> throwError $ cmdExn c ["You are not authorized to halt that robot."]
       _ -> badConst

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -507,6 +507,7 @@ testScenarioSolutions rs ui key =
         assertBool "Error message should mention tank treads but not treads" $
           not (any ("- treads" `T.isInfixOf`) msgs)
             && any ("- tank treads" `T.isInfixOf`) msgs
+    , testSolution Default "Testing/2253-halt-waiting"
     ]
  where
   -- expectFailIf :: Bool -> String -> TestTree -> TestTree


### PR DESCRIPTION
The code for `halt` used to (1) cancel the robot's CESK machine, and then (2) put it to sleep forever.  However, at some point the way we cancel CESK machines changed: instead of immediately putting the machine into a finished state, we simply put it into a state which will propagate an uncatchable error all the way up the stack.  This is necessary to make sure we finalize things appropriately, persist any definitions in the environment which ought to be persisted, etc., but it means that a "canceled" robot still has to run for a bit longer to do the finalization work.  Robots which were inactive when they were canceled thus never got a chance to finalize.  The solution is to *wake up* the robot after canceling rather than putting it to sleep!

Closes #2253.