### PR TITLE
Rename `return` to `pure`

### DIFF
--- a/app/game/Main.hs
+++ b/app/game/Main.hs
@@ -94,7 +94,7 @@ cliParser =
   widthOpt = option auto (long "width" <> metavar "COLUMNS" <> help "Use layout with maximum width")
 
   langVer :: Parser LanguageVersion
-  langVer = flag SwarmLangLatest SwarmLang0_5 (long "v0.5" <> help "Read (& convert) code from Swarm version 0.5")
+  langVer = flag SwarmLangLatest SwarmLang0_6 (long "v0.6" <> help "Read (& convert) code from Swarm version 0.6")
 
   printKeyMode :: Parser KeybindingPrint
   printKeyMode =

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -1180,14 +1180,14 @@
     - "A rubber band can tie multiple commands together so that other robots can't execute commands in between them.  It can be used via the `atomic` command. For example, suppose robot A executes the following code:"
     - |
       ```
-      b <- ishere "rock"; if b {grab; return ()} {}
+      b <- ishere "rock"; if b {grab; pure ()} {}
       ```
     - "This seems like a safe way to execute `grab` only when there is a rock to grab.  However, it is actually possible for the `grab` to fail, if some other robot B snatches the rock right after robot A sensed it and before robot A got around to grabbing it on the next game tick."
     - "This will make robot A very sad and it will crash."
     - "To prevent this situation, robot A can wrap the commands in `atomic`, like so:"
     - |
       ```
-      atomic (b <- ishere "rock"; if b {grab; return ()} {})
+      atomic (b <- ishere "rock"; if b {grab; pure ()} {})
       ```
   properties: [pickable]
   capabilities: [atomic]

--- a/data/scenarios/Challenges/2048.yaml
+++ b/data/scenarios/Challenges/2048.yaml
@@ -9,11 +9,11 @@ objectives:
     condition: |
       try {
         as base {has "2048"}
-      } { return false }
+      } { pure false }
 solution: |
   def makeN : Int -> Cmd Unit = \n.
     if (n == 1)
-      {harvest; return ()}
+      {harvest; pure ()}
       {makeN (n/2); makeN (n/2); make (format n)}
   end;
   place "1";

--- a/data/scenarios/Challenges/Mazes/easy_cave_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/easy_cave_maze.yaml
@@ -46,7 +46,7 @@ robots:
     system: true
     program: |
       def until = \c. b <- c; if b {} {until c} end;
-      until (d <- scan down; return (d == inl ()));
+      until (d <- scan down; pure (d == inl ()));
       create "goal"
 known: [water]
 entities:

--- a/data/scenarios/Challenges/Mazes/easy_spiral_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/easy_spiral_maze.yaml
@@ -46,7 +46,7 @@ robots:
     system: true
     program: |
       def until = \c. b <- c; if b {} {until c} end;
-      until (d <- scan down; return (d == inl ()));
+      until (d <- scan down; pure (d == inl ()));
       create "goal"
 entities:
   - name: wall

--- a/data/scenarios/Challenges/Mazes/invisible_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/invisible_maze.yaml
@@ -10,17 +10,17 @@ objectives:
       try {
         teleport self (27, -17);
         b <- ishere "goal";
-        return (not b)
-      } { return false }
+        pure (not b)
+      } { pure false }
 solution: |
   def tL = turn left end;
   def tR = turn right end;
   def ifC = \test. \then. \else. b <- test; if b then else end;
   def forever = \c. c ; forever c end;
-  def rightBlocked = tR; b <- blocked; tL; return b end;
+  def rightBlocked = tR; b <- blocked; tL; pure b end;
   def mazeStep = ifC rightBlocked {ifC blocked {tL} {move}} {tR; move} end;
   build {
-    forever (mazeStep; ifC (ishere "goal") {grab; return ()} {})
+    forever (mazeStep; ifC (ishere "goal") {grab; pure ()} {})
   }
 robots:
   - name: base

--- a/data/scenarios/Challenges/Mazes/loopy_maze.yaml
+++ b/data/scenarios/Challenges/Mazes/loopy_maze.yaml
@@ -10,8 +10,8 @@ objectives:
       try {
         teleport self (27, -17);
         b <- ishere "goal";
-        return (not b)
-      } { return false }
+        pure (not b)
+      } { pure false }
 solution: |
   run "scenarios/Challenges/Mazes/loopy_maze_sol.sw"
 robots:

--- a/data/scenarios/Challenges/Mazes/loopy_maze_sol.sw
+++ b/data/scenarios/Challenges/Mazes/loopy_maze_sol.sw
@@ -3,7 +3,7 @@ def tR = turn right end;
 def tB = turn back end;
 def ifM = \p.\t.\e. b <- p; if b t e end;
 def DFS =
-  ifM (ishere "goal") {grab; return ()} {};
+  ifM (ishere "goal") {grab; pure ()} {};
   ifM (ishere "rock") {} {
     place "rock";
     tL; b <- blocked; if b {} {move; DFS};

--- a/data/scenarios/Challenges/Ranching/_beekeeping/queenbee.sw
+++ b/data/scenarios/Challenges/Ranching/_beekeeping/queenbee.sw
@@ -37,7 +37,7 @@ def moveTuple = \tup.
 
 def randomDir =
     r <- random 4;
-    return $ if (r == 1) {north}
+    pure $ if (r == 1) {north}
         $ elif (r == 2) {west}
         $ elif (r == 3) {south}
         $ else {east};
@@ -136,7 +136,7 @@ def takeStepTowardItem = \item.
         // another bee gets here first
         try {
             harvest;
-            return ();
+            pure ();
         } {};
     } {
         // Include some random motion
@@ -159,7 +159,7 @@ def workerProgram = \structureLoc.
         goToHive structureLoc;
     } {
         takeStepTowardItem "wildflower";
-        return ();
+        pure ();
     };
     workerProgram structureLoc;
     end;
@@ -206,7 +206,7 @@ def createWorkerForStructure = \loc.
         require 1 "wax gland";
         workerProgramInit beename loc;
     };
-    return ();
+    pure ();
     end;
 
 def associateHive = \loc.
@@ -214,7 +214,7 @@ def associateHive = \loc.
    try {
        // Fails if the robot does not exist
        robotnamed beename;
-       return ();
+       pure ();
    } {
        createWorkerForStructure loc;
 
@@ -227,7 +227,7 @@ def associateHive = \loc.
 
 def mapM_ : (a -> Cmd b) -> (rec l. Unit + a * l) -> Cmd Unit = \f. \l.
   case l
-    (\_. return ())
+    (\_. pure ())
     (\cons. f (fst cons); mapM_ f (snd cons))
   end;
 

--- a/data/scenarios/Challenges/Ranching/_beekeeping/solution.sw
+++ b/data/scenarios/Challenges/Ranching/_beekeeping/solution.sw
@@ -113,14 +113,14 @@ def collectContiguous = \maxdist. \item. \hadFound. \dist.
             collectContiguous maxdist item true $ dist + 1;
         } {
             if hadFound {
-                return dist;
+                pure dist;
             } {
                 move;
                 collectContiguous maxdist item false $ dist + 1;
             }
         }
     } {
-        return dist;
+        pure dist;
     }
     end;
 
@@ -148,7 +148,7 @@ def collectAllHoneycombs = \targetCount.
 
         collectAllHoneycombs targetCount;
     } {
-        return currentCount;
+        pure currentCount;
     };
     end;
 
@@ -176,7 +176,7 @@ def pickRock =
     isRock <- ishere "rock";
     if isRock {
         grab;
-        return ();
+        pure ();
     } {};
     end;
 

--- a/data/scenarios/Challenges/Ranching/_capture/opponent.sw
+++ b/data/scenarios/Challenges/Ranching/_capture/opponent.sw
@@ -41,9 +41,9 @@ def countBlocked = \n.
         isBlocked <- blocked;
         turn left;
         lastCount <- countBlocked $ n - 1;
-        return $ lastCount + boolToInt isBlocked;
+        pure $ lastCount + boolToInt isBlocked;
     } {
-        return 0;
+        pure 0;
     }
     end;
 
@@ -54,7 +54,7 @@ def reWatch =
 def locationIsOpen =
     emptyHere <- isempty;
     blockedCount <- countBlocked 4;
-    return $ emptyHere && blockedCount == 0;
+    pure $ emptyHere && blockedCount == 0;
     end;
 
 def faceAwayFrom = \loc.
@@ -84,7 +84,7 @@ def relocateAway =
     findOpenArea;
     try {
         swap marker;
-        return ();
+        pure ();
     } {
         place marker;
     };

--- a/data/scenarios/Challenges/Ranching/_fishing/hauler.sw
+++ b/data/scenarios/Challenges/Ranching/_fishing/hauler.sw
@@ -20,13 +20,13 @@ def isEnclosureFull : Int * Int -> Cmd Bool = \encl.
     let notFull = c < area in
 
     teleport self prevLoc;
-    return $ not notFull;
+    pure $ not notFull;
     end;
 
 def any : (a -> Cmd Bool) -> (rec l. Unit + a * l) -> Cmd Bool = \p. \l.
   case l
-    (\_. return false)
-    (\c. b <- p (fst c); if b {return true} {any p (snd c)})
+    (\_. pure false)
+    (\c. b <- p (fst c); if b {pure true} {any p (snd c)})
 end;
 
 def isEitherEnclosureFull =
@@ -37,7 +37,7 @@ def isEitherEnclosureFull =
 def tryGrab =
     try {
         grab;
-        return ()
+        pure ()
     } {};
     end;
 

--- a/data/scenarios/Challenges/Ranching/_fishing/solution.sw
+++ b/data/scenarios/Challenges/Ranching/_fishing/solution.sw
@@ -17,7 +17,7 @@ def makeRoll =
 def checkIngredients =
     hasTuna <- has "crab";
     hasSeaweed <- has "seaweed";
-    return $ hasTuna && hasSeaweed;
+    pure $ hasTuna && hasSeaweed;
     end;
 
 def catchFish = \rod.
@@ -39,9 +39,9 @@ Precondition:
 At the top-right corner
 */
 def harvestRectangle =
-    intersperse 4 move $ harvest; return ();
+    intersperse 4 move $ harvest; pure ();
     turnAround left;
-    intersperse 4 move $ harvest; return ();
+    intersperse 4 move $ harvest; pure ();
     end;
 
 def harvestIngredients =
@@ -64,8 +64,8 @@ def harvestIngredients =
 
 def find : (a -> Cmd Bool) -> (rec l. Unit + a * l) -> Cmd (Unit + a) = \p. \l.
   case l
-    (\_. return (inl ()))
-    (\cons. h <- p (fst cons); if h {return $ inr (fst cons)} {find p (snd cons)})
+    (\_. pure (inl ()))
+    (\cons. h <- p (fst cons); if h {pure $ inr (fst cons)} {find p (snd cons)})
 end
 
 def tryPlace = \item.
@@ -108,7 +108,7 @@ def placeSerpentine = \placeFunc.
 
     end;
 
-def returnToCorner =
+def pureToCorner =
     turn back;
     move; move;
     turn right;
@@ -143,7 +143,7 @@ def burnTires =
 
         intersperse 2 move $ (
             placeSerpentine $ tryPlace "car tire";
-            returnToCorner;
+            pureToCorner;
             ignite forward;
 
             turn right;

--- a/data/scenarios/Challenges/Ranching/_gated-paddock/enclosure-checking.sw
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/enclosure-checking.sw
@@ -1,14 +1,14 @@
 def isBlockedOrFenced =
     b <- blocked;
-    return b;
+    pure b;
     end;
 
 def checkIsEnclosed =
     maybePath <- path (inL ()) (inR "water");
-    case maybePath (\_. return True) (\_. return False);
+    case maybePath (\_. pure True) (\_. pure False);
     end;
 
-def boolToInt = \b. if (b) {return 1} {return 0}; end;
+def boolToInt = \b. if (b) {pure 1} {pure 0}; end;
 
 def countAdjacentBlockages =
 
@@ -28,7 +28,7 @@ def countAdjacentBlockages =
     b4 <- isBlockedOrFenced;
     c4 <- boolToInt b4;
 
-    return $ c1 + c2 + c3 + c4;
+    pure $ c1 + c2 + c3 + c4;
     end;
 
 // Step forward, observing left and right.
@@ -44,7 +44,7 @@ def observeLeftAndRight =
 
     turn right;
     move;
-    return $ val1 + val2;
+    pure $ val1 + val2;
     end;
 
 
@@ -65,7 +65,7 @@ def countDiagonalBlockages =
     // Second, step to both sides
     fwdCount <- observeLeftAndRight;
     backCount <- observeLeftAndRight;
-    return $ fwdCount + backCount;
+    pure $ fwdCount + backCount;
     end;
 
 def isStandingOnBridge =
@@ -74,12 +74,12 @@ def isStandingOnBridge =
     if (onFence || onGate) {
         adjCount <- countAdjacentBlockages;
         if (adjCount > 1) {
-            return true;
+            pure true;
         } {
             diagCount <- countDiagonalBlockages;
-            return $ (adjCount + diagCount) > 1;
+            pure $ (adjCount + diagCount) > 1;
         };
-    } {return false};
+    } {pure false};
     end;
 
 def getValForSheepIndex = \predicateCmd. \i.
@@ -91,7 +91,7 @@ def getValForSheepIndex = \predicateCmd. \i.
 
         boolToInt didSucceed;
     } {
-        return 0;
+        pure 0;
     }
     end;
 
@@ -99,7 +99,7 @@ def countSheepWith = \predicateCmd.
     val1 <- getValForSheepIndex predicateCmd 1;
     val2 <- getValForSheepIndex predicateCmd 2;
     val3 <- getValForSheepIndex predicateCmd 3;
