### PR TITLE
Use `MonoidMap` to simplify `Inventory` functions.

### DIFF
--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -112,7 +112,7 @@ import Data.IntSet qualified as IS
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
-import Data.Maybe (isJust, listToMaybe, mapMaybe)
+import Data.Maybe (isJust, listToMaybe)
 import Data.MonoidMap (MonoidMap)
 import Data.MonoidMap qualified as MM
 import Data.MonoidMap.JSON ()
@@ -752,7 +752,7 @@ lookup e (Inventory cs _ _) = maybe 0 fst $ IM.lookup (e ^. entityHash) cs
 --   positive, or just use 'countByName' in the first place.
 lookupByName :: Text -> Inventory -> [Entity]
 lookupByName name (Inventory cs byN _) =
-  mapMaybe (fmap snd . (cs IM.!?)) . IS.elems $ MM.get (T.toLower name) byN
+  fmap snd . IM.elems . IM.restrictKeys cs $ MM.get (T.toLower name) byN
 
 -- | Look up an entity by name and see how many there are in the
 --   inventory.  If there are multiple entities with the same name, it

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -113,6 +113,9 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (isJust, listToMaybe, mapMaybe)
+import Data.MonoidMap (MonoidMap)
+import Data.MonoidMap qualified as MM
+import Data.MonoidMap.JSON ()
 import Data.Set (Set)
 import Data.Set qualified as Set (fromList, member)
 import Data.Text (Text)
@@ -716,7 +719,7 @@ data Inventory = Inventory
     counts :: IntMap (Count, Entity)
   , -- Mirrors the main map; just caching the ability to look up by
     -- name.
