### PR TITLE
background passthrough

### DIFF
--- a/src/swarm-scenario/Swarm/Game/Entity/Cosmetic.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity/Cosmetic.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
@@ -6,7 +8,9 @@ module Swarm.Game.Entity.Cosmetic where
 
 import Codec.Picture (PixelRGBA8 (..))
 import Data.Colour.SRGB (RGB (..))
+import Data.Hashable
 import Data.Word (Word8)
+import GHC.Generics (Generic)
 import Swarm.Game.Scenario.Topography.Rasterize
 
 data NamedColor
@@ -17,7 +21,7 @@ data NamedColor
   | Blue
   | BrightYellow
   | Yellow
-  deriving (Show)
+  deriving (Show, Eq, Generic, Hashable)
 
 -- | 8-bit color
 type RGBColor = RGB Word8
@@ -43,12 +47,15 @@ namedToTriple = \case
   BrightYellow -> RGB 233 173 12
   Yellow -> RGB 162 115 76
 
+instance Hashable RGBColor where
+  hashWithSalt a (RGB r g b) = hashWithSalt a (r, g, b)
+
 -- | High-fidelity color representation for rendering
 -- outside of the TUI.
 data TrueColor
   = AnsiColor NamedColor
   | Triple RGBColor
-  deriving (Show)
+  deriving (Show, Eq, Generic, Hashable)
 
 -- |
 -- A value of type @ColorLayers a@ represents the assignment of
@@ -74,7 +81,9 @@ data ColorLayers a
       a
       -- | background
       a
-  deriving (Show, Functor)
+  deriving (Show, Eq, Functor, Generic)
+
+instance Hashable (ColorLayers TrueColor)
 
 type PreservableColor = ColorLayers TrueColor
 
@@ -96,4 +105,4 @@ flattenBg = \case
   FgAndBg _ x -> x
 
 newtype WorldAttr = WorldAttr String
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic, Hashable)

--- a/src/swarm-scenario/Swarm/Game/Terrain.hs
+++ b/src/swarm-scenario/Swarm/Game/Terrain.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
@@ -37,7 +38,7 @@ import Data.Yaml
 import GHC.Generics (Generic)
 import Swarm.Failure
 import Swarm.Game.Display
-import Swarm.Game.Entity.Cosmetic (WorldAttr (..))
+import Swarm.Game.Entity.Cosmetic
 import Swarm.ResourceLoading (getDataFileNameSafe)
 import Swarm.Util (enumeratedMap, quote)
 import Swarm.Util.Effect (withThrow)
@@ -88,7 +89,17 @@ data TerrainObj = TerrainObj
 
 promoteTerrainObjects :: [TerrainItem] -> [TerrainObj]
 promoteTerrainObjects =
-  map (\(TerrainItem n a d) -> TerrainObj n d $ defaultTerrainDisplay (AWorld a))
+  map f
+ where
+  f (TerrainItem n a d) =
+    TerrainObj n d $
+      (defaultTerrainDisplay (AWorld a))
+        { _backgroundSources =
+            BackgroundSource
+              { terrainBgAttr = Just . WorldAttr . T.unpack $ getTerrainWord n
+              , entityBgAttr = Nothing
+              }
+        }
 
 invertedIndexMap :: IntMap TerrainObj -> Map TerrainType Int
 invertedIndexMap = M.fromList . map (first terrainName . swap) . IM.toList

--- a/src/swarm-scenario/Swarm/Util/Content.hs
+++ b/src/swarm-scenario/Swarm/Util/Content.hs
@@ -60,7 +60,14 @@ getTerrainEntityColor ::
 getTerrainEntityColor aMap (Cell terr cellEnt _) =
   (entityColor =<< erasableToMaybe cellEnt) <|> terrainFallback
  where
-  terrainFallback = M.lookup (WorldAttr $ T.unpack $ getTerrainWord terr) aMap
+  terrainFallback = getTerrainColor aMap terr
   entityColor (EntityFacade _ d) = case d ^. displayAttr of
     AWorld n -> M.lookup (WorldAttr $ T.unpack n) aMap
     _ -> Nothing
+
+getTerrainColor ::
+  M.Map WorldAttr PreservableColor ->
+  TerrainType ->
+  Maybe PreservableColor
+getTerrainColor aMap terr =
+  M.lookup (WorldAttr $ T.unpack $ getTerrainWord terr) aMap

--- a/src/swarm-tui/Swarm/TUI/Editor/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Model.hs
@@ -10,9 +10,11 @@ import Brick.Widgets.List qualified as BL
 import Control.Lens hiding (from, (.=), (<.>))
 import Data.List.Extra (enumerate)
 import Data.Map qualified as M
+import Data.Text qualified as T
 import Data.Vector qualified as V
-import Swarm.Game.Display (Display)
+import Swarm.Game.Display
 import Swarm.Game.Entity qualified as E
+import Swarm.Game.Entity.Cosmetic
 import Swarm.Game.Scenario.Topography.EntityFacade
 import Swarm.Game.Scenario.Topography.WorldPalette
 import Swarm.Game.Terrain (TerrainType)