-    return $ val1 + val2 + val3;
+    pure $ val1 + val2 + val3;
     end;
 
 justFilledGap <- as base {
@@ -108,7 +108,7 @@ justFilledGap <- as base {
 
 if (justFilledGap) {
     enclosedCount <- countSheepWith checkIsEnclosed;
-    return $ enclosedCount >= 1;
+    pure $ enclosedCount >= 1;
 } {
-    return false;
+    pure false;
 }

--- a/data/scenarios/Challenges/Ranching/_gated-paddock/fence-construction.sw
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/fence-construction.sw
@@ -54,10 +54,10 @@ def grabTrees =
 
 def harvestIfClover =
     x <- scan down;
-    case x return (\y.
+    case x pure (\y.
         if (y == "clover") {
             harvest;
-            return ();
+            pure ();
         } {};
     );
     end;
@@ -125,11 +125,11 @@ def harvestCloverField =
     turn right;
     wait 200;
     
-    plantCloverColumn right $ return ();
-    plantCloverColumn left $ return ();
-    plantCloverColumn right $ return ();
-    plantCloverColumn left $ return ();
-    plantCloverColumn right $ return ();
+    plantCloverColumn right $ pure ();
+    plantCloverColumn left $ pure ();
+    plantCloverColumn right $ pure ();
+    plantCloverColumn left $ pure ();
+    plantCloverColumn right $ pure ();
     end;
 
 
@@ -164,10 +164,10 @@ def distributeCloverInPaddock =
 
 def pickupWool =
     x <- scan down;
-    case x return (\y.
+    case x pure (\y.
         if (y == "wool") {
             grab;
-            return ();
+            pure ();
         } {};
     );
     end;

--- a/data/scenarios/Challenges/Ranching/_gated-paddock/meandering-sheep.sw
+++ b/data/scenarios/Challenges/Ranching/_gated-paddock/meandering-sheep.sw
@@ -5,12 +5,12 @@ def elif = \p.\t.\e. {if p t e} end;
 def turnToClover = \direction.
 
   x <- scan direction;
-  case x (\_. return false;) (\y.
+  case x (\_. pure false;) (\y.
     if (y == "clover") {
       turn direction;
-      return true;
+      pure true;
     } {
-      return false;
+      pure false;
     };
   );
   end;
@@ -23,11 +23,11 @@ turn that direction.
 def turnCloverDirection =
 
     foundN <- turnToClover north;
-    if (foundN) {return true} {
+    if (foundN) {pure true} {
       foundE <- turnToClover east;  
-      if (foundE) {return true} {
+      if (foundE) {pure true} {
         foundS <- turnToClover south;
-        if (foundS) {return true} {
+        if (foundS) {pure true} {
           turnToClover west;
         }
       }
@@ -38,7 +38,7 @@ def decideDirection =
 
   let randdir : Cmd Dir =
     d <- random 4;
-    return $ if (d == 0) {
+    pure $ if (d == 0) {
         north
       } $ elif (d == 1) {
         east
@@ -90,7 +90,7 @@ forever (
 
     // Eat clover.
     x <- scan down;
-    case x return (\y.
+    case x pure (\y.
         if (y == "clover") {
             harvest;
             cloverCount <- count "clover";
@@ -113,9 +113,9 @@ forever (
         // Make sure nothing's in the way before we place
         // our wool:
         x <- scan down;
-        case x return (\_.
+        case x pure (\_.
           grab;
-          return ();
+          pure ();
         );
 
         place item;

--- a/data/scenarios/Challenges/Ranching/_pied-piper/rat.sw
+++ b/data/scenarios/Challenges/Ranching/_pied-piper/rat.sw
@@ -20,10 +20,10 @@ def goFoodDir = \f. \r.
     if (d == down) {
         foodHere <- ishere "oats";
         if foodHere {
-            grab; return ()
+            grab; pure ()
         } {};
         f;
-        return ()
+        pure ()
     } {
         turn d;
 
@@ -40,7 +40,7 @@ def goFoodDir = \f. \r.
 def goHomeDir = \f. \r.
     let d = fst r in
     if (d == down) {
-        return ()
+        pure ()
     } {
         turn d;
 
@@ -81,12 +81,12 @@ def pauseAtRandom =
 
 def returnHome = \homeLoc.
     nextDir <- path (inL ()) (inL homeLoc);
-    case nextDir return $ goHomeDir $ returnHome homeLoc;
+    case nextDir pure $ goHomeDir $ returnHome homeLoc;
     end;
 
 def pursueFood = \hadSensedFood. \homeLoc.
     nextDir <- path (inR 5) (inR "oats");
-    case nextDir (\_. if hadSensedFood {returnHome homeLoc} {return ()}) $
+    case nextDir (\_. if hadSensedFood {returnHome homeLoc} {pure ()}) $
         goFoodDir $ pursueFood true homeLoc;
     end;
 

--- a/data/scenarios/Challenges/Ranching/_powerset/setup.sw
+++ b/data/scenarios/Challenges/Ranching/_powerset/setup.sw
@@ -9,7 +9,7 @@ end
 def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
 
 def until = \p. \c. q <- p; if q {} {c; until p c} end;
-def while = \p. until (x <- p; return $ not x) end;
+def while = \p. until (x <- p; pure $ not x) end;
 
 def isDivisibleBy = \dividend. \divisor.
     (dividend / divisor) * divisor == dividend;
@@ -67,7 +67,7 @@ def atLocation = \newLoc. \f.
     teleport self newLoc;
     retval <- f;
     teleport self prevLoc;
-    return retval;
+    pure retval;
     end;
 
 def placeSand =
@@ -86,7 +86,7 @@ def getUnusedRandom = \maxval. \bitmask.
     if (isBitSet bitmask nextRandomVal) {
         getUnusedRandom maxval bitmask;
     } {
-        return nextRandomVal;
+        pure nextRandomVal;
     }
     end;
 
@@ -140,7 +140,7 @@ def naiveRandomStack = \valueFunc. \maxval. \bitmask. \n.
         nextRandomVal <- getUnusedRandom maxval bitmask;
         let newBitmask = bitmask + shiftLeft 1 nextRandomVal in
         naiveRandomStack valueFunc maxval newBitmask $ n - 1;
-        return nextRandomVal;
+        pure nextRandomVal;
     } {
         // We're at the peak of the stack.
         // Now we unwind it.
@@ -148,7 +148,7 @@ def naiveRandomStack = \valueFunc. \maxval. \bitmask. \n.
         // Saves some time in generating the last number by inferring the
         // only remaining possible choice.
         let missingBit = getMissingBit bitmask maxval in
-        return missingBit;
+        pure missingBit;
     };
     valueFunc val;
     end;
@@ -193,7 +193,7 @@ def chooseExclusionValue = \powersetCardinality.
     if (exactlyOneBit false value) {
       chooseExclusionValue powersetCardinality;
     } {
-      return value;
+      pure value;
     }
     end;
 
@@ -208,7 +208,7 @@ def setup = \inputCardinality.
     move;
     exclusionValue <- chooseExclusionValue powersetCardinality;
     naiveRandomStack (columnFunc exclusionValue inputCardinality) powersetCardinality 0 powersetCardinality;
-    return exclusionValue;
+    pure exclusionValue;
     end;
 
 /**
@@ -220,7 +220,7 @@ def getOrdinal : Text -> Cmd Int = \item.
 
 def checkSolutionSum = \runningSum.
     maybeItem <- scan down;
-    case maybeItem (\_. return runningSum) (\item.
+    case maybeItem (\_. pure runningSum) (\item.
         // The bell is the only other item we can place in this
         // scenario besides the fruits.
         if (item != "bell") {
@@ -228,7 +228,7 @@ def checkSolutionSum = \runningSum.
             let binaryValue = shiftLeft 1 $ theOrdinal - 1 in
             move;
             checkSolutionSum $ binaryValue + runningSum;
-        } {return runningSum};
+        } {pure runningSum};
     );
     end;
 

--- a/data/scenarios/Challenges/Ranching/_powerset/solution.sw
+++ b/data/scenarios/Challenges/Ranching/_powerset/solution.sw
@@ -1,6 +1,6 @@
 def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
 def until = \p. \c. q <- p; if q {} {c; until p c} end;
-def while = \p. until (x <- p; return $ not x) end;
+def while = \p. until (x <- p; pure $ not x) end;
 
 def abs = \n. if (n < 0) {-n} {n} end;
 
@@ -28,7 +28,7 @@ def negateTuple = \t.
 
 def getRelativeLocation = \absCurrentLoc. \absDestLoc.
     let negatedLoc = negateTuple absCurrentLoc in
-    return $ sumTuples negatedLoc absDestLoc;
+    pure $ sumTuples negatedLoc absDestLoc;
     end;
 
 def splitStride = \n.
@@ -73,7 +73,7 @@ def recordFirstEncounter = \stashLoc. \item.
 
 def tryHarvest = \stashLoc.
     maybeItem <- scan down;
-    case maybeItem return (\item.
+    case maybeItem pure (\item.
         hasSome <- has item;
         harvest;
         if hasSome {} {
@@ -105,7 +105,7 @@ def countLine = \tally.
     if emptyhere {
         turn back;
         splitStride tally;
-        return tally;
+        pure tally;
     } {
         move;
         countLine $ tally + 1;
@@ -123,7 +123,7 @@ def placeFinalCopy = \item.
 
 def copyIfNeeded = \targetCount.
     maybeItem <- scan down;
-    case maybeItem return (\item.
+    case maybeItem pure (\item.
         quantity <- count item;
         if (quantity < targetCount) {
             placeFinalCopy item;

--- a/data/scenarios/Challenges/Ranching/beekeeping.yaml
+++ b/data/scenarios/Challenges/Ranching/beekeeping.yaml
@@ -33,7 +33,7 @@ objectives:
         `honeycomb`{=entity} production.
     condition: |
       foundStructure <- structures "beehive";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
   - teaser: Collect honeycomb
     goal:
       - |
@@ -67,7 +67,7 @@ objectives:
     condition: |
       as base {
         meadCount <- count "mead";
-        return $ meadCount >= 2;
+        pure $ meadCount >= 2;
       }
   - teaser: Tavern keeper
     optional: true
@@ -76,7 +76,7 @@ objectives:
         Construct a `mead hall`{=structure}.
     condition: |
       foundStructure <- structures "mead hall";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
 robots:
   - name: base
     display:

--- a/data/scenarios/Challenges/Ranching/capture.yaml
+++ b/data/scenarios/Challenges/Ranching/capture.yaml
@@ -25,10 +25,10 @@ objectives:
                   turn left;
                   isSurrounded $ n - 1;
               } {
-                  return false;
+                  pure false;
               }
           } {
-              return true;
+              pure true;
           }
           end;
 
@@ -59,16 +59,16 @@ objectives:
               let localBlockCount = boolToInt isBlocked in
               turn left;
               lastCount <- countBlocked $ n - 1;
-              return $ lastCount + localBlockCount;
+              pure $ lastCount + localBlockCount;
           } {
-              return 0;
+              pure 0;
           }
           end;
 
       opponent <- robotnamed "opponent";
       as opponent {
           blockCount <- countBlocked 4;
-          return $ blockCount > 0 && blockCount < 4;
+          pure $ blockCount > 0 && blockCount < 4;
       };
 robots:
   - name: base

--- a/data/scenarios/Challenges/Ranching/fishing.yaml
+++ b/data/scenarios/Challenges/Ranching/fishing.yaml
@@ -29,7 +29,7 @@ objectives:
     condition: |
       as base {
         rollCount <- count "california roll";
-        return $ rollCount >= 16;
+        pure $ rollCount >= 16;
       }
     prerequisite: made_sushi
   - teaser: Sushi chef
@@ -61,12 +61,12 @@ objectives:
     condition: |
       def hasAny : (rec l. Unit + Text * l) -> Cmd Bool = \items.
         case items
-          (\_. return false)
-          (\c. b <- has (fst c); if b {return true} {hasAny (snd c)})
+          (\_. pure false)
+          (\c. b <- has (fst c); if b {pure true} {hasAny (snd c)})
       end;
 
       let prohibited = tagmembers "junk" in
-      h <- hasAny prohibited; return (not h)
+      h <- hasAny prohibited; pure (not h)
   - teaser: No littering
     id: littered
     hidden: true
@@ -78,7 +78,7 @@ objectives:
         Note that certain items can be burned with a `torch`{=entity} to make room.
     condition: |
       def locIsInsideEnclosure = \loc. \dims. \boxPos.
-        return $ snd loc >= snd boxPos
+        pure $ snd loc >= snd boxPos
           && snd loc < snd dims + snd boxPos
           && fst loc >= fst boxPos
           && fst loc < fst dims + fst boxPos;
@@ -86,14 +86,14 @@ objectives:
 
       def junkOutsideEnclosure =
         result <- scan down;
-        case result (\_. return false) (\item.
+        case result (\_. pure false) (\item.
           let isJunk = hastag item "junk" in
           if isJunk {
             enclosures <- structures "rubbish enclosure";
 
-            case enclosures (\_. return false) (\cons0.
+            case enclosures (\_. pure false) (\cons0.
               let enclosure0 = fst cons0 in
-              case (snd cons0) (\_. return false) (\cons1.
+              case (snd cons0) (\_. pure false) (\cons1.
                 let enclosure1 = fst cons1 in
 
                 dims <- floorplan "rubbish enclosure";
@@ -101,11 +101,11 @@ objectives:
 
                 insideFirst <- locIsInsideEnclosure loc dims enclosure0;
                 insideSecond <- locIsInsideEnclosure loc dims enclosure1;
-                return $ not $ insideFirst || insideSecond;
+                pure $ not $ insideFirst || insideSecond;
               )
             )
           } {
-            return false;
+            pure false;
           };
         );
         end;

--- a/data/scenarios/Challenges/Ranching/gated-paddock.yaml
+++ b/data/scenarios/Challenges/Ranching/gated-paddock.yaml
@@ -23,15 +23,15 @@ objectives:
     condition: |-
       def isBlockedOrFenced =
           b <- blocked;
-          return b;
+          pure b;
           end;
 
       def checkIsEnclosed =
           maybePath <- path (inL ()) (inR "water");
-          case maybePath (\_. return True) (\_. return False);
+          case maybePath (\_. pure True) (\_. pure False);
           end;
 
-      def boolToInt = \b. if (b) {return 1} {return 0}; end;
+      def boolToInt = \b. if (b) {pure 1} {pure 0}; end;
 
       def countAdjacentBlockages =
 
@@ -51,7 +51,7 @@ objectives:
           b4 <- isBlockedOrFenced;
           c4 <- boolToInt b4;
 
-          return $ c1 + c2 + c3 + c4;
+          pure $ c1 + c2 + c3 + c4;
           end;
 
       // Step forward, observing left and right.
@@ -67,7 +67,7 @@ objectives:
 
           turn right;
           move;
-          return $ val1 + val2;
+          pure $ val1 + val2;
           end;
 
 
@@ -88,7 +88,7 @@ objectives:
           // Second, step to both sides
           fwdCount <- observeLeftAndRight;
           backCount <- observeLeftAndRight;
-          return $ fwdCount + backCount;
+          pure $ fwdCount + backCount;
           end;
 
       def isStandingOnBridge =
@@ -97,12 +97,12 @@ objectives:
           if (onFence || onGate) {
               adjCount <- countAdjacentBlockages;
               if (adjCount > 1) {
-                  return true;
+                  pure true;
               } {
                   diagCount <- countDiagonalBlockages;
-                  return $ (adjCount + diagCount) > 1;
+                  pure $ (adjCount + diagCount) > 1;
               };
-          } {return false};
+          } {pure false};
           end;
 
       def getValForSheepIndex = \predicateCmd. \i.
@@ -114,7 +114,7 @@ objectives:
 
               boolToInt didSucceed;
           } {
-              return 0;
+              pure 0;
           }
           end;
 
@@ -122,7 +122,7 @@ objectives:
           val1 <- getValForSheepIndex predicateCmd 1;
           val2 <- getValForSheepIndex predicateCmd 2;
           val3 <- getValForSheepIndex predicateCmd 3;
-          return $ val1 + val2 + val3;
+          pure $ val1 + val2 + val3;
           end;
 
       justFilledGap <- as base {
@@ -131,9 +131,9 @@ objectives:
 
       if (justFilledGap) {
           enclosedCount <- countSheepWith checkIsEnclosed;
-          return $ enclosedCount >= 1;
+          pure $ enclosedCount >= 1;
       } {
-          return false;
+          pure false;
       }
   - id: feed_sheep
     teaser: Feed sheep
@@ -155,7 +155,7 @@ objectives:
               r <- robotnumbered i;
               as r {predicateCmd};
           } {
-              return false;
+              pure false;
           };
           end;
 
@@ -164,12 +164,12 @@ objectives:
           if (i > 0) {
               didSucceed <- getTruthForSheepIndex predicateCmd i;
               if didSucceed {
-                  return true;
+                  pure true;
               } {
                   anySheep predicateCmd $ i - 1;
               };
           } {
-              return false;
+              pure false;
           };
           end;
 

--- a/data/scenarios/Challenges/Ranching/pied-piper.yaml
+++ b/data/scenarios/Challenges/Ranching/pied-piper.yaml
@@ -89,7 +89,7 @@ objectives:
     condition: |
       as base {
         loc <- locateme;
-        return $ fst loc == "silo";
+        pure $ fst loc == "silo";
       }
   - teaser: Moldy
     prerequisite: silo
@@ -109,8 +109,8 @@ objectives:
     condition: |
       try {
         r <- robotNamed "rat";
-        return false;
-      } {return true}
+        pure false;
+      } {pure true}
   - teaser: Spelunker
     prerequisite: silo
     goal:
@@ -119,7 +119,7 @@ objectives:
     condition: |
       as base {
         loc <- locateme;
-        return $ fst loc == "tunnel";
+        pure $ fst loc == "tunnel";
       }
 solution: |
   run "scenarios/Challenges/Ranching/_pied-piper/solution.sw"

--- a/data/scenarios/Challenges/Sliding Puzzles/_sliding-puzzle/maintainer.sw
+++ b/data/scenarios/Challenges/Sliding Puzzles/_sliding-puzzle/maintainer.sw
@@ -28,12 +28,12 @@ def atLocation = \newLoc. \f.
     teleport self newLoc;
     retval <- f;
     teleport self prevLoc;
-    return retval;
+    pure retval;
     end;
 
 def itemIsHere = \item.
     x <- scan down;
-    case x (\_. return false) (\found. return $ found == item);
+    case x (\_. pure false) (\found. pure $ found == item);
     end;
 
 def getLetterEntityByIndex = \idx.
@@ -52,7 +52,7 @@ def getOrdinal : Text -> Cmd Int = \item.
 
 def getValueHere =
     maybeItem <- scan down;
-    ordNum <- case maybeItem (\_. return 0) getOrdinal;
+    ordNum <- case maybeItem (\_. pure 0) getOrdinal;
     end;
 
 def getIndexesTotal = \boardWidth. \boardHeight. \n.
@@ -61,9 +61,9 @@ def getIndexesTotal = \boardWidth. \boardHeight. \n.
         teleport self (idx/boardHeight, -(mod idx boardWidth));
         valueHere <- getValueHere;
         runningTotal <- getIndexesTotal boardWidth boardHeight $ n - 1;
-        return $ valueHere + runningTotal;
+        pure $ valueHere + runningTotal;
     } {
-        return 0;
+        pure 0;
     }
     end;
 
@@ -77,7 +77,7 @@ def findMissingIndex = \boardWidth. \boardHeight.
     let tileCount = squareCount - 1 in
     let indicesSum = computeTriangularNumber tileCount in
     mySum <- getIndexesTotal boardWidth boardHeight squareCount;
-    return $ indicesSum - mySum;
+    pure $ indicesSum - mySum;
     end;
 
 def replenishInk =
@@ -114,12 +114,12 @@ Checks in the four directions.
 def hasAdjacentBlank = \tileIdx. \n.
     if (n > 0) {
         result <- scan forward;
-        case result (\_. handleLegalMove tileIdx; return true;) (\_.
+        case result (\_. handleLegalMove tileIdx; pure true;) (\_.
             turn left;
             hasAdjacentBlank tileIdx $ n - 1;
         );
     } {
-        return false;
+        pure false;
     }
     end;
 
@@ -141,7 +141,7 @@ Preconditions:
 def handleMarker = \boardWidth. \boardHeight.
     detectReferenceLoc <- whereami;
     result <- detect "sliding-tile" ((0, 0), (boardWidth - 1, boardHeight - 1));
-    case result return (\badLoc.
+    case result pure (\badLoc.
         teleportToDetectResult detectReferenceLoc badLoc;
         missingIdx <- atLocation (0, 0) $ findMissingIndex boardWidth boardHeight;
         markIsLegal <- isLegalMark missingIdx;

--- a/data/scenarios/Challenges/Sliding Puzzles/_sliding-puzzle/setup.sw
+++ b/data/scenarios/Challenges/Sliding Puzzles/_sliding-puzzle/setup.sw
@@ -29,7 +29,7 @@ def getOrdinal : Text -> Cmd Int = \item.
 
 def getValueHere =
     maybeItem <- scan down;
-    ordNum <- case maybeItem (\_. return 0) getOrdinal;
+    ordNum <- case maybeItem (\_. pure 0) getOrdinal;
     end;
 
 /**
@@ -81,9 +81,9 @@ def countInnerInversions = \n. \referenceVal. \j.
         let addend = if (referenceVal > valueHere) {1} {0} in
         recursiveSum <- countInnerInversions n referenceVal $ j + 1;
         let foo = recursiveSum in
-        return $ addend + foo;
+        pure $ addend + foo;
     } {
-        return 0;
+        pure 0;
     };
     end
 
@@ -102,9 +102,9 @@ def countInversions = \n. \i.
         turn back;
         subarrayInversions <- countInversions n $ i + 1;
         let foo = subarrayInversions in
-        return $ innerCountFoo + foo;
+        pure $ innerCountFoo + foo;
     } {
-        return 0;
+        pure 0;
     };
     end
 
@@ -115,13 +115,13 @@ Right is a valid tile entity name.
 def scanValid : Dir -> Cmd (Bool + Text) = \d.
     maybeTileForward <- scan d;
     case maybeTileForward
-        (\_. return $ inL false)
+        (\_. pure $ inL false)
         (\x.
             if (x == "sliding-tile") {
-                return $ inL true;
+                pure $ inL true;
             } {
                 y <- getOrdinal x;
-                return $ if (y > 0) {
+                pure $ if (y > 0) {
                     inR x;
                 } {
                     inL false;
@@ -145,14 +145,14 @@ def actOnItemComparison = \maybeNewItem. \original.
             move;
             grab;
             // Abort early from the recursion.
-            return false;
+            pure false;
         } {
             // The new tile is not a sliding tile.
             // We assume it's a blank tile and move there.
             // If it turns out not to be blank, that will
             // be addressed in the outer "observe" loop.
             move;
-            return false;
+            pure false;
         };
     ) (\newItem.
         let isSame = newItem == original in
@@ -160,7 +160,7 @@ def actOnItemComparison = \maybeNewItem. \original.
         if isSame {} {
             say $ "Original was " ++ original ++ "; newItem was " ++ newItem;
         };
-        return isSame;
+        pure isSame;
     );
     end;
 
@@ -179,14 +179,14 @@ def unwind = \keepChecking. \maybeItem.
                 // Our assumption was invalid; we don't have a
                 // valid reference tile to compared the drilled tile to.
                 say "Unexpected drilling; no reference tile.";
-                return false;
+                pure false;
             } {
-                return true;
+                pure true;
             }
         ) (actOnItemComparison maybeItem2);
-        return keepGoing;
+        pure keepGoing;
     } {
-        return false;
+        pure false;
     };
     end;
 

--- a/data/scenarios/Challenges/Sliding Puzzles/_sliding-puzzle/solution.sw
+++ b/data/scenarios/Challenges/Sliding Puzzles/_sliding-puzzle/solution.sw
@@ -57,13 +57,13 @@ def subtractTuple = \t1. \t2.
 def getRelativeLocation = \absLoc.
     myloc <- whereami;
     let negatedLoc = negateTuple myloc in
-    return $ sumTuples negatedLoc absLoc;
+    pure $ sumTuples negatedLoc absLoc;
     end;
 
 def getRelativeRectangle : (Int * Int) * (Int * Int) -> Cmd ((Int * Int) * (Int * Int)) = \corners.
     myloc <- whereami;
     let negatedLoc = negateTuple myloc in
-    return $ mapTuple (sumTuples negatedLoc) corners;
+    pure $ mapTuple (sumTuples negatedLoc) corners;
     end;
 
 /**
@@ -191,7 +191,7 @@ def blankCellLocatorCriteria = \rect.
     entCount <- density rect;
     let dims = getDimensions rect in
     let tileCount = getRectArea dims in
-    return $ entCount < tileCount;
+    pure $ entCount < tileCount;
     end;
 
 /**
@@ -209,10 +209,10 @@ def findEmptyCell = \foundCriteria. \rect.
     let tileCount = getRectArea dims in
 
     if (tileCount < 1) {
-        return $ inL ();
+        pure $ inL ();
     } $ elif (tileCount == 1) {
         foundHere <- foundCriteria rect;
-        return $ if foundHere {
+        pure $ if foundHere {
             inR $ fst rect;
         } {
             inL ();
@@ -297,7 +297,7 @@ def placeTile = \boardWidth. \idx. \blankLoc.
     log $ "absolute target loc: " ++ format targetLocAbsolute;
     targetRelativeLoc <- getRelativeLocation targetLocAbsolute;
 
-//    case eitherLetterloc return $ moveSpaceToTile blankLoc targetRelativeLoc;
+//    case eitherLetterloc pure $ moveSpaceToTile blankLoc targetRelativeLoc;
     moveTuple blankLoc;
     end;
 
@@ -412,7 +412,7 @@ def go = \boardWidth.
     corners <- getBoardRectangle;
     eitherBlankLoc <- findEmptyCell blankCellLocatorCriteria corners;
 
-    case eitherBlankLoc return $ placeTile boardWidth 1;
+    case eitherBlankLoc pure $ placeTile boardWidth 1;
 
     moveManually;
     end;

--- a/data/scenarios/Challenges/Sliding Puzzles/_sliding-puzzle/validate-board.sw
+++ b/data/scenarios/Challenges/Sliding Puzzles/_sliding-puzzle/validate-board.sw
@@ -4,7 +4,7 @@ def else = id end
 
 def itemIsHere = \item.
     x <- scan down;
-    case x (\_. return false) (\found. return $ found == item);
+    case x (\_. pure false) (\found. pure $ found == item);
     end;
 
 def getOrdinal : Text -> Cmd Int = \item.
@@ -19,10 +19,10 @@ def getOrdinal : Text -> Cmd Int = \item.
 def isMonotonic : Int -> Cmd (Unit + Int) = \expectedVal.
     maybeItem <- scan down;
     case maybeItem
-        (\_. return $ inR expectedVal) // Cell was blank
+        (\_. pure $ inR expectedVal) // Cell was blank
         (\entity.
             intVal <- getOrdinal entity;
-            return $ if (intVal == expectedVal) {
+            pure $ if (intVal == expectedVal) {
                 inR $ expectedVal + 1;
             } {
                 inL ();
@@ -41,11 +41,11 @@ def isMonotonic : Int -> Cmd (Unit + Int) = \expectedVal.
 def loopMonotonicityCheck : Int -> Cmd Bool = \expectedVal.
     isOnBottomBorder <- itemIsHere "border";
     if isOnBottomBorder {
-        return true;
+        pure true;
     } {
         maybeNextVal <- isMonotonic expectedVal;
         case maybeNextVal
-            (\_. return false)
+            (\_. pure false)
             (\nextVal.
                 move;
                 isOnRightBorder <- itemIsHere "border";
@@ -65,7 +65,7 @@ def go =
         teleport self (0, 0);
         loopMonotonicityCheck 1;
     } {
-        return false;
+        pure false;
     };
     end;
 

--- a/data/scenarios/Challenges/_blender/apprehension-checker.sw
+++ b/data/scenarios/Challenges/_blender/apprehension-checker.sw
@@ -2,12 +2,12 @@ def hasMetBase = \r.
     let basename = "base" in
     x <- as r {whoami};
     if (x == basename) {
-        return false;
+        pure false;
     } {
         mr0 <- as r {meet};
         case mr0
-          (\_. return false)
-          (\bot. name <- as bot {whoami}; return $ name == basename);
+          (\_. pure false)
+          (\bot. name <- as bot {whoami}; pure $ name == basename);
     };
     end;
 
@@ -26,11 +26,11 @@ def anyHasMetBase : Int -> Cmd Bool = \idx.
         let foo = intermediate in
         let newIdx = idx + 1 in
         recursiveResult <- anyHasMetBase newIdx;
-        return $ foo || recursiveResult;
+        pure $ foo || recursiveResult;
     } {
       // Terminates the recursion on the
       // lowest index at which a robot does not exist
-      return false;
+      pure false;
     };
     end;
 

--- a/data/scenarios/Challenges/_bridge-building/flower-ring-check.sw
+++ b/data/scenarios/Challenges/_bridge-building/flower-ring-check.sw
@@ -3,13 +3,13 @@ def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
 
 def isItemInDirection = \direction. \item. 
     x <- scan direction;
-    return $ case x (\_. false) (\y. y == item);
+    pure $ case x (\_. false) (\y. y == item);
     end;
 
 def isFlankedByItem = \item.
     hasLeft <- isItemInDirection left item;
     hasRight <- isItemInDirection right item;
-    return $ hasLeft && hasRight;
+    pure $ hasLeft && hasRight;
     end;
 
 def flowersInCardinalDirections = \item. \n.
@@ -19,10 +19,10 @@ def flowersInCardinalDirections = \item. \n.
             turn left;
             flowersInCardinalDirections item $ n - 1;
         } {
-            return false;
+            pure false;
         };
     } {
-        return true;
+        pure true;
     }
     end;
 
@@ -38,12 +38,12 @@ def flowersAround = \item.
             isFlanked2 <- isFlankedByItem item;
             turn back;
             move;
-            return isFlanked2;
+            pure isFlanked2;
         } {
-            return false;
+            pure false;
         }
     } {
-        return false;
+        pure false;
     }
     end;
 

--- a/data/scenarios/Challenges/_bucket-brigade/hauler.sw
+++ b/data/scenarios/Challenges/_bucket-brigade/hauler.sw
@@ -27,8 +27,8 @@ def patrol =
     traverseRoad;
     doNTimesOr 40 (
         briquetteIsHere <- ishere briquette;
-        if briquetteIsHere {grab; return ()} {};
-        return briquetteIsHere;
+        if briquetteIsHere {grab; pure ()} {};
+        pure briquetteIsHere;
     );
     turn back;
     traverseRoad;

--- a/data/scenarios/Challenges/_combo-lock/setup.sw
+++ b/data/scenarios/Challenges/_combo-lock/setup.sw
@@ -31,7 +31,7 @@ def checkCombo = \noMismatchYet. \stepsTaken. \colorString.
         // Replace the cell watches
         doN stepsTaken (watch down; move);
         turn back;
-        return noMismatchYet;
+        pure noMismatchYet;
     };
     end;
 
@@ -41,7 +41,7 @@ def unlockGate = \n.
     move;
     turn left;
     doN n (grab; move);
-    return ()
+    pure ()
     end;
 
 def doUntilCorrect = \colorString.
@@ -49,7 +49,7 @@ def doUntilCorrect = \colorString.
     if isCorrect {
         let remainingCount = chars colorString in
         unlockGate remainingCount;
-        return true;
+        pure true;
     } {
         wait 1000;
         doUntilCorrect colorString;
@@ -69,7 +69,7 @@ def createCombo = \colorString.
         createCombo $ newColor ++ colorString;
     } {
         turn back;
-        return colorString;
+        pure colorString;
     };
     end;
 

--- a/data/scenarios/Challenges/_combo-lock/solution.sw
+++ b/data/scenarios/Challenges/_combo-lock/solution.sw
@@ -10,7 +10,7 @@ def cycleCombos = \n.
         if (n > 0) {
             drill down;
             maybeNextEnt <- scan east;
-            case maybeNextEnt return (\_. turn east; move; cycleCombos 3);
+            case maybeNextEnt pure (\_. turn east; move; cycleCombos 3);
             cycleCombos $ n - 1;
         } {
             turn west;

--- a/data/scenarios/Challenges/_dimsum/cook.sw
+++ b/data/scenarios/Challenges/_dimsum/cook.sw
@@ -1,11 +1,11 @@
 def modifyCart = \cartType. \device.
     result <- scan forward;
-    case result return (\item.
+    case result pure (\item.
         if (item == cartType) {
             use device forward;
-            return ();
+            pure ();
         } {
-            return ();
+            pure ();
         };
     );
     end;

--- a/data/scenarios/Challenges/_dimsum/patron.sw
+++ b/data/scenarios/Challenges/_dimsum/patron.sw
@@ -1,11 +1,11 @@
 def modifyCart = \cartType. \device.
     result <- scan forward;
-    case result return (\item.
+    case result pure (\item.
         if (item == cartType) {
             use device forward;
-            return ();
+            pure ();
         } {
-            return ();
+            pure ();
         };
     );
     end;

--- a/data/scenarios/Challenges/_dna/lab.sw
+++ b/data/scenarios/Challenges/_dna/lab.sw
@@ -55,7 +55,7 @@ def waitUntilSomethingExists =
         watch down;
         wait 1000;
         waitUntilSomethingExists;
-    ) return;
+    ) pure;
     end;
 
 def waitUntilHere = \item.
@@ -81,7 +81,7 @@ def myStandby = \receptacleLoc.
     entToClone <- grab;
     teleport self (36, -11);
     turn back;
-    return $ inR entToClone;
+    pure $ inR entToClone;
     end;
 
 def placeBase = \standbyFunc. \n. 
@@ -102,9 +102,9 @@ def placeBase = \standbyFunc. \n.
         move;
 
         if isGood {
-            return clonedOrganism;
+            pure clonedOrganism;
         } {
-            return $ inL ();
+            pure $ inL ();
         }
     } {
         // Returns the clonedOrganism
@@ -151,7 +151,7 @@ def waitForCloneableOrganism =
         waitUntilOccupied;
 
         thingHere <- scan down;
-        return $ case thingHere (\x. inL x) (\item.
+        pure $ case thingHere (\x. inL x) (\item.
           if (hastag item "organism") {inR item} {inL ()}
         )
     );

--- a/data/scenarios/Challenges/_dna/resetter.sw
+++ b/data/scenarios/Challenges/_dna/resetter.sw
@@ -25,7 +25,7 @@ def watchSwitch = \lastState.
     watch down;
     wait 1000;
     found <- scan down;
-    case found return (\item.
+    case found pure (\item.
         if (item != lastState) {
             if (item == "switch (off)") {
                 loc <- whereami;
@@ -41,7 +41,7 @@ def watchSwitch = \lastState.
 def go =
     instant $ (
         found <- scan down;
-        case found return watchSwitch;
+        case found pure watchSwitch;
     );
     end;
 

--- a/data/scenarios/Challenges/_dna/solution.sw
+++ b/data/scenarios/Challenges/_dna/solution.sw
@@ -105,7 +105,7 @@ def waitForItem : Dir -> Cmd Text = \d.
         watch d;
         wait 1000;
         waitForItem d;
-    ) return;
+    ) pure;
     end;
 
 def waitForSpecificItem = \item. \d.
@@ -179,10 +179,10 @@ def pickFlowerAndWater =
     doN 23 move;
     
     turn right;
-    return dahlia;
+    pure dahlia;
     
-    // return mushroom;
-    // return d;
+    // pure mushroom;
+    // pure d;
     end;
 
 
@@ -245,7 +245,7 @@ def completeDnaTask = \sentinel.
 
 def mapM_ : (a -> Cmd b) -> (rec l. Unit + a * l) -> Cmd Unit = \f. \l.
   case l
-    (\_. return ())
+    (\_. pure ())
     (\c. f (fst c); mapM_ f (snd c))
 end;
 

--- a/data/scenarios/Challenges/_flower-count/judge.sw
+++ b/data/scenarios/Challenges/_flower-count/judge.sw
@@ -16,7 +16,7 @@ def judgeCount : Int -> Cmd Unit = \actual.
   wait 1024;
   s <- scan down;
   case s
-    (\_. return ())
+    (\_. pure ())
     (\p.
       try {
         let c = (read p : Int) in

--- a/data/scenarios/Challenges/_flower-count/solution.sw
+++ b/data/scenarios/Challenges/_flower-count/solution.sw
@@ -23,14 +23,14 @@ end
 def liftA2 : (a -> b -> c) -> Cmd a -> Cmd b -> Cmd c = \f. \ca. \cb.
   a <- ca;
   b <- cb;
-  return (f a b)
+  pure (f a b)
 end
 
 def add : Cmd Int -> Cmd Int -> Cmd Int = liftA2 (\x. \y. x + y) end
 
 def countCell : Cmd Int =
   s <- scan down;
-  return $ case s
+  pure $ case s
     (\_. 0)
     (\t. if (t == "flower") {1} {0})
 end
@@ -44,13 +44,13 @@ def sum : List Int -> Int = \l.
 end
 
 def for : Int -> (Int -> Cmd a) -> Cmd (List a) = \n. \k.
-  if (n == 0) {return (inl ())} {a <- k n; b <- for (n-1) k; return (inr (a,b))}
+  if (n == 0) {pure (inl ())} {a <- k n; b <- for (n-1) k; pure (inr (a,b))}
 end
 
 def countRow : Int -> Cmd Int = \w.
-  ns <- for (w-1) (\_. n <- countCell; move; return n);
+  ns <- for (w-1) (\_. n <- countCell; move; pure n);
   last <- countCell;
-  return (sum ns + last)
+  pure (sum ns + last)
 end
 
 def isEven : Int -> Bool = \n. (n / 2) * 2 == n end
@@ -66,15 +66,15 @@ def countFlowers : Int * Int -> Int * Int -> Cmd Int = \size. \ll.
   cnts <- for (h-1) (\i.
     cnt <- countRow w;
     if (isEven i) { around right } { around left };
-    return cnt
+    pure cnt
   );
   last <- countRow w;
-  return (sum cnts + last)
+  pure (sum cnts + last)
 end
 
 def acquire : Cmd Text =
-  thing <- atomic (b <- isempty; if b {return ""} {grab});
-  if (thing == "") {acquire} {return thing}
+  thing <- atomic (b <- isempty; if b {pure ""} {grab});
+  if (thing == "") {acquire} {pure thing}
 end
 
 def countAndReport : Int * Int -> Int * Int -> Cmd Unit = \size. \ll.
@@ -92,7 +92,7 @@ def until : Cmd Bool -> Cmd a -> Cmd Unit = \test. \body.
 end
 
 def acquireFlower : Cmd Unit =
-  until (ishere "flower") move; grab; return ()
+  until (ishere "flower") move; grab; pure ()
 end
 
 def go =
@@ -108,7 +108,7 @@ def go =
   turn back;
   goto (20,0);
   res <- meet;
-  case res (\_. return ()) (\truelove. give truelove "flower")
+  case res (\_. pure ()) (\truelove. give truelove "flower")
 end;
 
 go;

--- a/data/scenarios/Challenges/_friend/cat.sw
+++ b/data/scenarios/Challenges/_friend/cat.sw
@@ -11,7 +11,7 @@ def abs = \n. if (n < 0) {-n} {n} end
 
 def randdir : Cmd Dir =
   d <- random 4;
-  return (
+  pure (
     if (d == 0) {north}
     $ elif (d == 1) {east}
     $ elif (d == 2) {south}
@@ -21,7 +21,7 @@ end
 
 def chooseWait : Cmd Int =
   t <- random (16*2);
-  return (16 + t)
+  pure (16 + t)
 end
 
 def wander =

--- a/data/scenarios/Challenges/_gallery/setup.sw
+++ b/data/scenarios/Challenges/_gallery/setup.sw
@@ -62,7 +62,7 @@ def getUnusedRandom = \maxval. \bitmask.
     if (isBitSet bitmask nextRandomVal) {
         getUnusedRandom maxval bitmask;
     } {
-        return nextRandomVal;
+        pure nextRandomVal;
     }
     end;
 
@@ -77,7 +77,7 @@ def naiveRandomStack = \valueFunc. \maxval. \bitmask. \n.
         nextRandomVal <- getUnusedRandom maxval bitmask;
         let newBitmask = bitmask + shiftLeft 1 nextRandomVal in
         naiveRandomStack valueFunc maxval newBitmask $ n - 1;
-        return nextRandomVal;
+        pure nextRandomVal;
     } {
         // We're at the peak of the stack.
         // Now we unwind it.
@@ -85,7 +85,7 @@ def naiveRandomStack = \valueFunc. \maxval. \bitmask. \n.
         // Saves some time in generating the last number by inferring the
         // only remaining possible choice.
         let missingBit = getMissingBit bitmask maxval in
-        return missingBit;
+        pure missingBit;
     };
     valueFunc val;
     end;

--- a/data/scenarios/Challenges/_gallery/solution.sw
+++ b/data/scenarios/Challenges/_gallery/solution.sw
@@ -3,7 +3,7 @@ def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
 def countRow = \currentCount.
     emptyHere <- isempty;
     if emptyHere {
-        return currentCount;
+        pure currentCount;
     } {
         move;
         countRow $ 1 + currentCount;
@@ -12,9 +12,9 @@ def countRow = \currentCount.
 
 def getOrdinal = \d.
     maybeEntity <- scan d;
-    case maybeEntity (\nothing. return $ inL nothing) (\item.
+    case maybeEntity (\nothing. pure $ inL nothing) (\item.
         myCount <- count item;
-        return $ inR myCount;
+        pure $ inR myCount;
     );
     end;
 
@@ -72,7 +72,7 @@ def swapAdjacent = \remainingSteps. \previousOrdinal.
     thisOrdinal <- if (remainingSteps > 1) {
         getOrdinal right;
     } {
-        return $ inL ();
+        pure $ inL ();
     };
 
     case thisOrdinal (\_.
@@ -83,9 +83,9 @@ def swapAdjacent = \remainingSteps. \previousOrdinal.
         let shouldSwap = num < previousOrdinal in
         ordinal <- if shouldSwap {
             doSwap;
-            return previousOrdinal;
+            pure previousOrdinal;
         } {
-            return num;
+            pure num;
         };
         move;
         swapAdjacent (remainingSteps - 1) ordinal;
@@ -96,7 +96,7 @@ def doLoop = \unsortedCount.
     if (unsortedCount > 1) {
         prevOrdinal <- getOrdinal right;
         move;
-        case prevOrdinal return $ swapAdjacent unsortedCount;
+        case prevOrdinal pure $ swapAdjacent unsortedCount;
         doLoop $ unsortedCount - 1;
     } {}
     end;

--- a/data/scenarios/Challenges/_gopher/gopher.sw
+++ b/data/scenarios/Challenges/_gopher/gopher.sw
@@ -7,9 +7,9 @@ def else = \t. t end
 def randSign = \x.
     opposite <- random 2;
     if (opposite == 1) {
-        return (-x);
+        pure (-x);
     } {
-        return x;
+        pure x;
     }
     end;
 
@@ -84,7 +84,7 @@ def waitWhileHere = \e. \remainingTime.
                 // but *before* it executes `grab`, the gopher will crash.
                 // Thus we have wrapped this `grab` in a `try`.
                 grab;
-                return ();
+                pure ();
             } {};
         };
     } {};
@@ -115,7 +115,7 @@ def go = \width. \height. \lastTauntIndex. \startingAmount. \dropping.
             place reward;
         } {
             swap reward;
-            return ();
+            pure ();
         };
 
         baseloc <- as base {whereami};

--- a/data/scenarios/Challenges/_gopher/solution.sw
+++ b/data/scenarios/Challenges/_gopher/solution.sw
@@ -34,15 +34,15 @@ def scanDirections = \n.
     let d = getDirection n in
     out <- scan d;
     shouldContinue <- case out
-        (\_. return true)
+        (\_. pure true)
         (\x. if (x == "mound") {
             drill d;
-            return true;
+            pure true;
         } {
             // A "flower" shall serve as
             // a semaphore to terminate the loop,
             // so that the base can `salvage` us.
-            return $ x != "flower";
+            pure $ x != "flower";
         });
 
     if shouldContinue {
@@ -58,7 +58,7 @@ def scanDirections = \n.
 
 def deploySensor =
     _s <- build {scanDirections 0};
-    return ();
+    pure ();
     end;
 
 def isDivisibleBy = \dividend. \divisor.
@@ -100,13 +100,13 @@ def deployGrid = \f. \width. \height.
 def pickupToolkit =
     x <- scan down;
     case x
-        (\_. return false)
+        (\_. pure false)
         (\y. if (y == "toolkit") {
             tk <- grab;
             equip tk;
-            return true
+            pure true
         } {
-            return false
+            pure false
         });
     end;
 

--- a/data/scenarios/Challenges/_hackman/ghost.sw
+++ b/data/scenarios/Challenges/_hackman/ghost.sw
@@ -6,7 +6,7 @@ an intersection. Then randomly choose any available direction
 
 def isItemInDirection = \direction. \item.
     x <- scan direction;
-    return $ case x (\_. false) (\y. y == item);
+    pure $ case x (\_. false) (\y. y == item);
     end;
 
 // A ghost is not blocked by a "gate" when it is leaving the "nursery".
@@ -14,27 +14,27 @@ def canCrossGate =
     isGate <- isItemInDirection forward "gate";
     loc <- whereami;
     let amCentered = loc == (0, 0) in
-    return $ isGate && amCentered;
+    pure $ isGate && amCentered;
     end;
 
 def isBlockedAhead =
     isBlockedByWall <- blocked;
     ghostCanCrossGate <- canCrossGate;
-    return $ isBlockedByWall && not ghostCanCrossGate;
+    pure $ isBlockedByWall && not ghostCanCrossGate;
     end;
 
 def checkLeftBlocked =
     turn left;
     isBlocked <- isBlockedAhead;
     turn right;
-    return isBlocked;
+    pure isBlocked;
     end;
 
 def checkRightBlocked =
     turn right;
     isBlocked <- isBlockedAhead;
     turn left;
-    return isBlocked;
+    pure isBlocked;
     end;
 
 def chooseDirection : Cmd Dir =
@@ -43,7 +43,7 @@ def chooseDirection : Cmd Dir =
     forwardBlocked <- isBlockedAhead;
     if (leftBlocked && rightBlocked && forwardBlocked) {
         say "Dead end; turning back";
-        return back;
+        pure back;
     } {
         // Since we're in the "else" case of all three
         // being blocked, we know that at least one
@@ -51,13 +51,13 @@ def chooseDirection : Cmd Dir =
         // the combinations.
         if (leftBlocked && rightBlocked) {
             // Keep going straight
-            return forward;
+            pure forward;
         } {
             if (leftBlocked && forwardBlocked) {
-                return right;
+                pure right;
             } {
                 if (rightBlocked && forwardBlocked) {
-                    return left;
+                    pure left;
                 } {
                     // Now we have exhaused all of the combinations
                     // of *two* directions being blocked, so we
@@ -67,30 +67,30 @@ def chooseDirection : Cmd Dir =
                         // Decide whether to go right or straight
                         d <- random 2;
                         if (d == 0) {
-                            return right;
+                            pure right;
                         } {
                             // go straight
-                            return forward;
+                            pure forward;
                         }
                     } {
                         if rightBlocked {
                             // Decide whether to go left or straight
                             d <- random 2;
                             if (d == 0) {
-                                return left;
+                                pure left;
                             } {
                                 // go straight
-                                return forward;
+                                pure forward;
                             }
                         } {
                             if forwardBlocked {
                                 // Decide whether to go left or right
                                 d <- random 2;
                                 if (d == 0) {
-                                    return left;
+                                    pure left;
                                 } {
                                     // go right
-                                    return right;
+                                    pure right;
                                 }
                             } {
                                 // No directions are blocked, so we can
@@ -99,13 +99,13 @@ def chooseDirection : Cmd Dir =
 
                                 d <- random 3;
                                 if (d == 0) {
-                                    return left;
+                                    pure left;
                                 } {
                                     if (d == 1) {
-                                        return right;
+                                        pure right;
                                     } {
                                         // go straight
-                                        return forward;
+                                        pure forward;
                                     }
                                 }
                             }

--- a/data/scenarios/Challenges/_hackman/solution.sw
+++ b/data/scenarios/Challenges/_hackman/solution.sw
@@ -3,7 +3,7 @@ def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
 def tryGrab =
     try {
         grab;
-        return ();
+        pure ();
     } {};
     end;
 
@@ -12,7 +12,7 @@ def tryGive = \thing.
     if hasPowerup {
         r <- meet;
         case r
-            (\_. return ())
+            (\_. pure ())
             (\r. give r thing; wait 10);
     } {};
     end;

--- a/data/scenarios/Challenges/_hanoi/hanoi-count.sw
+++ b/data/scenarios/Challenges/_hanoi/hanoi-count.sw
@@ -9,7 +9,7 @@ end;
 
 def cscan = \d.
   s <- scan d;
-  if (s == inl ()) {return 0} {return 1}
+  if (s == inl ()) {pure 0} {pure 1}
 end;
 
 def count_column =
@@ -24,7 +24,7 @@ def count_column =
   // wait 8;
   // log (format k);
   // wait 8;
-  return (i + j + k)
+  pure (i + j + k)
 end;
 
 
@@ -47,7 +47,7 @@ repeat {
         // log (format y);
         // wait 8;
         // log (format z);
-        return $ i2e (x + y + z)
+        pure $ i2e (x + y + z)
     };
     //let sum = i2e (x + y + z) in
     teleport self (0,-6);
@@ -57,6 +57,6 @@ repeat {
     case counted (\e.
         fail $ "Fatal error: there should always be a count entity at (0,-6)! " ++ format e ++ " " ++ format counted
     ) (\e.
-        if (e == sum) {} {swap sum; return ()}
+        if (e == sum) {} {swap sum; pure ()}
     )
 }

--- a/data/scenarios/Challenges/_hanoi/hanoi-increasing.sw
+++ b/data/scenarios/Challenges/_hanoi/hanoi-increasing.sw
@@ -34,15 +34,15 @@ repeat (
         z <- scan north;
         if (z == null) {
           if (y == null) {
-            return true
+            pure true
           } {
-            return $ f x y
+            pure $ f x y
           }
         } {
-          return $ f x y && f y z
+          pure $ f x y && f y z
         }
     };
     try {
-        if o {place "OK"} {grab; return ()}
+        if o {place "OK"} {grab; pure ()}
     } {}
 )

--- a/data/scenarios/Challenges/_hanoi/hanoi-invariant.sw
+++ b/data/scenarios/Challenges/_hanoi/hanoi-invariant.sw
@@ -10,7 +10,7 @@ end;
 
 repeat (
 me <- scan down;
-case me (\_. return ()) (\e.
+case me (\_. pure ()) (\e.
 // if
 //  0. I stand on unlocked X
 //  1. place north of me is NOT empty
@@ -25,13 +25,13 @@ if (isUnlocked e)
       case mn (\_.
         teleport self (0,-6);
         allPlaced <- ishere "three";
-        return (not allPlaced)
+        pure (not allPlaced)
       ) (\_.
-        return true
+        pure true
       );
     };
     if northFullOrAllPlaced {
-      swap ("blocked " ++ e); return ()
+      swap ("blocked " ++ e); pure ()
     } {}
 }
 // if
@@ -56,9 +56,9 @@ if (isUnlocked e)
         o2 <- ishere "OK";
         teleport self (2,-5);
         o3 <- ishere "OK";
-        return (o1 && o2 && o3)
+        pure (o1 && o2 && o3)
       };
-      if (allPlaced && allSorted) {swap (unlock e); return ()} {}
-    ) (\_. return ())
+      if (allPlaced && allSorted) {swap (unlock e); pure ()} {}
+    ) (\_. pure ())
 }
 ))

--- a/data/scenarios/Challenges/_hanoi/hanoi-solution.sw
+++ b/data/scenarios/Challenges/_hanoi/hanoi-solution.sw
@@ -4,12 +4,12 @@ def rep = \n. \c. if (n == 0) {} {c; rep (n-1) c} end;
 def ifC = \p. \t. \e. res <- p; if res t e end;
 
 def orC = \c1. \c2.
-  b1 <- c1; b2 <- c2; return (b1 || b2)
+  b1 <- c1; b2 <- c2; pure (b1 || b2)
 end;
 
 def somethingHere =
   res <- scan down;
-  return (res != inl ())
+  pure (res != inl ())
 end;
 
 def fwdToThing = until blocked move end;
@@ -26,7 +26,7 @@ def getDisk =
   fwdToThing;
   d <- grab;
   goBack;
-  return d
+  pure d
 end;
 
 def placeDisk = \d.
@@ -49,7 +49,7 @@ def hanoi :
   Int -> // The offset to third column
   Cmd Int
   = \n. \o. \a. \b. \c.
-  if (n == 0) {return o}
+  if (n == 0) {pure o}
   {
     o_new <- hanoi (n-1) o a c b;
     moveToCol o_new a;

--- a/data/scenarios/Challenges/_ice-cream/customer.sw
+++ b/data/scenarios/Challenges/_ice-cream/customer.sw
@@ -11,13 +11,13 @@ def placeOrder =
     scoopCountExtra <- random 4000;
     let scoopCount = 1000 + scoopCountExtra in
     say $ format scoopCount ++ " scoops of vanilla ice cream, no more, no less! And top it with a cherry, please.";
-    return scoopCount;
+    pure scoopCount;
     end;
 
 def waitForItem = \item.
     hasItem <- has item;
     if hasItem {
-        return ();
+        pure ();
     } {
         wait 1;
         waitForItem item;

--- a/data/scenarios/Challenges/_ice-cream/solution.sw
+++ b/data/scenarios/Challenges/_ice-cream/solution.sw
@@ -30,12 +30,12 @@ def getIngredients =
     move;
     move;
     turn right;
-    return (cone, cherry);
+    pure (cone, cherry);
     end;
 
 def meetCustomer =
     maybeCustomer <- meet;
-    case maybeCustomer (\_. meetCustomer) return;
+    case maybeCustomer (\_. meetCustomer) pure;
     end;
 
 def serveScoop = \customer.

--- a/data/scenarios/Challenges/_lights-out/solution.sw
+++ b/data/scenarios/Challenges/_lights-out/solution.sw
@@ -12,7 +12,7 @@ def intersperse = \n. \f2. \f1. if (n > 0) {
 /** Precondition: facing "d" direction */
 def toggleToDark = \d.
     onHere <- ishere "on";
-    if onHere {drill d; return ()} {};
+    if onHere {drill d; pure ()} {};
     end;
 
 def visitSingleRow = \rowWidth. \d.
@@ -48,7 +48,7 @@ def goToCorner =
 
 def onInDirection = \d.
     entHere <- scan d;
-    return $ case entHere (\_. false) (\e. e == "on");
+    pure $ case entHere (\_. false) (\e. e == "on");
     end;
 
 /**

--- a/data/scenarios/Challenges/_maypole/monitor.sw
+++ b/data/scenarios/Challenges/_maypole/monitor.sw
@@ -55,7 +55,7 @@ def getQuadrantIncrement = \oldQuadrant. \newQuadrant.
 
 def getCurrentQuadrant : (Int * Int) -> Cmd Int = \myLoc.
   baseLoc <- as base {whereami};
-  return $ getQuadrant baseLoc myLoc;
+  pure $ getQuadrant baseLoc myLoc;
   end;
 
 def checkNewQuadrant = \myLoc. \prevQuadrant. \quadrantTraversalCount.
@@ -65,9 +65,9 @@ def checkNewQuadrant = \myLoc. \prevQuadrant. \quadrantTraversalCount.
 
   if (changeCount != 0) {
     swap $ "maypole " ++ format currentQuadrant;
-    return ();
+    pure ();
   } {};
-  return (currentQuadrant, newQuadrantCount);
+  pure (currentQuadrant, newQuadrantCount);
   end;
 
 /*
@@ -91,7 +91,7 @@ def monitorAngle : (Int * Int) -> Int -> Int -> Int -> Cmd Unit =
   } {
     create "dizzy";
     swap "bitcoin";
-    return ();
+    pure ();
   }
   end;
 

--- a/data/scenarios/Challenges/_telephone/judge.sw
+++ b/data/scenarios/Challenges/_telephone/judge.sw
@@ -6,24 +6,24 @@ end
 
 def andC : Cmd Bool -> Cmd Bool -> Cmd Bool = \c1. \c2.
   b1 <- c1;
-  if b1 {c2} {return false}
+  if b1 {c2} {pure false}
 end
 
 tydef List a = rec l. Unit + a * l end
 
 def for : Int -> (Int -> Cmd a) -> Cmd (List a) = \n. \k.
   if (n == 0)
-    { return $ inl () }
+    { pure $ inl () }
     { x <- k (n-1);
       xs <- for (n-1) k;
-      return (inr (x,xs))
+      pure (inr (x,xs))
     }
 end
 
 def readRow : Cmd (List (Unit + Text)) =
-  r <- for 8 (\_. s <- scan down; move; return s);
+  r <- for 8 (\_. s <- scan down; move; pure s);
   turn back; x 8 move; turn right; move; turn right;
-  return r
+  pure r
 end
 
 tydef Rect = List (List (Unit + Text)) end
@@ -31,24 +31,24 @@ tydef Rect = List (List (Unit + Text)) end
 def readRect : Cmd Rect =
   lst <- for 4 (\_. readRow);
   turn right; x 4 move; turn left;
-  return lst
+  pure lst
 end
 
 def checkCell : Unit + Text -> Cmd Bool = \pat.
   actual <- scan down;
   move;
-  return (actual == pat)
+  pure (actual == pat)
 end
 
 def checkRow : List (Unit + Text) -> Cmd Bool = \row.
   case row
-    (\_. turn back; x 8 move; turn right; move; turn right; return true)
+    (\_. turn back; x 8 move; turn right; move; turn right; pure true)
     (\cons. andC (checkCell (fst cons)) (checkRow (snd cons)))
 end
 
 def checkRect : Rect -> Cmd Bool = \rect.
   case rect
-    (\_. return true)
+    (\_. pure true)
     (\cons. andC (checkRow (fst cons)) (checkRect (snd cons)))
 end
 

--- a/data/scenarios/Challenges/_telephone/photocopier.sw
+++ b/data/scenarios/Challenges/_telephone/photocopier.sw
@@ -25,7 +25,7 @@ end
 
 def copy : Cmd Unit =
   watch down; wait 1024;
-  p <- atomic (b <- isempty; if b {return ""} {grab});
+  p <- atomic (b <- isempty; if b {pure ""} {grab});
   if (p == "") {} {followInstructions p}
 end
 

--- a/data/scenarios/Challenges/_telephone/shuttle.sw
+++ b/data/scenarios/Challenges/_telephone/shuttle.sw
@@ -12,11 +12,11 @@ end
 def forever: ∀ a b. {Cmd a} -> Cmd b = \c. force c; forever c end
 
 def notC : Cmd Bool -> Cmd Bool = \c.
-  b <- c; return (not b)
+  b <- c; pure (not b)
 end
 
 def or : Cmd Bool -> Cmd Bool -> Cmd Bool = \c1. \c2.
-  ifC c1 {return true} {c2}
+  ifC c1 {pure true} {c2}
 end
 
 def followTrack : Cmd Unit =
@@ -26,11 +26,11 @@ def followTrack : Cmd Unit =
 end
 
 def pickup : Cmd Text =
-  atomic (b <- isempty; if b {return ""} {grab});
+  atomic (b <- isempty; if b {pure ""} {grab});
 end
 
 def dropoff : Text -> Cmd Bool = \thing.
-  atomic (b <- isempty; if b {place thing} {}; return b)
+  atomic (b <- isempty; if b {place thing} {}; pure b)
 end
 
 def deliver : Text -> Cmd Unit = \thing.

--- a/data/scenarios/Challenges/_telephone/solution.sw
+++ b/data/scenarios/Challenges/_telephone/solution.sw
@@ -19,7 +19,7 @@ end
 
 def harvestMay =
   e <- isempty;
-  if e {} {harvest; return ()}
+  if e {} {harvest; pure ()}
 end
 
 def harvestTrees =
@@ -46,18 +46,18 @@ def scanAt : Int -> Int -> Cmd (Unit + Text) = \h. \v.
   x h move; turn right; x v move;
   s <- scan down;
   turn back; x v move; turn left; x h move; turn back;
-  return s
+  pure s
 end
 
 def atTerminal : Cmd a -> Cmd a = \c.
   x 12 move; turn left; x 2 move;
   a <- c;
   turn back; x 2 move; turn right; x 12 move; turn back;
-  return a
+  pure a
 end
 
 def waitToPlace : Text -> Cmd Unit = \t.
-  success <- atomic (b <- isempty; if b {place t} {}; return b);
+  success <- atomic (b <- isempty; if b {place t} {}; pure b);
   if success {} { watch down; wait 1024; waitToPlace t }
 end
 
@@ -68,7 +68,7 @@ def go =
     for 4 (\v.
       res <- scanAt (h-1) (v-1);
       case res
-        (\_. return ())
+        (\_. pure ())
         (\t. atTerminal (p <- print "paper" (format ((h-1,v-1),t)); waitToPlace p))
     )
   )

--- a/data/scenarios/Challenges/_wolf-goat-cabbage/multi-item-possession.sw
+++ b/data/scenarios/Challenges/_wolf-goat-cabbage/multi-item-possession.sw
@@ -1,4 +1,4 @@
 has_wolf <- has "wolf";
 has_goat <- has "goat";
 has_cabbage <- has "cabbage";
-return $ (has_wolf && has_goat) || (has_goat && has_cabbage) || (has_wolf && has_cabbage);
+pure $ (has_wolf && has_goat) || (has_goat && has_cabbage) || (has_wolf && has_cabbage);

--- a/data/scenarios/Challenges/_wolf-goat-cabbage/together-on-east-bank.sw
+++ b/data/scenarios/Challenges/_wolf-goat-cabbage/together-on-east-bank.sw
@@ -1,7 +1,7 @@
 def get_x_coord = \r.
     as r {
         pos <- whereami;
-        return $ fst pos;
+        pure $ fst pos;
     };
     end;
 
@@ -10,16 +10,16 @@ def all_on_bank = \baseX. \robotName.
     thisX <- get_x_coord r;
 
     as r {
-        try {grab; return ()} {};
+        try {grab; pure ()} {};
         move;
-        try {grab; return ()} {};
+        try {grab; pure ()} {};
         move;
-        try {grab; return ()} {};
+        try {grab; pure ()} {};
 
         has_wolf <- has "wolf";
         has_goat <- has "goat";
         has_cabbage <- has "cabbage";
-        return $ baseX == thisX && has_wolf && has_goat && has_cabbage;
+        pure $ baseX == thisX && has_wolf && has_goat && has_cabbage;
     };
     end;
 

--- a/data/scenarios/Challenges/_wolf-goat-cabbage/unattended-together.sw
+++ b/data/scenarios/Challenges/_wolf-goat-cabbage/unattended-together.sw
@@ -1,7 +1,7 @@
 def get_x_coord = \r.
     as r {
         pos <- whereami;
-        return $ fst pos;
+        pure $ fst pos;
     };
     end;
 
@@ -10,19 +10,19 @@ def is_unattended_together = \baseX. \robotName.
     thisX <- get_x_coord r;
 
     if (baseX == thisX) {
-        return false;
+        pure false;
     } {
         as r {
-            try {grab; return ()} {};
+            try {grab; pure ()} {};
             move;
-            try {grab; return ()} {};
+            try {grab; pure ()} {};
             move;
-            try {grab; return ()} {};
+            try {grab; pure ()} {};
 
             has_wolf <- has "wolf";
             has_goat <- has "goat";
             has_cabbage <- has "cabbage";
-            return $ (has_wolf && has_goat) || (has_goat && has_cabbage);
+            pure $ (has_wolf && has_goat) || (has_goat && has_cabbage);
         };        
     }
     end;
@@ -32,4 +32,4 @@ baseX <- get_x_coord base;
 west_bad <- is_unattended_together baseX "west_detector";
 east_bad <- is_unattended_together baseX "east_detector";
 
-return $ west_bad || east_bad;
+pure $ west_bad || east_bad;

--- a/data/scenarios/Challenges/_word-search/create-puzzle.sw
+++ b/data/scenarios/Challenges/_word-search/create-puzzle.sw
@@ -11,15 +11,15 @@ def intersperse = \n. \f2. \f1. if (n > 0) {
 
 def whichOrdinal = \str.
     if (str == "capital C") {
-        return 0;
+        pure 0;
     } {
         if (str == "capital O") {
-            return 1;
+            pure 1;
         } {
             if (str == "capital W") {
-                return 2;
+                pure 2;
             } {
-                return (-1);
+                pure (-1);
             }
         }
     }
@@ -30,7 +30,7 @@ Returns -1 if not a recognized letter.
 */
 def getAdjacentOrdinal = \d.
     maybeEntity <- scan d;
-    str <- case maybeEntity (\_. return "") (\s. return s);
+    str <- case maybeEntity (\_. pure "") (\s. pure s);
     whichOrdinal str;
     end;
 
@@ -48,12 +48,12 @@ def iterN = \n. \f.
 
 def chooseLetter = \i.
     if (i == 0) {
-        return "capital C";
+        pure "capital C";
     } {
         if (i == 1) {
-            return "capital O";
+            pure "capital O";
         } {
-            return "capital W";
+            pure "capital W";
         }
     };
     end;
@@ -73,16 +73,16 @@ def getExcludedVerticalLetter =
         teleport self currentLoc;
 
         if (doubleNorthOrdinal == 2) {
-            return 0;
+            pure 0;
         } {
             if (doubleNorthOrdinal == 0) {
-                return 2;
+                pure 2;
             } {
-                return (-1);
+                pure (-1);
             }
         }
     } {
-        return (-1);
+        pure (-1);
     }
     end;
 
@@ -106,18 +106,18 @@ def reRoll = \excludedVertical. \expectedFwdOrdinal. \expectedBkwdOrdinal.
 
     if excludeZero {
         if (excludedVertical == 2) {
-            return 1;
+            pure 1;
         } {
             // Zero is the only excluded value,
             // so just offset a choice between 0 and 1 upward by 1, 
             // to make it a choice between 1 and 2.
             val <- random 2;
-            return $ val + 1;
+            pure $ val + 1;
         };
     } {
         if excludeTwo {
             if (excludedVertical == 0) {
-                return 1;
+                pure 1;
             } {
                 // Two is the only excluded value,
                 // so make it a choice between 0 and 1.
@@ -129,7 +129,7 @@ def reRoll = \excludedVertical. \expectedFwdOrdinal. \expectedBkwdOrdinal.
                 // so just offset a choice between 0 and 1 upward by 1, 
                 // to make it a choice between 1 and 2.
                 val <- random 2;
-                return $ val + 1;
+                pure $ val + 1;
             } {
                 if (excludedVertical == 2) {
                     // Two is the only excluded value,
@@ -150,7 +150,7 @@ def singleTile = \expectedFwdOrdinal. \expectedBkwdOrdinal.
     letterIndex <- reRoll excludedVertical expectedFwdOrdinal expectedBkwdOrdinal;
     chosenLetter <- chooseLetter letterIndex;
     place chosenLetter;
-    return letterIndex;
+    pure letterIndex;
     end;
 
 def crossBack = \_n.
@@ -169,15 +169,15 @@ def layTilesRow = \expectedFwdOrdinal. \expectedBkwdOrdinal. \n.
         move;
 
         newFwdOrdinal <- if (placedIndex == expectedFwdOrdinal || placedIndex == 0) {
-            return $ placedIndex + 1;
+            pure $ placedIndex + 1;
         } {
-            return 0;
+            pure 0;
         };
 
         newBkwdOrdinal <- if (placedIndex == expectedBkwdOrdinal || placedIndex == 2) {
-            return $ placedIndex - 1;
+            pure $ placedIndex - 1;
         } {
-            return 2;
+            pure 2;
         };
 
         layTilesRow newFwdOrdinal newBkwdOrdinal $ n - 1;

--- a/data/scenarios/Challenges/_word-search/solution.sw
+++ b/data/scenarios/Challenges/_word-search/solution.sw
@@ -20,17 +20,17 @@ def waitUntilUnblocked =
 def whichOrdinal =
     isC <- ishere "capital C";
     if (isC) {
-        return 0;
+        pure 0;
     } {
         isO <- ishere "capital O";
         if (isO) {
-            return 1;
+            pure 1;
         } {
             isW <- ishere "capital W";
             if (isW) {
-                return 2;
+                pure 2;
             } {
-                return (-1);
+                pure (-1);
             }
         }
     }
@@ -57,23 +57,23 @@ def traverseRow = \expectedOrdinal. \colCount.
     // considered a "match".
     let shouldAdvance = theFoundOrdinal == expectedOrdinal || theFoundOrdinal == 0 in
     newExpectedOrdinal <- if shouldAdvance {
-        return $ theFoundOrdinal + 1;
+        pure $ theFoundOrdinal + 1;
     } {
         // Reset the progress
-        return 0;
+        pure 0;
     };
 
     if (newExpectedOrdinal == 3) {
         turn back;
 
         intersperse 3 move highlightLetter;
-        return true;
+        pure true;
     } {
         if (colCount > 1) {
             move;
             traverseRow newExpectedOrdinal (colCount - 1);
         } {
-          return false;
+          pure false;
         };
     };
     end;
@@ -92,18 +92,18 @@ in either direction.
 def traverseCols = \width. \height. 
     didWin <- traverseRow 0 width;
     if didWin {
-        return true;
+        pure true;
     } {
         turn back;
         didWinBackward <- traverseRow 0 width;
         if didWinBackward {
-            return true;
+            pure true;
         } {
             if (height > 1) {
                 advanceRow;
                 traverseCols width $ height - 1;
             } {
-                return false;
+                pure false;
             };
         }
     } 
@@ -115,7 +115,7 @@ def solve = \boardWidth. \boardHeight.
 
     wonHorizontally <- traverseCols boardWidth boardHeight;
     if wonHorizontally {
-        return true;
+        pure true;
     } {
         // If we did not find a horizontal solution,
         // look for vertical solutions.

--- a/data/scenarios/Challenges/arbitrage.yaml
+++ b/data/scenarios/Challenges/arbitrage.yaml
@@ -20,7 +20,7 @@ objectives:
     condition: |
       as base {
         pcount <- count "paperclip";
-        return $ pcount >= 100;
+        pure $ pcount >= 100;
       };
   - teaser: Beginner capital
     goal:
@@ -32,7 +32,7 @@ objectives:
     condition: |
       as base {
         pcount <- count "paperclip";
-        return $ pcount >= 20;
+        pure $ pcount >= 20;
       };
 attrs:
   - name: shopA

--- a/data/scenarios/Challenges/blender.yaml
+++ b/data/scenarios/Challenges/blender.yaml
@@ -28,12 +28,12 @@ objectives:
           let basename = "base" in
           x <- as r {whoami};
           if (x == basename) {
-              return false;
+              pure false;
           } {
               mr0 <- as r {meet};
               case mr0
-                (\_. return false)
-                (\bot. name <- as bot {whoami}; return $ name == basename);
+                (\_. pure false)
+                (\bot. name <- as bot {whoami}; pure $ name == basename);
           };
           end;
 
@@ -52,11 +52,11 @@ objectives:
               let foo = intermediate in
               let newIdx = idx + 1 in
               recursiveResult <- anyHasMetBase newIdx;
-              return $ foo || recursiveResult;
+              pure $ foo || recursiveResult;
           } {
             // Terminates the recursion on the
             // lowest index at which a robot does not exist
-            return false;
+            pure false;
           };
           end;
 

--- a/data/scenarios/Challenges/bridge-building.yaml
+++ b/data/scenarios/Challenges/bridge-building.yaml
@@ -72,7 +72,7 @@ objectives:
       as base {
         c <- whereami;
         let x = fst c in
-        return $ x >= 1 && x <= 2 && snd c == -30;
+        pure $ x >= 1 && x <= 2 && snd c == -30;
       };
   - id: get_pebble
     teaser: Off-piste

--- a/data/scenarios/Challenges/chess_horse.yaml
+++ b/data/scenarios/Challenges/chess_horse.yaml
@@ -12,8 +12,8 @@ objectives:
         bloc <- as base {whereami};
         king <- robotNamed "king";
         kloc <- as king {whereami};
-        return (bloc == kloc)
-      } { return false }
+        pure (bloc == kloc)
+      } { pure false }
 solution: |
   move; move; move; turn right; move; turn left; move;
 robots:

--- a/data/scenarios/Challenges/dimsum.yaml
+++ b/data/scenarios/Challenges/dimsum.yaml
@@ -12,7 +12,7 @@ objectives:
       p <- robotnamed "patron";
       as p {
         foodCount <- count "food";
-        return $ foodCount >= 2;
+        pure $ foodCount >= 2;
       }
 solution: |
   run "scenarios/Challenges/_dimsum/solution.sw"

--- a/data/scenarios/Challenges/dna.yaml
+++ b/data/scenarios/Challenges/dna.yaml
@@ -87,8 +87,8 @@ objectives:
     condition: |
       def hasAll : (rec l. Unit + Text * l) -> Cmd Bool = \l.
         case l
-          (\_. return true)
-          (\c. b1 <- has (fst c); if b1 {hasAll (snd c)} {return false})
+          (\_. pure true)
+          (\c. b1 <- has (fst c); if b1 {hasAll (snd c)} {pure false})
       end;
 
       k <- robotnamed "keeper";
@@ -107,15 +107,15 @@ objectives:
     condition: |
       def hasCount : (rec l. Unit + Text * l) -> Cmd Int = \l.
         case l
-          (\_. return 0)
-          (\c. b <- has (fst c); n <- hasCount (snd c); return (if b {1} {0} + n))
+          (\_. pure 0)
+          (\c. b <- has (fst c); n <- hasCount (snd c); pure (if b {1} {0} + n))
       end;
 
       k <- robotnamed "keeper";
       as k {
         let organisms = tagmembers "organism" in
         c <- hasCount organisms;
-        return $ c >= 4;
+        pure $ c >= 4;
       }
 robots:
   - name: base

--- a/data/scenarios/Challenges/flower-count.yaml
+++ b/data/scenarios/Challenges/flower-count.yaml
@@ -40,7 +40,7 @@ objectives:
       f <- as base { has "flower" };
       judge <- robotNamed "judge";
       g <- as judge { has "gold" };
-      return (not g && f)
+      pure (not g && f)
   - id: out_of_time
     hidden: true
     optional: true
@@ -53,7 +53,7 @@ objectives:
         Perhaps you would like to go back in time and try again.
     condition: |
       truelove <- robotNamed "truelove";
-      as truelove { b <- ishere "fuse"; return (not b) }
+      as truelove { b <- ishere "fuse"; pure (not b) }
   - id: joinpoint
     hidden: true
     teaser: Follow instructions!
@@ -64,7 +64,7 @@ objectives:
           - not: pick_flower
           - not: out_of_time
     condition: |
-      return true
+      pure true
   - id: win
     teaser: Give a flower
     prerequisite: joinpoint

--- a/data/scenarios/Challenges/friend.yaml
+++ b/data/scenarios/Challenges/friend.yaml
@@ -63,7 +63,7 @@ objectives:
       c <- robotNamed "cat";
       catLoc <- as c {whereami};
       baseLoc <- as base {whereami};
-      return (catLoc == baseLoc)
+      pure (catLoc == baseLoc)
 solution: |
   run "scenarios/Challenges/_friend/friend-solution.sw"
 entities:

--- a/data/scenarios/Challenges/gallery.yaml
+++ b/data/scenarios/Challenges/gallery.yaml
@@ -51,13 +51,13 @@ objectives:
     condition: |
       def ensureMonotonicDecreasing = \itemCount. \prevOrdinal.
         maybeEntity <- scan down;
-        case maybeEntity (\_. return $ itemCount == 0) (\item.
+        case maybeEntity (\_. pure $ itemCount == 0) (\item.
             myCount <- count item;
             if (myCount <= prevOrdinal) {
               move;
               ensureMonotonicDecreasing (itemCount - 1) myCount;
             } {
-              return false;
+              pure false;
             };
         );
         end;
@@ -75,7 +75,7 @@ objectives:
           let bustCount = length busts in
           ensureMonotonicDecreasing bustCount $ bustCount + 1;
         } {
-          return false;
+          pure false;
         }
       };
 robots:

--- a/data/scenarios/Challenges/gopher.yaml
+++ b/data/scenarios/Challenges/gopher.yaml
@@ -20,9 +20,9 @@ objectives:
     condition: |
       try {
         robotnamed "gopher";
-        return false;
+        pure false;
       } {
-        return true;
+        pure true;
       }
   - teaser: Recover equipment
     prerequisite: defeat_gopher
@@ -34,7 +34,7 @@ objectives:
     condition: |
       as base {
         sCount <- count "scanner";
-        return $ sCount >= 120;
+        pure $ sCount >= 120;
       }
 robots:
   - name: base

--- a/data/scenarios/Challenges/hackman.yaml
+++ b/data/scenarios/Challenges/hackman.yaml
@@ -29,7 +29,7 @@ objectives:
       as base {
         pcount <- count "pellet";
         donut_count <- count "donut";
-        return $ pcount >= 181;
+        pure $ pcount >= 181;
       };
   - id: donut_given
     teaser: Give to ghost
@@ -47,12 +47,12 @@ objectives:
           };
 
           if hasPowerup {
-              return true;
+              pure true;
           } {
               if (n > 1) {
                   anyHasPowerup $ n - 1;
               } {
-                  return false;
+                  pure false;
               }
           }
           end;
@@ -68,7 +68,7 @@ objectives:
       loc <- as base {
         whereami;
       };
-      return $ loc == (0, 0);
+      pure $ loc == (0, 0);
   - teaser: World wrap
     hidden: true
     optional: true
@@ -109,10 +109,10 @@ objectives:
               if (n > 1) {
                   allHasPowerup $ n - 1;
               } {
-                  return true;
+                  pure true;
               }
           } {
-              return false;
+              pure false;
           }
           end;
 

--- a/data/scenarios/Challenges/hanoi.yaml
+++ b/data/scenarios/Challenges/hanoi.yaml
@@ -13,7 +13,7 @@ objectives:
       y <- ishere "blocked two";
       teleport self (2,-3);
       z <- ishere "blocked three";
-      return (x && y && z)
+      pure (x && y && z)
 solution: |
   run "scenarios/Challenges/_hanoi/hanoi-solution.sw"
 robots:

--- a/data/scenarios/Challenges/lights-out.yaml
+++ b/data/scenarios/Challenges/lights-out.yaml
@@ -27,13 +27,13 @@ objectives:
           if (n > 0) {
               onHere <- ishere "on";
               if onHere {
-                  return false;
+                  pure false;
               } {
                   move;
                   isRowDark $ n - 1;
               }
           } {
-              return true;
+              pure true;
           }
           end;
 
@@ -44,10 +44,10 @@ objectives:
                   advanceRow;
                   areAllOff rowWidth $ n - 1;
               } {
-                  return false;
+                  pure false;
               }
           } {
-              return true;
+              pure true;
           }
           end;
 
@@ -57,7 +57,7 @@ objectives:
               teleport self (0, 0);
               turn east;
               areAllOff 5 5;
-          } {return false};
+          } {pure false};
           end;
 
       j <- robotnamed "judge";

--- a/data/scenarios/Challenges/pack-tetrominoes.yaml
+++ b/data/scenarios/Challenges/pack-tetrominoes.yaml
@@ -22,7 +22,7 @@ objectives:
     condition: |
       def found = \s.
         fs <- structures s;
-        return $ case fs (\_. false) (\_. true);
+        pure $ case fs (\_. false) (\_. true);
         end;
 
       foundT <- found "tee";
@@ -30,7 +30,7 @@ objectives:
       foundI <- found "line";
       foundZ <- found "zee";
       foundQ <- found "square";
-      return $ foundT && foundJ && foundI && foundZ && foundQ;
+      pure $ foundT && foundJ && foundI && foundZ && foundQ;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Challenges/telephone.yaml
+++ b/data/scenarios/Challenges/telephone.yaml
@@ -28,7 +28,7 @@ objectives:
     condition: |
       as base {
         pcount <- count "paper";
-        return $ pcount >= 8;
+        pure $ pcount >= 8;
       };
   - teaser: Duplicate the design
     prerequisite: 'paper'

--- a/data/scenarios/Challenges/teleport.yaml
+++ b/data/scenarios/Challenges/teleport.yaml
@@ -11,7 +11,7 @@ objectives:
     condition: |
       try {
         as base {has "lambda"}
-      } { return false }
+      } { pure false }
 solution: |
   def w2 = turn back; turn back end;
   def w10 = w2; w2; w2; w2; w2 end;

--- a/data/scenarios/Challenges/wave.yaml
+++ b/data/scenarios/Challenges/wave.yaml
@@ -21,7 +21,7 @@ objectives:
       - |
         The robots caught you!
     condition: |
-      as base {x <- meet; return $ case x (\_. false) (\_. true)};
+      as base {x <- meet; pure $ case x (\_. false) (\_. true)};
 robots:
   - name: base
     dir: north

--- a/data/scenarios/Challenges/word-search.yaml
+++ b/data/scenarios/Challenges/word-search.yaml
@@ -15,7 +15,7 @@ objectives:
         Diagonal appearances are not valid.
     condition: |
       foundStructures <- structures "cow";
-      return $ case foundStructures (\_. false) (\_. true);
+      pure $ case foundStructures (\_. false) (\_. true);
 robots:
   - name: base
     display:

--- a/data/scenarios/Fun/GoL.yaml
+++ b/data/scenarios/Fun/GoL.yaml
@@ -33,7 +33,7 @@ robots:
         h <- scan down;
         f <- scan forward;
         b <- scan back;
-        return (cnt h + cnt f + cnt b)
+        pure (cnt h + cnt f + cnt b)
       end;
       def mod : Int -> Int -> Int = \a. \b. a - (a/b)*b end;
       def waitUntil = \p.
@@ -42,20 +42,20 @@ robots:
       end;
       forever (
         h <- scan down;
-        alive <- return (h != inl ());
+        alive <- pure (h != inl ());
         n1 <- count3;
         turn left; move; turn right; n2 <- count3;
         turn right; move; move; turn left; n3 <- count3;
         turn left; move; turn right;
-        total <- return (n1 + n2 + n3 - if alive {1} {0});
+        total <- pure (n1 + n2 + n3 - if alive {1} {0});
         if (alive && (total < 2 || total > 3))
-          { grab; return () }
+          { grab; pure () }
           { if (not alive && total == 3)
             { place "rock" }
             {}
           };
         // synchronize
-        waitUntil (t <- time; return (mod t 0x20 == 0))
+        waitUntil (t <- time; pure (mod t 0x20 == 0))
       )
 world:
   dsl: |

--- a/data/scenarios/Fun/_logo-burst/drone.sw
+++ b/data/scenarios/Fun/_logo-burst/drone.sw
@@ -8,7 +8,7 @@ def else = \t. t end
 
 def randdir : Cmd Dir =
   d <- random 4;
-  return (
+  pure (
     if (d == 0) {north}
     $ elif (d == 1) {east}
     $ elif (d == 2) {south}

--- a/data/scenarios/Fun/_snake/snake.sw
+++ b/data/scenarios/Fun/_snake/snake.sw
@@ -86,7 +86,7 @@ def doAtLoc = \currLoc. \targetLoc. \func.
   teleport self targetLoc;
   x <- func;
   teleport self currLoc;
-  return x;
+  pure x;
   end;
 
 def moveTail = \tailList.
@@ -95,7 +95,7 @@ def moveTail = \tailList.
     let maybeShifted = pop tailList in
     case maybeShifted (\_.
       // Nothing to pick up or replace
-      return tailList;
+      pure tailList;
 
     ) (\newPair.
 
@@ -105,10 +105,10 @@ def moveTail = \tailList.
         grabbedItem <- doAtLoc newLoc farthestTail grab;
         place grabbedItem;
 
-        return $ snoc newLoc newInit;
+        pure $ snoc newLoc newInit;
     );
   } {
-    return tailList;
+    pure tailList;
   }
   end;
 
@@ -119,11 +119,11 @@ def moveOneStep = \tailList.
     targetLoc <- as r {whereami};
 
     maybeD <- getDir targetLoc;
-    case maybeD (\_. say "Dead!"; return "") (\d.
+    case maybeD (\_. say "Dead!"; pure "") (\d.
       turn $ fst d;
       newList <- moveTail tailList;
       move;
-      return newList
+      pure newList
     );
     end
 
@@ -139,10 +139,10 @@ def moveToApple = \tailList.
     modifiedTailList <- try {
       make "tail";
       swap "tail";
-      return $ snoc myLoc tailList;
+      pure $ snoc myLoc tailList;
     } {
       grab;
-      return tailList;
+      pure tailList;
     };
     // Need to move here so that we get out of the way
     // if the tail gets elongated

--- a/data/scenarios/Fun/horton.yaml
+++ b/data/scenarios/Fun/horton.yaml
@@ -12,7 +12,7 @@ objectives:
     condition: |
       as base {
         flowerCount <- count "flower";
-        return $ flowerCount >= 399;
+        pure $ flowerCount >= 399;
       }
 robots:
   - name: Horton
@@ -41,7 +41,7 @@ solution: |
 
   def followRoute =
       nextDir <- path (inL ()) (inR "flower");
-      case nextDir return $ goDir followRoute;
+      case nextDir pure $ goDir followRoute;
       end;
 
   followRoute;

--- a/data/scenarios/Fun/snake.yaml
+++ b/data/scenarios/Fun/snake.yaml
@@ -13,7 +13,7 @@ objectives:
       r <- robotnamed "snake";
       as r {
         appleCoreCount <- count "apple core";
-        return $ appleCoreCount >= 40;
+        pure $ appleCoreCount >= 40;
       }
 robots:
   - name: base

--- a/data/scenarios/Speedruns/forester.yaml
+++ b/data/scenarios/Speedruns/forester.yaml
@@ -5,7 +5,7 @@ description: Race to harvest 1024 `tree`{=entity}s as quickly as possible. See t
 objectives:
   - goal:
       - Harvest 1024 `tree`{=entity}s as quickly as possible!
-    condition: as base {n <- count "tree"; return (n >= 1024)}
+    condition: as base {n <- count "tree"; pure (n >= 1024)}
 robots:
   - name: base
     loc: [0, 0]

--- a/data/scenarios/Testing/1024-sand.yaml
+++ b/data/scenarios/Testing/1024-sand.yaml
@@ -6,7 +6,7 @@ description: |
   https://github.com/swarm-game/swarm/pull/1024
 objectives:
   - condition: |
-      as base {n <- count "sand"; return (n >= 32)}
+      as base {n <- count "sand"; pure (n >= 32)}
     goal:
       - Obtain 32 sand.
 solution: |

--- a/data/scenarios/Testing/1034-custom-attributes.yaml
+++ b/data/scenarios/Testing/1034-custom-attributes.yaml
@@ -61,7 +61,7 @@ objectives:
       - Do nothing
     condition: |
       pos <- as base {whereami};
-      return $ fst pos > 7;
+      pure $ fst pos > 7;
 entities:
   - name: color1
     display:

--- a/data/scenarios/Testing/1140-detect-command.yaml
+++ b/data/scenarios/Testing/1140-detect-command.yaml
@@ -10,7 +10,7 @@ objectives:
 solution: |
   def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
   loc <- detect "tree" ((0, 0), (6, 4));
-  case loc return (\delta.
+  case loc pure (\delta.
     let xDelta = fst delta in
     let yDelta = snd delta in
     if (yDelta < 0) {turn south;} {};
@@ -18,7 +18,7 @@ solution: |
     if (xDelta < 0) {turn west;} {turn east};
     doN xDelta move; // x-movement
     grab;
-    return ();
+    pure ();
   );
 robots:
   - name: base

--- a/data/scenarios/Testing/1157-drill-return-value.yaml
+++ b/data/scenarios/Testing/1157-drill-return-value.yaml
@@ -8,7 +8,7 @@ objectives:
       as base {ishere "gumball"};
 solution: |
   out <- drill forward;
-  case out return place;
+  case out pure place;
 robots:
   - name: base
     dir: north

--- a/data/scenarios/Testing/1171-resonate-command.yaml
+++ b/data/scenarios/Testing/1171-resonate-command.yaml
@@ -9,7 +9,7 @@ objectives:
       j <- robotnamed "judge";
       as j {
         c <- resonate "tree" ((0, 0), (8, -2));
-        return $ c >= 7;
+        pure $ c >= 7;
       };
 solution: |
   def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;

--- a/data/scenarios/Testing/1171-sniff-command.yaml
+++ b/data/scenarios/Testing/1171-sniff-command.yaml
@@ -16,9 +16,9 @@ solution: |
         turn back;
         move;
         turn left;
-        return oldDistance;
+        pure oldDistance;
       } {
-        return newDistance;
+        pure newDistance;
       };
       homeIn item d;
     } {

--- a/data/scenarios/Testing/1218-stride-command.yaml
+++ b/data/scenarios/Testing/1218-stride-command.yaml
@@ -26,7 +26,7 @@ solution: |
   try {
     stride 5;
     grab;
-    return ();
+    pure ();
   } {
     log "Could not grab northern flower";
   };
@@ -42,7 +42,7 @@ solution: |
   try {
     stride 5;
     grab;
-    return ();
+    pure ();
   } {
     log "Could not grab southern flower";
   };

--- a/data/scenarios/Testing/1256-halt-command.yaml
+++ b/data/scenarios/Testing/1256-halt-command.yaml
@@ -9,7 +9,7 @@ objectives:
       as base {has "flower"}
 solution: |
   mr <- meet;
-  case mr (\_. return ()) (\r. halt r; turn west; move; salvage )
+  case mr (\_. pure ()) (\r. halt r; turn west; move; salvage )
 robots:
   - name: base
     dir: south

--- a/data/scenarios/Testing/1271-wall-boundaries.yaml
+++ b/data/scenarios/Testing/1271-wall-boundaries.yaml
@@ -17,7 +17,7 @@ objectives:
     condition: |
       as base {
         hasFence <- has "fence";
-        return $ not hasFence;
+        pure $ not hasFence;
       }
 solution: |
   def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;

--- a/data/scenarios/Testing/1295-density-command.yaml
+++ b/data/scenarios/Testing/1295-density-command.yaml
@@ -9,7 +9,7 @@ objectives:
       j <- robotnamed "judge";
       as j {
         c <- density ((0, 0), (3, 3));
-        return $ c <= 13;
+        pure $ c <= 13;
       };
 solution: |
   def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;

--- a/data/scenarios/Testing/1320-world-DSL/constant.yaml
+++ b/data/scenarios/Testing/1320-world-DSL/constant.yaml
@@ -5,7 +5,7 @@ description: |
   single cell value.
 objectives:
   - condition: |
-      as base { n <- count "tree"; return (n >= 4) }
+      as base { n <- count "tree"; pure (n >= 4) }
     goal:
       - Get 4 trees
 solution: |

--- a/data/scenarios/Testing/1320-world-DSL/erase.yaml
+++ b/data/scenarios/Testing/1320-world-DSL/erase.yaml
@@ -4,7 +4,7 @@ description: |
   Test that we can erase entities when overlaying
 objectives:
   - condition: |
-      as base { n <- count "tree"; return (n == 0) }
+      as base { n <- count "tree"; pure (n == 0) }
     goal:
       - Get rid of your trees.
 solution: |

--- a/data/scenarios/Testing/1320-world-DSL/override.yaml
+++ b/data/scenarios/Testing/1320-world-DSL/override.yaml
@@ -4,7 +4,7 @@ description: |
   Test that later entities override earlier ones when overlaying
 objectives:
   - condition: |
-      as base { n <- count "tree"; return (n == 1) }
+      as base { n <- count "tree"; pure (n == 1) }
     goal:
       - Get a tree.
 solution: |

--- a/data/scenarios/Testing/1320-world-DSL/reflect.yaml
+++ b/data/scenarios/Testing/1320-world-DSL/reflect.yaml
@@ -8,7 +8,7 @@ objectives:
   - goal:
       - Pick up four trees
     condition: |
-      as base {n <- count "tree"; return (n >= 4)}
+      as base {n <- count "tree"; pure (n >= 4)}
 robots:
   - name: base
     loc: [0, 0]
@@ -27,7 +27,7 @@ solution: |
   def x = \n. \c. if (n==0) {} {c; x (n-1) c} end
   def ifC = \p. \t. \e. b <- p; if b t e end
   def findTree = ifC (ishere "tree") {whereami} {move; findTree} end
-  def ell = \d. turn right; x (2*d) move; grab; return () end
+  def ell = \d. turn right; x (2*d) move; grab; pure () end
   def grabTrees = \loc. let x = fst loc in let y = snd loc in grab; ell y; ell x; ell y end
   n <- random 10;
   x (n+1) move; turn right; move;

--- a/data/scenarios/Testing/1322-wait-with-instant.yaml
+++ b/data/scenarios/Testing/1322-wait-with-instant.yaml
@@ -19,7 +19,7 @@ objectives:
 
       let xDiff = fst hareloc - fst tortoiseloc in
 
-      return $ fst hareloc == 0 && xDiff == 3;
+      pure $ fst hareloc == 0 && xDiff == 3;
 solution: |
   noop;
 robots:

--- a/data/scenarios/Testing/1341-command-count.yaml
+++ b/data/scenarios/Testing/1341-command-count.yaml
@@ -22,7 +22,7 @@ solution: |
     move;
     grab;
   } {
-    return "";
+    pure "";
   };
 robots:
   - name: base

--- a/data/scenarios/Testing/1356-portals/_automatic-waypoint-patrol/program.sw
+++ b/data/scenarios/Testing/1356-portals/_automatic-waypoint-patrol/program.sw
@@ -15,7 +15,7 @@ def negateTuple = \t.
 
 def getRelativeLocation = \absCurrentLoc. \absDestLoc.
     let negatedLoc = negateTuple absCurrentLoc in
-    return $ sumTuples negatedLoc absDestLoc;
+    pure $ sumTuples negatedLoc absDestLoc;
     end;
 
 def moveTuple = \tup.

--- a/data/scenarios/Testing/1356-portals/_portals-flip-and-rotate/solution.sw
+++ b/data/scenarios/Testing/1356-portals/_portals-flip-and-rotate/solution.sw
@@ -16,7 +16,7 @@ def negateTuple = \t.
 
 def getRelativeLocation = \absCurrentLoc. \absDestLoc.
     let negatedLoc = negateTuple absCurrentLoc in
-    return $ sumTuples negatedLoc absDestLoc;
+    pure $ sumTuples negatedLoc absDestLoc;
     end;
 
 def moveTuple = \tup.

--- a/data/scenarios/Testing/1430-built-robot-ownership.yaml
+++ b/data/scenarios/Testing/1430-built-robot-ownership.yaml
@@ -48,7 +48,7 @@ objectives:
     condition: |
       r2 <- robotNumbered 2;
       r3 <- robotNumbered 3;
-      return true
+      pure true
 known: []
 world:
   palette:

--- a/data/scenarios/Testing/144-subworlds/_subworld-located-robots/solution.sw
+++ b/data/scenarios/Testing/144-subworlds/_subworld-located-robots/solution.sw
@@ -6,5 +6,5 @@ f <- grab;
 
 doN 5 move;
 r <- meet;
-case r return $ \j. give j f;
+case r pure $ \j. give j f;
 

--- a/data/scenarios/Testing/144-subworlds/_subworld-mapped-robots/judges.sw
+++ b/data/scenarios/Testing/144-subworlds/_subworld-mapped-robots/judges.sw
@@ -2,7 +2,7 @@
 def getRobotNumber = \n.
     r <- robotnumbered n;
     if (r == self) {
-        return n;
+        pure n;
     } {getRobotNumber $ n + 1};
     end;
 
@@ -10,7 +10,7 @@ def amLowestRecursive = \targetName. \idx.
     r <- robotnumbered idx;
     thisName <- as r {whoami};
     if (thisName == targetName) {
-        return $ r == self;
+        pure $ r == self;
     } {amLowestRecursive targetName $ idx + 1};
     end;
 

--- a/data/scenarios/Testing/144-subworlds/_subworld-mapped-robots/solution.sw
+++ b/data/scenarios/Testing/144-subworlds/_subworld-mapped-robots/solution.sw
@@ -4,5 +4,5 @@ def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;
 doN 16 move;
 
 r <- meet;
-case r return $ \j. give j "bitcoin";
+case r pure $ \j. give j "bitcoin";
 

--- a/data/scenarios/Testing/144-subworlds/teleport-and-query.yaml
+++ b/data/scenarios/Testing/144-subworlds/teleport-and-query.yaml
@@ -10,7 +10,7 @@ objectives:
     condition: |
       as base {
         myloc <- locateme;
-        return $ fst myloc == "underground";
+        pure $ fst myloc == "underground";
       }
 solution: |
   noop

--- a/data/scenarios/Testing/1533-sow-command.yaml
+++ b/data/scenarios/Testing/1533-sow-command.yaml
@@ -34,7 +34,7 @@ objectives:
       r <- robotnamed "kudzubot";
       as r {
         kCount <- resonate "kudzu" ((0, 0), (10, 4));
-        return $ kCount >= 45;
+        pure $ kCount >= 45;
       }
 solution: |
   def doN = \n. \f. if (n > 0) {f; doN (n - 1) f} {}; end;

--- a/data/scenarios/Testing/1533-sow-seed-maturation.yaml
+++ b/data/scenarios/Testing/1533-sow-seed-maturation.yaml
@@ -22,7 +22,7 @@ objectives:
     condition: |
       as base {
         x <- has "acorn";
-        return $ not x;
+        pure $ not x;
       }
   - goal:
       - |

--- a/data/scenarios/Testing/1535-ping/1535-out-of-range.yaml
+++ b/data/scenarios/Testing/1535-ping/1535-out-of-range.yaml
@@ -11,7 +11,7 @@ objectives:
       r <- robotnamed "buddy";
       as r {
         response <- ping base;
-        return $ case response (\_. true) (\_. false);
+        pure $ case response (\_. true) (\_. false);
       }
 solution: |
   run "scenarios/Testing/1535-ping/_1535-out-of-range/solution.sw"

--- a/data/scenarios/Testing/1535-ping/_1535-in-range/solution.sw
+++ b/data/scenarios/Testing/1535-ping/_1535-in-range/solution.sw
@@ -7,9 +7,9 @@ def goToBuddy = \loc.
     let longitudinalDist = snd loc in
     absFwd <- if (longitudinalDist < 0) {
         turn back;
-        return $ -longitudinalDist;
+        pure $ -longitudinalDist;
     } {
-        return longitudinalDist;
+        pure longitudinalDist;
     };
     doN absFwd move;
     if (longitudinalDist < 0) {
@@ -19,10 +19,10 @@ def goToBuddy = \loc.
     let lateralDist = fst loc in
     absSide <- if (lateralDist < 0) {
         turn left;
-        return $ -lateralDist;
+        pure $ -lateralDist;
     } {
         turn right;
-        return lateralDist;
+        pure lateralDist;
     };
     doN absSide move;
     end;
@@ -30,7 +30,7 @@ def goToBuddy = \loc.
 def checkNeedToMove = \f. \loc.
     wait 3;
     if (loc == (0, 0)) {
-        return ()
+        pure ()
     } {
         goToBuddy loc;
         f;
@@ -39,7 +39,7 @@ def checkNeedToMove = \f. \loc.
 
 def pingLoop = \buddy.
     maybeLoc <- ping buddy;
-    case maybeLoc return $ checkNeedToMove $ pingLoop buddy;
+    case maybeLoc pure $ checkNeedToMove $ pingLoop buddy;
     end;
 
 def giveToBuddy = \buddy.
@@ -50,7 +50,7 @@ def giveToBuddy = \buddy.
 def go =
     move;
     maybeBuddy <- meet;
-    case maybeBuddy return giveToBuddy;
+    case maybeBuddy pure giveToBuddy;
     grab;
     end;
 

--- a/data/scenarios/Testing/1569-pathfinding-cache/1569-harvest-batch.yaml
+++ b/data/scenarios/Testing/1569-pathfinding-cache/1569-harvest-batch.yaml
@@ -12,7 +12,7 @@ objectives:
     condition: |
       as base {
         fCount <- count "flower";
-        return $ fCount >= 4;
+        pure $ fCount >= 4;
       };
 solution: |
   def goDir = \f. \result.
@@ -22,7 +22,7 @@ solution: |
 
   def followRoute =
       nextDir <- path (inL ()) (inR "flower");
-      case nextDir return $ goDir followRoute;
+      case nextDir pure $ goDir followRoute;
       end;
 
   followRoute;

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-bounding-box-overlap.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-bounding-box-overlap.yaml
@@ -18,7 +18,7 @@ objectives:
         case l (\_. 0) (\cons. 1 + length (snd cons))
       end;
       foundStructures <- structures "chevron";
-      return $ length foundStructures >= 3
+      pure $ length foundStructures >= 3
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-browse-structures.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-browse-structures.yaml
@@ -15,7 +15,7 @@ objectives:
         Build a `precious`{=structure} structure
     condition: |
       foundStructure <- structures "precious";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-construction-count.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-construction-count.yaml
@@ -13,7 +13,7 @@ objectives:
         case l (\_. 0) (\cons. 1 + length (snd cons))
       end;
       foundGreen <- structures "green_jewel";
-      return $ length foundGreen >= 12;
+      pure $ length foundGreen >= 12;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-disjoint.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-disjoint.yaml
@@ -20,7 +20,7 @@ objectives:
         case l (\_. 0) (\cons. 1 + length (snd cons))
       end;
       foundStructures <- structures "chessboard";
-      return $ length foundStructures >= 2
+      pure $ length foundStructures >= 2
   - id: premature_win
     teaser: Don't count win early
     optional: true
@@ -35,7 +35,7 @@ objectives:
       robotHasSilver <- as base {has "silver"};
 
       foundStructures <- structures "chessboard";
-      return $ length foundStructures >= 2 && robotHasSilver;
+      pure $ length foundStructures >= 2 && robotHasSilver;
 robots:
   - name: base
     dir: south

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-single-recognition.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-ensure-single-recognition.yaml
@@ -17,7 +17,7 @@ objectives:
         case l (\_. 0) (\cons. 1 + length (snd cons))
       end;
       foundStructures <- structures "chessboard";
-      return $ length foundStructures >= 2;
+      pure $ length foundStructures >= 2;
   - id: premature_win
     teaser: Don't count win early
     optional: true
@@ -32,7 +32,7 @@ objectives:
       robotHasGold <- as base {has "gold"};
 
       foundStructures <- structures "chessboard";
-      return $ length foundStructures >= 2 && robotHasGold;
+      pure $ length foundStructures >= 2 && robotHasGold;
 robots:
   - name: base
     dir: south

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-floorplan-command.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-floorplan-command.yaml
@@ -12,7 +12,7 @@ objectives:
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
       foundBox <- structures "wooden box";
-      return $ isRight foundBox;
+      pure $ isRight foundBox;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-handle-overlapping.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-handle-overlapping.yaml
@@ -11,7 +11,7 @@ objectives:
         Build a `precious`{=structure} structure
     condition: |
       foundStructure <- structures "precious";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-interior-entity-placement.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-interior-entity-placement.yaml
@@ -18,7 +18,7 @@ objectives:
         Place the `rock`{=entity} entity back inside the `pigpen`{=structure}.
     condition: |
       foundBoxes <- structures "pigpen";
-      case foundBoxes (\_. return false) (\cons.
+      case foundBoxes (\_. pure false) (\cons.
         let structPos = fst cons in
         j <- robotnamed "judge";
         as j {
@@ -28,7 +28,7 @@ objectives:
           teleport self structPos;
 
           rockCount <- resonate "rock" ((0, 0), structBounds);
-          return $ rockCount > 0;
+          pure $ rockCount > 0;
         }
       );
   - teaser: Grab rock
@@ -50,7 +50,7 @@ objectives:
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
       foundBoxes <- structures "pigpen";
-      return $ isRight foundBoxes;
+      pure $ isRight foundBoxes;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-nested-structure-definition.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-nested-structure-definition.yaml
@@ -14,7 +14,7 @@ objectives:
         The `double ring`{=structure} structure should be recognized again.
     condition: |
       foundStructure <- structures "double ring";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
   - teaser: Pre-recognized
     id: pre_recognized
     prerequisite:
@@ -24,7 +24,7 @@ objectives:
         Pre-placed structure must be recognized
     condition: |
       foundStructure <- structures "double ring";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
   - teaser: Grab tree
     id: grab_tree
     goal:

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-overlapping-tiebreaker-by-largest.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-overlapping-tiebreaker-by-largest.yaml
@@ -12,7 +12,7 @@ objectives:
         Build a 3x3 structure
     condition: |
       foundStructure <- structures "large";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
   - id: wrong_structure
     teaser: Don't recognize small structure
     optional: true
@@ -21,7 +21,7 @@ objectives:
         The small structure shouldn't be recognized.
     condition: |
       foundStructure <- structures "small";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-overlapping-tiebreaker-by-location.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-overlapping-tiebreaker-by-location.yaml
@@ -13,7 +13,7 @@ objectives:
         Build a `topleft`{=structure} structure
     condition: |
       foundStructure <- structures "topleft";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
   - id: wrong_structure
     teaser: Don't recognize small structure
     optional: true
@@ -22,7 +22,7 @@ objectives:
         The `bottomright`{=structure} structure shouldn't be recognized.
     condition: |
       foundStructure <- structures "bottomright";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-placement-occlusion.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-placement-occlusion.yaml
@@ -16,7 +16,7 @@ objectives:
       def isRight = \x. case x (\_. false) (\_. true); end;
 
       foundGreen <- structures "green_jewel";
-      return $ isRight foundGreen;
+      pure $ isRight foundGreen;
   - id: complete_red_structure
     optional: true
     teaser: Complete red structure
@@ -27,7 +27,7 @@ objectives:
       def isRight = \x. case x (\_. false) (\_. true); end;
 
       foundRed <- structures "red_jewel";
-      return $ isRight foundRed;
+      pure $ isRight foundRed;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-remove-structure.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-remove-structure.yaml
@@ -12,7 +12,7 @@ objectives:
         Remove a piece of the structure to destroy it
     condition: |
       foundStructures <- structures "chessboard";
-      return $ case foundStructures (\_. true) (\_. false);
+      pure $ case foundStructures (\_. true) (\_. false);
   - id: complete_structure
     teaser: Complete structure
     goal:
@@ -20,7 +20,7 @@ objectives:
         Build a `chessboard`{=structure} structure
     condition: |
       foundStructures <- structures "chessboard";
-      return $ case foundStructures (\_. false) (\_. true);
+      pure $ case foundStructures (\_. false) (\_. true);
 robots:
   - name: base
     dir: south

--- a/data/scenarios/Testing/1575-structure-recognizer/1575-swap-structure.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1575-swap-structure.yaml
@@ -16,7 +16,7 @@ objectives:
       foundBlue <- structures "blue_jewel";
       foundGreen <- structures "green_jewel";
       foundRed <- structures "red_jewel";
-      return $ isRight foundBlue && not (isRight foundRed) && not (isRight foundRed);
+      pure $ isRight foundBlue && not (isRight foundRed) && not (isRight foundRed);
   - id: complete_green_structure
     teaser: Complete green structure
     prerequisite: complete_red_structure
@@ -28,7 +28,7 @@ objectives:
 
       foundGreen <- structures "green_jewel";
       foundRed <- structures "red_jewel";
-      return $ isRight foundGreen && not (isRight foundRed);
+      pure $ isRight foundGreen && not (isRight foundRed);
   - id: complete_red_structure
     teaser: Complete red structure
     goal:
@@ -38,7 +38,7 @@ objectives:
       def isRight = \x. case x (\_. false) (\_. true); end;
 
       foundRed <- structures "red_jewel";
-      return $ isRight foundRed;
+      pure $ isRight foundRed;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1644-rotated-preplacement-recognition.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1644-rotated-preplacement-recognition.yaml
@@ -10,7 +10,7 @@ objectives:
         Have a `tee`{=structure} structure
     condition: |
       foundStructure <- structures "tee";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/1644-rotated-recognition.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/1644-rotated-recognition.yaml
@@ -10,7 +10,7 @@ objectives:
         Build a `tee`{=structure} structure
     condition: |
       foundStructure <- structures "tee";
-      return $ case foundStructure (\_. false) (\_. true);
+      pure $ case foundStructure (\_. false) (\_. true);
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/2115-encroaching-upon-exterior-transparent-cells.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2115-encroaching-upon-exterior-transparent-cells.yaml
@@ -20,7 +20,7 @@ objectives:
       def isRight = \x. case x (\_. false) (\_. true); end;
 
       foundBoxes <- structures "chevron";
-      return $ isRight foundBoxes;
+      pure $ isRight foundBoxes;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/2115-encroaching-upon-interior-transparent-cells.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2115-encroaching-upon-interior-transparent-cells.yaml
@@ -19,7 +19,7 @@ objectives:
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
       foundBoxes <- structures "pigpen";
-      return $ isRight foundBoxes;
+      pure $ isRight foundBoxes;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/2201-initial-recognition-overlap.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2201-initial-recognition-overlap.yaml
@@ -22,7 +22,7 @@ objectives:
         case l (\_. 0) (\c. 1 + length (snd c))
       end;
       foundStructures <- structures "square";
-      return $ length foundStructures == 1;
+      pure $ length foundStructures == 1;
 robots:
   - name: base
     dir: north

--- a/data/scenarios/Testing/1575-structure-recognizer/2201-piecewise-lines.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2201-piecewise-lines.yaml
@@ -16,7 +16,7 @@ objectives:
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
       foundStructures <- structures "spaceship";
-      return $ isRight foundStructures;
+      pure $ isRight foundStructures;
 robots:
   - name: base
     dir: east

--- a/data/scenarios/Testing/1575-structure-recognizer/2201-preclude-overlapping-recognition.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2201-preclude-overlapping-recognition.yaml
@@ -11,7 +11,7 @@ objectives:
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
       foundStructures <- structures "line";
-      return $ isRight foundStructures;
+      pure $ isRight foundStructures;
   - teaser: Recognize second structure
     id: found_elbow
     optional: true
@@ -21,7 +21,7 @@ objectives:
     condition: |
       def isRight = \x. case x (\_. false) (\_. true); end;
       foundStructures <- structures "elbow";
-      return $ isRight foundStructures;
+      pure $ isRight foundStructures;
   - teaser: Grab tree
     prerequisite:
       not: found_elbow

--- a/data/scenarios/Testing/1575-structure-recognizer/2229-position-uniqueness-multiple-orientations.yaml
+++ b/data/scenarios/Testing/1575-structure-recognizer/2229-position-uniqueness-multiple-orientations.yaml
@@ -20,7 +20,7 @@ objectives:
         case l (\_. 0) (\c. 1 + length (snd c))
       end;
       foundStructures <- structures "thingy";
-      return $ length foundStructures == 2;
+      pure $ length foundStructures == 2;
 robots:
   - name: base
     dir: north

--- a/data/scenarios/Testing/1631-tags.yaml
+++ b/data/scenarios/Testing/1631-tags.yaml
@@ -16,8 +16,8 @@ objectives:
     condition: |
       def hasAny : (rec l. Unit + Text * l) -> Cmd Bool = \items.
         case items
-          (\_. return false)
-          (\c. b <- has (fst c); if b {return true} {hasAny (snd c)})
+          (\_. pure false)
+          (\c. b <- has (fst c); if b {pure true} {hasAny (snd c)})
       end;
 
       let prohibited = tagmembers "fruit" in
@@ -28,15 +28,15 @@ objectives:
 solution: |
   def findTarget =
     result <- scan down;
-    isTarget <- case result (\_. return false) (\item.
+    isTarget <- case result (\_. pure false) (\item.
       let isEdible = hastag item "edible" in
       let isFruit = hastag item "fruit" in
-      return $ isEdible && not isFruit;
+      pure $ isEdible && not isFruit;
     );
 
     if isTarget {
       grab;
-      return ();
+      pure ();
     } {
       move;
       findTarget;

--- a/data/scenarios/Testing/1642-biomes.yaml
+++ b/data/scenarios/Testing/1642-biomes.yaml
@@ -15,7 +15,7 @@ objectives:
     condition: |
       as base {
         c <- count "wheat";
-        return $ c == 2;
+        pure $ c == 2;
       }
   - id: western_wheat_regrew
     optional: true
@@ -40,7 +40,7 @@ objectives:
       baseLoc <- as base {whereami};
       as goalbot {
         goalLoc <- whereami;
-        return $ baseLoc == goalLoc;
+        pure $ baseLoc == goalLoc;
       }
     prerequisite:
       logic:

--- a/data/scenarios/Testing/1721-custom-walkable-entities.yaml
+++ b/data/scenarios/Testing/1721-custom-walkable-entities.yaml
@@ -16,7 +16,7 @@ objectives:
       m <- robotnamed "monkey";
       as m {
         p <- path (inR 10) (inR "banana");
-        return $ case p (\_. false) (\_. true);
+        pure $ case p (\_. false) (\_. true);
       };
   - id: placed_tree
     teaser: Tree placed
@@ -26,7 +26,7 @@ objectives:
       - Tree must be placed
     condition: |
       x <- as base {has "tree"};
-      return $ not x;
+      pure $ not x;
 solution: |
   move;
   move;

--- a/data/scenarios/Testing/1721-walkability-whitelist-path-cache.yaml
+++ b/data/scenarios/Testing/1721-walkability-whitelist-path-cache.yaml
@@ -10,12 +10,12 @@ objectives:
 solution: |
   def goDir = \f. \result.
     let d = fst result in
-    if (d == down) {return ()} {turn d; move; f;}
+    if (d == down) {pure ()} {turn d; move; f;}
     end;
 
   def followRoute =
       nextDir <- path (inL ()) (inR "platform");
-      case nextDir return $ goDir followRoute;
+      case nextDir pure $ goDir followRoute;
       end;
 
   followRoute;

--- a/data/scenarios/Testing/1747-volume-command.yaml
+++ b/data/scenarios/Testing/1747-volume-command.yaml
@@ -11,7 +11,7 @@ objectives:
       as base {
         let targetVolume = 14 in
         vol <- volume targetVolume;
-        return $case vol (\_. false) (\x. x == targetVolume);
+        pure $case vol (\_. false) (\x. x == targetVolume);
       }
 solution: |
   move;

--- a/data/scenarios/Testing/1777-capability-cost.yaml
+++ b/data/scenarios/Testing/1777-capability-cost.yaml
@@ -17,10 +17,10 @@ objectives:
         judge <- robotnamed "judge";
         as judge {
           maybePath <- path (inL ()) (inR "packing peanut");
-          return $ case maybePath (\_. true) (\d. false);
+          pure $ case maybePath (\_. true) (\d. false);
         }
       } {
-        return false;
+        pure false;
       };
 solution: |
   move;

--- a/data/scenarios/Testing/1780-structure-merge-expansion/coordinate-offset-propagation.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/coordinate-offset-propagation.yaml
@@ -15,7 +15,7 @@ objectives:
   - goal:
       - Enjoy the view.
     condition: |
-      return true
+      pure true
 solution: |
   noop
 known: [boulder, log, pixel (R), pixel (G), pixel (B), gold]

--- a/data/scenarios/Testing/1780-structure-merge-expansion/sequential-placement.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/sequential-placement.yaml
@@ -21,7 +21,7 @@ objectives:
         g <- countColor "pixel (G)";
         b <- countColor "pixel (B)";
         y <- countColor "gold";
-        return $ r == 3 && g == 3 && b == 3 && y == 3;
+        pure $ r == 3 && g == 3 && b == 3 && y == 3;
       }
 solution: |
   noop

--- a/data/scenarios/Testing/1780-structure-merge-expansion/simultaneous-north-and-west-offset.yaml
+++ b/data/scenarios/Testing/1780-structure-merge-expansion/simultaneous-north-and-west-offset.yaml
@@ -12,7 +12,7 @@ objectives:
   - goal:
       - Enjoy the view.
     condition: |
-      return true
+      pure true
 solution: |
   noop
 known: [pixel (R), gold]

--- a/data/scenarios/Testing/201-require/1664-require-system-robot-children.yaml
+++ b/data/scenarios/Testing/201-require/1664-require-system-robot-children.yaml
@@ -11,9 +11,9 @@ objectives:
   - condition: |
       try {
         robotnamed "childbot";
-        return true;
+        pure true;
       } {
-        return false;
+        pure false;
       }
 solution: |
   noop;

--- a/data/scenarios/Testing/201-require/201-require-device-creative.yaml
+++ b/data/scenarios/Testing/201-require/201-require-device-creative.yaml
@@ -11,8 +11,8 @@ objectives:
         boatEquipped <- as r {equipped "boat"};
         b1 <- as r {count "boat"};
         b0 <- as base {count "boat"};
-        return (p == (2,0) && b0 == 0 && boatEquipped && b1 == 0);
-      } { return false }
+        pure (p == (2,0) && b0 == 0 && boatEquipped && b1 == 0);
+      } { pure false }
 creative: true
 solution: |
   build {require "boat"; move; move}

--- a/data/scenarios/Testing/201-require/201-require-device-creative1.yaml
+++ b/data/scenarios/Testing/201-require/201-require-device-creative1.yaml
@@ -11,8 +11,8 @@ objectives:
         boatEquipped <- as r {equipped "boat"};
         b1 <- as r {count "boat"};
         b0 <- as base {count "boat"};
-        return (p == (2,0) && b0 == 1 && boatEquipped && b1 == 0);
-      } { return false }
+        pure (p == (2,0) && b0 == 1 && boatEquipped && b1 == 0);
+      } { pure false }
 creative: true
 solution: |
   build {require "boat"; move; move}

--- a/data/scenarios/Testing/201-require/201-require-device.yaml
+++ b/data/scenarios/Testing/201-require/201-require-device.yaml
@@ -11,8 +11,8 @@ objectives:
         boatEquipped <- as r {equipped "boat"};
         b1 <- as r {count "boat"};
         b0 <- as base {count "boat"};
-        return (p == (2,0) && b0 == 0 && boatEquipped && b1 == 0);
-      } { return false }
+        pure (p == (2,0) && b0 == 0 && boatEquipped && b1 == 0);
+      } { pure false }
 solution: |
   build {require "boat"; move; require "boat"; move}
 robots:

--- a/data/scenarios/Testing/201-require/201-require-entities-def.yaml
+++ b/data/scenarios/Testing/201-require/201-require-entities-def.yaml
@@ -10,8 +10,8 @@ objectives:
         p <- as r {whereami};
         r1 <- as r {count "rock"};
         r0 <- as base {count "rock"};
-        return (p == (4,0) && r0 == 5 && r1 == 1);
-      } { return false }
+        pure (p == (4,0) && r0 == 5 && r1 == 1);
+      } { pure false }
 solution: |
   def mp = move; place "rock" end;
   build { log "hi"; require 5 "rock"; mp; mp; mp; mp }

--- a/data/scenarios/Testing/201-require/201-require-entities.yaml
+++ b/data/scenarios/Testing/201-require/201-require-entities.yaml
@@ -9,8 +9,8 @@ objectives:
         r <- robotNumbered 1;
         r1 <- as r {count "rock"};
         r0 <- as base {count "rock"};
-        return (r0 == 5 && r1 == 3);
-      } { return false }
+        pure (r0 == 5 && r1 == 3);
+      } { pure false }
 solution: |
   build { require 5 "rock"; move; place "rock"; move; place "rock" }
 robots:

--- a/data/scenarios/Testing/201-require/533-reprogram-simple.yaml
+++ b/data/scenarios/Testing/201-require/533-reprogram-simple.yaml
@@ -19,12 +19,12 @@ objectives:
         solarEquipped <- as fred {equipped "solar panel"};
         treadsEquipped <- as fred {equipped "treads"};
 
-        return (p == (2,0)
+        pure (p == (2,0)
                 && boatEquipped && drillEquipped && solarEquipped && treadsEquipped
                 && base_boats == 1 && base_solar == 1
                 && base_treads == 1 && base_drills == 1
                );
-      } { return false }
+      } { pure false }
 solution: |
   fred <- build {require "boat"; setname "fred"};
   wait 5;

--- a/data/scenarios/Testing/201-require/533-reprogram.yaml
+++ b/data/scenarios/Testing/201-require/533-reprogram.yaml
@@ -19,12 +19,12 @@ objectives:
         drillEquipped <- as fred {equipped "metal drill"};
         fred_rocks <- as fred {count "rock"};
 
-        return (p == (2,0) && boatEquipped && drillEquipped
+        pure (p == (2,0) && boatEquipped && drillEquipped
                 && base_boats == 1 && base_solar == 1
                 && base_treads == 1 && base_drills == 1
                 && base_rocks == 42 && fred_rocks == 8
                );
-      } { return false }
+      } { pure false }
 solution: |
   fred <- build {require "boat"; require 5 "rock"; setname "fred"};
   wait 5;

--- a/data/scenarios/Testing/2239-custom-entity.yaml
+++ b/data/scenarios/Testing/2239-custom-entity.yaml
@@ -9,7 +9,7 @@ objectives:
     condition: |
       as base {
         loc <- whereami;
-        return $ loc == (1,0)
+        pure $ loc == (1,0)
       };
 entities:
   - name: rock

--- a/data/scenarios/Testing/373-drill.yaml
+++ b/data/scenarios/Testing/373-drill.yaml
@@ -9,8 +9,8 @@ objectives:
         i <- as base {has "iron ore"};
         c <- as base {has "copper ore"};
         s <- as base {has "rock"};
-        return (i && c && s)
-      } { return false }
+        pure (i && c && s)
+      } { pure false }
 solution: |
   build {
     move; drill forward; turn back; move; turn left;

--- a/data/scenarios/Testing/378-objectives.yaml
+++ b/data/scenarios/Testing/378-objectives.yaml
@@ -10,12 +10,12 @@ objectives:
     condition: |
       try {
         n <- as base {count "tree"};
-        return (n >= 3)
-      } { return false }
+        pure (n >= 3)
+      } { pure false }
   - goal:
       - Nice job.  Now, build a harvester.
     condition: |
-      try { as base {has "harvester"} } {return false}
+      try { as base {has "harvester"} } {pure false}
     prerequisite: get_trees
 solution: |
   build {turn right; move; move; grab; move; grab; move; grab; turn back; move; move; move; move};

--- a/data/scenarios/Testing/394-build-drill.yaml
+++ b/data/scenarios/Testing/394-build-drill.yaml
@@ -7,12 +7,12 @@ creative: True
 objectives:
   - condition: |
       try {
-        as base {l <- has "detonator"; return (not l)}
-      } { return false }
+        as base {l <- has "detonator"; pure (not l)}
+      } { pure false }
 # When testing, add `s <- build {...}; n <- as s {whoami}; log n`
 solution: |
   def forever = \c. c ; forever c end;
