### PR TITLE
Replace `surfaceEmpty` with `guarded`.

### DIFF
--- a/src/swarm-scenario/Swarm/Game/World/Render.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Render.hs
@@ -20,6 +20,7 @@ import Control.Carrier.Throw.Either (runThrow)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.Throw
 import Control.Lens (view, (^.))
+import Control.Monad.Extra (guarded)
 import Control.Monad.Logger
 import Control.Monad.Trans (MonadIO)
 import Data.Aeson
@@ -49,7 +50,7 @@ import Swarm.Game.Universe
 import Swarm.Game.World.Coords
 import Swarm.Game.World.Gen (Seed)
 import Swarm.Pretty (prettyText)
-import Swarm.Util (failT, surfaceEmpty)
+import Swarm.Util (failT)
 import Swarm.Util.Content
 import Swarm.Util.Erasable (erasableToMaybe)
 import Swarm.Util.Yaml
@@ -131,7 +132,7 @@ getBoundingBox vc scenarioWorld maybeSize =
   mapAreaDims = getGridDimensions worldArea
   areaDims@(AreaDimensions w h) =
     fromMaybe (AreaDimensions 20 10) $
-      maybeSize <|> surfaceEmpty isEmpty mapAreaDims
+      maybeSize <|> guarded (not . isEmpty) mapAreaDims
 
 getDisplayGrid ::
   Location ->

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -25,7 +25,6 @@ module Swarm.Util (
   findDup,
   both,
   allEqual,
-  surfaceEmpty,
   tails1,
   prependList,
   deleteKeys,
@@ -83,11 +82,10 @@ module Swarm.Util (
   smallHittingSet,
 ) where
 
-import Control.Applicative (Alternative)
 import Control.Carrier.Throw.Either
 import Control.Effect.State (State, modify, state)
 import Control.Lens (ASetter', Lens', LensLike, LensLike', Over, lens, (<&>), (<>~))
-import Control.Monad (filterM, guard, unless)
+import Control.Monad (filterM, unless)
 import Control.Monad.Trans.Maybe (MaybeT (..))
 import Data.Bifunctor (Bifunctor (bimap), first)
 import Data.Char (isAlphaNum, toLower)
@@ -239,9 +237,6 @@ both f = bimap f f
 allEqual :: (Ord a) => [a] -> Bool
 allEqual [] = True
 allEqual (x : xs) = all (== x) xs
-
-surfaceEmpty :: Alternative f => (a -> Bool) -> a -> f a
-surfaceEmpty isEmpty t = t <$ guard (not (isEmpty t))
 
 -- | Taken from here:
 -- https://hackage.haskell.org/package/ghc-9.8.1/docs/GHC-Data-FiniteMap.html#v:deleteList

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -196,7 +196,7 @@ common exceptions
   build-depends: exceptions >=0.10 && <0.11
 
 common extra
-  build-depends: extra >=1.7 && <1.8
+  build-depends: extra >=1.8 && <1.9
 
 common filepath
   build-depends: filepath >=1.4 && <1.6
@@ -241,7 +241,7 @@ common linear
   build-depends: linear >=1.21.6 && <1.24
 
 common lsp
-  build-depends: lsp >=2.4 && <2.7
+  build-depends: lsp >=2.4 && <2.8
 
 common megaparsec
   build-depends: megaparsec >=9.6.1 && <9.7


### PR DESCRIPTION
This PR replaces `surfaceEmpty` with [`guarded`](https://hackage.haskell.org/package/extra-1.8/docs/Control-Monad-Extra.html#v:guarded) (from [`extra`](https://hackage.haskell.org/package/extra)) in `getBoundingBox`.

Since `guarded` was only made available in version `1.8` of `extra`, we need to bump the upper bound for `extra`, which in turn requires us to bump the upper bound for `lsp`.

Note that `guarded p == surfaceEmpty (not . p)`:
```hs
> guarded             even  (2 :: Int) == [2]
True
> surfaceEmpty (not . even) (2 :: Int) == [2]
True
```
```hs
> guarded             odd  (2 :: Int) == Nothing
True
> surfaceEmpty (not . odd) (2 :: Int) == Nothing
True
```
```hs
> guarded (not . null) "My Name" == Just "My Name"
True
> surfaceEmpty   null  "My Name" == Just "My Name"
True
```