### PR TITLE
Water disappears when placed, via new `evanescent` property

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -478,14 +478,14 @@
     char: ' '
   description:
     - Liquid dihydrogen monoxide, which seems to be plentiful on this planet.
-  properties: [pickable, infinite, liquid]
+  properties: [pickable, infinite, liquid, evanescent]
 - name: wavy water
   display:
     attr: water
     char: '~'
   description:
     - A wavy section of water.  The same as normal water, but with more waves.
-  properties: [pickable, infinite, liquid]
+  properties: [pickable, infinite, liquid, evanescent]
   yields: water
 - name: boat
   display:

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -348,8 +348,9 @@ execConst runChildProg c vs s k = do
         -- Make sure the robot has the thing in its inventory
         e <- hasInInventoryOrFail name
 
-        -- Place the entity and remove it from the inventory
-        updateEntityAt loc (const (Just e))
+        -- Place the entity (if it is not evanescent) and remove it from the inventory
+        unless (Evanescent `S.member` (e ^. entityProperties)) $
+          updateEntityAt loc (const (Just e))
         robotInventory %= delete e
 
         flagRedraw

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -171,6 +171,9 @@ data EntityProperty
     Infinite
   | -- | Robots drown if they walk on this without a boat.
     Liquid
+  | -- | If robots try to 'Swarm.Language.Syntax.Place' this,
+    --   it disappears
+    Evanescent
   | -- | Robots automatically know what this is without having to scan it.
     Known
   | -- | Text can be printed on this entity with the

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -1137,6 +1137,7 @@ displayProperties = displayList . mapMaybe showProperty
   showProperty Unwalkable = Just "blocking"
   showProperty Opaque = Just "opaque"
   showProperty Boundary = Just "boundary"
+  showProperty Evanescent = Just "evanescent"
   -- Most things are pickable so we don't show that.
   showProperty Pickable = Nothing
   -- 'Known' is just a technical detail of how we handle some entities


### PR DESCRIPTION
Based on the [discussion here](https://github.com/swarm-game/swarm/issues/1435#issuecomment-2425192480).  The idea is that you can `grab` a bucket full of water, but if you try to `place` it somewhere you just dump it and it disappears --- it doesn't create a permanent lake.  This also solves the awkward issue that technically if you created a lake underneath yourself without a `boat` equipped you should drown.