-  def unblock = try {drill forward; return ()} {} end;
+  def unblock = try {drill forward; pure ()} {} end;
   def doPush = unblock; move end;
   log "Hi, I am base";
   r <- build {

--- a/data/scenarios/Testing/397-wrong-missing.yaml
+++ b/data/scenarios/Testing/397-wrong-missing.yaml
@@ -8,7 +8,7 @@ description: |
   https://github.com/swarm-game/swarm/issues/397
 objectives:
   - condition: |
-      t <- time; return (t == 2)
+      t <- time; pure (t == 2)
     goal:
       - |
         This is a dummy condition that just ensures the base has had

--- a/data/scenarios/Testing/428-drowning-destroy.yaml
+++ b/data/scenarios/Testing/428-drowning-destroy.yaml
@@ -8,13 +8,13 @@ objectives:
       def isAlive = \n. try {
         _ <- robotNamed n;
         log ("Is alive: " ++ n);
-        return true
-      } { return false } end;
+        pure true
+      } { pure false } end;
       try {
         baseAlive <- isAlive "base";
         botAlive <- isAlive "bot";
-        return (baseAlive && not botAlive);
-      } { return false; }
+        pure (baseAlive && not botAlive);
+      } { pure false; }
 solution: |
   log "start";
   wait 5;

