### PR TITLE
Use original variable names in error messages about Skolem variables

### DIFF
--- a/src/swarm-lang/Swarm/Effect/Unify/Fast.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify/Fast.hs
@@ -312,7 +312,7 @@ unifyF t1 t2 = case (t1, t2) of
   (TyConF {}, _) -> unifyErr
   -- Note that *type variables* are not the same as *unification variables*.
   -- Type variables must match exactly.
-  (TyVarF v1, TyVarF v2) -> case v1 == v2 of
+  (TyVarF _ v1, TyVarF _ v2) -> case v1 == v2 of
     True -> pure t1
     False -> unifyErr
   (TyVarF {}, _) -> unifyErr

--- a/src/swarm-lang/Swarm/Effect/Unify/Naive.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify/Naive.hs
@@ -155,7 +155,7 @@ unifyF t1 t2 = case (t1, t2) of
     True -> compose <$> zipWithM unify ts1 ts2
     False -> unifyErr
   (TyConF {}, _) -> unifyErr
-  (TyVarF v1, TyVarF v2) -> case v1 == v2 of
+  (TyVarF _ v1, TyVarF _ v2) -> case v1 == v2 of
     True -> return idS
     False -> unifyErr
   (TyVarF {}, _) -> unifyErr

--- a/src/swarm-lang/Swarm/Language/Kindcheck.hs
+++ b/src/swarm-lang/Swarm/Language/Kindcheck.hs
@@ -91,7 +91,7 @@ checkKind ty@(Fix tyF) = case tyF of
       Just a -> case compare (length tys) a of
         EQ -> mapM_ checkKind tys
         _ -> throwError $ ArityMismatch c a tys
-  TyVarF _ -> return ()
+  TyVarF _ _ -> return ()
   TyRcdF m -> mapM_ checkKind m
   TyRecF x t -> do
     -- It's important to call checkKind first, to rule out undefined
@@ -100,7 +100,7 @@ checkKind ty@(Fix tyF) = case tyF of
     -- index 0 in the body.  This doesn't affect the checking but it
     -- does ensure that error messages will use the variable name and
     -- not de Bruijn indices.
-    checkKind (substRec (TyVarF x) t NZ)
+    checkKind (substRec (TyVarF x x) t NZ)
     -- Now check that the recursive type is well-formed.  We call this
     -- with the *unsubstituted* t because the check will be looking
     -- for de Bruijn variables specifically.

--- a/src/swarm-lang/Swarm/Language/Parser/Type.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Type.hs
@@ -67,7 +67,7 @@ parseTypeMolecule =
 --   constructor.
 parseTypeAtom :: Parser Type
 parseTypeAtom =
-  (\x -> TyVar x x) <$> tyVar
+  TyVar <$> tyVar
     <|> TyConApp <$> parseTyCon <*> pure []
     <|> TyDelay <$> braces parseType
     <|> TyRcd <$> brackets (parseRecord (symbol ":" *> parseType))

--- a/src/swarm-lang/Swarm/Language/Parser/Type.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Type.hs
@@ -67,7 +67,7 @@ parseTypeMolecule =
 --   constructor.
 parseTypeAtom :: Parser Type
 parseTypeAtom =
-  TyVar <$> tyVar
+  (\x -> TyVar x x) <$> tyVar
     <|> TyConApp <$> parseTyCon <*> pure []
     <|> TyDelay <$> braces parseType
     <|> TyRcd <$> brackets (parseRecord (symbol ":" *> parseType))
@@ -101,7 +101,7 @@ tyRec x = TyRec x . ($ NZ) . foldFix s
   s :: TypeF (Nat -> Type) -> Nat -> Type
   s = \case
     TyRecF y ty -> Fix . TyRecF y . ty . NS
-    TyVarF y
+    TyVarF orig y
       | x == y -> Fix . TyRecVarF
-      | otherwise -> const (Fix (TyVarF y))
+      | otherwise -> const (Fix (TyVarF orig y))
     fty -> \i -> Fix (fmap ($ i) fty)

