### PR TITLE
Check movement when unequipping, and add more code comments

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -107,7 +107,8 @@ import Text.Megaparsec (runParser)
 import Witch (From (from), into)
 import Prelude hiding (Applicative (..), lookup)
 
--- | How to handle failure, for example when moving to blocked location
+-- | How to handle failure, for example when moving into liquid or
+--   attempting to move to a blocked location
 data RobotFailure = ThrowExn | Destroy | IgnoreFail
 
 -- | How to handle different types of failure when moving/teleporting
@@ -417,9 +418,34 @@ execConst runChildProg c vs s k = do
       [VText itemName] -> do
         item <- ensureEquipped itemName
         myID <- use robotID
+
+        -- Speculatively unequip the item
         focusedID <- use $ robotInfo . focusedRobotID
         equippedDevices %= delete item
         robotInventory %= insert item
+
+        -- Now check whether being on the current cell would still be
+        -- allowed.
+        loc <- use robotLocation
+        mfail <- checkMoveFailure loc
+        case mfail of
+          Nothing -> pure ()
+          Just (PathBlockedBy blocker) -> do
+            -- If unequipping the device would somehow result in the
+            -- path being blocked, don't allow it; re-equip the device
+            -- and throw an exception.
+            robotInventory %= delete item
+            equippedDevices %= insert item
+            throwError . cmdExn Unequip $
+              [ "You can't unequip the", item ^. entityName, "right now!"]
+          Just (PathLiquid liquid) -> do
+            -- Unequipping a device that gives the Float capability in
+            -- the middle of liquid results in drowning, EVEN for
+            -- base!  This is currently the only (known) way to get
+            -- the `DestroyedBase` achievement.
+            selfDestruct .= True
+            when (myID == 0) $ grantAchievementForRobot DestroyedBase
+
         -- Flag the UI for a redraw if we are currently showing our inventory
         when (focusedID == myID) flagRedraw
         return $ mkReturn ()
@@ -1642,6 +1668,9 @@ execConst runChildProg c vs s k = do
     selfDestruct .= True
     forM_ (mAch True) grantAchievementForRobot
 
+  -- Try to move the current robot once cell in a specific direction,
+  -- checking for and applying any relevant effects (e.g. throwing an
+  -- exception if blocked, drowning in water, etc.)
   moveInDirection :: (HasRobotStepState sig m, Has (Lift IO) sig m) => Heading -> m CESK
   moveInDirection orientation = do
     -- Figure out where we're going
@@ -1653,6 +1682,8 @@ execConst runChildProg c vs s k = do
     updateRobotLocation loc nextLoc
     return $ mkReturn ()
 
+  -- Given a possible movement failure, apply a movement failure
+  -- handler to generate the appropriate effect.
   applyMoveFailureEffect ::
     (HasRobotStepState sig m, Has (Lift IO) sig m) =>
     Maybe MoveFailureMode ->
@@ -1671,7 +1702,8 @@ execConst runChildProg c vs s k = do
             Nothing -> ["There is nothing to travel on!"]
           PathLiquid e -> ["There is a dangerous liquid", e ^. entityName, "in the way!"]
 
-  -- Determine the move failure mode and apply the corresponding effect.
+  -- Check whether there is any failure in moving to the given
+  -- location, and apply the corresponding effect if so.
   checkMoveAhead ::
     (HasRobotStepState sig m, Has (Lift IO) sig m) =>
     Cosmic Location ->

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -430,7 +430,7 @@ execConst runChildProg c vs s k = do
         mfail <- checkMoveFailure loc
         case mfail of
           Nothing -> pure ()
-          Just (PathBlockedBy blocker) -> do
+          Just (PathBlockedBy _) -> do
             -- If unequipping the device would somehow result in the
             -- path being blocked, don't allow it; re-equip the device
             -- and throw an exception.
@@ -438,7 +438,7 @@ execConst runChildProg c vs s k = do
             equippedDevices %= insert item
             throwError . cmdExn Unequip $
               ["You can't unequip the", item ^. entityName, "right now!"]
-          Just (PathLiquid liquid) -> do
+          Just (PathLiquid _) -> do
             -- Unequipping a device that gives the Float capability in
             -- the middle of liquid results in drowning, EVEN for
             -- base!  This is currently the only (known) way to get

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -437,7 +437,7 @@ execConst runChildProg c vs s k = do
             robotInventory %= delete item
             equippedDevices %= insert item
             throwError . cmdExn Unequip $
-              [ "You can't unequip the", item ^. entityName, "right now!"]
+              ["You can't unequip the", item ^. entityName, "right now!"]
           Just (PathLiquid liquid) -> do
             -- Unequipping a device that gives the Float capability in
             -- the middle of liquid results in drowning, EVEN for

--- a/src/swarm-engine/Swarm/Game/Step/Path/Walkability.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Walkability.hs
@@ -11,31 +11,41 @@ import Swarm.Game.Robot.Walk
 import Swarm.Language.Capability
 
 data MoveFailureMode