--- a/data/scenarios/Testing/475-wait-one.yaml
+++ b/data/scenarios/Testing/475-wait-one.yaml
@@ -11,7 +11,7 @@ objectives:
       try {
         teleport self (0,0);
         ishere "lambda"
-      } { return false }
+      } { pure false }
 solution: |
   log "I will win next tick!"; wait 1; place "lambda";
 robots:

--- a/data/scenarios/Testing/479-atomic-race.yaml
+++ b/data/scenarios/Testing/479-atomic-race.yaml
@@ -28,7 +28,7 @@ objectives:
       try {
         p <- robotNamed "planter";
         as p {has "Win"}
-      } { return false }
+      } { pure false }
 solution: |
   def forever = \c. force c ; forever c end
   def tryharvest =

--- a/data/scenarios/Testing/479-atomic.yaml
+++ b/data/scenarios/Testing/479-atomic.yaml
@@ -11,14 +11,14 @@ objectives:
   - condition: |
       try {
         p <- robotNamed "planter";
-        as p {n <- count "weed"; return (n == 0)}
-      } { return false }
+        as p {n <- count "weed"; pure (n == 0)}
+      } { pure false }
 solution: |
   def forever = \c. force c ; forever c end
   def tryharvest =
     atomic (
       b <- ishere "weed";
-      if b {harvest; return ()} {}
+      if b {harvest; pure ()} {}
     );
     n <- random 4; wait n
   end;

