### PR TITLE
Make base visible in backstory

### DIFF
--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -38,7 +38,6 @@ entities:
     properties: [known, pickable]
 robots:
   - name: base
-    system: true
     display:
       char: 'Ω'
       attr: robot
@@ -72,6 +71,7 @@ robots:
         } {log "Something bad happened!"}
       }
 seed: 0
+creative: true
 world:
   scrollable: false
   dsl: |


### PR DESCRIPTION
Make the backstory tutorial creative instead of the base being a system robot, which made it invisible by default.