@@ -33,8 +35,19 @@ data EntityPaint
   deriving (Eq)
 
 getDisplay :: EntityPaint -> Display
-getDisplay (Facade (EntityFacade _ d)) = d
-getDisplay (Ref e) = e ^. E.entityDisplay
+getDisplay ep = mkEntBgSource $ case ep of
+  Facade (EntityFacade _ d) -> d
+  Ref e -> e ^. E.entityDisplay
+ where
+  mkEntBgSource d = d {_backgroundSources = src}
+   where
+    src = case d ^. displayAttr of
+      AWorld n ->
+        BackgroundSource
+          { terrainBgAttr = Just . WorldAttr $ T.unpack n
+          , entityBgAttr = Nothing
+          }
+      _ -> mempty
 
 toFacade :: EntityPaint -> EntityFacade
 toFacade = \case

--- a/src/swarm-tui/Swarm/TUI/View/Robot.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Robot.hs
@@ -44,6 +44,7 @@ import Swarm.Game.Location
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Activity
 import Swarm.Game.Robot.Concrete
+import Swarm.Game.Scenario
 import Swarm.Game.State
 import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
@@ -319,11 +320,12 @@ mkLibraryEntries c =
         , rowLog = strWidget $ pure rLog
         }
    where
+    aMap = maybe mempty (view (scenarioLandscape . scenarioCosmetics) . fst) $ c ^. gameplay . scenarioRef
     nameWidget = WithWidth (2 + T.length nameTxt) w
      where
       w =
         hBox
-          [ renderDisplay (r ^. robotDisplay)
+          [ renderDisplay aMap (r ^. robotDisplay)
           , highlightSystem . txt $ " " <> nameTxt
           ]
       nameTxt = r ^. robotName

--- a/src/swarm-tui/Swarm/TUI/View/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Util.hs
@@ -17,6 +17,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Graphics.Vty qualified as V
 import Swarm.Game.Entity as E
+import Swarm.Game.Entity.Cosmetic
 import Swarm.Game.Land
 import Swarm.Game.Scenario (scenarioMetadata, scenarioName)
 import Swarm.Game.ScenarioInfo (scenarioItemName)
@@ -164,13 +165,17 @@ drawMarkdown d = do
     "type" -> magentaAttr
     _snippet -> highlightAttr -- same as plain code
 
-drawLabeledTerrainSwatch :: TerrainMap -> TerrainType -> Widget Name
-drawLabeledTerrainSwatch tm a =
+drawLabeledTerrainSwatch ::
+  M.Map WorldAttr PreservableColor ->
+  TerrainMap ->
+  TerrainType ->
+  Widget Name
+drawLabeledTerrainSwatch aMap tm a =
   tile <+> str materialName
  where
   tile =
     padRight (Pad 1)
-      . renderDisplay
+      . renderDisplay aMap
       . maybe mempty terrainDisplay
       $ M.lookup a (terrainByName tm)
 
@@ -243,10 +248,13 @@ maybeScroll vpName contents =
 
 -- | Draw the name of an entity, labelled with its visual
 --   representation as a cell in the world.
-drawLabelledEntityName :: Entity -> Widget n
-drawLabelledEntityName e =
+drawLabelledEntityName ::
+  M.Map WorldAttr PreservableColor ->
+  Entity ->
+  Widget n
+drawLabelledEntityName aMap e =
   hBox
-    [ padRight (Pad 2) (renderDisplay (e ^. entityDisplay))
+    [ padRight (Pad 2) (renderDisplay aMap (e ^. entityDisplay))
     , txt (e ^. entityName)
     ]
 


### PR DESCRIPTION
Closes #1662.

This is an attempt at an alternate approach from #1672.
```
scripts/play.sh --scenario data/scenarios/Testing/1034-custom-attributes.yaml --autoplay --speed 2 --hide-goal
```

# Comparison
```
scripts/play.sh -i creative --seed 2
```
| Before | After |
| --- | --- |
| ![Screenshot from 2025-01-05 11-40-10](https://github.com/user-attachments/assets/fdbdbf8d-47d3-4588-b5c6-fdf3fe84ec39) | ![Screenshot from 2025-01-05 11-37-49](https://github.com/user-attachments/assets/a7b228f5-8db4-441d-a310-b64d4c60ca0e) |

# Overview

This approach required threading an attribute map (`aMap`) through a lot of places.  Fundamentally, it is because we need to arbitrate between an potentially entity-provided background color and a terrain-provided background color late in the rendering pipeline.  We need to preserve whether that background originated from an Entity or a Terrain, so that we can prioritize the Entity.

However, we also want to let the `Terrain` win if we find that, after looking up the color of the `Entity` in the attribute map, the `Entity` has no provided background color.

# Asciinema recordings

## Before

[![asciicast](https://asciinema.org/a/tuMAwH1AdSSlhXanDdIPr8WXT.svg)](https://asciinema.org/a/tuMAwH1AdSSlhXanDdIPr8WXT)

## After

[![asciicast](https://asciinema.org/a/aYa9TR72JDnAtcVqVGPg7Q0qT.svg)](https://asciinema.org/a/aYa9TR72JDnAtcVqVGPg7Q0qT)