--- a/data/scenarios/Testing/490-harvest.yaml
+++ b/data/scenarios/Testing/490-harvest.yaml
@@ -11,9 +11,9 @@ objectives:
         t1 <- ishere "tree";
         move;
         t2 <- ishere "tree";
-        t3 <- as base {n <- count "water"; return (n == 4)};
-        return (t1 && not t2 && t3)
-      } { return false }
+        t3 <- as base {n <- count "water"; pure (n == 4)};
+        pure (t1 && not t2 && t3)
+      } { pure false }
 solution: |
   move; harvest; move; grab; turn right; move; grab; grab; harvest; grab
 robots:

--- a/data/scenarios/Testing/504-teleport-self.yaml
+++ b/data/scenarios/Testing/504-teleport-self.yaml
@@ -9,7 +9,7 @@ objectives:
         create "tree"; place "tree";
         teleport self (5,0);
         ishere "tree"
-      } { return false }
+      } { pure false }
 solution: |
   place "tree"
 robots:

--- a/data/scenarios/Testing/508-capability-subset.yaml
+++ b/data/scenarios/Testing/508-capability-subset.yaml
@@ -10,8 +10,8 @@ objectives:
         p <- as r {whereami};
         g <- as base {count "GPS"};
         t <- as base {count "Tardis"};
