### PR TITLE
Throw an error if any world description fails to parse or typecheck

### DIFF
--- a/src/swarm-scenario/Swarm/Game/Scenario.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario.hs
@@ -440,6 +440,11 @@ loadScenarioFile scenarioInputs fileName =
  where
   adaptError = AssetNotLoaded (Data Scenarios) fileName . CanNotParseYaml
 
+-- | Load a single scenario from disk, first loading needed entity +
+--   recipe data.  This function should only be called in the case of
+--   "peripheral" tools that need to load a scenario (for example,
+--   documentation generation, scenario world rendering, etc.), not as
+--   part of the normal game code path.
 loadStandaloneScenario ::
   (Has (Throw SystemFailure) sig m, Has (Lift IO) sig m) =>
   FilePath ->

--- a/weeder.toml
+++ b/weeder.toml
@@ -45,6 +45,7 @@ roots = [
     "^Swarm.Util.replaceLast$",
     "^Swarm.Util.reflow$",
     "^Swarm.Util._NonEmpty$",
+    "^Swarm.Util.Effect.throwToWarning$",
 
     # True positives (unused lenses):
     # -------------------------------


### PR DESCRIPTION
Fixes #2304.  Previously, any `data/worlds/*.world` which failed to parse or typecheck only generated a warning, which could be viewed in Messages, but could not be seen if loading a single scenario.

There is not much use to only display a warning and keep going in such a circumstance; presumably the only time this would happen is if someone is developing a world description, in which case they want to know immediately about any errors.  This PR makes such world loading failures into an exception rather than a warning.