### PR TITLE
Disallow `IntMap.!`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -34,6 +34,7 @@
   - {name: undefined, within: [Swarm.Language.Key, TestUtil]}
   - {name: fromJust, within: []}
   - {name: Data.Colour.SRGB.sRGB24read, within: []}
+  - {name: Data.IntMap.!, within: []}
 # - {name: Data.Map.!, within: []} # TODO: #1494
 # - {name: error, within: []} # TODO: #1494
 

--- a/src/swarm-engine/Swarm/Game/State.hs
+++ b/src/swarm-engine/Swarm/Game/State.hs
@@ -224,7 +224,7 @@ pathCaching :: Lens' GameState PathCaching
 -- | Get all the robots within a given Manhattan distance from a
 --   location.
 robotsInArea :: Cosmic Location -> Int32 -> Robots -> [Robot]
-robotsInArea (Cosmic subworldName o) d rs = map (rm IM.!) rids
+robotsInArea (Cosmic subworldName o) d rs = mapMaybe (rm IM.!?) rids
  where
   rm = rs ^. robotMap
   rl = rs ^. robotsByLocation

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -112,7 +112,7 @@ import Data.IntSet qualified as IS
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
-import Data.Maybe (isJust, listToMaybe)
+import Data.Maybe (isJust, listToMaybe, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set (fromList, member)
 import Data.Text (Text)
@@ -748,7 +748,7 @@ lookup e (Inventory cs _ _) = maybe 0 fst $ IM.lookup (e ^. entityHash) cs
 --   positive, or just use 'countByName' in the first place.
 lookupByName :: Text -> Inventory -> [Entity]
 lookupByName name (Inventory cs byN _) =
-  maybe [] (map (snd . (cs IM.!)) . IS.elems) (M.lookup (T.toLower name) byN)
+  maybe [] (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems) (M.lookup (T.toLower name) byN)
 
 -- | Look up an entity by name and see how many there are in the
 --   inventory.  If there are multiple entities with the same name, it


### PR DESCRIPTION
`IntMap.!` is partial and should not be allowed.  Fixes #2294 .  Towards #1494.