-        return (p == (5,0) && g == 1 && t == 0);
-      } { return false }
+        pure (p == (5,0) && g == 1 && t == 0);
+      } { pure false }
 solution: |
   log "Hi, I can build teleporting robots!";
   try {

--- a/data/scenarios/Testing/555-teleport-location.yaml
+++ b/data/scenarios/Testing/555-teleport-location.yaml
@@ -8,7 +8,7 @@ objectives:
   - condition: |
       try {
         as base {has "rock"}
-      } { return false }
+      } { pure false }
 solution: |
   fred <- robotNamed "fred";
   myLoc <- whereami;

--- a/data/scenarios/Testing/562-lodestone.yaml
+++ b/data/scenarios/Testing/562-lodestone.yaml
@@ -7,7 +7,7 @@ objectives:
     condition: |
       try {
         as base {has "drill bit"};
-      } { return false }
+      } { pure false }
 solution: |
   run "scenarios/Testing/562-lodestone.sw"
 robots:

--- a/data/scenarios/Testing/684-swap.yaml
+++ b/data/scenarios/Testing/684-swap.yaml
@@ -9,10 +9,10 @@ objectives:
         as base {
           l <- has "lambda";
           b <- has "bitcoin";
-          return $ l && b
+          pure $ l && b
         }
       } {
-        return false
+        pure false
       }
 solution: |
   swap "bitcoin"; swap "gold coin";
@@ -41,7 +41,7 @@ robots:
         case d (\_.
           say "Fatal error: swap does not work atomically!"
         ) (\_.
-          return ()
+          pure ()
         )
       )
 world:

--- a/data/scenarios/Testing/699-movement-fail/699-move-blocked.yaml
+++ b/data/scenarios/Testing/699-movement-fail/699-move-blocked.yaml
@@ -5,12 +5,12 @@ description: |
   https://github.com/swarm-game/swarm/issues/699
 objectives:
   - condition: |
-      def isAliveOn = \name.\loc. try {r <- robotNamed name; l <- as r {whereami}; return $ l == loc} {return false} end;
-      def isDead = \name. try {robotNamed name; return false} {return true} end;
+      def isAliveOn = \name.\loc. try {r <- robotNamed name; l <- as r {whereami}; pure $ l == loc} {pure false} end;
+      def isDead = \name. try {robotNamed name; pure false} {pure true} end;
       a1 <- isAliveOn "one" (0,-1);
       a2 <- isAliveOn "two" (1,-2);
       b <- isAliveOn "base" (0,0);
-      return (a1 && a2 && b)
+      pure (a1 && a2 && b)
 solution: |
   move; say "Fatal error: base was able to move into a boulder and not fail!"
 robots:

--- a/data/scenarios/Testing/699-movement-fail/699-move-liquid.yaml
+++ b/data/scenarios/Testing/699-movement-fail/699-move-liquid.yaml
@@ -5,13 +5,13 @@ description: |
   https://github.com/swarm-game/swarm/issues/699
 objectives:
   - condition: |
-      def isAliveOn = \name.\loc. try {r <- robotNamed name; l <- as r {whereami}; return $ l == loc} {return false} end;
-      def isDead = \name. try {robotNamed name; return false} {return true} end;
+      def isAliveOn = \name.\loc. try {r <- robotNamed name; l <- as r {whereami}; pure $ l == loc} {pure false} end;
+      def isDead = \name. try {robotNamed name; pure false} {pure true} end;
       d1 <- isDead "one";
       a2 <- isAliveOn "two" (1,-2);
       a3 <- isAliveOn "three" (1,-3);
       b <- isAliveOn "base" (0,0);
-      return (d1 && a2 && a3 && b)
+      pure (d1 && a2 && a3 && b)
 solution: |
   move; say "Fatal error: base was able to move into water and not fail!"
 robots:

--- a/data/scenarios/Testing/699-movement-fail/699-teleport-blocked.yaml
+++ b/data/scenarios/Testing/699-movement-fail/699-teleport-blocked.yaml
@@ -6,14 +6,14 @@ description: |
 creative: true
 objectives:
   - condition: |
-      def isAliveOn = \name.\loc. try {r <- robotNamed name; l <- as r {whereami}; return $ l == loc} {return false} end;
-      def isDead = \name. try {robotNamed name; return false} {return true} end;
+      def isAliveOn = \name.\loc. try {r <- robotNamed name; l <- as r {whereami}; pure $ l == loc} {pure false} end;
+      def isDead = \name. try {robotNamed name; pure false} {pure true} end;
       d1 <- isDead "one";
       d2 <- isDead "two";
       a3 <- isAliveOn "three" (3,0);
       a4 <- isAliveOn "four" (3,0);
       b <- isAliveOn "base" (5,0);
-      return (d1 && d2 && a3 && a4 && b)
+      pure (d1 && d2 && a3 && a4 && b)
 solution: |
   o <- robotNamed "one"; reprogram o {t <- robotNamed "two"; teleport t (3,0); teleport self (3,0)};
   try {teleport self (3,0)} {teleport self (5,0)}

--- a/data/scenarios/Testing/710-multi-robot.yaml
+++ b/data/scenarios/Testing/710-multi-robot.yaml
@@ -67,8 +67,8 @@ robots:
       until (
         try {
           loc <- as base {whereami};
-          return (loc == l)
-        } { return false }
+          pure (loc == l)
+        } { pure false }
       );
       create "Win"
   - name: check2
@@ -83,8 +83,8 @@ robots:
       until (
         try {
           loc <- as base {whereami};
-          return (loc == l)
-        } { return false }
+          pure (loc == l)
+        } { pure false }
       );
       create "Win"
   - name: check3
@@ -99,8 +99,8 @@ robots:
       until (
         try {
           loc <- as base {whereami};
-          return (loc == l)
-        } { return false }
+          pure (loc == l)
+        } { pure false }
       );
       create "Win"
   - name: horizon
@@ -111,7 +111,7 @@ robots:
     inventory: [[1, horizontal wall]]
     program: |
       def until = \c. b <- c; if b {} {until c} end;
-      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") return);
+      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") pure);
       c1 <- robotNamed ("check" ++ n);
       until (as c1 {has "Win"});
       swap "horizontal wall"
@@ -123,7 +123,7 @@ robots:
     inventory: [[1, vertical wall]]
     program: |
       def until = \c. b <- c; if b {} {until c} end;
-      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") return);
+      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") pure);
       c1 <- robotNamed ("check" ++ n);
       until (as c1 {has "Win"});
       swap "vertical wall"
@@ -135,7 +135,7 @@ robots:
     inventory: [[1, upper right corner]]
     program: |
       def until = \c. b <- c; if b {} {until c} end;
-      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") return);
+      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") pure);
       c1 <- robotNamed ("check" ++ n);
       until (as c1 {has "Win"});
       swap "upper right corner"
@@ -147,7 +147,7 @@ robots:
     inventory: [[1, lower right corner]]
     program: |
       def until = \c. b <- c; if b {} {until c} end;
-      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") return);
+      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") pure);
       c1 <- robotNamed ("check" ++ n);
       until (as c1 {has "Win"});
       swap "lower right corner"
@@ -159,7 +159,7 @@ robots:
     inventory: [[1, upper left corner]]
     program: |
       def until = \c. b <- c; if b {} {until c} end;
-      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") return);
+      n <- (s <- scan down; case s (\_. fail "Fatal error: missing room number!") pure);
       c1 <- robotNamed ("check" ++ n);
       until (as c1 {has "Win"});
       swap "upper left corner"

--- a/data/scenarios/Testing/795-prerequisite/795-prerequisite-and.yaml
+++ b/data/scenarios/Testing/795-prerequisite/795-prerequisite-and.yaml
@@ -7,7 +7,7 @@ objectives:
   - goal:
       - Achieve both of two other objectives
     condition: |
-      return true;
+      pure true;
     prerequisite:
       previewable: true
       logic:

--- a/data/scenarios/Testing/795-prerequisite/795-prerequisite-mutually-exclusive.yaml
+++ b/data/scenarios/Testing/795-prerequisite/795-prerequisite-mutually-exclusive.yaml
@@ -7,7 +7,7 @@ objectives:
   - goal:
       - Either obtain a "furnace" WITHOUT a "flower", or obtain both a "wooden gear" and "flower".
     condition: |
-      return true;
+      pure true;
     prerequisite:
       previewable: true
       logic:

--- a/data/scenarios/Testing/795-prerequisite/795-prerequisite-or.yaml
+++ b/data/scenarios/Testing/795-prerequisite/795-prerequisite-or.yaml
@@ -7,7 +7,7 @@ objectives:
   - goal:
       - Achieve one of two other objectives
     condition: |
-      return true;
+      pure true;
     prerequisite:
       previewable: true
       logic:

--- a/data/scenarios/Testing/836-pathfinding/836-automatic-waypoint-navigation.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-automatic-waypoint-navigation.yaml
@@ -11,7 +11,7 @@ objectives:
     condition: |
       as base {
         eggCount <- count "egg";
-        return $ eggCount >= 64;
+        pure $ eggCount >= 64;
       };
 attrs:
   - name: easter_egg

--- a/data/scenarios/Testing/836-pathfinding/836-no-path-exists1.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-no-path-exists1.yaml
@@ -10,7 +10,7 @@ objectives:
     condition: |
       as base {
         nextDir <- path (inL ()) (inR "flower");
-        return $ case nextDir (\_. true) (\_. false);
+        pure $ case nextDir (\_. true) (\_. false);
       };
 solution: |
   noop;

--- a/data/scenarios/Testing/836-pathfinding/836-no-path-exists2.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-no-path-exists2.yaml
@@ -16,7 +16,7 @@ objectives:
     condition: |
       as base {
         nextDir <- path (inL ()) (inR "flower");
-        return $ case nextDir (\_. true) (\_. false);
+        pure $ case nextDir (\_. true) (\_. false);
       };
 solution: |
   noop;

--- a/data/scenarios/Testing/836-pathfinding/836-path-exists-distance-limit-reachable.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-path-exists-distance-limit-reachable.yaml
@@ -9,7 +9,7 @@ objectives:
     condition: |
       as base {
         nextDir <- path (inR 3) (inR "flower");
-        return $ case nextDir (\_. false) (\_. true);
+        pure $ case nextDir (\_. false) (\_. true);
       };
 solution: |
   move;

--- a/data/scenarios/Testing/836-pathfinding/836-path-exists-distance-limit-unreachable.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-path-exists-distance-limit-unreachable.yaml
@@ -9,7 +9,7 @@ objectives:
     condition: |
       as base {
         nextDir <- path (inR 3) (inR "flower");
-        return $ case nextDir (\_. true) (\_. false);
+        pure $ case nextDir (\_. true) (\_. false);
       };
 solution: |
   turn back;

