### PR TITLE
only meet interactive robots

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -926,14 +926,15 @@ execConst runChildProg c vs s k = do
       let neighbor =
             find ((/= rid) . (^. robotID)) -- pick one other than ourself
               . sortOn ((manhattan `on` view planar) loc . (^. robotLocation)) -- prefer closer
-              $ robotsInArea loc 1
+              . filter isInteractive
+              . robotsInArea loc 1
               $ g ^. robotInfo -- all robots within Manhattan distance 1
       return $ mkReturn neighbor
     MeetAll -> do
       loc <- use robotLocation
       rid <- use robotID
       g <- get @GameState
-      let neighborIDs = filter ((/= rid) . (^. robotID)) . robotsInArea loc 1 $ g ^. robotInfo
+      let neighborIDs = filter ((/= rid) . (^. robotID)) . filter isInteractive . robotsInArea loc 1 $ g ^. robotInfo
       return $ mkReturn neighborIDs
     Whoami -> case vs of
       [] -> do

--- a/src/swarm-scenario/Swarm/Game/Robot.hs
+++ b/src/swarm-scenario/Swarm/Game/Robot.hs
@@ -58,6 +58,7 @@ module Swarm.Game.Robot (
 
   -- ** Query
   robotKnows,
+  isInteractive,
 
   -- ** Constants
   hearingDistance,
@@ -275,6 +276,9 @@ inventoryHash = to (\r -> 17 `hashWithSalt` (r ^. (robotEntity . entityHash)) `h
 -- | Does a robot know of an entity's existence?
 robotKnows :: Robot -> Entity -> Bool
 robotKnows r e = contains0plus e (r ^. robotInventory) || contains0plus e (r ^. equippedDevices)
+
+isInteractive :: Robot -> Bool
+isInteractive r = not $ r ^. robotDisplay . invisible && r ^. systemRobot
 
 -- | Get the set of capabilities this robot possesses.  This is only a
 --   getter, not a lens, because it is automatically generated from


### PR DESCRIPTION
As I was trying to solve #2249, I was rather confused after trying to `meet` a built robot and `give` them an item, but the item was not delivered.  It turns out that I had been `meet`-ing the `judge` robot instead.

We should distinguish between robots that are intended to be interactive or not, and only allow `meet`-ing an interactive robot.