### PR TITLE
Make `Tutorial` menu choice auto-start first *unsolved* tutorial scenario

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -47,7 +47,7 @@ import Data.List (find)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
-import Data.Maybe (fromMaybe, isJust, mapMaybe, listToMaybe)
+import Data.Maybe (fromMaybe, isJust, listToMaybe, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as S
 import Data.Text (Text)
@@ -215,7 +215,6 @@ handleMainMenuEvent menu = \case
         -- Finally, set the menu stack, and start the scenario!
         uiState . uiMenu .= NewGameMenu menuStack
         startGame firstUnsolvedInfo Nothing
-
       Achievements -> uiState . uiMenu .= AchievementsMenu (BL.list AchievementList (V.fromList listAchievements) 1)
       Messages -> do
         runtimeState . eventLog . notificationsCount .= 0


### PR DESCRIPTION
Choosing `Tutorial` from the main menu now automatically starts playing the first *unsolved* tutorial scenario, rather than always starting with the first.  Closes #2308.