--- a/data/scenarios/Testing/836-pathfinding/836-path-exists-find-entity-unwalkable.yaml
+++ b/data/scenarios/Testing/836-pathfinding/836-path-exists-find-entity-unwalkable.yaml
@@ -9,7 +9,7 @@ objectives:
     condition: |
       as base {
         itemAhead <- scan forward;
-        return $ case itemAhead (\_. false) (\item. item == "water");
+        pure $ case itemAhead (\_. false) (\item. item == "water");
       };
 solution: |
   run "scenarios/Testing/836-pathfinding/_836-path-exists/find-entity-unwalkable-solution.sw";

--- a/data/scenarios/Testing/836-pathfinding/_836-automatic-waypoint-navigation/gardener.sw
+++ b/data/scenarios/Testing/836-pathfinding/_836-automatic-waypoint-navigation/gardener.sw
@@ -6,7 +6,7 @@ def harvestPlant =
   } {
     wait 50;
     harvest;
-    return ();
+    pure ();
   };
   end;
 

--- a/data/scenarios/Testing/836-pathfinding/_836-automatic-waypoint-navigation/patrol.sw
+++ b/data/scenarios/Testing/836-pathfinding/_836-automatic-waypoint-navigation/patrol.sw
@@ -2,8 +2,8 @@ def goDir = \f. \r.
   let d = fst r in
   if (d == down) {
     eggHere <- ishere "egg";
-    if eggHere {grab; return ()} {};
-    return ()
+    if eggHere {grab; pure ()} {};
+    pure ()
   } {
     turn d;
 
@@ -19,7 +19,7 @@ def goDir = \f. \r.
 
 def followRoute = \loc.
     nextDir <- path (inL ()) (inL loc);
-    case nextDir return $ goDir $ followRoute loc;
+    case nextDir pure $ goDir $ followRoute loc;
     end;
 
 def visitNextWaypoint = \nextWpIdx.

--- a/data/scenarios/Testing/836-pathfinding/_836-path-exists/find-entity-solution.sw
+++ b/data/scenarios/Testing/836-pathfinding/_836-path-exists/find-entity-solution.sw
@@ -1,7 +1,7 @@
 def goDir = \f. \r.
   let d = fst r in
   if (d == down) {
-    grab; return ()
+    grab; pure ()
   } {
     turn d; move; f;
   }
@@ -9,7 +9,7 @@ def goDir = \f. \r.
 
 def followRoute =
     nextDir <- path (inL ()) (inR "flower");
-    case nextDir return $ goDir followRoute;
+    case nextDir pure $ goDir followRoute;
     end;
 
 followRoute;

--- a/data/scenarios/Testing/836-pathfinding/_836-path-exists/find-entity-unwalkable-solution.sw
+++ b/data/scenarios/Testing/836-pathfinding/_836-path-exists/find-entity-unwalkable-solution.sw
@@ -1,13 +1,13 @@
 def goDir = \goalItem. \f. \r.
   let d = fst r in
   if (d == down) {
-    grab; return ()
+    grab; pure ()
   } {
     turn d;
     itemAhead <- scan forward;
     let isGoalAhead = case itemAhead (\_. false) (\item. item == goalItem) in
     if isGoalAhead {
-      return ();
+      pure ();
     } {
       move; f;
     };
@@ -17,7 +17,7 @@ def goDir = \goalItem. \f. \r.
 def followRoute =
     let goalItem = "water" in
     nextDir <- path (inL ()) (inR goalItem);
-    case nextDir return $ goDir goalItem followRoute;
+    case nextDir pure $ goDir goalItem followRoute;
     end;
 
 followRoute;

--- a/data/scenarios/Testing/836-pathfinding/_836-path-exists/find-location-solution.sw
+++ b/data/scenarios/Testing/836-pathfinding/_836-path-exists/find-location-solution.sw
@@ -1,7 +1,7 @@
 def goDir = \f. \r.
   let d = fst r in
   if (d == down) {
-    grab; return ()
+    grab; pure ()
   } {
     turn d; move; f;
   }
@@ -9,7 +9,7 @@ def goDir = \f. \r.
 
 def followRoute =
     nextDir <- path (inL ()) (inL (4, 0));
-    case nextDir return $ goDir followRoute;
+    case nextDir pure $ goDir followRoute;
     end;
 
 followRoute;

--- a/data/scenarios/Testing/858-inventory/858-counting-objective.yaml
+++ b/data/scenarios/Testing/858-inventory/858-counting-objective.yaml
@@ -12,7 +12,7 @@ objectives:
     condition: |-
       as base {
         itemCount <- count "tree";
-        return $ itemCount > 0;
+        pure $ itemCount > 0;
       };
 robots:
   - name: base

--- a/data/scenarios/Testing/858-inventory/858-nonpossession-objective.yaml
+++ b/data/scenarios/Testing/858-inventory/858-nonpossession-objective.yaml
@@ -10,7 +10,7 @@ objectives:
     condition: |-
       as base {
         x <- has "tree";
-        return $ not x;
+        pure $ not x;
       };
 robots:
   - name: base

--- a/data/scenarios/Testing/920-meet.yaml
+++ b/data/scenarios/Testing/920-meet.yaml
@@ -10,19 +10,19 @@ objectives:
       teleport self (0,0);
       def all : (rec l. Unit + a * l) -> (a -> Cmd Bool) -> Cmd Bool =
         \xs. \f. case xs
-          (\_. return true)
-          (\cons. b <- f (fst cons); if b {all (snd cons) f} {return false})
+          (\_. pure true)
+          (\cons. b <- f (fst cons); if b {all (snd cons) f} {pure false})
       end;
       rs <- meetAll;
       b1 <- all rs (\r. as r {has "boat"});
       n2 <- as r0 { count "boat" };
-      return (b0 && b1 && (n2 == 2))
+      pure (b0 && b1 && (n2 == 2))
 solution: |
   mr0 <- meet;
-  case mr0 (\_. return ()) (\r0. give r0 "boat");
+  case mr0 (\_. pure ()) (\r0. give r0 "boat");
   def forM_ : (rec l. Unit + a * l) -> (a -> Cmd b) -> Cmd Unit =
     \xs. \f. case xs
-      (\_. return ())
+      (\_. pure ())
       (\cons. f (fst cons); forM_ (snd cons) f)
   end;
   rs <- meetAll;

--- a/data/scenarios/Testing/955-heading.yaml
+++ b/data/scenarios/Testing/955-heading.yaml
@@ -7,7 +7,7 @@ objectives:
   - condition: |
       loc <- as base {whereami};
       h <- as base {heading};
-      return $ loc == (1,-1) && h == north
+      pure $ loc == (1,-1) && h == north
 solution: |
   h <- heading; turn east; move; move; turn right; move; move; turn h
 robots:

--- a/data/scenarios/Testing/956-GPS.yaml
+++ b/data/scenarios/Testing/956-GPS.yaml
@@ -6,7 +6,7 @@ description: |
 objectives:
   - condition: |
       loc <- as base {whereami};
-      return $ loc == (0,0)
+      pure $ loc == (0,0)
     goal:
       - |
         The goal is to move back to the origin after being

--- a/data/scenarios/Testing/961-custom-capabilities.yaml
+++ b/data/scenarios/Testing/961-custom-capabilities.yaml
@@ -7,7 +7,7 @@ description: |
 objectives:
   - condition: |
       mover <- robotNumbered 1;
-      as mover { loc <- whereami; return $ loc == (0,1) }
+      as mover { loc <- whereami; pure $ loc == (0,1) }
     goal:
       - |
         Get a robot to (0,1)!

--- a/data/scenarios/Testing/Achievements/RobotIntoWater.yaml
+++ b/data/scenarios/Testing/Achievements/RobotIntoWater.yaml
@@ -6,12 +6,12 @@ objectives:
     goal:
       - Build a robot
     condition: |
-      try {robotNumbered 1; return True} {return False}
+      try {robotNumbered 1; pure True} {pure False}
   - goal:
       - Drown it
     prerequisite: build
     condition: |
-      try {robotNumbered 1; return False} {return True}
+      try {robotNumbered 1; pure False} {pure True}
 solution: |
   build { turn right; move; move; move }
 robots:

--- a/data/scenarios/Testing/_Validation/795-prerequisite-nonexistent-reference.yaml
+++ b/data/scenarios/Testing/_Validation/795-prerequisite-nonexistent-reference.yaml
@@ -7,7 +7,7 @@ objectives:
   - goal:
       - Achieve one of two other objectives
     condition: |
-      return true;
+      pure true;
     prerequisite: shave_furnace
   - id: have_furnace
     goal:

--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -18,7 +18,7 @@ objectives:
       try {
         l <- robotNamed "listener";
         as l {has "READY"}
-      } { return false }
+      } { pure false }
 solution: |
   say "Ready!"
 entities:

--- a/data/scenarios/Tutorials/bind2.yaml
+++ b/data/scenarios/Tutorials/bind2.yaml
@@ -19,8 +19,8 @@ objectives:
       try {
         p <- robotnamed "floorspot";
         w <- as p {ishere "Hastur"};
-        return (not w);
-      } { return false }
+        pure (not w);
+      } { pure false }
   - goal:
       - |
         Your robot obtained the misplaced artifact! Next you need to put it back
@@ -58,8 +58,8 @@ objectives:
       try {
         p <- robotnamed "pedestal";
         w <- as p {ishere "Hastur"};
-        return w;
-      } { return false }
+        pure w;
+      } { pure false }
     prerequisite: grab_artifact
 solution: |
   build {

--- a/data/scenarios/Tutorials/build.yaml
+++ b/data/scenarios/Tutorials/build.yaml
@@ -25,8 +25,8 @@ objectives:
         b <- ishere "flower";
         move;
         c <- ishere "flower";
-        return (a || b || c);
-      } { return false }
+        pure (a || b || c);
+      } { pure false }
 solution: |
   build {turn right; move; move; harvest; turn right; move; place "flower"}
 robots:

--- a/data/scenarios/Tutorials/conditionals.yaml
+++ b/data/scenarios/Tutorials/conditionals.yaml
@@ -51,19 +51,19 @@ objectives:
         **TIP:** the two branches of an `if` must have the same type. In particular,
         `if ... {grab} {}`{=snippet} is not
         allowed, because `{grab}` has type `{Cmd Text}`{=type} whereas `{}`{=snippet} has type `{Cmd Unit}`{=type}.
-        In this case `{grab; return ()}` has the right type.
+        In this case `{grab; pure ()}` has the right type.
     condition: |
       try {
         n <- as base {count "very small rock"};
-        return (n == 4)
-      } { return false}
+        pure (n == 4)
+      } { pure false}
 solution: |
   def tL = turn left end;
   def tB = turn back end;
   def x4 = \c. c;c;c;c end;
   def VSR = "very small rock" end;
   def ifC = \c.\t.\e. b <- c; if b t e end;
-  def pick = move; ifC (ishere VSR) {grab; return ()} {} end;
+  def pick = move; ifC (ishere VSR) {grab; pure ()} {} end;
   def pickrow = x4 pick; turn back; x4 move end;
   build {
     turn south; x4 (move; tL; pickrow; tL); tB; x4 move; x4 (give base VSR)

--- a/data/scenarios/Tutorials/craft.yaml
+++ b/data/scenarios/Tutorials/craft.yaml
@@ -19,7 +19,7 @@ objectives:
     condition: |
       try {
         as base {has "branch predictor"}
-      } { return false }
+      } { pure false }
 solution: |
   make "branch"; make "branch predictor"
 robots:

--- a/data/scenarios/Tutorials/crash-secret.sw
+++ b/data/scenarios/Tutorials/crash-secret.sw
@@ -1,7 +1,7 @@
 // A for cycle from start to end (excluded) that carries a state.
 def foreachF = \s.\e.\com.\state.
   if (s >= e) {
-    return state
+    pure state
   } {
     n <- com state s;
     foreachF (s+1) e com n
@@ -23,7 +23,7 @@ myLoc <- whereami;
 
 def foldM : (rec l. Unit + a * l) -> b -> (b -> a -> Cmd b) -> Cmd b =
   \xs. \b. \f. case xs
-    (\_. return b)
+    (\_. pure b)
     (\cons. b' <- f b (fst cons); foldM (snd cons) b' f)
 end
 
@@ -34,22 +34,22 @@ def tryGive: Text -> (Actor -> Bool) -> Cmd (Actor -> Bool) = \msg. \ok.
   foldM rs ok $ \f.\rob.
     if (not $ f rob) {
       log $ "skipping the robot " ++ format rob ++ "because it already has a Win";
-      return f
+      pure f
     } {
       robLoc <- as rob {whereami};
       if (robLoc != myLoc) {
         log $ "the robot" ++ format rob ++ "is not in my cell";
-        return f;
+        pure f;
       } {
         try {
           reprogram rob { log msg; };
           log $ "successfully reprogrammed robot " ++ format rob;
           give rob "Win";
           log $ "successfully gave Win to robot " ++ format rob;
-          return (\r. (rob != r && f rob));
+          pure (\r. (rob != r && f rob));
         } {
           log $ "the robot " ++ format rob ++ "is missing a logger!";
-          return f;
+          pure f;
         };
       }
     }

--- a/data/scenarios/Tutorials/crash.yaml
+++ b/data/scenarios/Tutorials/crash.yaml
@@ -26,7 +26,7 @@ objectives:
     condition: |
       try {
         as base {has "Win"}
-      } { return false }
+      } { pure false }
 entities:
   - name: Win
     display:

--- a/data/scenarios/Tutorials/def.yaml
+++ b/data/scenarios/Tutorials/def.yaml
@@ -32,7 +32,7 @@ objectives:
     condition: |
       try {
         as base {has "flower"}
-      } { return false }
+      } { pure false }
 solution: |
   def m2 = move; move end;
   def m4 = m2; m2 end;

--- a/data/scenarios/Tutorials/equip.yaml
+++ b/data/scenarios/Tutorials/equip.yaml
@@ -18,8 +18,8 @@ objectives:
     condition: |
       try {
         _ <- robotNumbered 1;
-        return true;
-      } { return false }
+        pure true;
+      } { pure false }
 solution: |
   turn south; move; grab; equip "3D printer"; build {};
 robots:

--- a/data/scenarios/Tutorials/farming.sw
+++ b/data/scenarios/Tutorials/farming.sw
@@ -27,7 +27,7 @@ def plant_field : Text -> Cmd Unit = \thing.
 end;
 def harvest_field : Text -> Cmd Unit = \thing.
   x4 (
-    x12 (move; ifC (ishere thing) {harvest; return ()} {});
+    x12 (move; ifC (ishere thing) {harvest; pure ()} {});
     next_row
   );
   tL; m4; tR

--- a/data/scenarios/Tutorials/farming.yaml
+++ b/data/scenarios/Tutorials/farming.yaml
@@ -34,9 +34,9 @@ objectives:
       try {
         as base {
           n <- count "lambda";
-          return (n >= 256)
+          pure (n >= 256)
         }
-      } { return false }
+      } { pure false }
   - goal:
       - Congratulations!  You have completed the most difficult simulated exercise and are ready to begin exploring the new planet in earnest.  Of course there is much more remaining to explore in the world, and many additional programming language features to unlock.
       - |
@@ -45,7 +45,7 @@ objectives:
       - Afterwards, you will return to the menu where you can select "Classic game" for the complete game experience.  Or, play a "Creative game" if you just want to play around with programming robots, without any constraints or need to collect resources.  You could also choose to redo some tutorial scenarios, or explore the other challenge scenarios listed in the menu.
       - Now go forth and build your swarm!
     condition: |
-      try {as base {has "curry"}} {return false}
+      try {as base {has "curry"}} {pure false}
     prerequisite: get_many_lambdas
 solution: |
   run "scenarios/Tutorials/farming.sw";

--- a/data/scenarios/Tutorials/give.yaml
+++ b/data/scenarios/Tutorials/give.yaml
@@ -16,7 +16,7 @@ objectives:
           b0 <- has "bit (0)";
           lx <- has "LaTeX";
           co <- has "copper ore";
-          return $ bd && b0 && lx && co;
+          pure $ bd && b0 && lx && co;
       };
 solution: |
   build {

--- a/data/scenarios/Tutorials/grab.yaml
+++ b/data/scenarios/Tutorials/grab.yaml
@@ -10,8 +10,8 @@ objectives:
     condition: |
       try {
         t <- as base {count "tree"};
-        return (t >= 6);
-      } { return false }
+        pure (t >= 6);
+      } { pure false }
 solution: |
   move;
   move; grab;

--- a/data/scenarios/Tutorials/lambda.yaml
+++ b/data/scenarios/Tutorials/lambda.yaml
@@ -23,8 +23,8 @@ objectives:
       try {
         teleport self (32,-16);
         b <- ishere "flower";
-        return (not b)
-      } { return false }
+        pure (not b)
+      } { pure false }
 solution: |
   def x4 = \c. c; c; c; c end;
   def m2 = move; move end;

--- a/data/scenarios/Tutorials/move.yaml
+++ b/data/scenarios/Tutorials/move.yaml
@@ -16,7 +16,7 @@ objectives:
 
         You can open this popup window at any time to remind yourself of the goal using **Ctrl+G**.
     condition: |
-      as base {l <- whereami; return (l == (2,0))}
+      as base {l <- whereami; pure (l == (2,0))}
   - id: move_along_corridor
     teaser: Down the corridor
     goal:
@@ -35,7 +35,7 @@ objectives:
 
         You can open this popup window at any time to remind yourself of the goal using **Ctrl+G**.
     condition: |
-      as base {l <- whereami; return (l == (8,0))}
+      as base {l <- whereami; pure (l == (8,0))}
     prerequisite: move_to_first_flower
   - id: move_northeast_corner
     teaser: To northeast corner
@@ -59,7 +59,7 @@ objectives:
 
         You can open this popup window at any time to remind yourself of the goal using **Ctrl+G**.
     condition: |
-      as base {l <- whereami; return (l == (8,4))}
+      as base {l <- whereami; pure (l == (8,4))}
     prerequisite: move_along_corridor
   - goal:
       - Good job! You are now ready to move and turn on your own.
@@ -67,7 +67,7 @@ objectives:
       - Remember you can press the upward arrow on your keyboard to select previous commands.
       - You can open this popup window at any time to remind yourself of the goal using **Ctrl+G**.
     condition: |
-      as base {l <- whereami; return (l == (8,8))}
+      as base {l <- whereami; pure (l == (8,8))}
     prerequisite: move_northeast_corner
 solution: |
   // 0
@@ -145,7 +145,7 @@ robots:
   - name: 1P wall
     system: true
     program: |
-      def main = \a. return noop end
+      def main = \a. pure noop end
       instant (
         run "scenarios/Tutorials/move_surveil.sw";
         main [entity="wall", room=1]

--- a/data/scenarios/Tutorials/move_check.sw
+++ b/data/scenarios/Tutorials/move_check.sw
@@ -13,7 +13,7 @@ end
 def waitForBaseAt = \l. \get_timeout.
     loc <- as base {whereami};
     if (loc == l) {
-        return true
+        pure true
     } {
         wait (get_timeout l loc);
         waitForBaseAt l get_timeout

--- a/data/scenarios/Tutorials/place.yaml
+++ b/data/scenarios/Tutorials/place.yaml
@@ -30,8 +30,8 @@ objectives:
     condition: |
       try {
         t <- as base {count "spruce"};
-        return (t >= 6);
-      } { return false }
+        pure (t >= 6);
+      } { pure false }
 entities:
   # faster tree (the normal one grows 500-600 ticks)
   - name: spruce

--- a/data/scenarios/Tutorials/require.yaml
+++ b/data/scenarios/Tutorials/require.yaml
@@ -11,7 +11,7 @@ objectives:
     condition: |
       try {
         as base {has "periwinkle"}
-      } { return false }
+      } { pure false }
 entities:
   - name: periwinkle
     display:

--- a/data/scenarios/Tutorials/requireinv.yaml
+++ b/data/scenarios/Tutorials/requireinv.yaml
@@ -25,8 +25,8 @@ objectives:
           );
           turn back; move; move; move; move; turn left
         );
-        ifC (has "tree") {return false} {return true}
-      } { return false }
+        ifC (has "tree") {pure false} {pure true}
+      } { pure false }
 solution: |
   def x4 = \c. c;c;c;c end;
   def mp = move; place "rock" end;

--- a/data/scenarios/Tutorials/scan.yaml
+++ b/data/scenarios/Tutorials/scan.yaml
@@ -12,8 +12,8 @@ objectives:
         bm <- as base {knows "mountain"};
         bt <- as base {knows "tree"};
         bw <- as base {knows "wavy water"};
-        return (bm || bt || bw)
-      } { return false }
+        pure (bm || bt || bw)
+      } { pure false }
 solution: |
   build {
     turn east; move; move; move;

--- a/data/scenarios/Tutorials/type-errors.yaml
+++ b/data/scenarios/Tutorials/type-errors.yaml
@@ -21,8 +21,8 @@ objectives:
     condition: |
       try {
         w <- as base {has "Win"};
-        return (not w);
-      } { return false }
+        pure (not w);
+      } { pure false }
 entities:
   - name: Win
     display:

--- a/data/scenarios/Tutorials/types.yaml
+++ b/data/scenarios/Tutorials/types.yaml
@@ -25,8 +25,8 @@ objectives:
     condition: |
       try {
         w <- as base {has "Win"};
-        return (not w);
-      } { return false }
+        pure (not w);
+      } { pure false }
 entities:
   - name: Win
     display:

--- a/data/scenarios/Tutorials/world101.yaml
+++ b/data/scenarios/Tutorials/world101.yaml
@@ -13,14 +13,14 @@ objectives:
     condition: |
       try {
         n <- as base {count "tree"};
-        return (n >= 3)
-      } { return false }
+        pure (n >= 3)
+      } { pure false }
   - id: get_harvester
     teaser: Make a harvester
     goal:
       - Nice work!  Now, use the `tree`{=entity}s to make a `harvester`{=entity} device. This will require several intermediate products; try making various things, and take a look at your available recipes (**F3**) and at the recipes listed for items in your inventory.  Of course, you may end up needing some additional trees.
     condition: |
-      try { as base {has "harvester"} } {return false}
+      try { as base {has "harvester"} } {pure false}
     prerequisite: get_trees
   - goal:
       - Now that you have a `harvester`{=entity}, you can use `harvest` instead of `grab` whenever you pick up a growing item (check for the word "growing" at the top of the item description), to leave behind a seed that will regrow.
@@ -28,7 +28,7 @@ objectives:
       - One of the next things you will probably want is a `lambda`{=entity}, so you can define and use parameterized commands.  Scan some things and use the process of elimination to find one.  Since lambdas regrow, once you find one, try getting it with `harvest`.
       - "**TIP:** remember that you can click on cells in the world to see their coordinates."
     condition: |
-      try { as base {has "lambda"} } {return false}
+      try { as base {has "lambda"} } {pure false}
     prerequisite: get_harvester
 solution: |
   run "scenarios/Tutorials/world101.sw"

--- a/data/scenarios/Vignettes/_roadway/coordinator.sw
+++ b/data/scenarios/Vignettes/_roadway/coordinator.sw
@@ -9,13 +9,13 @@ def atLocation = \newLoc. \f.
     teleport self newLoc;
     retval <- f;
     teleport self prevLoc;
-    return retval;
+    pure retval;
     end;
 
 def swapItem = \ent.
   create ent;
   emptyHere <- isempty;
-  if emptyHere {} {grab; return ()};
+  if emptyHere {} {grab; pure ()};
   place ent;
   end;
 

--- a/data/scenarios/Vignettes/_roadway/drone.sw
+++ b/data/scenarios/Vignettes/_roadway/drone.sw
@@ -58,13 +58,13 @@ def init :
     } in
     turn $ fst locdir;
     teleport self $ snd locdir;
-    return (isLongitudinal, idx);
+    pure (isLongitudinal, idx);
     end;
 
 def isGreenLight = \isLongitudinal.
     r <- robotnamed "stoplight";
     isGreen <- as r {has "bit (1)"};
-    return $ isLongitudinal != isGreen;
+    pure $ isLongitudinal != isGreen;
     end;
 
 def getCanMove :
@@ -89,30 +89,30 @@ def getCanMove :
     eitherNeighbor <- meet;
     // TODO: Make sure we only consider the neighbor directly in front of us.
     neighborIsStopped <- case eitherNeighbor
-        (\_. return false)
+        (\_. pure false)
         (\r. as r {has "bit (0)"}); // zero-bit means stopped
 
-    return $ hasGreenLight || not (atStopLine || neighborIsStopped);
+    pure $ hasGreenLight || not (atStopLine || neighborIsStopped);
     end;
 
 def doTunnelWrap : [xMin : Int, xMax : Int, yMin : Int, yMax : Int] -> Cmd Bool = \extents.
     myloc <- whereami;
     didWrap <- if (fst myloc < extents.xMin) {
         teleport self (extents.xMax, snd myloc);
-        return true;
+        pure true;
     } $ elif (fst myloc > extents.xMax) {
         teleport self (extents.xMin, snd myloc);
-        return true;
+        pure true;
     } $ elif (snd myloc < extents.yMin) {
         teleport self (fst myloc, extents.yMax);
-        return true;
+        pure true;
     } $ elif (snd myloc > extents.yMax) {
         teleport self (fst myloc, extents.yMin);
-        return true;
+        pure true;
     } $ else {
-        return false;
+        pure false;
     };
