### PR TITLE
Remove `Show` and `Eq` instances for `Value` and `Env`

### DIFF
--- a/src/swarm-engine/Swarm/Game/CESK.hs
+++ b/src/swarm-engine/Swarm/Game/CESK.hs
@@ -164,7 +164,7 @@ data Frame
   | -- | If an exception bubbles all the way up to this frame, then
     --   switch to Suspended mode with this saved top-level context.
     FRestoreEnv Env
-  deriving (Eq, Show, Generic)
+  deriving (Generic)
 
 instance ToJSON Frame where
   toJSON = genericToJSON optionsMinimize
@@ -181,7 +181,7 @@ type Addr = Int
 -- | 'Store' represents a store, /i.e./ memory, indexing integer
 --   locations to 'Value's.
 data Store = Store {next :: Addr, mu :: IntMap Value}
-  deriving (Show, Eq, Generic, ToJSON)
+  deriving (Generic, ToJSON)
 
 emptyStore :: Store
 emptyStore = Store 0 IM.empty
@@ -261,7 +261,7 @@ data CESK
     --   evaluation, and otherwise it is just like 'In' with a hole
     --   for the 'Term' we are going to evaluate.
     Suspended Value Env Store Cont
-  deriving (Eq, Show, Generic)
+  deriving (Generic)
 
 instance ToJSON CESK where
   toJSON = genericToJSON optionsMinimize

--- a/src/swarm-engine/Swarm/Game/State/Substate.hs
+++ b/src/swarm-engine/Swarm/Game/State/Substate.hs
@@ -130,7 +130,7 @@ data REPLStatus
     --   entered.  The @Maybe Value@ starts out as 'Nothing' and gets
     --   filled in with a result once the command completes.
     REPLWorking Polytype (Maybe Value)
-  deriving (Eq, Show, Generic, ToJSON)
+  deriving (Eq, Generic, ToJSON)
 
 data WinStatus
   = -- | There are one or more objectives remaining that the player

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -392,8 +392,6 @@ hypotheticalWinCheck em g ws oc = do
         T.unwords
           [ "Non boolean value:"
           , prettyValue val
-          , "real:"
-          , T.pack (show val)
           ]
 
   -- Log exceptions in the message queue so we can check for them in tests

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -1383,8 +1383,6 @@ execConst runChildProg c vs s k = do
   badConstMsg =
     T.unlines
       [ "Bad application of execConst:"
-      , T.pack (show c)
-      , T.pack (show vs)
       , prettyText (Out (VCApp c (reverse vs)) s k)
       ]
 

--- a/src/swarm-lang/Swarm/Language/Value.hs
+++ b/src/swarm-lang/Swarm/Language/Value.hs
@@ -152,7 +152,10 @@ data Env = Env
   }
   deriving (Hashable, Generic)
 
--- XXX comment me
+-- A derived `Eq` instance for `Env` can cause exponential blowup (see
+-- Note [Env Show and Eq instances]), but we need an `Eq` instance in
+-- order to have a `Hashable` instance.  So we just implement equality
+-- testing by comparing hashes.
 instance Eq Env where
   (==) = (==) `on` hash
 

--- a/src/swarm-lang/Swarm/Language/Value.hs
+++ b/src/swarm-lang/Swarm/Language/Value.hs
@@ -30,7 +30,8 @@ module Swarm.Language.Value (
 import Control.Lens hiding (Const)
 import Data.Bool (bool)
 import Data.Foldable (Foldable (..))
-import Data.Hashable (Hashable)
+import Data.Function (on)
+import Data.Hashable (Hashable, hash)
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Set qualified as S
@@ -123,7 +124,10 @@ data Value where
   -- | A special value used to represent runtime type information
   --   passed to ad-hoc polymorphic functions.
   VType :: Type -> Value
-  deriving (Eq, Show, Generic, Hashable)
+  deriving (Eq, Generic, Hashable)
+
+-- For the lack of Show and Eq instances, see Note [Env Show and Eq
+-- instances]
 
 -- | A value context is a mapping from variable names to their runtime
 --   values.
@@ -146,7 +150,20 @@ data Env = Env
   , _envTydefs :: TDCtx
   -- ^ Type synonym definitions.
   }
-  deriving (Eq, Show, Generic, Hashable)
+  deriving (Hashable, Generic)
+
+-- XXX comment me
+instance Eq Env where
+  (==) = (==) `on` hash
+
+-- ~~~~ Note [Env Show and Eq instances]
+-- Env contains values, which can be e.g. closures, which
+-- contain more Envs.  Normally, in memory, there is a lot of sharing,
+-- but when naively printing it out all the sharing is lost and it can
+-- generate tons of output.  This is why we intentionally do NOT have
+-- a Show instance for Env (hence neither for Value).  Similarly, we
+-- do not have a derived Eq instance since it would be incredibly
+-- inefficient and there is no good reason to use it.  See #2197.
 
 makeLenses ''Env
 

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -513,7 +513,7 @@ testEval g =
     case result of
       Left err -> assertFailure ("Evaluation failed: " ++ from @Text @String err)
       Right (v, steps) -> do
-        assertEqual "" val v
+        assertBool "Values are not equal" (val == v)
         assertBool ("Took more than " ++ show maxSteps ++ " steps!") (steps <= maxSteps)
 
   evaluate :: Text -> IO (Either Text (Value, Int))

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -497,7 +497,7 @@ testEval g =
   evaluatesTo :: Text -> Value -> Assertion
   evaluatesTo tm val = do
     result <- evaluate tm
-    assertEqual "" (Right val) (fst <$> result)
+    assertBool "" $ Right val == (fst <$> result)
 
   evaluatesToV :: Valuable v => Text -> v -> Assertion
   evaluatesToV tm val = tm `evaluatesTo` asValue val
@@ -505,7 +505,7 @@ testEval g =
   evaluatesToP :: Text -> Value -> Property
   evaluatesToP tm val = ioProperty $ do
     result <- evaluate tm
-    return $ Right val === (fst <$> result)
+    return . property $ Right val == (fst <$> result)
 
   evaluatesToInAtMost :: Text -> (Value, Int) -> Assertion
   evaluatesToInAtMost tm (val, maxSteps) = do


### PR DESCRIPTION
Closes #2197.  There is no reason we need `Show` instances for these types, and naively calling `Show` on `Env` in particular can lead to exponential blowup.