### PR TITLE
Move parse + typecheck failures from `LoadingFailure` to `SystemFailure`

### DIFF
--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -490,7 +490,7 @@ validateEntityAttrRefs validAttrs es =
       AWorld n ->
         unless (Set.member (WorldAttr $ T.unpack n) validAttrs)
           . throwError
-          . General
+          . SystemFailure
           . CustomFailure
           $ T.unwords
             [ "Nonexistent attribute"
@@ -510,7 +510,7 @@ buildEntityMap es = do
   forM_ (findDup $ map fst namedEntities) $
     throwError . Duplicate Entities
   case combineEntityCapsM entsByName es of
-    Left x -> throwError . General . CustomFailure $ x
+    Left x -> throwError . SystemFailure . CustomFailure $ x
     Right ebc ->
       return $
         EntityMap

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -490,7 +490,8 @@ validateEntityAttrRefs validAttrs es =
       AWorld n ->
         unless (Set.member (WorldAttr $ T.unpack n) validAttrs)
           . throwError
-          . CustomMessage
+          . General
+          . CustomFailure
           $ T.unwords
             [ "Nonexistent attribute"
             , quote n
@@ -509,7 +510,7 @@ buildEntityMap es = do
   forM_ (findDup $ map fst namedEntities) $
     throwError . Duplicate Entities
   case combineEntityCapsM entsByName es of
-    Left x -> throwError $ CustomMessage x
+    Left x -> throwError . General . CustomFailure $ x
     Right ebc ->
       return $
         EntityMap

--- a/src/swarm-scenario/Swarm/Game/Recipe.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe.hs
@@ -163,7 +163,7 @@ loadRecipes em = do
     withThrow (AssetNotLoaded (Data Recipes) fileName . CanNotParseYaml)
       . (liftEither <=< sendIO)
       $ decodeFileEither @[Recipe Text] fileName
-  withThrow (AssetNotLoaded (Data Recipes) fileName . General . CustomFailure)
+  withThrow (AssetNotLoaded (Data Recipes) fileName . SystemFailure . CustomFailure)
     . liftEither
     . left (T.append "Unknown entities in recipe(s): " . T.intercalate ", ")
     . validationToEither

--- a/src/swarm-scenario/Swarm/Game/Recipe.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe.hs
@@ -163,7 +163,7 @@ loadRecipes em = do
     withThrow (AssetNotLoaded (Data Recipes) fileName . CanNotParseYaml)
       . (liftEither <=< sendIO)
       $ decodeFileEither @[Recipe Text] fileName
-  withThrow (AssetNotLoaded (Data Recipes) fileName . CustomMessage)
+  withThrow (AssetNotLoaded (Data Recipes) fileName . General . CustomFailure)
     . liftEither
     . left (T.append "Unknown entities in recipe(s): " . T.intercalate ", ")
     . validationToEither

--- a/src/swarm-scenario/Swarm/Game/Terrain.hs
+++ b/src/swarm-scenario/Swarm/Game/Terrain.hs
@@ -134,7 +134,7 @@ validateTerrainAttrRefs validAttrs rawTerrains =
   forM rawTerrains $ \(TerrainItem n a d) -> do
     unless (Set.member (WorldAttr $ T.unpack a) validAttrs)
       . throwError
-      . General
+      . SystemFailure
       . CustomFailure
       $ T.unwords
         [ "Nonexistent attribute"

--- a/src/swarm-scenario/Swarm/Game/Terrain.hs
+++ b/src/swarm-scenario/Swarm/Game/Terrain.hs
@@ -134,7 +134,8 @@ validateTerrainAttrRefs validAttrs rawTerrains =
   forM rawTerrains $ \(TerrainItem n a d) -> do
     unless (Set.member (WorldAttr $ T.unpack a) validAttrs)
       . throwError
-      . CustomMessage
+      . General
+      . CustomFailure
       $ T.unwords
         [ "Nonexistent attribute"
         , quote a

--- a/src/swarm-scenario/Swarm/Game/World/Load.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Load.hs
@@ -46,10 +46,10 @@ loadWorld ::
   m (Text, Some (TTerm '[]))
 loadWorld dir tem (fp, src) = do
   wexp <-
-    liftEither . left (AssetNotLoaded (Data Worlds) fp . General . CanNotParseMegaparsec) $
+    liftEither . left (AssetNotLoaded (Data Worlds) fp . SystemFailure . CanNotParseMegaparsec) $
       runParser parseWExp (into @Text src)
   t <-
-    withThrow (AssetNotLoaded (Data Worlds) fp . General . DoesNotTypecheck . prettyText @CheckErr) $
+    withThrow (AssetNotLoaded (Data Worlds) fp . SystemFailure . DoesNotTypecheck . prettyText @CheckErr) $
       runReader tem . runReader @WorldMap M.empty $
         infer CNil wexp
   return (into @Text (dropExtension (stripDir dir fp)), t)

--- a/src/swarm-scenario/Swarm/Game/World/Load.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Load.hs
@@ -46,10 +46,10 @@ loadWorld ::
   m (Text, Some (TTerm '[]))
 loadWorld dir tem (fp, src) = do
   wexp <-
-    liftEither . left (AssetNotLoaded (Data Worlds) fp . CanNotParseMegaparsec) $
+    liftEither . left (AssetNotLoaded (Data Worlds) fp . General . CanNotParseMegaparsec) $
       runParser parseWExp (into @Text src)
   t <-
-    withThrow (AssetNotLoaded (Data Worlds) fp . DoesNotTypecheck . prettyText @CheckErr) $
+    withThrow (AssetNotLoaded (Data Worlds) fp . General . DoesNotTypecheck . prettyText @CheckErr) $
       runReader tem . runReader @WorldMap M.empty $
         infer CNil wexp
   return (into @Text (dropExtension (stripDir dir fp)), t)

--- a/src/swarm-tui/Swarm/TUI/Model/KeyBindings.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/KeyBindings.hs
@@ -41,7 +41,7 @@ loadKeybindingConfig = do
     else do
       loadedCustomBindings <- sendIO $ keybindingsFromFile swarmEvents "keybindings" ini
       case loadedCustomBindings of
-        Left e -> throwError $ AssetNotLoaded Keybindings ini (CustomMessage $ T.pack e)
+        Left e -> throwError $ AssetNotLoaded Keybindings ini (General . CustomFailure $ T.pack e)
         Right bs -> pure $ fromMaybe [] bs
 
 initKeyHandlingState ::

--- a/src/swarm-tui/Swarm/TUI/Model/KeyBindings.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/KeyBindings.hs
@@ -41,7 +41,7 @@ loadKeybindingConfig = do
     else do
       loadedCustomBindings <- sendIO $ keybindingsFromFile swarmEvents "keybindings" ini
       case loadedCustomBindings of
-        Left e -> throwError $ AssetNotLoaded Keybindings ini (General . CustomFailure $ T.pack e)
+        Left e -> throwError $ AssetNotLoaded Keybindings ini (SystemFailure . CustomFailure $ T.pack e)
         Right bs -> pure $ fromMaybe [] bs
 
 initKeyHandlingState ::

--- a/src/swarm-util/Swarm/Failure.hs
+++ b/src/swarm-util/Swarm/Failure.hs
@@ -53,7 +53,7 @@ data LoadingFailure
   | EntryNot Entry
   | CanNotParseYaml ParseException
   | Duplicate AssetData Text
-  | General SystemFailure
+  | SystemFailure SystemFailure
   deriving (Show)
 
 -- ~~~~ Note [Pretty-printing typechecking errors]
@@ -114,7 +114,7 @@ instance PrettyPrec LoadingFailure where
         "Parse failure:"
           : map pretty (T.lines (into @Text (prettyPrintParseException p)))
     Duplicate thing duped -> "Duplicate" <+> ppr thing <> ":" <+> squotes (pretty duped)
-    General g -> prettyPrec prec g
+    SystemFailure g -> prettyPrec prec g
 
 instance PrettyPrec OrderFileWarning where
   prettyPrec _ = \case

--- a/src/swarm-util/Swarm/ResourceLoading.hs
+++ b/src/swarm-util/Swarm/ResourceLoading.hs
@@ -146,7 +146,7 @@ readAppData = do
   dirMembers :: [FilePath] <-
     (liftEither <=< sendIO) $
       (pure <$> listDirectory d) `catch` \(e :: IOException) ->
-        return . Left . AssetNotLoaded (Data AppAsset) d . General . CustomFailure . T.pack $ show e
+        return . Left . AssetNotLoaded (Data AppAsset) d . SystemFailure . CustomFailure . T.pack $ show e
   let fs = filter ((== ".txt") . takeExtension) dirMembers
 
   filesList <- sendIO $ forM fs (\f -> (into @Text (dropExtension f),) <$> readFileMayT (d </> f))

--- a/src/swarm-util/Swarm/ResourceLoading.hs
+++ b/src/swarm-util/Swarm/ResourceLoading.hs
@@ -146,7 +146,7 @@ readAppData = do
   dirMembers :: [FilePath] <-
     (liftEither <=< sendIO) $
       (pure <$> listDirectory d) `catch` \(e :: IOException) ->
-        return . Left . AssetNotLoaded (Data AppAsset) d . CustomMessage . T.pack $ show e
+        return . Left . AssetNotLoaded (Data AppAsset) d . General . CustomFailure . T.pack $ show e
   let fs = filter ((== ".txt") . takeExtension) dirMembers
 
   filesList <- sendIO $ forM fs (\f -> (into @Text (dropExtension f),) <$> readFileMayT (d </> f))


### PR DESCRIPTION
Two constructors in `LoadingFailure` represented failures that are not necessarily limited to failures that can only happen when loading an asset, namely, parsing failures and typechecking failures.  For example, we could fail to parse or typecheck a term entered at the REPL, which has nothing to do with loading an asset.  This PR:

1. Moves those constructors into `SystemFailure`.
2. Adds a way to embed any `SystemFailure` into a `LoadingFailure` (via the new `General` constructor; name bikeshedding welcome)
3. Removes the `CustomMessage` constructor from `LoadingFailure` since now that can be achieved via `General . CustomFailure`.

This is a preliminary refactoring moving towards a PR for #495.