-    return didWrap;
+    pure didWrap;
     end;
 
 def moveWithWrap :
@@ -129,7 +129,7 @@ def moveWithWrap :
         move;
         doTunnelWrap extents;
     } {
-        return false;
+        pure false;
     };
 
     try {
@@ -137,7 +137,7 @@ def moveWithWrap :
         if canMove {make "bit (1)"} {make "bit (0)"}
     } {};
 
-    return (canMove, wentThroughTunnel);
+    pure (canMove, wentThroughTunnel);
     end;
 
 def getNewDelayState :

--- a/data/scenarios/Vignettes/progress-bar.yaml
+++ b/data/scenarios/Vignettes/progress-bar.yaml
@@ -12,7 +12,7 @@ objectives:
       teleport self (1,-1); c; move; c; move; c; move; c; move; c; move; c; move; c; move; c; move; c; move; c;
       teleport self (1,-5); c; move; c; move; c; move; c; move; c; move; c; move; c; move; c; move; c; move; c;
       teleport self (1,-9); c; move; c; move; c; move; c; move; c; move; c; move; c; move; c; move; c; move; c;
-      return true
+      pure true
 solution: |
   wait 100;
 robots:

--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -113,7 +113,7 @@
       "setname"
       "random"
       "run"
-      "return"
+      "pure"
       "try"
       "print"
       "erase"

--- a/editors/vim/swarm.vim
+++ b/editors/vim/swarm.vim
@@ -1,6 +1,6 @@
 syn keyword Keyword def tydef rec end let in require
 syn keyword Builtins waypoint waypoints hastag tagmembers self parent base if inl inr case fst snd force undefined fail not format read chars split charat tochar key
-syn keyword Command noop wait selfdestruct move backup volume path push stride turn grab harvest sow ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami locateme structures floorplan detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run return try print erase swap atomic instant installkeyhandler teleport warp as robotnamed robotnumbered knows
+syn keyword Command noop wait selfdestruct move backup volume path push stride turn grab harvest sow ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami locateme structures floorplan detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random run pure try print erase swap atomic instant installkeyhandler teleport warp as robotnamed robotnumbered knows
 syn keyword Direction east north west south down forward left back right
 syn match Type "\<[A-Z][a-zA-Z_]*\>"
 syn match Operators "[-=!<>|&+*/^$:]"

--- a/editors/vscode/syntaxes/swarm.tmLanguage.yaml
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.yaml
@@ -46,7 +46,7 @@ repository:
       keyword:
         name: keyword.other
         match: >-
-          \b(waypoint|waypoints|hastag|tagmembers|self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|read|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|backup|volume|path|push|stride|turn|grab|harvest|sow|ignite|place|ping|give|equip|unequip|make|has|equipped|count|drill|use|build|salvage|reprogram|say|listen|log|view|appear|create|halt|time|scout|whereami|locateme|structures|floorplan|detect|resonate|density|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|return|try|print|erase|swap|atomic|instant|installkeyhandler|teleport|warp|as|robotnamed|robotnumbered|knows)\b
+          \b(waypoint|waypoints|hastag|tagmembers|self|parent|base|if|inl|inr|case|fst|snd|force|undefined|fail|not|format|read|chars|split|charat|tochar|key|noop|wait|selfdestruct|move|backup|volume|path|push|stride|turn|grab|harvest|sow|ignite|place|ping|give|equip|unequip|make|has|equipped|count|drill|use|build|salvage|reprogram|say|listen|log|view|appear|create|halt|time|scout|whereami|locateme|structures|floorplan|detect|resonate|density|sniff|chirp|watch|surveil|heading|blocked|scan|upload|ishere|isempty|meet|meetall|whoami|setname|random|run|pure|try|print|erase|swap|atomic|instant|installkeyhandler|teleport|warp|as|robotnamed|robotnumbered|knows)\b
       require:
         name: keyword.control.require
         match: \b(require)\b

--- a/editors/vscode/test/hello.sw
+++ b/editors/vscode/test/hello.sw
@@ -2,4 +2,4 @@
 
 def hello: Text = "Hello World" end;
 
-return hello;
+pure hello;

--- a/editors/vscode/test/hello.sw.snap
+++ b/editors/vscode/test/hello.sw.snap
@@ -18,9 +18,9 @@
 #                                ^^^ source.swarm keyword.control.dictionary.def.end
 #                                   ^ source.swarm keyword.operator.chain
 >
->return hello;
-#^^^^^^ source.swarm keyword.other
-#      ^ source.swarm
-#       ^^^^^ source.swarm variable.parameter
-#            ^ source.swarm keyword.operator.chain
+>pure hello;
+#^^^^ source.swarm keyword.other
+#    ^ source.swarm
+#     ^^^^^ source.swarm variable.parameter
+#          ^ source.swarm keyword.operator.chain
 >

--- a/example/BFS-clear.sw
+++ b/example/BFS-clear.sw
@@ -13,11 +13,11 @@ def while : Cmd Bool -> Cmd Unit -> Cmd Unit = \test.\c.
 end;
 def getX : Cmd Int =
   pos <- whereami;
-  return (fst pos);
+  pure (fst pos);
 end;
 def getY : Cmd Int =
   pos <- whereami;
-  return (snd pos);
+  pure (snd pos);
 end;
 def gotoX : Int -> Cmd Unit = \tgt.
   cur <- getX;
@@ -47,7 +47,7 @@ def spawnfwd : {Cmd Unit} -> Cmd Unit = \c.
      move;
      b <- isHere "tree";
      if b
-       { build c; return () }
+       { build c; pure () }
        {};
      turn back;
      move

--- a/example/cat.sw
+++ b/example/cat.sw
@@ -6,7 +6,7 @@ let repeat : Int -> Cmd Unit -> Cmd Unit =
   \n. \c. if (n == 0) {} {c ; repeat (n-1) c} in
 let randdir : Cmd Dir =
   d <- random 4;
-  return (
+  pure (
     if (d == 0) {north}
     {if (d == 1) {east}
     {if (d == 2) {south} {west}}})

--- a/example/multi-key-handler.sw
+++ b/example/multi-key-handler.sw
@@ -5,7 +5,7 @@ def cons : a * b -> (a -> b) -> (a -> b) = \p. \k. \a.
   if (a == fst p) {snd p} {k a}
 end
 
-def nil : a -> Cmd Unit = \a. return () end
+def nil : a -> Cmd Unit = \a. pure () end
 
 // The delay around the first argument is necessary to prevent
 // infinite recursion

--- a/example/pilotmode.sw
+++ b/example/pilotmode.sw
@@ -2,7 +2,7 @@ def cons : a * b -> (a -> b) -> (a -> b) = \p. \k. \a.
   if (a == fst p) {snd p} {k a}
 end
 
-def nil : a -> Cmd Unit = \a. return () end
+def nil : a -> Cmd Unit = \a. pure () end
 
 // Suitable to use as e.g.
 //   installKeyHandler "(S-)←↓↑→ [Del] [g]rab [h]arvest [d]rill [s]can [b]locked [u]pload" pilot
@@ -18,8 +18,8 @@ def pilot : Key -> Cmd Unit =
   cons (key "Del",     selfdestruct) $
   cons (key "g",       res <- grab; log res) $
   cons (key "h",       res <- harvest; log res) $
-  cons (key "d",       res <- drill forward; case res (\_. return ()) log) $
-  cons (key "s",       res <- scan forward; case res (\_. return ()) log) $
+  cons (key "d",       res <- drill forward; case res (\_. pure ()) log) $
+  cons (key "s",       res <- scan forward; case res (\_. pure ()) log) $
   cons (key "b",       b <- blocked; if b {log "blocked"} {log "not blocked"}) $
   cons (key "u",       upload base) $
   nil

--- a/example/recursive-containers.sw
+++ b/example/recursive-containers.sw
@@ -535,7 +535,7 @@ end
 def group = \i. \m. \tests.
   log $ indent i ++ "START " ++ m ++ ":";
   tests $ i + 1;
-  return ()
+  pure ()
 end
 
 def test_empty: Int -> Cmd Unit = \i.
@@ -585,7 +585,7 @@ def test_insert: Int -> Cmd Unit = \i.
 end
 
 def randomTestS: Int -> Set Int -> (Set Int -> Cmd a) -> Cmd (Set Int) = \i.\s.\test.
-  if (i <= 0) {return s} {
+  if (i <= 0) {pure s} {
     x <- random 20;
     let ns = tree_set.insert x s in
     test ns;
@@ -650,7 +650,7 @@ def benchmark: Int -> s -> (s -> s) -> Cmd (Int * (Int * Int)) = \times.\s.\act.
   let max = \x.\y. if (x > y) {x} {y} in
   let runM: (Int * Maybe (Int * Int)) -> s -> Int -> Cmd (Int * Maybe (Int * Int)) = \acc.\s.\n.
     if (n <= 0) {
-      return acc
+      pure acc
     } {
       t0 <- time;
       //log $ "START " ++ format t0;
@@ -667,7 +667,7 @@ def benchmark: Int -> s -> (s -> s) -> Cmd (Int * (Int * Int)) = \times.\s.\act.
   //log "end run";
   let avg = fst res / times in
   let lim = case (snd res) (\_. fail "BENCHMARK NOT RUN") (\l.l) in
-  return (avg, lim)
+  pure (avg, lim)
 end
 
 def cmp_bench : Int -> Text -> (Int * (Int * Int)) -> Text -> (Int * (Int * Int)) -> Cmd Unit
@@ -691,7 +691,7 @@ end
 // Get a list of random integers of given length and maximum element number
 def gen_random_list: Int -> Int -> Cmd (List Int) = 
   let gen = \acc.\n.\rlim.
-    if (n <= 0) { return acc } {
+    if (n <= 0) { pure acc } {
       x <- random rlim;
       gen (cons x acc) (n - 1) rlim
     }
@@ -701,7 +701,7 @@ end
 // Get a number of lists of random integers of given length and maximum element number
 def gen_random_lists: Int -> Int -> Int -> Cmd (List (List Int)) = \m.\n.\rlim.
   let gen = \acc.\m.
-    if (m <= 0) { return acc } {
+    if (m <= 0) { pure acc } {
       l <- gen_random_list n rlim;
       gen (cons l acc) (m - 1)
     }

--- a/src/swarm-doc/Swarm/Doc/Pedagogy.hs
+++ b/src/swarm-doc/Swarm/Doc/Pedagogy.hs
@@ -120,7 +120,7 @@ getDescCommands s = S.fromList $ concatMap filterConst allCode
 isConsidered :: Const -> Bool
 isConsidered c = isUserFunc c && c `S.notMember` ignoredCommands
  where
-  ignoredCommands = S.fromList [Run, Return, Noop, Force]
+  ignoredCommands = S.fromList [Run, Pure, Noop, Force]
 
 -- | Extract the command names from the source code of the solution.
 --

--- a/src/swarm-engine/Swarm/Game/CESK.hs
+++ b/src/swarm-engine/Swarm/Game/CESK.hs
@@ -320,7 +320,7 @@ cont = lens get set
 -- | Create a brand new CESK machine, with empty environment and
 --   store, to evaluate a given term.  We always initialize the
 --   machine with a single FExec frame as the continuation; if the
---   given term does not have a command type, we wrap it in @return@.
+--   given term does not have a command type, we wrap it in @pure@.
 initMachine :: TSyntax -> CESK
 initMachine t = In (prepareTerm mempty t) mempty emptyStore [FExec]
 
@@ -353,14 +353,14 @@ continue t = \case
 
 -- | Prepare a term for evaluation by a CESK machine in the given
 --   environment: erase all type annotations, and optionally wrap it
---   in @return@ if it does not have a command type.  Note that since
+--   in @pure@ if it does not have a command type.  Note that since
 --   the environment might contain type aliases, we have to be careful
 --   to expand them before concluding whether the term has a command
 --   type or not.
 prepareTerm :: Env -> TSyntax -> Term
 prepareTerm e t = case whnfType (e ^. envTydefs) (ptBody (t ^. sType)) of
   TyCmd _ -> t'
-  _ -> TApp (TConst Return) t'
+  _ -> TApp (TConst Pure) t'
  where
   t' = eraseS t
 

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -143,7 +143,7 @@ execConst runChildProg c vs s k = do
   -- Now proceed to actually carry out the operation.
   case c of
     Noop -> return $ mkReturn ()
-    Return -> case vs of
+    Pure -> case vs of
       [v] -> return $ Out v s k
       _ -> badConst
     Wait -> case vs of

--- a/src/swarm-lang/Swarm/Language/Capability.hs
+++ b/src/swarm-lang/Swarm/Language/Capability.hs
@@ -120,7 +120,7 @@ constCaps = \case
   Knows -> Nothing
   Noop -> Nothing
   Parent -> Nothing
-  Return -> Nothing
+  Pure -> Nothing
   Say -> Nothing -- speaking is natural to robots (unlike listening)
   Setname -> Nothing
   Undefined -> Nothing

--- a/src/swarm-lang/Swarm/Language/Elaborate.hs
+++ b/src/swarm-lang/Swarm/Language/Elaborate.hs
@@ -74,8 +74,8 @@ insertSuspend t = case t of
   TTydef x pty mtd t1 -> TTydef x pty mtd (insertSuspend t1)
   TBind mx mty mreq c1 c2 -> TBind mx mty mreq c1 (insertSuspend c2)
   TAnnotate t1 ty -> TAnnotate (insertSuspend t1) ty
-  -- Replace return or noop with suspend
-  TApp (TConst Return) t1 -> TSuspend t1
+  -- Replace pure or noop with suspend
+  TApp (TConst Pure) t1 -> TSuspend t1
   TConst Noop -> TSuspend TUnit
   -- Anything else: p => (__res__ <- p; suspend __res__)
   --

--- a/src/swarm-lang/Swarm/Language/Parser/Core.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Core.hs
@@ -57,7 +57,7 @@ data Antiquoting = AllowAntiquoting | DisallowAntiquoting
 -- | Which version of the Swarm language are we parsing?  As a general
 --   rule, we want to support one older version in addition to the
 --   current version, to allow for upgrading code via @swarm format@.
-data LanguageVersion = SwarmLang0_5 | SwarmLangLatest
+data LanguageVersion = SwarmLang0_6 | SwarmLangLatest
   deriving (Eq, Ord, Show, Enum, Bounded)
 
 -- | Read-only parser configuration.

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -43,10 +43,17 @@ parseDirection = asum (map alternative allDirs) <?> "direction constant"
 
 -- | Parse Const as reserved words (e.g. @Fail <$ reserved "fail"@)
 parseConst :: Parser Const
-parseConst = asum (map alternative consts) <?> "built-in user function"
+parseConst = do
+  ver <- view languageVersion
+  asum (map (alternative ver) consts) <?> "built-in user function"
  where
   consts = filter isUserFunc allConst
-  alternative c = c <$ reserved (syntax $ constInfo c)
+  alternative ver c = c <$ reserved (syntax $ constInfo' ver c)
+
+  -- Version 0.6 of the language had a constant named @return@, which
+  -- is now renamed to @pure@
+  constInfo' SwarmLang0_6 Pure = (constInfo Pure) {syntax = "return"}
+  constInfo' _ c = constInfo c
 
 -- | Parse an atomic term, optionally trailed by record projections like @t.x.y.z@.
 --   Record projection binds more tightly than function application.
@@ -136,7 +143,7 @@ parseTerm = sepEndBy1 parseStmt (symbol ";") >>= mkBindChain
 
 mkBindChain :: [Stmt] -> Parser Syntax
 mkBindChain stmts = case last stmts of
-  Binder x _ -> return $ foldr mkBind (STerm (TApp (TConst Return) (TVar (lvVar x)))) stmts
+  Binder x _ -> return $ foldr mkBind (STerm (TApp (TConst Pure) (TVar (lvVar x)))) stmts
   BareTerm t -> return $ foldr mkBind t (init stmts)
  where
   mkBind (BareTerm t1) t2 = loc Nothing t1 t2 $ SBind Nothing Nothing Nothing Nothing t1 t2

--- a/src/swarm-lang/Swarm/Language/Parser/Type.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Type.hs
@@ -13,13 +13,12 @@ module Swarm.Language.Parser.Type (
   parseTyCon,
 ) where
 
-import Control.Lens (view)
 import Control.Monad.Combinators (many)
 import Control.Monad.Combinators.Expr (Operator (..), makeExprParser)
 import Data.Fix (Fix (..), foldFix)
 import Data.List.Extra (enumerate)
 import Data.Maybe (fromMaybe)
-import Swarm.Language.Parser.Core (LanguageVersion (..), Parser, languageVersion)
+import Swarm.Language.Parser.Core (Parser)
 import Swarm.Language.Parser.Lex (
   braces,
   brackets,
@@ -78,14 +77,8 @@ parseTypeAtom =
 -- | A type constructor.
 parseTyCon :: Parser TyCon
 parseTyCon = do
-  ver <- view languageVersion
-  let reservedCase = case ver of
-        -- Version 0.5 of the language accepted type names in any case
-        SwarmLang0_5 -> reserved
-        -- The latest version requires them to be uppercase
-        SwarmLangLatest -> reservedCS
-  choice (map (\b -> TCBase b <$ reservedCase (baseTyName b)) enumerate)
-    <|> TCCmd <$ reservedCase "Cmd"
+  choice (map (\b -> TCBase b <$ reservedCS (baseTyName b)) enumerate)
+    <|> TCCmd <$ reservedCS "Cmd"
     <|> TCUser <$> tyName
 
 -- | Close over a recursive type, replacing any bound occurrences

--- a/src/swarm-lang/Swarm/Language/Syntax/Constants.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Constants.hs
@@ -226,8 +226,8 @@ data Const
     Snd
   | -- | Force a delayed evaluation.
     Force
-  | -- | Return for the cmd monad.
-    Return
+  | -- | Pure for the cmd monad.
+    Pure
   | -- | Try/catch block
     Try
   | -- | Undefined
@@ -790,7 +790,7 @@ constInfo c = case c of
     command 1 Intangible . doc (Set.singleton $ Query PRNG) "Get a uniformly random integer." $
       ["The random integer will be chosen from the range 0 to n-1, exclusive of the argument."]
   Run -> command 1 long $ shortDoc (Set.singleton $ Mutation $ RobotChange BehaviorChange) "Run a program loaded from a file."
-  Return -> command 1 Intangible $ shortDoc Set.empty "Make the value a result in `cmd`."
+  Pure -> command 1 Intangible $ shortDoc Set.empty "Create a pure `Cmd a`{=type} computation that yields the given value."
   Try -> command 2 Intangible $ shortDoc Set.empty "Execute a command, catching errors."
   Undefined -> function 0 $ shortDoc Set.empty "A value of any type, that is evaluated as error."
   Fail -> function 1 $ shortDoc Set.empty "A value of any type, that is evaluated as error with message."

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -206,19 +206,19 @@ testEval g =
             ("fail \"foo\"" `throwsError` ("foo" `T.isInfixOf`))
         , testCase
             "try / no exception 1"
-            ("try {return 1} {return 2}" `evaluatesTo` VInt 1)
+            ("try {pure 1} {pure 2}" `evaluatesTo` VInt 1)
         , testCase
             "try / no exception 2"
-            ("try {return 1} {let x = x in x}" `evaluatesTo` VInt 1)
+            ("try {pure 1} {let x = x in x}" `evaluatesTo` VInt 1)
         , testCase
             "try / fail"
-            ("try {fail \"foo\"} {return 3}" `evaluatesTo` VInt 3)
+            ("try {fail \"foo\"} {pure 3}" `evaluatesTo` VInt 3)
         , testCase
             "try / fail / fail"
             ("try {fail \"foo\"} {fail \"bar\"}" `throwsError` ("bar" `T.isInfixOf`))
         , testCase
             "try / div by 0"
-            ("try {return (1/0)} {return 3}" `evaluatesTo` VInt 3)
+            ("try {pure (1/0)} {pure 3}" `evaluatesTo` VInt 3)
         ]
     , testGroup
         "text"
@@ -446,33 +446,33 @@ testEval g =
         "scope - #681"
         [ testCase
             "binder in local scope"
-            ("def f = a <- scan down end; let a = 2 in f; return (a+1)" `evaluatesTo` VInt 3)
+            ("def f = a <- scan down end; let a = 2 in f; pure (a+1)" `evaluatesTo` VInt 3)
         , testCase
             "binder in local scope, no type change"
-            ("def f = a <- return 1 end; let a = 2 in f; return a" `evaluatesTo` VInt 2)
+            ("def f = a <- pure 1 end; let a = 2 in f; pure a" `evaluatesTo` VInt 2)
         , testCase
             "repeat with scan"
-            ("def x = \\n. \\c. if (n==0) {} {c; x (n-1) c} end; x 10 ( c <- scan down; case c (\\_. say \"Hi\") (\\_. return ()))" `evaluatesTo` VUnit)
+            ("def x = \\n. \\c. if (n==0) {} {c; x (n-1) c} end; x 10 ( c <- scan down; case c (\\_. say \"Hi\") (\\_. pure ()))" `evaluatesTo` VUnit)
         , testCase
             "nested recursion with binder - #1032"
-            ("def go = \\n. if (n > 0) {i <- return n; s <- go (n-1); return (s+i)} {return 0} end; go 4" `evaluatesTo` VInt 10)
+            ("def go = \\n. if (n > 0) {i <- pure n; s <- go (n-1); pure (s+i)} {pure 0} end; go 4" `evaluatesTo` VInt 10)
         , testCase
             "binder in local scope - #1796"
-            ("def x = \\x.x end; def foo = x <- return 0 end; foo; return (x 42)" `evaluatesTo` VInt 42)
+            ("def x = \\x.x end; def foo = x <- pure 0 end; foo; pure (x 42)" `evaluatesTo` VInt 42)
         ]
     , testGroup
         "nesting"
         [ testCase
             "def nested in def"
-            ("def x : Cmd Int = def y : Int = 3 end; return (y + 2) end; x" `evaluatesTo` VInt 5)
+            ("def x : Cmd Int = def y : Int = 3 end; pure (y + 2) end; x" `evaluatesTo` VInt 5)
         , testCase
             "nested def does not escape"
-            ( "def z = 1 end; def x = def z = 3 end; return (z + 2) end; n <- x; return (n + z)"
+            ( "def z = 1 end; def x = def z = 3 end; pure (z + 2) end; n <- x; pure (n + z)"
                 `evaluatesTo` VInt 6
             )
         , testCase
             "nested tydef"
-            ( "def x = (tydef X = Int end; def z : X = 3 end; return (z + 2)) end; x"
+            ( "def x = (tydef X = Int end; def z : X = 3 end; pure (z + 2)) end; x"
                 `evaluatesTo` VInt 5
             )
         ]

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -220,10 +220,10 @@ testLanguagePipeline =
             )
         , testCase
             "grabif"
-            (valid "def grabif : Text -> Cmd Unit = \\x. atomic (b <- ishere x; if b {grab; return ()} {}) end")
+            (valid "def grabif : Text -> Cmd Unit = \\x. atomic (b <- ishere x; if b {grab; pure ()} {}) end")
         , testCase
             "placeif"
-            (valid "def placeif : Text -> Cmd Bool = \\thing. atomic (res <- scan down; if (res == inl ()) {place thing; return true} {return false}) end")
+            (valid "def placeif : Text -> Cmd Bool = \\thing. atomic (res <- scan down; if (res == inl ()) {place thing; pure true} {pure false}) end")
         , testCase
             "atomic move+move"
             ( process
@@ -568,13 +568,13 @@ testLanguagePipeline =
         "generalize top-level binds #351 #1501"
         [ testCase
             "top-level polymorphic bind is OK"
-            (valid "r <- return (\\x.x)")
+            (valid "r <- pure (\\x.x)")
         , testCase
             "top-level bind is polymorphic"
-            (valid "f <- return (\\x.x); return (f 3, f \"hi\")")
+            (valid "f <- pure (\\x.x); pure (f 3, f \"hi\")")
         , testCase
             "local bind is polymorphic"
-            (valid "def foo : Cmd (Int * Text) = f <- return (\\x.x); return (f 3, f \"hi\") end")
+            (valid "def foo : Cmd (Int * Text) = f <- pure (\\x.x); pure (f 3, f \"hi\") end")
         ]
     , testGroup
         "type synonyms"
@@ -703,7 +703,7 @@ testLanguagePipeline =
             (valid "let x = 3 in x + 2")
         , testCase
             "let at cmd type"
-            (valid "let x = 3 in move; return (x+2)")
+            (valid "let x = 3 in move; pure (x+2)")
         , testCase
             "def at non-cmd type"
             ( process
@@ -712,7 +712,7 @@ testLanguagePipeline =
             )
         , testCase
             "def at cmd type"
-            (valid "def x = 3 end; move; return (x+2)")
+            (valid "def x = 3 end; move; pure (x+2)")
         ]
     , testGroup
         "nested let/def/annot #2101"


### PR DESCRIPTION
Closes #700.

The most interesting changes are in `swarm-lang/Swarm/Language/Parser/{Lex,Term}.hs`, where I remove the code for parsing swarm-0.5 and add an option to parse swarm-0.6 with `return` instead of `pure`, so `swarm format --v0.6` can be used to auto-convert code using `return` to code using `pure`.

Let me know how you feel about this change!  Another possible choice would be to leave `return` as a synonym for `pure`.  I could be convinced to do that as well.