### PR TITLE
Make bind tutorial easier to understand

### DIFF
--- a/data/scenarios/Tutorials/bind2.yaml
+++ b/data/scenarios/Tutorials/bind2.yaml
@@ -11,56 +11,49 @@ objectives:
         A pedestal stands conspicuously empty in the center of the room.
         Perhaps its intended contents lie nearby?
       - |
-        Build a robot to retrieve and restore the mystery artifact to its proper place!
+        Build a robot to retrieve and restore the mystery artifact to its proper place
+        in the center of the pedestal!
       - |
-        **NOTE:** If you find yourself stuck, you can select "Start over" from
-        the "Quit" (**Ctrl+Q**) dialog.
-    condition: |
-      try {
-        p <- robotnamed "floorspot";
-        w <- as p {ishere "Hastur"};
-        pure (not w);
-      } { pure false }
-  - goal:
-      - |
-        Your robot obtained the misplaced artifact! Next you need to put it back
-        on the pedestal.  But neither you nor your robot knows the
-        artifact's name.  How can it be placed?
-      - |
-        Every command returns a value.  However, some simple commands, like
-        `move`, do not have any meaningful
-        value to return.  Swarm has a special type, `Unit`{=type}, with only one value,
-        called `()`. Since there is only one possible value of type
-        `Unit`{=type}, returning it does not convey any information.
-        Thus, the type of `move` is `Cmd Unit`{=type}.
-      - |
-        Other commands do return a nontrivial value after executing.
-        For example, `grab` has type `Cmd Text`{=type}, and returns the name of the
-        grabbed entity as a text value.
+        The robot will need to `place "ARTIFACT NAME"`{=snippet}, but you do not know the name yet!
+        Fortunatelly, the `grab` command has type `Cmd Text`{=type}, and returns
+        the name of the grabbed entity as a text value. 
       - |
         To use the result of a command later, you need _bind notation_, which
         consists of a variable name and a leftwards-pointing arrow
-        before the command.  For example:
+        before the command. Like this:
       - |
-        ```
-        move; t <- grab; place t
-        ```
+        `move; art <- grab; place art`
       - |
-        In the above example, the result returned by `grab` is assigned
-        to the variable name `t`{=snippet}, which can then be used later.
-        This is useful, for example, if you do not care what you
-        grabbed and just want to move it to another cell, or if you
-        are not sure of the name of the thing being grabbed.
-      - |
-        Reminder: if you need to start over, your previous commands are
-        accessible in the REPL history (up-arrow).
+        **NOTE:** If you find yourself stuck, you can select "Start over" from
+        the "Quit" (**Ctrl+Q**) dialog.
+    prerequisite:
+      not: fail_to_grab
     condition: |
       try {
-        p <- robotnamed "pedestal";
-        w <- as p {ishere "Hastur"};
-        pure w;
+        teleport self (0,3);
+        ishere "Hastur"
       } { pure false }
