### PR TITLE
Grant `AttemptSelfDestructBase` achievement for movement as well as `selfdestruct`

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -1661,6 +1661,7 @@ execConst runChildProg c vs s k = do
       IgnoreFail -> return ()
       Destroy -> destroyIfNotBase $ \b -> case (b, failureMode) of
         (True, PathLiquid _) -> Just RobotIntoWater -- achievement for drowning
+        (False, _) -> Just AttemptSelfDestructBase
         _ -> Nothing
       ThrowExn -> throwError . cmdExn c $
         case failureMode of


### PR DESCRIPTION
Previously, we only granted this achievement when literally executing the `selfdestruct` command, but that's kind of difficult since you have to first craft a `detonator`.  This PR also grants the achievement from the `applyMoveFailureEffect` function, so e.g. if you attempt to move the base into water without a `boat` equipped.