### PR TITLE
Tweaks towards minimizing generated JSON

### DIFF
--- a/src/swarm-lang/Swarm/Language/JSON.hs
+++ b/src/swarm-lang/Swarm/Language/JSON.hs
@@ -34,7 +34,7 @@ instance ToJSON Term where
   toJSON = genericToJSON optionsMinimize
 
 instance ToJSON Syntax where
- toJSON = genericToJSON optionsMinimize
+  toJSON = genericToJSON optionsMinimize
 
 instance ToJSON Value where
   toJSON = genericToJSON optionsMinimize

--- a/src/swarm-lang/Swarm/Language/JSON.hs
+++ b/src/swarm-lang/Swarm/Language/JSON.hs
@@ -8,7 +8,7 @@
 -- to put them all here to avoid circular module dependencies.
 module Swarm.Language.JSON where
 
-import Data.Aeson (FromJSON (..), ToJSON (..), genericToJSON, withText)
+import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON, withText)
 import Data.Aeson qualified as Ae
 import Swarm.Language.Pipeline (processTermEither)
 import Swarm.Language.Syntax (Term)
@@ -24,10 +24,17 @@ instance FromJSON TSyntax where
 instance ToJSON TSyntax where
   toJSON = Ae.String . prettyText
 
-instance FromJSON Term
-instance FromJSON Syntax
-instance ToJSON Term
-instance ToJSON Syntax
+instance FromJSON Term where
+  parseJSON = genericParseJSON optionsMinimize
+
+instance FromJSON Syntax where
+  parseJSON = genericParseJSON optionsMinimize
+
+instance ToJSON Term where
+  toJSON = genericToJSON optionsMinimize
+
+instance ToJSON Syntax where
+ toJSON = genericToJSON optionsMinimize
 
 instance ToJSON Value where
   toJSON = genericToJSON optionsMinimize

--- a/src/swarm-lang/Swarm/Language/Syntax/Loc.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Loc.hs
@@ -34,9 +34,11 @@ data SrcLoc
 
 instance ToJSON SrcLoc where
   toJSON = genericToJSON optionsUntagged
+  omitField = (== NoLoc)
 
 instance FromJSON SrcLoc where
   parseJSON = genericParseJSON optionsUntagged
+  omittedField = Just NoLoc
 
 -- | @x <> y@ is the smallest 'SrcLoc' that subsumes both @x@ and @y@.
 instance Semigroup SrcLoc where

--- a/src/swarm-scenario/Swarm/Game/Display.hs
+++ b/src/swarm-scenario/Swarm/Game/Display.hs
@@ -185,7 +185,6 @@ instance ToJSON Display where
       , "attr" .= (d ^. displayAttr)
       ]
         ++ ["priority" .= (d ^. displayPriority) | (d ^. displayPriority) /= (defaultEntityDisplay ' ' ^. displayPriority)]
-
         ++ ["orientationMap" .= (d ^. orientationMap) | not (M.null (d ^. orientationMap))]
         ++ ["invisible" .= (d ^. invisible) | d ^. invisible]
 

--- a/src/swarm-scenario/Swarm/Game/Display.hs
+++ b/src/swarm-scenario/Swarm/Game/Display.hs
@@ -183,8 +183,9 @@ instance ToJSON Display where
     object $
       [ "char" .= (d ^. defaultChar)
       , "attr" .= (d ^. displayAttr)
-      , "priority" .= (d ^. displayPriority)
       ]
+        ++ ["priority" .= (d ^. displayPriority) | (d ^. displayPriority) /= (defaultEntityDisplay ' ' ^. displayPriority)]
+
         ++ ["orientationMap" .= (d ^. orientationMap) | not (M.null (d ^. orientationMap))]
         ++ ["invisible" .= (d ^. invisible) | d ^. invisible]
 

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -117,7 +117,7 @@ import Data.MonoidMap (MonoidMap)
 import Data.MonoidMap qualified as MM
 import Data.MonoidMap.JSON ()
 import Data.Set (Set)
-import Data.Set qualified as Set (fromList, member)
+import Data.Set qualified as Set (fromList, member, null)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Yaml
@@ -591,8 +591,8 @@ instance ToJSON Entity where
       [ "display" .= (e ^. entityDisplay)
       , "name" .= (e ^. entityName)
       , "description" .= (e ^. entityDescription)
-      , "tags" .= (e ^. entityTags)
       ]
+        ++ ["tags" .= (e ^. entityTags) | not (Set.null (e ^. entityTags))]
         ++ ["plural" .= (e ^. entityPlural) | isJust (e ^. entityPlural)]
         ++ ["orientation" .= (e ^. entityOrientation) | isJust (e ^. entityOrientation)]
         ++ ["growth" .= (e ^. entityGrowth) | isJust (e ^. entityGrowth)]


### PR DESCRIPTION
Towards #1907 .

- Get rid of empty comments
- Get rid of empty `sLoc`
- Get rid of empty `tags`
- Get rid of default `priority`

The major things still remaining from #1907 are the empty `ingredients` and duplicated device descriptions.