-    prerequisite: grab_artifact
+  - id: fail_to_grab
+    teaser: Robor stopped
+    hidden: true
+    optional: true
+    goal:
+      - |
+        You sent a robot, but it failed to put the artifact in its rightful place.
+      - |
+        Try again by selecting "Start over" from the "Quit" (**Ctrl+Q**) dialog.
+    condition: |
+      as base {
+        try {
+          r <- robotnumbered 1;
+          reprogram r {};
+          teleport self (0,3);
+          h <- ishere "Hastur";
+          pure (not h)
+        } {
+          pure false
+        }
+      }
 solution: |
   build {
     move; move;
@@ -81,6 +74,14 @@ entities:
     description:
       - The Unspeakable One
     properties: [pickable]
+  - name: pedestal
+    display:
+      attr: gold
+      char: '+'
+    description:
+      - A stone pedestal.
+    properties:
+      - boundary
 robots:
   - name: base
     dir: north
@@ -95,19 +96,15 @@ robots:
       - [1, treads]
       - [1, grabber]
       - [1, compass]
-  - name: floorspot
-    system: true
-  - name: pedestal
-    system: true
 world:
   palette:
+    'Ω': [stone, null, base]
     '.': [blank, null]
-    'Ω': [blank, null, base]
-    'x': [dirt, null]
-    'H': [blank, Hastur, floorspot]
-    's': [stone, null, pedestal]
+    'x': [stone, pedestal]
+    's': [stone, null]
+    'H': [blank, Hastur]
     '+': [stone, wall]
-  upperleft: [-1, -3]
+  upperleft: [-5, 6]
   map: |
     +++++++++++
     +.........+
@@ -115,5 +112,5 @@ world:
     +...xsx...+
     +...xxxH..+
     +.........+
-    +Ω+++++++++
-    +++........
+    +++++Ω+++++
+    ....+++....

--- a/data/scenarios/Tutorials/bind2.yaml
+++ b/data/scenarios/Tutorials/bind2.yaml
@@ -57,14 +57,11 @@ objectives:
 solution: |
   build {
     move; move;
-    turn right;
-    move; move; move; move; move; move;
-    x <- grab;
-    turn left;
-    move;
-    turn left;
-    move; move;
-    place x;
+    turn right; move; move;
+    f <- grab;
+    turn back; move; move;
+    turn right; move;
+    place f
   }
 entities:
   - name: Hastur

--- a/data/scenarios/Tutorials/bind2.yaml
+++ b/data/scenarios/Tutorials/bind2.yaml
@@ -34,7 +34,7 @@ objectives:
         ishere "Hastur"
       } { pure false }
   - id: fail_to_grab
-    teaser: Robor stopped
+    teaser: Robot stopped
     hidden: true
     optional: true
     goal:

--- a/data/scenarios/Tutorials/bind2.yaml
+++ b/data/scenarios/Tutorials/bind2.yaml
@@ -16,7 +16,7 @@ objectives:
       - |
         The robot will need to `place "ARTIFACT NAME"`{=snippet}, but you do not know the name yet!
         Fortunatelly, the `grab` command has type `Cmd Text`{=type}, and returns
-        the name of the grabbed entity as a text value. 
+        the name of the grabbed entity as a text value.
       - |
         To use the result of a command later, you need _bind notation_, which
         consists of a variable name and a leftwards-pointing arrow

--- a/src/swarm-tui/Swarm/TUI/View/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Util.hs
@@ -12,7 +12,7 @@ import Control.Lens hiding (Const, from)
 import Control.Monad.Reader (withReaderT)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict qualified as M
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Graphics.Vty qualified as V
@@ -93,7 +93,7 @@ generateModal s mt = Modal mt (dialog (Just $ str title) buttons (maxModalWindow
   mkLoseModal =
     ( ""
     , Just
-        ( Button QuitButton
+        ( Button $ if isJust currentScenario then StartOverButton else QuitButton
         , catMaybes
             [ Just (stopMsg, Button QuitButton, QuitAction)
             , maybeStartOver


### PR DESCRIPTION
* move the bind explanation back to the first goal
  * remove the goal description of `Cmd Unit` as the previous types tutorial explained it already
* add a new hidden objective that will recognize that the sent robot has stopped short of delivering the artifact
  * make the "Start over" button the default on loss
* simplify room layout 
  * make the pedestal a golden connected boundary to make it easier to see
  * move the base entrance to the center so that it's easier to guess the number of moves
* closes #2310

| <img width="117" alt="Screenshot 2025-03-30 at 1 16 11 AM" src="https://github.com/user-attachments/assets/f3b29f00-5ac5-4378-903b-d0455acba3c7" /> |
| --- |
| New room layout |

The description of _bind notation_ was not shown unless the player sent a robot that successfully grabbed the artifact.
This could have paralyzed the player if they wanted to get it right the first time.

Now, the goal description is more upfront. If the player fails their one try, a hidden objective automatically detects it, fails the main objective, and a window with a retry option pops up.
