### PR TITLE
Make FPS toggle and "recenter view" into global events

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -16,6 +16,7 @@ import Control.Monad.IO.Class (liftIO)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type (originalStructureDefinitions)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
+import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Step (finishGameTick)
 import Swarm.TUI.Controller.EventHandlers.Frame (runGameTickUI)
@@ -56,6 +57,8 @@ mainEventHandlers = allHandlers Main $ \case
   ToggleCreativeModeEvent -> ("Toggle creative mode", whenDebug ToggleCreative toggleCreativeMode)
   ToggleWorldEditorEvent -> ("Toggle world editor mode", whenDebug ToggleWorldEditor toggleWorldEditor)
   ToggleREPLVisibilityEvent -> ("Collapse/Expand REPL panel", toggleREPLVisibility)
+  ViewBaseEvent -> ("View the base robot", viewBase)
+  ToggleFPSEvent -> ("Toggle the FPS display", toggleFPS)
 
 toggleQuitGameDialog :: EventM Name AppState ()
 toggleQuitGameDialog = do
@@ -138,6 +141,14 @@ toggleREPLVisibility :: EventM Name AppState ()
 toggleREPLVisibility = do
   invalidateCacheEntry WorldCache
   uiState . uiGameplay . uiShowREPL %= not
+
+viewBase :: EventM Name AppState ()
+viewBase = do
+  invalidateCacheEntry WorldCache
+  gameState . robotInfo . viewCenterRule .= VCRobot 0
+
+toggleFPS :: EventM Name AppState ()
+toggleFPS = uiState . uiGameplay . uiTiming . uiShowFPS %= not
 
 -- ----------------------------------------------
 --                 HELPER UTILS

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/World.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/World.hs
@@ -22,23 +22,11 @@ import Swarm.Language.Syntax.Direction (Direction (..), directionSyntax)
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Event
-import Swarm.TUI.Model.UI
-import Swarm.TUI.Model.UI.Gameplay
 
 -- | Handle a user input event in the world view panel.
 worldEventHandlers :: [KeyEventHandler SwarmEvent (EventM Name AppState)]
 worldEventHandlers = allHandlers World $ \case
-  ViewBaseEvent -> ("View the base robot", viewBase)
-  ShowFpsEvent -> ("Show frames per second", showFps)
   MoveViewEvent d -> ("Scroll world view in the " <> directionSyntax (DAbsolute d) <> " direction", scrollViewInDir $ toHeading d)
-
-viewBase :: EventM Name AppState ()
-viewBase = do
-  invalidateCacheEntry WorldCache
-  gameState . robotInfo . viewCenterRule .= VCRobot 0
-
-showFps :: EventM Name AppState ()
-showFps = uiState . uiGameplay . uiTiming . uiShowFPS %= not
 
 scrollViewInDir :: V2 Int32 -> EventM Name AppState ()
 scrollViewInDir d = do

--- a/src/swarm-tui/Swarm/TUI/Model/Event.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Event.hs
@@ -174,7 +174,7 @@ defaultReplBindings = allBindings $ \case
 --                 REPL EVENTS
 -- ----------------------------------------------
 
-data WorldEvent
+newtype WorldEvent
   = MoveViewEvent AbsoluteDir
   deriving (Eq, Ord, Show, Generic)
   deriving (Enum, Bounded) via (FiniteEnumeration WorldEvent)

--- a/src/swarm-tui/Swarm/TUI/Model/Event.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Event.hs
@@ -89,6 +89,8 @@ data MainEvent
   | ToggleCreativeModeEvent
   | ToggleWorldEditorEvent
   | ToggleREPLVisibilityEvent
+  | ViewBaseEvent
+  | ToggleFPSEvent
   deriving (Eq, Ord, Show, Enum, Bounded)
 
 mainEvents :: KeyEvents MainEvent
@@ -114,6 +116,8 @@ mainEvents = allKeyEvents $ \case
   ToggleCreativeModeEvent -> "creative mode"
   ToggleWorldEditorEvent -> "world editor"
   ToggleREPLVisibilityEvent -> "toggle REPL"
+  ViewBaseEvent -> "view base robot"
+  ToggleFPSEvent -> "toggle FPS"
 
 defaultMainBindings :: [(MainEvent, [Binding])]
 defaultMainBindings = allBindings $ \case
@@ -138,6 +142,8 @@ defaultMainBindings = allBindings $ \case
   ToggleCreativeModeEvent -> [ctrl 'v']
   ToggleWorldEditorEvent -> []
   ToggleREPLVisibilityEvent -> [meta ',']
+  ViewBaseEvent -> [meta 'c']
+  ToggleFPSEvent -> [meta 'f']
 
 -- ----------------------------------------------
 --                 REPL EVENTS
@@ -169,22 +175,16 @@ defaultReplBindings = allBindings $ \case
 -- ----------------------------------------------
 
 data WorldEvent
-  = ViewBaseEvent
-  | ShowFpsEvent
-  | MoveViewEvent AbsoluteDir
+  = MoveViewEvent AbsoluteDir
   deriving (Eq, Ord, Show, Generic)
   deriving (Enum, Bounded) via (FiniteEnumeration WorldEvent)
 
 worldPanelEvents :: KeyEvents WorldEvent
 worldPanelEvents = allKeyEvents $ \case
-  ViewBaseEvent -> "view base"
-  ShowFpsEvent -> "show fps"
   MoveViewEvent d -> "move view " <> directionSyntax (DAbsolute d)
 
 defaultWorldPanelBindings :: [(WorldEvent, [Binding])]
 defaultWorldPanelBindings = allBindings $ \case
-  ViewBaseEvent -> [bind 'c']
-  ShowFpsEvent -> [bind 'f']
   MoveViewEvent DWest -> [bind V.KLeft, bind 'h']
   MoveViewEvent DSouth -> [bind V.KDown, bind 'j']
   MoveViewEvent DNorth -> [bind V.KUp, bind 'k']

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -894,7 +894,6 @@ drawKeyMenu s =
   isReplWorking = gs ^. gameControls . replWorking
   isPaused = gs ^. temporal . paused
   hasDebug = hasDebugCapability creative s
-  viewingBase = (gs ^. robotInfo . viewCenterRule) == VCRobot 0
   creative = gs ^. creativeMode
   showCreative = s ^. uiState . uiDebugOptions . Lens.contains ToggleCreative
   showEditor = s ^. uiState . uiDebugOptions . Lens.contains ToggleWorldEditor
@@ -965,8 +964,6 @@ drawKeyMenu s =
       ++ [("PgUp/Dn", "scroll")]
   keyCmdsFor (Just (FocusablePanel WorldPanel)) =
     [(T.intercalate "/" $ map keyW enumerate, "scroll") | canScroll]
-      ++ [(keyW SE.ViewBaseEvent, "recenter") | not viewingBase]
-      ++ [(keyW SE.ShowFpsEvent, "FPS")]
   keyCmdsFor (Just (FocusablePanel RobotPanel)) =
     ("Enter", "pop out")
       : if isJust inventorySearch


### PR DESCRIPTION
Remove FPS toggle and "recenter view" from the world panel and make them into globally available events with default keybindings (M-f and M-c, respectively).

Closes #1992.