-    byName :: Map Text IntSet
+    byName :: MonoidMap Text IntSet
   , -- Cached hash of the inventory, using a homomorphic hashing scheme
     -- (see https://github.com/swarm-game/swarm/issues/229).
     --
@@ -749,7 +752,7 @@ lookup e (Inventory cs _ _) = maybe 0 fst $ IM.lookup (e ^. entityHash) cs
 --   positive, or just use 'countByName' in the first place.
 lookupByName :: Text -> Inventory -> [Entity]
 lookupByName name (Inventory cs byN _) =
-  maybe [] (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems) (M.lookup (T.toLower name) byN)
+  mapMaybe (fmap snd . (cs IM.!?)) . IS.elems $ MM.get (T.toLower name) byN
 
 -- | Look up an entity by name and see how many there are in the
 --   inventory.  If there are multiple entities with the same name, it
@@ -760,7 +763,7 @@ countByName name inv =
 
 -- | The empty inventory.
 empty :: Inventory
-empty = Inventory IM.empty M.empty 0
+empty = Inventory IM.empty MM.empty 0
 
 -- | Create an inventory containing one entity.
 singleton :: Entity -> Inventory
@@ -786,7 +789,7 @@ insertCount :: Count -> Entity -> Inventory -> Inventory
 insertCount k e (Inventory cs byN h) =
   Inventory
     (IM.insertWith (\(m, _) (n, _) -> (m + n, e)) (e ^. entityHash) (k, e) cs)
-    (M.insertWith IS.union (T.toLower $ e ^. entityName) (IS.singleton (e ^. entityHash)) byN)
+    (MM.adjust (IS.union (IS.singleton (e ^. entityHash))) (T.toLower $ e ^. entityName) byN)
     (h + (k + extra) * (e ^. entityHash)) -- homomorphic hashing
  where
   -- Include the hash of an entity once just for "knowing about" it;
@@ -876,7 +879,7 @@ union :: Inventory -> Inventory -> Inventory
 union (Inventory cs1 byN1 h1) (Inventory cs2 byN2 h2) =
   Inventory
     (IM.unionWith (\(c1, e) (c2, _) -> (c1 + c2, e)) cs1 cs2)
-    (M.unionWith IS.union byN1 byN2)
+    (MM.unionWith IS.union byN1 byN2)
     (h1 + h2 - common)
  where
   -- Need to subtract off the sum of the hashes in common, because

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -879,7 +879,7 @@ union :: Inventory -> Inventory -> Inventory
 union (Inventory cs1 byN1 h1) (Inventory cs2 byN2 h2) =
   Inventory
     (IM.unionWith (\(c1, e) (c2, _) -> (c1 + c2, e)) cs1 cs2)
-    (MM.unionWith IS.union byN1 byN2)
+    (MM.union byN1 byN2)
     (h1 + h2 - common)
  where
   -- Need to subtract off the sum of the hashes in common, because

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -789,7 +789,7 @@ insertCount :: Count -> Entity -> Inventory -> Inventory
 insertCount k e (Inventory cs byN h) =
   Inventory
     (IM.insertWith (\(m, _) (n, _) -> (m + n, e)) (e ^. entityHash) (k, e) cs)
-    (MM.adjust (IS.union (IS.singleton (e ^. entityHash))) (T.toLower $ e ^. entityName) byN)
+    (MM.adjust (IS.insert (e ^. entityHash)) (T.toLower $ e ^. entityName) byN)
     (h + (k + extra) * (e ^. entityHash)) -- homomorphic hashing
  where
   -- Include the hash of an entity once just for "knowing about" it;

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -255,6 +255,12 @@ common MissingH
 common monad-logger
   build-depends: monad-logger >=0.3.0 && <0.4.0
 
+common monoidmap
+  build-depends: monoidmap >=0.0.3.0 && <0.1
+
+common monoidmap-aeson
+  build-depends: monoidmap-aeson >=0.0.0.1 && <0.1
+
 common mtl
   build-depends: mtl >=2.2.2 && <2.4
 
@@ -585,6 +591,8 @@ library swarm-scenario
     linear,
     megaparsec,
     monad-logger,
+    monoidmap,
+    monoidmap-aeson,
     mtl,
     murmur3,
     palette,


### PR DESCRIPTION
Addresses part of #2300 (but does not close it).

## Summary

This PR uses [`MonoidMap`](https://hackage.haskell.org/package/monoidmap/docs/Data-MonoidMap.html) to make the following transformation:

```patch
  data Inventory = Inventory
    { counts :: IntMap (Count, Entity)
-   , byName ::       Map Text IntSet
+   , byName :: MonoidMap Text IntSet
    , inventoryHash :: Int
    }
```

This allows us to simplify several functions that manipulate `Inventory` objects.
For example (formatted for clarity):

```patch
  lookupByName :: Text -> Inventory -> [Entity]
  lookupByName name (Inventory cs byN _) =
-   maybe
-     []
      (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems)
-     (M.lookup (T.toLower name) byN)
+     (MM.get   (T.toLower name) byN)
```

## Justification

Consider a situation where a given `name` does not map to any hashes. The use of `Map` gives us **two** possible representations for this state:

1. The `name` is **not** present in the `Map`, and `lookup` returns `Nothing`.
2. The `name` **is** present in the `Map`, but maps to `Just IntSet.empty`.

In some cases, it's useful to distinguish between these two representations.

However, the current implementation:
- assigns the same semantics to both representations;
- must handle both representations explicitly.

Let's consider the original `lookupByName` function:

```hs
lookupByName name (Inventory cs byN _) =
  maybe [] (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems) (M.lookup (T.toLower name) byN)
```

When `name` is **not** present in the map, `lookupByName` evaluates to `[]`:

```hs
   maybe [] (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems) (M.lookup (T.toLower name) byN)
== maybe [] (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems) (Nothing)
==       []
```

When `name` **is** present in the map, but maps to the empty `IntSet`, `lookupByName` also evaluates to `[]`:

```hs
   maybe [] (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems) (M.lookup (T.toLower name) byN)
== maybe [] (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems) (Just IntSet.empty)
==          (mapMaybe (fmap snd . (cs IM.!?)) . IS.elems) (     IntSet.empty)
==           mapMaybe (fmap snd . (cs IM.!?))  (IS.elems        IntSet.empty)
==           mapMaybe (fmap snd . (cs IM.!?))  []
==                                             []
```

In contrast, the `MonoidMap` data type provides a single, canonical representation for "null" or "empty" values, according to the following conceptual mapping:

| `Map.lookup k m`        | ⟼ | `MonoidMap.get k m`     |
|:------------------------|---|:------------------------|
| `Nothing`               | ⟼ | `mempty`                |
| `Just v \| v == mempty` | ⟼ | `mempty`                |
| `Just v \| v /= mempty` | ⟼ | `v`                     |

In our context, `mempty` corresponds to `IntSet.empty`.

In the case where a given `name` does not map to any hashes, the use of `MonoidMap` allows `lookupByName` (and other functions) to handle just one representation instead of two.

## Other changes

### `MonoidMap.union`

In contrast to `Map.union`, the `MonoidMap.union` function applies the `<>` operator to pairs of matching values. In the case of `IntSet`, the `<>` operator corresponds to `IntSet.union`. This allows us make the following simplification:

```patch
  union (Inventory cs1 byN1 h1) (Inventory cs2 byN2 h2) =
    Inventory
      (IM.unionWith (\(c1, e) (c2, _) -> (c1 + c2, e)) cs1 cs2)
-     ( M.unionWith IS.union byN1 byN2)
+     (MM.union              byN1 byN2)
      (h1 + h2 - common)
```

### `MonoidMap.adjust`

The `Map.adjust` function is only able to adjust a value for a given key `k` if `k` is already in the map. If `k` is not in the map, then `Map.adjust` returns the original map. 

In contrast, `MonoidMap.adjust` treats missing keys as though they were mapped to `mempty`. This allows us to simplify `insertCount`:

```patch
  insertCount k e (Inventory cs byN h) =
    Inventory
      (IM.insertWith (\(m, _) (n, _) -> (m + n, e)) (e ^. entityHash) (k, e) cs)
-     (      M.insertWith IS.union (T.toLower $ e ^. entityName) (IS.singleton (e ^. entityHash)) byN)
+     (flip MM.adjust              (T.toLower $ e ^. entityName) (IS.insert    (e ^. entityHash)) byN)
      (h + (k + extra) * (e ^. entityHash)) -- homomorphic hashing
```
(Note: `flip` is used here for ease of comparison. The final code does not use `flip`.)

Now, when a name is missing, `MonoidMap.adjust` will apply `IntSet.insert` to `IntSet.empty`. We also avoid the construction of an intermediate singleton `IntSet`.