--- a/src/swarm-lang/Swarm/Language/Requirements/Analysis.hs
+++ b/src/swarm-lang/Swarm/Language/Requirements/Analysis.hs
@@ -177,7 +177,7 @@ typeRequirements = go
   go (Fix tyF) = goF tyF
 
   goF = \case
-    TyVarF _ -> pure ()
+    TyVarF _ _ -> pure ()
     TyConF (TCUser u) tys -> do
       mapM_ go tys
       ty' <- expandTydef u tys

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -300,7 +300,7 @@ substU m =
   ucata
     (\v -> fromMaybe (Free.Pure v) (M.lookup (Right v) m))
     ( \case
-        TyVarF o v -> fromMaybe (UTyVar o v) (M.lookup (Left v) m)
+        TyVarF o v -> fromMaybe (UTyVar' o v) (M.lookup (Left v) m)
         f -> Free.Free f
     )
 
@@ -406,7 +406,7 @@ skolemize (unPoly -> (xs, uty)) = do
     s <- mkVarName "s" <$> U.freshIntVar
     pure (x, s)
   boundSubst <- ask @TVCtx
-  let xs' = map (uncurry UTyVar) skolemNames
+  let xs' = map (uncurry UTyVar') skolemNames
       newSubst = M.fromList $ zip xs xs'
       s = M.mapKeys Left (newSubst `M.union` unCtx boundSubst)
   pure (Ctx.fromMap newSubst, substU s uty)
@@ -431,7 +431,7 @@ generalize uty = do
   return . absQuantify $
     mkPoly
       (map snd renaming)
