### PR TITLE
Use `MonoidMap` for `robotsWatching`.

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -24,6 +24,7 @@ import Data.IntSet qualified as IS
 import Data.List (find)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
+import Data.MonoidMap qualified as MM
 import Data.Sequence qualified as Seq
 import Data.Set (Set)
 import Data.Set qualified as S
@@ -158,7 +159,7 @@ purgeFarAwayWatches = do
         applyWhen (not $ isNearby loc) $
           IS.delete rid
 
-  robotInfo . robotsWatching %= M.filter (not . IS.null) . M.mapWithKey f
+  robotInfo . robotsWatching %= MM.mapWithKey f
 
 verbedGrabbingCmd :: GrabbingCmd -> Text
 verbedGrabbingCmd = \case
@@ -335,7 +336,7 @@ addWatchedLocation ::
   m ()
 addWatchedLocation loc = do
   rid <- use robotID
-  robotInfo . robotsWatching %= M.insertWith (<>) loc (IS.singleton rid)
+  robotInfo . robotsWatching %= MM.adjust (IS.insert rid) loc
 
 -- | Give some entities from a parent robot (the robot represented by
 --   the ambient @State Robot@ effect) to a child robot (represented

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -688,6 +688,7 @@ library swarm-engine
     lens,
     linear,
     megaparsec,
+    monoidmap,
     mtl,
     nonempty-containers,
     prettyprinter,


### PR DESCRIPTION
Related to https://github.com/swarm-game/swarm/issues/2300.

This PR redefines `Robots.robotsWatching` to use `MonoidMap` instead of `Map`:

```patch
  data Robots = Robots
    { ...
-   , _robotsWatching ::       Map (Cosmic Location) IntSet
+   , _robotsWatching :: MonoidMap (Cosmic Location) IntSet
    , ...
    }
```

Queries of the original `Map` did not distinguish between mappings to `Nothing` and mappings to `Just mempty`. By using `MonoidMap`, we can simplify such queries, as well as functions that create or update the map.

For example, within `wakeWatchingRobots`:

```patch
      botsWatchingThisLoc =
        mapMaybe (`IM.lookup` rMap) $
          IS.toList $
-           M.findWithDefault mempty loc watchingMap
+           MM.get                   loc watchingMap
```

Within `purgeFarAwayWatches`, we also no longer need to manually remove empty sets of robots, as `MonoidMap.mapWithkey` will remove these automatically, requiring only a single traversal of the map:

```patch
- robotInfo . robotsWatching %= M.filter (not . IS.null) . M.mapWithKey f
+ robotInfo . robotsWatching %=                           MM.mapWithKey f
```