-  = -- | If the robot has a path Whitelist,
-    -- then the absence of an entity could prevent walkability (represented by `PathBlockedBy Nothing`).
+  = -- | Can't move due to something blocking the path.  Note that if
+    --   the robot has a path Whitelist, then the /absence/ of an entity
+    --   could block the path (represented by `PathBlockedBy
+    --   Nothing`).
     PathBlockedBy (Maybe Entity)
+    -- | Some liquid entity is in the path.
   | PathLiquid Entity
 
 -- | Pure logic used inside of
--- 'Swarm.Game.Step.Util.checkMoveFailureUnprivileged'
+--   'Swarm.Game.Step.Util.checkMoveFailureUnprivileged'.  Given a
+--   (possibly empty) walkable entity whitelist or blacklist, and the
+--   entity (or lack thereof) in the cell we are trying to move to,
+--   determine whether there is some kind of movement failure.
 checkUnwalkable ::
   WalkabilityContext ->
   Maybe Entity ->
   Maybe MoveFailureMode
 checkUnwalkable (WalkabilityContext _ walkExceptions) Nothing =
+  -- If there's no entity in the path, we are blocked only if a
+  -- whitelist of walkable entities is specified
   case walkExceptions of
     Whitelist _ -> Just $ PathBlockedBy Nothing
     Blacklist _ -> Nothing
 checkUnwalkable (WalkabilityContext caps walkExceptions) (Just e)
-  -- robots can not walk through walls
   | isUnwalkableEntity =
       Just $ PathBlockedBy $ Just e
-  -- robots drown if they walk over liquid without boat
+  -- Robots drown if they walk over liquid without the Float capability
   | e `hasProperty` Liquid && CFloat `S.notMember` caps =
       Just $ PathLiquid e
   | otherwise = Nothing
  where
   eName = e ^. entityName
+  -- An entity blocks a robot if...
   isUnwalkableEntity = case walkExceptions of
+    -- ...it's not one of the whitelisted entities...
     Whitelist onlyWalkables -> eName `S.notMember` onlyWalkables
+    -- ...OR if it is inherently unwalkable, or is blacklisted.
     Blacklist unwalkables -> e `hasProperty` Unwalkable || eName `S.member` unwalkables

--- a/src/swarm-engine/Swarm/Game/Step/Path/Walkability.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Walkability.hs
@@ -16,8 +16,8 @@ data MoveFailureMode
     --   could block the path (represented by `PathBlockedBy
     --   Nothing`).
     PathBlockedBy (Maybe Entity)
-    -- | Some liquid entity is in the path.
-  | PathLiquid Entity
+  | -- | Some liquid entity is in the path.
+    PathLiquid Entity
 
 -- | Pure logic used inside of
 --   'Swarm.Game.Step.Util.checkMoveFailureUnprivileged'.  Given a

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -177,8 +177,9 @@ randomName = do
 
 -- * Moving
 
--- | Make sure nothing is in the way.
--- No exception for system robots
+-- | Raw check whether moving to the given location causes any kind of
+--   failure, with no special checks for system robots (see also
+--   'checkMoveFailure').
 checkMoveFailureUnprivileged ::
   HasRobotStepState sig m =>
   Cosmic Location ->
@@ -188,8 +189,10 @@ checkMoveFailureUnprivileged nextLoc = do
   wc <- use walkabilityContext
   return $ checkUnwalkable wc me
 
--- | Make sure nothing is in the way. Note that system robots implicitly ignore
--- and base throws on failure.
+-- | Check whether moving to the given location causes any kind of
+--   failure.  Note that system robots have unrestricted movement and
+--   never fail, but non-system robots have restricted movement even
+--   in creative mode.
 checkMoveFailure :: HasRobotStepState sig m => Cosmic Location -> m (Maybe MoveFailureMode)
 checkMoveFailure nextLoc = do
   systemRob <- use systemRobot


### PR DESCRIPTION
Towards #1435.  In this PR:

- A bunch of extended/updated code comments I added while getting my head around the way we do movement checks
- When executing `unequip`, checks whether moving to the current cell would be allowed without the device equipped.
    - If it would not be allowed because the path is blocked, simply disallow unequipping the device and throw an exception instead.
        - I am not sure how to test this case.  It would require having some sort of custom device that grants e.g. a special capability to move on top of entities that would normally block movement.  I am not even sure if that is possible right now. @kostmo ?
    - If moving to the current cell would be disallowed because of liquid, then the robot drowns.  In addition, if it is `base`, the `DestroyedBase` achivement is granted.

Thus, in order to get the `DestroyedBase` achievement in classic mode, you must:
- Build some `tank treads` and `equip` them
- Equip a `boat`
- Drive into the middle of some water
- `unequip` the boat

This seems deliberate enough that no one would do it by accident, i.e. it's not going to frustrate beginning players.  (There are probably some scenarios where it is easier to achieve, e.g. because the `base` actually starts out with `tank treads`.)
