### PR TITLE
Remove say command one message limit

### DIFF
--- a/data/scenarios/Testing/00-ORDER.txt
+++ b/data/scenarios/Testing/00-ORDER.txt
@@ -57,6 +57,7 @@ Achievements
 1721-walkability-whitelist-path-cache.yaml
 1535-ping
 1575-structure-recognizer
+1592-shared-template-robot-say-logs.yaml
 1631-tags.yaml
 1634-message-colors.yaml
 1681-pushable-entity.yaml

--- a/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
+++ b/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
@@ -1,5 +1,6 @@
 version: 1
 name: Logs from same-template robots
+creative: false
 description: |
   Logs from different robots generated from the same template.
 

--- a/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
+++ b/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
@@ -2,14 +2,26 @@ version: 1
 name: Logs from same-template robots
 description: |
   Logs from different robots generated from the same template.
+
+  The objective checks that base hears one message each tick,
+  afterwards the integration test checks that all messages
+  are present in the base log.
 objectives:
   - goal:
-    - Please `grab` the `token`{=entity} if you hear what you expected.
+      - Please `grab` the `token`{=entity} if you hear what you expected.
     condition: |
       as base { has "token" }
 solution: |
   s <- listen;
-  if (s == "Hello from (4, -2)!") {grab; say "OK!"} {say $ "Not what I expected: " ++ s}
+  if (s == "Hello from (2, -2)!") {
+    s <- listen;
+    if (s == "Hello from (3, -2)!") {
+      s <- listen;
+      if (s == "Hello from (4, -2)!") {
+        grab; say "OK!"
+      } {say $ "3: Not what I expected: " ++ s}
+    } {say $ "2: Not what I expected: " ++ s}
+  } {say $ "1: Not what I expected: " ++ s}
 robots:
   - name: base
     devices:
@@ -26,7 +38,7 @@ robots:
       attr: blue
     program: |
       loc <- whereami;
-      wait $ snd loc;
+      wait $ fst loc;
       say ("Hello from " ++ format loc ++ "!");
 entities:
   - name: token
@@ -41,9 +53,8 @@ world:
   palette:
     '.': [grass]
     'B': [grass, token, base]
-    's': [grass, null, saybot]    
+    's': [grass, null, saybot]
   map: |
-    ....s
-    ...ss
     B...s
-    
+    ...ss
+    ..sss

--- a/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
+++ b/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
@@ -2,11 +2,23 @@ version: 1
 name: Logs from same-template robots
 description: |
   Logs from different robots generated from the same template.
+objectives:
+  - goal:
+    - Please `grab` the `token`{=entity} if you hear what you expected.
+    condition: |
+      as base { has "token" }
+solution: |
+  s <- listen;
+  if (s == "Hello from (4, -2)!") {grab; say "OK!"} {say $ "Not what I expected: " ++ s}
 robots:
   - name: base
     devices:
       - logger
       - hearing aid
+      - comparator
+      - branch predictor
+      - string
+      - grabber
   - name: saybot
     system: true
     display:
@@ -15,14 +27,21 @@ robots:
     program: |
       loc <- whereami;
       wait $ snd loc;
-      say "Hello";
+      say ("Hello from " ++ format loc ++ "!");
+entities:
+  - name: token
+    display:
+      char: 'W'
+    properties:
+      - known
+      - pickable
+    description:
+      - Signals a success.
 world:
   palette:
     '.': [grass]
-    'B': [grass, null, base]
-    's': [grass, null, saybot]
-    
-  upperleft: [0, 4]
+    'B': [grass, token, base]
+    's': [grass, null, saybot]    
   map: |
     ....s
     ...ss

--- a/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
+++ b/data/scenarios/Testing/1592-shared-template-robot-say-logs.yaml
@@ -1,0 +1,30 @@
+version: 1
+name: Logs from same-template robots
+description: |
+  Logs from different robots generated from the same template.
+robots:
+  - name: base
+    devices:
+      - logger
+      - hearing aid
+  - name: saybot
+    system: true
+    display:
+      invisible: false
+      attr: blue
+    program: |
+      loc <- whereami;
+      wait $ snd loc;
+      say "Hello";
+world:
+  palette:
+    '.': [grass]
+    'B': [grass, null, base]
+    's': [grass, null, saybot]
+    
+  upperleft: [0, 4]
+  map: |
+    ....s
+    ...ss
+    B...s
+    

