### PR TITLE
Warn the user when debugging options are on

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Model/Dialog/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Dialog/Popup.hs
@@ -32,6 +32,7 @@ data Popup
   = AchievementPopup CategorizedAchievement
   | RecipesPopup
   | CommandsPopup [Const]
+  | DebugWarningPopup
 
 -- | State to track pending popup queue as well as any
 --   popup which is currently being displayed.

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -28,7 +28,7 @@ import Control.Effect.Accum
 import Control.Effect.Lift
 import Control.Effect.Throw
 import Control.Lens hiding (from, (<.>))
-import Control.Monad (guard, void)
+import Control.Monad (guard, unless, void)
 import Control.Monad.Except (ExceptT (..))
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.State (MonadState, execStateT)
@@ -217,6 +217,13 @@ startGameWithSeed siPair@(_scene, si) lp = do
   -- Beware: currentScenarioPath must be set so that progress/achievements can be saved.
   -- It has just been cleared in scenarioToAppState.
   gameState . currentScenarioPath .= Just p
+
+  -- Warn the user that the use of debugging options means progress
+  -- will not be saved.
+  debugging <- use $ uiState . uiDebugOptions
+  unless (null debugging) $
+    uiState . uiPopups %= addPopup DebugWarningPopup
+
  where
   prevBest t = case si ^. scenarioStatus of
     NotStarted -> emptyBest t

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -223,7 +223,6 @@ startGameWithSeed siPair@(_scene, si) lp = do
   debugging <- use $ uiState . uiDebugOptions
   unless (null debugging) $
     uiState . uiPopups %= addPopup DebugWarningPopup
-
  where
   prevBest t = case si ^. scenarioStatus of
     NotStarted -> emptyBest t

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -56,6 +56,11 @@ drawPopup s = \case
           ]
       , txt $ "Hit " <> bindingText s (SE.Main SE.ViewCommandsEvent) <> " to view all available commands."
       ]
+  DebugWarningPopup ->
+    hBox
+      [ withAttr notifAttr (txt "Warning: ")
+      , txt $ "No progress will be saved, since debugging flags are in use."
+      ]
 
 -- | Compute the number of rows of the notification popup we should be
 --   showing, based on the number of frames the popup has existed.

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -59,7 +59,7 @@ drawPopup s = \case
   DebugWarningPopup ->
     hBox
       [ withAttr notifAttr (txt "Warning: ")
-      , txt $ "No progress will be saved, since debugging flags are in use."
+      , txt "No progress will be saved, since debugging flags are in use."
       ]
 
 -- | Compute the number of rows of the notification popup we should be


### PR DESCRIPTION
Closes #1270.  When any debugging options are enabled, pop up a warning that progress will not be saved.

Note, in #1270, we discussed the possibility of saving progress even if `--debug=creative` is on, as long as creative mode is never actually engaged, but I'm not sure it's really worth going to that length.  The warning should be enough.