-      (substU (M.fromList . map (Right *** (\x -> UTyVar x x)) $ renaming) uty')
+      (substU (M.fromList . map (Right *** UTyVar) $ renaming) uty')
 
 ------------------------------------------------------------
 -- Type errors

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -157,7 +157,7 @@ import Swarm.Pretty (PrettyPrec (..), pparens, pparens', ppr, prettyBinding)
 import Swarm.Util (parens, showT, unsnocNE)
 import Swarm.Util.JSON (optionsMinimize, optionsUnwrapUnary)
 import Text.Show.Deriving (deriveShow1)
-import Witch
+import Witch (into)
 
 ------------------------------------------------------------
 -- Base types
@@ -270,8 +270,12 @@ data TypeF t
     --   directly store a list of all arguments (as opposed to
     --   iterating binary application).
     TyConF TyCon [t]
-  | -- | A type variable.
-    TyVarF Var
+  | -- | A type variable.  The first Var represents the original name,
+    --   and should be ignored except for use in e.g. error messages.
+    --   The second Var is the real name of the variable; it may be the
+    --   same as the first, or it may be different e.g. if it is a
+    --   freshly generated skolem variable.
+    TyVarF Var Var
   | -- | Record type.
     TyRcdF (Map Var t)
   | -- | A recursive type variable bound by an enclosing Rec,
@@ -332,7 +336,7 @@ ucata f g (Free t) = g (fmap (ucata f g) t)
 --   as a unification variable) into a unique variable name, by
 --   appending a number to the given name.
 mkVarName :: Text -> IntVar -> Var
-mkVarName nm (IntVar v) = T.append nm (from @String (show v))
+mkVarName nm (IntVar v) = T.append nm (into @Var (show v))
 
 -- | Get all the free unification variables in a 'UType'.
 fuvs :: UType -> Set IntVar
@@ -356,10 +360,13 @@ isPure _ = False
 
 -- | For convenience, so we can write /e.g./ @"a"@ instead of @TyVar "a"@.
 instance IsString Type where
-  fromString x = TyVar (from @String x)
+  fromString x = TyVar v v
+    where v = into @Var x
 
 instance IsString UType where
-  fromString x = UTyVar (from @String x)
+  fromString x = UTyVar v v
+    where
+      v = into @Var x
 
 --------------------------------------------------
 -- Recursive type utilities
@@ -410,7 +417,7 @@ instance UnchainableFun (Free TypeF ty) where
 
 instance (UnchainableFun t, PrettyPrec t, SubstRec t) => PrettyPrec (TypeF t) where
   prettyPrec p = \case
-    TyVarF v -> pretty v
+    TyVarF v _ -> pretty v
     TyRcdF m -> brackets $ hsep (punctuate "," (map prettyBinding (M.assocs m)))
     -- Special cases for type constructors with special syntax.
     -- Always use parentheses around sum and product types, see #1625
@@ -430,7 +437,7 @@ instance (UnchainableFun t, PrettyPrec t, SubstRec t) => PrettyPrec (TypeF t) wh
             flatAlt (concatWith multiLine funs) (concatWith inLine funs)
     TyRecF x ty ->
       pparens (p > 0) $
-        "rec" <+> pretty x <> "." <+> prettyPrec 0 (substRec (TyVarF x) ty NZ)
+        "rec" <+> pretty x <> "." <+> prettyPrec 0 (substRec (TyVarF x x) ty NZ)
     -- This case shouldn't be possible, since TyRecVar should only occur inside a TyRec,
     -- and pretty-printing the TyRec (above) will substitute a variable name for
     -- any bound TyRecVars before recursing.
@@ -483,7 +490,7 @@ instance Typical UType where
 -- | Get all the type variables (/not/ unification variables)
 --   contained in a 'Type' or 'UType'.
 tyVars :: Typical t => t -> Set Var
-tyVars = foldT S.empty (\case TyVarF x -> S.singleton x; f -> fold f)
+tyVars = foldT S.empty (\case TyVarF _ x -> S.singleton x; f -> fold f)
 
 ------------------------------------------------------------
 -- Polytypes
@@ -622,8 +629,8 @@ pattern TyConApp c tys = Fix (TyConF c tys)
 pattern TyBase :: BaseTy -> Type
 pattern TyBase b = TyConApp (TCBase b) []
 
-pattern TyVar :: Var -> Type
-pattern TyVar v = Fix (TyVarF v)
+pattern TyVar :: Var -> Var -> Type
+pattern TyVar x y = Fix (TyVarF x y)
 
 pattern TyVoid :: Type
 pattern TyVoid = TyBase BVoid
@@ -688,8 +695,8 @@ pattern UTyConApp c tys = Free (TyConF c tys)
 pattern UTyBase :: BaseTy -> UType
 pattern UTyBase b = UTyConApp (TCBase b) []
 
-pattern UTyVar :: Var -> UType
-pattern UTyVar v = Free (TyVarF v)
+pattern UTyVar :: Var -> Var -> UType
+pattern UTyVar x y = Free (TyVarF x y)
 
 pattern UTyVoid :: UType
 pattern UTyVoid = UTyBase BVoid
@@ -840,7 +847,7 @@ substTydef (TydefInfo (Forall as ty) _) tys = refoldT @t substF (fromType ty)
  where
   argMap = M.fromList $ zip as tys
 
-  substF tyF@(TyVarF x) = case M.lookup x argMap of
+  substF tyF@(TyVarF _ x) = case M.lookup x argMap of
     Nothing -> rollT tyF
     Just ty' -> ty'
   substF tyF = rollT tyF

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -59,6 +59,7 @@ module Swarm.Language.Types (
   pattern UTyConApp,
   pattern UTyBase,
   pattern UTyVar,
+  pattern UTyVar',
   pattern UTyVoid,
   pattern UTyUnit,
   pattern UTyInt,
@@ -360,13 +361,10 @@ isPure _ = False
 
 -- | For convenience, so we can write /e.g./ @"a"@ instead of @TyVar "a"@.
 instance IsString Type where
-  fromString x = TyVar v v
-    where v = into @Var x
+  fromString = TyVar . into @Var
 
 instance IsString UType where
-  fromString x = UTyVar v v
-    where
-      v = into @Var x
+  fromString = UTyVar . into @Var
 
 --------------------------------------------------
 -- Recursive type utilities
@@ -629,8 +627,10 @@ pattern TyConApp c tys = Fix (TyConF c tys)
 pattern TyBase :: BaseTy -> Type
 pattern TyBase b = TyConApp (TCBase b) []
 
-pattern TyVar :: Var -> Var -> Type
-pattern TyVar x y = Fix (TyVarF x y)
+pattern TyVar :: Var -> Type
+pattern TyVar x <- Fix (TyVarF _ x)
+  where
+    TyVar x = Fix (TyVarF x x)
 
 pattern TyVoid :: Type
 pattern TyVoid = TyBase BVoid
@@ -695,8 +695,13 @@ pattern UTyConApp c tys = Free (TyConF c tys)
 pattern UTyBase :: BaseTy -> UType
 pattern UTyBase b = UTyConApp (TCBase b) []
 
-pattern UTyVar :: Var -> Var -> UType
-pattern UTyVar x y = Free (TyVarF x y)
+pattern UTyVar :: Var -> UType
+pattern UTyVar x <- Free (TyVarF _ x)
+  where
+    UTyVar x = Free (TyVarF x x)
+
+pattern UTyVar' :: Var -> Var -> UType
+pattern UTyVar' x y = Free (TyVarF x y)
 
 pattern UTyVoid :: UType
 pattern UTyVoid = UTyBase BVoid

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -51,7 +51,7 @@ testLanguagePipeline =
             "type variable scope #2178 - shadowing"
             ( process
                 "def f : a -> (a * Int) = \\x. let g : forall a. a * Int = (x, 3) in g end"
-                "1:59: Type mismatch:\n  From context, expected `x` to have type `s2`,\n  but it actually has type `s1`"
+                "1:59: Type mismatch:\n  From context, expected `x` to have type `a`,\n  but it actually has type `a`"
             )
         ]
     , testCase
@@ -396,7 +396,7 @@ testLanguagePipeline =
             (valid "((\\x . x) : a -> a) 3")
         , testCase
             "type ascription too general"
-            (process "1 : a" "1:1: Type mismatch:\n  From context, expected `1` to have type `s0`,\n  but it actually has type `Int`")
+            (process "1 : a" "1:1: Type mismatch:\n  From context, expected `1` to have type `a`,\n  but it actually has type `Int`")
         , testCase
             "type specialization through type ascription"
             (valid "fst:(Int + b) * a -> Int + b")
@@ -404,7 +404,7 @@ testLanguagePipeline =
             "type ascription doesn't allow rank 2 types"
             ( process
                 "\\f. (f:forall a. a->a) 3"
-                "1:24: Type mismatch:\n  From context, expected `3` to have type `s3`,\n  but it actually has type `Int`"
+                "1:24: Type mismatch:\n  From context, expected `3` to have type `a`,\n  but it actually has type `Int`"
             )
         , testCase
             "checking a lambda with the wrong argument type"


### PR DESCRIPTION
Each type variable now carries two variable names: one, the original, user-supplied name of the type variable, and another, the (potentially different) current freshly generated name.  These can diverge specifically in the case that we skolemize a user-supplied polymorphic type.  We use the second name for all comparisons, but the first name when pretty-printing.

For example, `def f : a -> a = \x. 3 end` used to generate an error message saying something like "expected `3` to have type `s1` ; it now says "expected `3` to have type `a`".

Closes #2102.  That issue also talks about improving the error message that says "skolem variable would escape its scope", but at the moment I can't even find a way to get that error message to be generated at all, so I propose to not worry about it for now.

There is one specific situation where this can be confusing, when one type variable is shadowed by another with the same name.  For example:
```
> def f : a -> (a * Int) = \\x. let g : forall a. a * Int = (x, 3) in g end
1:59: Type mismatch:\n  From context, expected `x` to have type `a`,\n  but it actually has type `a`
```
Not sure whether it's worth doing anything about this; open to suggestions.