--- a/data/schema/entity.json
+++ b/data/schema/entity.json
@@ -122,7 +122,7 @@
                 "type": "string",
                 "examples": [
                     "unwalkable",
-                    "portable",
+                    "pickable",
                     "infinite",
                     "known",
                     "growable"

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -749,34 +749,21 @@ execConst runChildProg c vs s k = do
       [VText msg] -> do
         isPrivileged <- isPrivilegedBot
         loc <- use robotLocation
-
         -- current robot will be inserted into the robot set, so it needs the log
         m <- traceLog Said Info msg
         emitMessage m
         let measureToLog robLoc = \case
               RobotLog _ _ logLoc -> cosmoMeasure manhattan robLoc logLoc
               SystemLog -> Measurable 0
-            addLatestClosest rl = \case
-              Seq.Empty -> Seq.singleton m
-              es Seq.:|> e
-                | e `isEarlierThan` m -> es |> e |> m
-                | e `isFartherThan` m -> es |> m
-                | otherwise -> es |> e
-             where
-              isEarlierThan = (<) `on` (^. leTime)
-              isFartherThan = (>) `on` (measureToLog rl . view leSource)
         let addToRobotLog :: (Has (State GameState) sgn m) => Robot -> m ()
             addToRobotLog r = do
               maybeRidLoc <- evalState r $ do
                 hasLog <- hasCapability $ CExecute Log
                 hasListen <- hasCapability $ CExecute Listen
-                loc' <- use robotLocation
                 rid <- use robotID
-                return $ do
-                  guard $ hasLog && hasListen
-                  Just (rid, loc')
-              forM_ maybeRidLoc $ \(rid, loc') ->
-                robotInfo . robotMap . at rid . _Just . robotLog %= addLatestClosest loc'
+                return $ if hasLog && hasListen then Just rid else Nothing
+              forM_ maybeRidLoc $ \rid ->
+                robotInfo . robotMap . at rid . _Just . robotLog %= (|> m)
         robotsAround <-
           zoomRobots $
             if isPrivileged

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -753,13 +753,11 @@ execConst runChildProg c vs s k = do
         m <- traceLog Said Info msg
         emitMessage m
         let addToRobotLog :: (Has (State GameState) sgn m) => Robot -> m ()
-            addToRobotLog r = do
-              maybeRidLoc <- evalState r $ do
-                hasLog <- hasCapability $ CExecute Log
-                hasListen <- hasCapability $ CExecute Listen
-                rid <- use robotID
-                return $ if hasLog && hasListen then Just rid else Nothing
-              forM_ maybeRidLoc $ \rid ->
+            addToRobotLog r = evalState r $ do
+              hasLog <- hasCapability $ CExecute Log
+              hasListen <- hasCapability $ CExecute Listen
+              rid <- use robotID
+              when (hasLog && hasListen) $
                 robotInfo . robotMap . at rid . _Just . robotLog %= (|> m)
         robotsAround <-
           zoomRobots $

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -752,9 +752,6 @@ execConst runChildProg c vs s k = do
         -- current robot will be inserted into the robot set, so it needs the log
         m <- traceLog Said Info msg
         emitMessage m
-        let measureToLog robLoc = \case
-              RobotLog _ _ logLoc -> cosmoMeasure manhattan robLoc logLoc
-              SystemLog -> Measurable 0
         let addToRobotLog :: (Has (State GameState) sgn m) => Robot -> m ()
             addToRobotLog r = do
               maybeRidLoc <- evalState r $ do


### PR DESCRIPTION
* remove the `say` command limitation that only keeps one last said message in hearing robot logs
* add test case from #1593 
  * add correct behavior check to scenario objective and integration test
* closes #1592
* closes #1593
* see the original merge request #565 for context

Co-authored-by: Karl Ostmo <kostmo@gmail.com>
Co-authored-by: Brent Yorgey <byorgey@gmail.com>