### PR TITLE
toplevel records zoom

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -328,11 +328,11 @@ handleMainEvent forceRedraw ev = do
     VtyEvent vev
       | isJust (s ^. playState . uiGameplay . uiDialogs . uiModal) -> handleModalEvent vev
     MouseDown (TerrainListItem pos) V.BLeft _ _ ->
-      Brick.zoom playState $ uiGameplay . uiWorldEditor . terrainList %= BL.listMoveTo pos
+      playState . uiGameplay . uiWorldEditor . terrainList %= BL.listMoveTo pos
     MouseDown (EntityPaintListItem pos) V.BLeft _ _ ->
-      Brick.zoom playState $ uiGameplay . uiWorldEditor . entityPaintList %= BL.listMoveTo pos
+      playState . uiGameplay . uiWorldEditor . entityPaintList %= BL.listMoveTo pos
     MouseDown WorldPositionIndicator _ _ _ ->
-      Brick.zoom playState $ uiGameplay . uiWorldCursor .= Nothing
+      playState . uiGameplay . uiWorldCursor .= Nothing
     MouseDown (FocusablePanel WorldPanel) V.BMiddle _ mouseLoc ->
       -- Eye Dropper tool
       Brick.zoom playState $ EC.handleMiddleClick mouseLoc
@@ -351,9 +351,8 @@ handleMainEvent forceRedraw ev = do
             uiGameplay . uiWorldCursor .= mouseCoordsM
         REPLInput -> handleREPLEvent ev
         _ -> continueWithoutRedraw
-    MouseUp n _ _mouseLoc -> do
-      m <- use $ uiState . uiMenu
-      Brick.zoom playState $ do
+    MouseUp n _ _mouseLoc ->
+      playStateWithMenu $ \m -> do
         case n of
           InventoryListItem pos -> uiGameplay . uiInventory . uiInventoryList . traverse . _2 %= BL.listMoveTo pos
           x@(WorldEditorPanelControl y) -> do
@@ -387,9 +386,7 @@ handleMainEvent forceRedraw ev = do
             wh <- use $ keyEventHandling . keyDispatchers . to worldDispatcher
             void $ B.handleKey wh k m
           WorldPanel | otherwise -> continueWithoutRedraw
-          WorldEditorPanel -> do
-            m <- use $ uiState . uiMenu
-            Brick.zoom playState $ EC.handleWorldEditorPanelEvent m ev
+          WorldEditorPanel -> playStateWithMenu $ EC.handleWorldEditorPanelEvent ev
           RobotPanel -> handleRobotPanelEvent ev
           InfoPanel -> handleInfoPanelEvent infoScroll ev
         _ -> continueWithoutRedraw

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -311,14 +311,15 @@ handleMainEvent forceRedraw ev = do
         if s ^. playState . gameState . temporal . paused
           then updateAndRedrawUI forceRedraw
           else runFrameUI forceRedraw
-      Web (RunWebCode e r) -> runBaseWebCode e r
+      Web (RunWebCode e r) -> Brick.zoom playState $ runBaseWebCode e r
       UpstreamVersion _ -> error "version event should be handled by top-level handler"
     VtyEvent (V.EvResize _ _) -> invalidateCache
     EscapeKey
       | Just m <- s ^. playState . uiGameplay . uiDialogs . uiModal ->
-          if s ^. playState . uiGameplay . uiDialogs . uiRobot . isDetailsOpened
-            then playState . uiGameplay . uiDialogs . uiRobot . isDetailsOpened .= False
-            else closeModal m
+          Brick.zoom playState $
+            if s ^. playState . uiGameplay . uiDialogs . uiRobot . isDetailsOpened
+              then uiGameplay . uiDialogs . uiRobot . isDetailsOpened .= False
+              else closeModal m
     -- Pass to key handler (allows users to configure bindings)
     -- See Note [how Swarm event handlers work]
     VtyEvent (V.EvKey k m)
@@ -354,7 +355,8 @@ handleMainEvent forceRedraw ev = do
         InventoryListItem pos -> playState . uiGameplay . uiInventory . uiInventoryList . traverse . _2 %= BL.listMoveTo pos
         x@(WorldEditorPanelControl y) -> do
           playState . uiGameplay . uiWorldEditor . editorFocusRing %= focusSetCurrent x
-          EC.activateWorldEditorFunction y
+          m <- use $ uiState . uiMenu
+          Brick.zoom playState $ EC.activateWorldEditorFunction m y
         _ -> return ()
       flip whenJust setFocus $ case n of
         -- Adapt click event origin to the right panel.  For the world
@@ -383,19 +385,21 @@ handleMainEvent forceRedraw ev = do
             wh <- use $ keyEventHandling . keyDispatchers . to worldDispatcher
             void $ B.handleKey wh k m
           WorldPanel | otherwise -> continueWithoutRedraw
-          WorldEditorPanel -> EC.handleWorldEditorPanelEvent ev
+          WorldEditorPanel -> do
+            m <- use $ uiState . uiMenu
+            Brick.zoom playState $ EC.handleWorldEditorPanelEvent m ev
           RobotPanel -> handleRobotPanelEvent ev
           InfoPanel -> handleInfoPanelEvent infoScroll ev
         _ -> continueWithoutRedraw
 
-closeModal :: Modal -> EventM Name AppState ()
+closeModal :: Modal -> EventM Name PlayState ()
 closeModal m = do
   safeAutoUnpause
-  playState . uiGameplay . uiDialogs . uiModal .= Nothing
+  uiGameplay . uiDialogs . uiModal .= Nothing
   -- message modal is not autopaused, so update notifications when leaving it
   when ((m ^. modalType) == MessagesModal) $ do
-    t <- use $ playState . gameState . temporal . ticks
-    playState . gameState . messageInfo . lastSeenMessageTime .= t
+    t <- use $ gameState . temporal . ticks
+    gameState . messageInfo . lastSeenMessageTime .= t
 
 -- TODO: #2010 Finish porting Controller to KeyEventHandlers
 handleModalEvent :: V.Event -> EventM Name AppState ()
@@ -413,10 +417,11 @@ handleModalEvent = \case
               updateRobotDetailsPane $ snd x
       _ -> do
         mdialog <- preuse $ playState . uiGameplay . uiDialogs . uiModal . _Just . modalDialog
-        toggleModal QuitModal
+        m <- use $ uiState . uiMenu
+        Brick.zoom playState $ toggleModal m QuitModal
         case dialogSelection =<< mdialog of
           Just (Button QuitButton, _) -> quitGame
-          Just (Button KeepPlayingButton, _) -> toggleModal KeepPlayingModal
+          Just (Button KeepPlayingButton, _) -> Brick.zoom playState $ toggleModal m KeepPlayingModal
           Just (Button StartOverButton, StartOver currentSeed siPair) -> do
             invalidateCache
             restartGame currentSeed siPair
@@ -425,37 +430,37 @@ handleModalEvent = \case
             invalidateCache
             startGame siPair Nothing
           _ -> return ()
-  ev -> do
-    Brick.zoom (playState . uiGameplay . uiDialogs . uiModal . _Just . modalDialog) (handleDialogEvent ev)
-    modal <- preuse $ playState . uiGameplay . uiDialogs . uiModal . _Just . modalType
+  ev -> Brick.zoom playState $ do
+    Brick.zoom (uiGameplay . uiDialogs . uiModal . _Just . modalDialog) (handleDialogEvent ev)
+    modal <- preuse $ uiGameplay . uiDialogs . uiModal . _Just . modalType
     case modal of
       Just TerrainPaletteModal ->
-        refreshList $ playState . uiGameplay . uiWorldEditor . terrainList
+        refreshList $ uiGameplay . uiWorldEditor . terrainList
       Just EntityPaletteModal -> do
-        refreshList $ playState . uiGameplay . uiWorldEditor . entityPaintList
+        refreshList $ uiGameplay . uiWorldEditor . entityPaintList
       Just GoalModal -> case ev of
-        V.EvKey (V.KChar '\t') [] -> playState . uiGameplay . uiDialogs . uiGoal . focus %= focusNext
+        V.EvKey (V.KChar '\t') [] -> uiGameplay . uiDialogs . uiGoal . focus %= focusNext
         _ -> do
-          focused <- use $ playState . uiGameplay . uiDialogs . uiGoal . focus
+          focused <- use $ uiGameplay . uiDialogs . uiGoal . focus
           case focusGetCurrent focused of
             Just (GoalWidgets w) -> case w of
               ObjectivesList -> do
-                lw <- use $ playState . uiGameplay . uiDialogs . uiGoal . listWidget
+                lw <- use $ uiGameplay . uiDialogs . uiGoal . listWidget
                 newList <- refreshGoalList lw
-                playState . uiGameplay . uiDialogs . uiGoal . listWidget .= newList
+                uiGameplay . uiDialogs . uiGoal . listWidget .= newList
               GoalSummary -> handleInfoPanelEvent modalScroll (VtyEvent ev)
             _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
       Just StructuresModal -> case ev of
-        V.EvKey (V.KChar '\t') [] -> playState . uiGameplay . uiDialogs . uiStructure . structurePanelFocus %= focusNext
+        V.EvKey (V.KChar '\t') [] -> uiGameplay . uiDialogs . uiStructure . structurePanelFocus %= focusNext
         _ -> do
-          focused <- use $ playState . uiGameplay . uiDialogs . uiStructure . structurePanelFocus
+          focused <- use $ uiGameplay . uiDialogs . uiStructure . structurePanelFocus
           case focusGetCurrent focused of
             Just (StructureWidgets w) -> case w of
               StructuresList ->
-                refreshList $ playState . uiGameplay . uiDialogs . uiStructure . structurePanelListWidget
+                refreshList $ uiGameplay . uiDialogs . uiStructure . structurePanelListWidget
               StructureSummary -> handleInfoPanelEvent modalScroll (VtyEvent ev)
             _ -> handleInfoPanelEvent modalScroll (VtyEvent ev)
-      Just RobotsModal -> Brick.zoom (playState . uiGameplay . uiDialogs . uiRobot) $ case ev of
+      Just RobotsModal -> Brick.zoom (uiGameplay . uiDialogs . uiRobot) $ case ev of
         V.EvKey (V.KChar '\t') [] -> robotDetailsFocus %= focusNext
         _ -> do
           isInDetailsMode <- use isDetailsOpened
@@ -514,6 +519,7 @@ handleREPLEvent x = do
   s <- get
   let controlMode = s ^. playState . uiGameplay . uiREPL . replControlMode
   let keyHandler = s ^. keyEventHandling . keyDispatchers . to replDispatcher
+  let menu = s ^. uiState . uiMenu
   case x of
     -- Pass to key handler (allows users to configure bindings)
     -- See Note [how Swarm event handlers work]
@@ -522,19 +528,19 @@ handleREPLEvent x = do
           void $ B.handleKey keyHandler k m
     -- Handle other events in a way appropriate to the current REPL
     -- control mode.
-    _ -> case controlMode of
-      Typing -> handleREPLEventTyping x
-      Piloting -> handleREPLEventPiloting x
+    _ -> Brick.zoom playState $ case controlMode of
+      Typing -> handleREPLEventTyping menu x
+      Piloting -> handleREPLEventPiloting menu x
       Handling -> case x of
         -- Handle keypresses using the custom installed handler
         VtyEvent (V.EvKey k mods) -> runInputHandler (mkKeyCombo mods k)
         -- Handle all other events normally
-        _ -> handleREPLEventTyping x
+        _ -> handleREPLEventTyping menu x
 
 -- | Run the installed input handler on a key combo entered by the user.
-runInputHandler :: KeyCombo -> EventM Name AppState ()
+runInputHandler :: KeyCombo -> EventM Name PlayState ()
 runInputHandler kc = do
-  mhandler <- use $ playState . gameState . gameControls . inputHandler
+  mhandler <- use $ gameState . gameControls . inputHandler
   forM_ mhandler $ \(_, handler) -> do
     -- Shouldn't be possible to get here if there is no input handler, but
     -- if we do somehow, just do nothing.
@@ -542,20 +548,20 @@ runInputHandler kc = do
     -- Make sure the base is currently idle; if so, apply the
     -- installed input handler function to a `key` value
     -- representing the typed input.
-    working <- use $ playState . gameState . gameControls . replWorking
+    working <- use $ gameState . gameControls . replWorking
     unless working $ do
       s <- get
-      let env = s ^. playState . gameState . baseEnv
-          store = s ^. playState . gameState . baseStore
+      let env = s ^. gameState . baseEnv
+          store = s ^. gameState . baseStore
           handlerCESK = Out (VKey kc) store [FApp handler, FExec, FSuspend env]
-      playState . gameState . baseRobot . machine .= handlerCESK
-      playState . gameState %= execState (zoomRobots $ activateRobot 0)
+      gameState . baseRobot . machine .= handlerCESK
+      gameState %= execState (zoomRobots $ activateRobot 0)
 
 -- | Handle a user "piloting" input event for the REPL.
 --
 -- TODO: #2010 Finish porting Controller to KeyEventHandlers
-handleREPLEventPiloting :: BrickEvent Name AppEvent -> EventM Name AppState ()
-handleREPLEventPiloting x = case x of
+handleREPLEventPiloting :: Menu -> BrickEvent Name AppEvent -> EventM Name PlayState ()
+handleREPLEventPiloting m x = case x of
   Key V.KUp -> inputCmd "move"
   Key V.KDown -> inputCmd "turn back"
   Key V.KLeft -> inputCmd "turn left"
@@ -576,35 +582,35 @@ handleREPLEventPiloting x = case x of
   _ -> inputCmd "noop"
  where
   inputCmd cmdText = do
-    playState . uiGameplay . uiREPL %= setCmd (cmdText <> ";")
+    uiGameplay . uiREPL %= setCmd (cmdText <> ";")
     modify validateREPLForm
-    handleREPLEventTyping $ Key V.KEnter
+    handleREPLEventTyping m $ Key V.KEnter
 
   setCmd nt theRepl =
     theRepl
       & replPromptText .~ nt
       & replPromptType .~ CmdPrompt []
 
-runBaseWebCode :: (MonadState AppState m, MonadIO m) => T.Text -> (WebInvocationState -> IO ()) -> m ()
+runBaseWebCode :: (MonadState PlayState m, MonadIO m) => T.Text -> (WebInvocationState -> IO ()) -> m ()
 runBaseWebCode uinput ureply = do
   s <- get
-  if s ^. playState . gameState . gameControls . replWorking
+  if s ^. gameState . gameControls . replWorking
     then liftIO . ureply $ Rejected AlreadyRunning
     else do
-      playState . gameState . gameControls . replListener .= (ureply . Complete . T.unpack)
+      gameState . gameControls . replListener .= (ureply . Complete . T.unpack)
       runBaseCode uinput
         >>= liftIO . ureply . \case
           Left err -> Rejected . ParseError $ T.unpack err
           Right () -> InProgress
 
-runBaseCode :: (MonadState AppState m) => T.Text -> m (Either Text ())
+runBaseCode :: (MonadState PlayState m) => T.Text -> m (Either Text ())
 runBaseCode uinput = do
   addREPLHistItem (mkREPLSubmission uinput)
   resetREPL "" (CmdPrompt [])
-  env <- use $ playState . gameState . baseEnv
+  env <- use $ gameState . baseEnv
   case processTerm' env uinput of
     Right mt -> do
-      playState . uiGameplay . uiREPL . replHistory . replHasExecutedManualInput .= True
+      uiGameplay . uiREPL . replHistory . replHasExecutedManualInput .= True
       runBaseTerm mt
       return (Right ())
     Left err -> do
@@ -614,8 +620,8 @@ runBaseCode uinput = do
 -- | Handle a user input event for the REPL.
 --
 -- TODO: #2010 Finish porting Controller to KeyEventHandlers
-handleREPLEventTyping :: BrickEvent Name AppEvent -> EventM Name AppState ()
-handleREPLEventTyping = \case
+handleREPLEventTyping :: Menu -> BrickEvent Name AppEvent -> EventM Name PlayState ()
+handleREPLEventTyping m = \case
   -- Scroll the REPL on PageUp or PageDown
   Key V.KPageUp -> vScrollPage replScroll Brick.Up
   Key V.KPageDown -> vScrollPage replScroll Brick.Down
@@ -625,10 +631,10 @@ handleREPLEventTyping = \case
     case k of
       Key V.KEnter -> do
         s <- get
-        let theRepl = s ^. playState . uiGameplay . uiREPL
+        let theRepl = s ^. uiGameplay . uiREPL
             uinput = theRepl ^. replPromptText
 
-        if not $ s ^. playState . gameState . gameControls . replWorking
+        if not $ s ^. gameState . gameControls . replWorking
           then case theRepl ^. replPromptType of
             CmdPrompt _ -> do
               void $ runBaseCode uinput
@@ -644,7 +650,7 @@ handleREPLEventTyping = \case
           else continueWithoutRedraw
       Key V.KUp -> modify $ adjReplHistIndex Older
       Key V.KDown -> do
-        repl <- use $ playState . uiGameplay . uiREPL
+        repl <- use $ uiGameplay . uiREPL
         let hist = repl ^. replHistory
             uinput = repl ^. replPromptText
         case repl ^. replPromptType of
@@ -659,7 +665,7 @@ handleREPLEventTyping = \case
           -- Otherwise, just move around in the history as normal.
           _ -> modify $ adjReplHistIndex Newer
       ControlChar 'r' ->
-        Brick.zoom (playState . uiGameplay . uiREPL) $ do
+        Brick.zoom (uiGameplay . uiREPL) $ do
           uir <- get
           let uinput = uir ^. replPromptText
           case uir ^. replPromptType of
@@ -668,29 +674,29 @@ handleREPLEventTyping = \case
               replPromptType .= SearchPrompt (removeEntry found rh)
       CharKey '\t' -> do
         s <- get
-        let names = s ^.. playState . gameState . baseEnv . envTypes . to assocs . traverse . _1
-        playState . uiGameplay . uiREPL %= tabComplete (CompletionContext (s ^. playState . gameState . creativeMode)) names (s ^. playState . gameState . landscape . terrainAndEntities . entityMap)
+        let names = s ^.. gameState . baseEnv . envTypes . to assocs . traverse . _1
+        uiGameplay . uiREPL %= tabComplete (CompletionContext (s ^. gameState . creativeMode)) names (s ^. gameState . landscape . terrainAndEntities . entityMap)
         modify validateREPLForm
       EscapeKey -> do
-        formSt <- use $ playState . uiGameplay . uiREPL . replPromptType
+        formSt <- use $ uiGameplay . uiREPL . replPromptType
         case formSt of
           CmdPrompt {} -> continueWithoutRedraw
           SearchPrompt _ -> resetREPL "" (CmdPrompt [])
       ControlChar 'd' -> do
-        text <- use $ playState . uiGameplay . uiREPL . replPromptText
+        text <- use $ uiGameplay . uiREPL . replPromptText
         if text == T.empty
-          then toggleModal QuitModal
+          then toggleModal m QuitModal
           else continueWithoutRedraw
       MetaKey V.KBS ->
-        playState . uiGameplay . uiREPL . replPromptEditor %= applyEdit TZ.deletePrevWord
+        uiGameplay . uiREPL . replPromptEditor %= applyEdit TZ.deletePrevWord
       -- finally if none match pass the event to the editor
       ev -> do
-        Brick.zoom (playState . uiGameplay . uiREPL . replPromptEditor) $ case ev of
+        Brick.zoom (uiGameplay . uiREPL . replPromptEditor) $ case ev of
           CharKey c
             | c `elem` ("([{" :: String) -> insertMatchingPair c
             | c `elem` (")]}" :: String) -> insertOrMovePast c
           _ -> handleEditorEvent ev
-        playState . uiGameplay . uiREPL . replPromptType %= \case
+        uiGameplay . uiREPL . replPromptType %= \case
           CmdPrompt _ -> CmdPrompt [] -- reset completions on any event passed to editor
           SearchPrompt a -> SearchPrompt a
         modify validateREPLForm
@@ -795,16 +801,16 @@ tabComplete CompletionContext {..} names em theRepl = case theRepl ^. replPrompt
 
 -- | Validate the REPL input when it changes: see if it parses and
 --   typechecks, and set the color accordingly.
-validateREPLForm :: AppState -> AppState
+validateREPLForm :: PlayState -> PlayState
 validateREPLForm s =
   case replPrompt of
     CmdPrompt _
       | T.null uinput ->
-          let theType = s ^. playState . gameState . gameControls . replStatus . replActiveType
-           in s & playState . uiGameplay . uiREPL . replType .~ theType
+          let theType = s ^. gameState . gameControls . replStatus . replActiveType
+           in s & uiGameplay . uiREPL . replType .~ theType
     CmdPrompt _
       | otherwise ->
-          let env = s ^. playState . gameState . baseEnv
+          let env = s ^. gameState . baseEnv
               (theType, errSrcLoc) = case readTerm' defaultParserConfig uinput of
                 Left err ->
                   let ((_y1, x1), (_y2, x2), _msg) = showErrorPos err
@@ -814,18 +820,18 @@ validateREPLForm s =
                   Right t -> (Just (t ^. sType), Right ())
                   Left err -> (Nothing, Left (cteSrcLoc err))
            in s
-                & playState . uiGameplay . uiREPL . replValid .~ errSrcLoc
-                & playState . uiGameplay . uiREPL . replType .~ theType
+                & uiGameplay . uiREPL . replValid .~ errSrcLoc
+                & uiGameplay . uiREPL . replType .~ theType
     SearchPrompt _ -> s
  where
-  uinput = s ^. playState . uiGameplay . uiREPL . replPromptText
-  replPrompt = s ^. playState . uiGameplay . uiREPL . replPromptType
+  uinput = s ^. uiGameplay . uiREPL . replPromptText
+  replPrompt = s ^. uiGameplay . uiREPL . replPromptType
 
 -- | Update our current position in the REPL history.
-adjReplHistIndex :: TimeDir -> AppState -> AppState
+adjReplHistIndex :: TimeDir -> PlayState -> PlayState
 adjReplHistIndex d s =
   s
-    & playState . uiGameplay . uiREPL %~ moveREPL
+    & uiGameplay . uiREPL %~ moveREPL
     & validateREPLForm
  where
   moveREPL :: REPLState -> REPLState
@@ -852,7 +858,7 @@ adjReplHistIndex d s =
 -- | Handle user events in the info panel (just scrolling).
 --
 -- TODO: #2010 Finish porting Controller to KeyEventHandlers
-handleInfoPanelEvent :: ViewportScroll Name -> BrickEvent Name AppEvent -> EventM Name AppState ()
+handleInfoPanelEvent :: ViewportScroll Name -> BrickEvent Name AppEvent -> EventM Name s ()
 handleInfoPanelEvent vs = \case
   Key V.KDown -> vScrollBy vs 1
   Key V.KUp -> vScrollBy vs (-1)

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -419,11 +419,10 @@ handleModalEvent = \case
               updateRobotDetailsPane $ snd x
       _ -> do
         mdialog <- preuse $ playState . uiGameplay . uiDialogs . uiModal . _Just . modalDialog
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ toggleModal m QuitModal
+        playStateWithMenu $ toggleModal QuitModal
         case dialogSelection =<< mdialog of
           Just (Button QuitButton, _) -> quitGame
-          Just (Button KeepPlayingButton, _) -> Brick.zoom playState $ toggleModal m KeepPlayingModal
+          Just (Button KeepPlayingButton, _) -> playStateWithMenu $ toggleModal KeepPlayingModal
           Just (Button StartOverButton, StartOver currentSeed siPair) -> do
             invalidateCache
             restartGame currentSeed siPair
@@ -687,7 +686,7 @@ handleREPLEventTyping m = \case
       ControlChar 'd' -> do
         text <- use $ uiGameplay . uiREPL . replPromptText
         if text == T.empty
-          then toggleModal m QuitModal
+          then toggleModal QuitModal m
           else continueWithoutRedraw
       MetaKey V.KBS ->
         uiGameplay . uiREPL . replPromptEditor %= applyEdit TZ.deletePrevWord

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -44,62 +44,7 @@ runFrameUI forceRedraw = runFrame >> updateAndRedrawUI forceRedraw
 -- | Run the game for a single frame, without updating the UI.
 runFrame :: EventM Name AppState ()
 runFrame = do
-  -- Reset the needsRedraw flag.  While processing the frame and stepping the robots,
-  -- the flag will get set to true if anything changes that requires redrawing the
-  -- world (e.g. a robot moving or disappearing).
-  playState . gameState . needsRedraw .= False
-
-  -- The logic here is taken from https://gafferongames.com/post/fix_your_timestep/ .
-
-  curTime <- liftIO $ getTime Monotonic
-  Brick.zoom (playState . uiGameplay . uiTiming) $ do
-    -- Find out how long the previous frame took, by subtracting the
-    -- previous time from the current time.
-    prevTime <- use lastFrameTime
-    let frameTime = diffTimeSpec curTime prevTime
-
-    -- Remember now as the new previous time.
-    lastFrameTime .= curTime
-
-    -- We now have some additional accumulated time to play with.  The
-    -- idea is to now "catch up" by doing as many ticks as are supposed
-    -- to fit in the accumulated time.  Some accumulated time may be
-    -- left over, but it will roll over to the next frame.  This way we
-    -- deal smoothly with things like a variable frame rate, the frame
-    -- rate not being a nice multiple of the desired ticks per second,
-    -- etc.
-    accumulatedTime += frameTime
-
-  -- Update TPS/FPS counters every second
-  infoUpdateTime <- use (playState . uiGameplay . uiTiming . lastInfoTime)
-  let updateTime = toNanoSecs $ diffTimeSpec curTime infoUpdateTime
-  when (updateTime >= oneSecond) $ do
-    -- Wait for at least one second to have elapsed
-    when (infoUpdateTime /= 0) $ do
-      Brick.zoom (playState . uiGameplay . uiTiming) $ do
-        -- set how much frame got processed per second
-        frames <- use frameCount
-        uiFPS .= fromIntegral (frames * fromInteger oneSecond) / fromIntegral updateTime
-
-        -- set how much ticks got processed per frame
-        uiTicks <- use tickCount
-        uiTPF .= fromIntegral uiTicks / fromIntegral frames
-
-      -- ensure this frame gets drawn
-      playState . gameState . needsRedraw .= True
-
-    Brick.zoom (playState . uiGameplay . uiTiming) $ do
-      -- Reset the counter and wait another seconds for the next update
-      tickCount .= 0
-      frameCount .= 0
-      lastInfoTime .= curTime
-
-  Brick.zoom (playState . uiGameplay . uiTiming) $ do
-    -- Increment the frame count
-    frameCount += 1
-
-    -- Now do as many ticks as we need to catch up.
-    frameTickCount .= 0
+  runFramePlayState
 
   -- Figure out how many ticks per second we're supposed to do,
   -- and compute the timestep `dt` for a single tick.
@@ -111,6 +56,63 @@ runFrame = do
   runFrameTicks (fromNanoSecs dt)
  where
   oneSecond = 1_000_000_000 -- one second = 10^9 nanoseconds
+  runFramePlayState = Brick.zoom playState $ do
+    -- Reset the needsRedraw flag.  While processing the frame and stepping the robots,
+    -- the flag will get set to true if anything changes that requires redrawing the
+    -- world (e.g. a robot moving or disappearing).
+    gameState . needsRedraw .= False
+
+    -- The logic here is taken from https://gafferongames.com/post/fix_your_timestep/ .
+
+    curTime <- liftIO $ getTime Monotonic
+    Brick.zoom (uiGameplay . uiTiming) $ do
+      -- Find out how long the previous frame took, by subtracting the
+      -- previous time from the current time.
+      prevTime <- use lastFrameTime
+      let frameTime = diffTimeSpec curTime prevTime
+
+      -- Remember now as the new previous time.
+      lastFrameTime .= curTime
+
+      -- We now have some additional accumulated time to play with.  The
+      -- idea is to now "catch up" by doing as many ticks as are supposed
+      -- to fit in the accumulated time.  Some accumulated time may be
+      -- left over, but it will roll over to the next frame.  This way we
+      -- deal smoothly with things like a variable frame rate, the frame
+      -- rate not being a nice multiple of the desired ticks per second,
+      -- etc.
+      accumulatedTime += frameTime
+
+    -- Update TPS/FPS counters every second
+    infoUpdateTime <- use (uiGameplay . uiTiming . lastInfoTime)
+    let updateTime = toNanoSecs $ diffTimeSpec curTime infoUpdateTime
+    when (updateTime >= oneSecond) $ do
+      -- Wait for at least one second to have elapsed
+      when (infoUpdateTime /= 0) $ do
+        Brick.zoom (uiGameplay . uiTiming) $ do
+          -- set how much frame got processed per second
+          frames <- use frameCount
+          uiFPS .= fromIntegral (frames * fromInteger oneSecond) / fromIntegral updateTime
+
+          -- set how much ticks got processed per frame
+          uiTicks <- use tickCount
+          uiTPF .= fromIntegral uiTicks / fromIntegral frames
+
+        -- ensure this frame gets drawn
+        gameState . needsRedraw .= True
+
+      Brick.zoom (uiGameplay . uiTiming) $ do
+        -- Reset the counter and wait another seconds for the next update
+        tickCount .= 0
+        frameCount .= 0
+        lastInfoTime .= curTime
+
+    Brick.zoom (uiGameplay . uiTiming) $ do
+      -- Increment the frame count
+      frameCount += 1
+
+      -- Now do as many ticks as we need to catch up.
+      frameTickCount .= 0
 
 -- | Do zero or more ticks, with each tick notionally taking the given
 --   timestep, until we have used up all available accumulated time,

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -41,6 +41,67 @@ ticksPerFrameCap = 30
 runFrameUI :: Bool -> EventM Name AppState ()
 runFrameUI forceRedraw = runFrame >> updateAndRedrawUI forceRedraw
 
+oneSecond :: Integer
+oneSecond = 1_000_000_000 -- one second = 10^9 nanoseconds
+
+runFramePlayState :: EventM Name AppState ()
+runFramePlayState = Brick.zoom playState $ do
+  -- Reset the needsRedraw flag.  While processing the frame and stepping the robots,
+  -- the flag will get set to true if anything changes that requires redrawing the
+  -- world (e.g. a robot moving or disappearing).
+  gameState . needsRedraw .= False
+
+  -- The logic here is taken from https://gafferongames.com/post/fix_your_timestep/ .
+
+  curTime <- liftIO $ getTime Monotonic
+  Brick.zoom (uiGameplay . uiTiming) $ do
+    -- Find out how long the previous frame took, by subtracting the
+    -- previous time from the current time.
+    prevTime <- use lastFrameTime
+    let frameTime = diffTimeSpec curTime prevTime
+
+    -- Remember now as the new previous time.
+    lastFrameTime .= curTime
+
+    -- We now have some additional accumulated time to play with.  The
+    -- idea is to now "catch up" by doing as many ticks as are supposed
+    -- to fit in the accumulated time.  Some accumulated time may be
+    -- left over, but it will roll over to the next frame.  This way we
+    -- deal smoothly with things like a variable frame rate, the frame
+    -- rate not being a nice multiple of the desired ticks per second,
+    -- etc.
+    accumulatedTime += frameTime
+
+  -- Update TPS/FPS counters every second
+  infoUpdateTime <- use (uiGameplay . uiTiming . lastInfoTime)
+  let updateTime = toNanoSecs $ diffTimeSpec curTime infoUpdateTime
+  when (updateTime >= oneSecond) $ do
+    -- Wait for at least one second to have elapsed
+    when (infoUpdateTime /= 0) $ do
+      Brick.zoom (uiGameplay . uiTiming) $ do
+        -- set how much frame got processed per second
+        frames <- use frameCount
+        uiFPS .= fromIntegral (frames * fromInteger oneSecond) / fromIntegral updateTime
+
+        -- set how much ticks got processed per frame
+        uiTicks <- use tickCount
+        uiTPF .= fromIntegral uiTicks / fromIntegral frames
+
+      -- ensure this frame gets drawn
+      gameState . needsRedraw .= True
+
+    Brick.zoom (uiGameplay . uiTiming) $ do
+      -- Reset the counter and wait another seconds for the next update
+      tickCount .= 0
+      frameCount .= 0
+      lastInfoTime .= curTime
+
+  Brick.zoom (uiGameplay . uiTiming) $ do
+    -- Increment the frame count
+    frameCount += 1
+
+    frameTickCount .= 0
+
 -- | Run the game for a single frame, without updating the UI.
 runFrame :: EventM Name AppState ()
 runFrame = do
@@ -53,66 +114,8 @@ runFrame = do
         | lgTPS >= 0 = oneSecond `div` (1 `shiftL` lgTPS)
         | otherwise = oneSecond * (1 `shiftL` abs lgTPS)
 
+  -- Now do as many ticks as we need to catch up.
   runFrameTicks (fromNanoSecs dt)
- where
-  oneSecond = 1_000_000_000 -- one second = 10^9 nanoseconds
-  runFramePlayState = Brick.zoom playState $ do
-    -- Reset the needsRedraw flag.  While processing the frame and stepping the robots,
-    -- the flag will get set to true if anything changes that requires redrawing the
-    -- world (e.g. a robot moving or disappearing).
-    gameState . needsRedraw .= False
-
-    -- The logic here is taken from https://gafferongames.com/post/fix_your_timestep/ .
-
-    curTime <- liftIO $ getTime Monotonic
-    Brick.zoom (uiGameplay . uiTiming) $ do
-      -- Find out how long the previous frame took, by subtracting the
-      -- previous time from the current time.
-      prevTime <- use lastFrameTime
-      let frameTime = diffTimeSpec curTime prevTime
-
-      -- Remember now as the new previous time.
-      lastFrameTime .= curTime
-
-      -- We now have some additional accumulated time to play with.  The
-      -- idea is to now "catch up" by doing as many ticks as are supposed
-      -- to fit in the accumulated time.  Some accumulated time may be
-      -- left over, but it will roll over to the next frame.  This way we
-      -- deal smoothly with things like a variable frame rate, the frame
-      -- rate not being a nice multiple of the desired ticks per second,
-      -- etc.
-      accumulatedTime += frameTime
-
-    -- Update TPS/FPS counters every second
-    infoUpdateTime <- use (uiGameplay . uiTiming . lastInfoTime)
-    let updateTime = toNanoSecs $ diffTimeSpec curTime infoUpdateTime
-    when (updateTime >= oneSecond) $ do
-      -- Wait for at least one second to have elapsed
-      when (infoUpdateTime /= 0) $ do
-        Brick.zoom (uiGameplay . uiTiming) $ do
-          -- set how much frame got processed per second
-          frames <- use frameCount
-          uiFPS .= fromIntegral (frames * fromInteger oneSecond) / fromIntegral updateTime
-
-          -- set how much ticks got processed per frame
-          uiTicks <- use tickCount
-          uiTPF .= fromIntegral uiTicks / fromIntegral frames
-
-        -- ensure this frame gets drawn
-        gameState . needsRedraw .= True
-
-      Brick.zoom (uiGameplay . uiTiming) $ do
-        -- Reset the counter and wait another seconds for the next update
-        tickCount .= 0
-        frameCount .= 0
-        lastInfoTime .= curTime
-
-    Brick.zoom (uiGameplay . uiTiming) $ do
-      -- Increment the frame count
-      frameCount += 1
-
-      -- Now do as many ticks as we need to catch up.
-      frameTickCount .= 0
 
 -- | Do zero or more ticks, with each tick notionally taking the given
 --   timestep, until we have used up all available accumulated time,
@@ -163,5 +166,5 @@ updateAchievements = do
 --   etc.).
 runGameTick :: EventM Name AppState ()
 runGameTick = do
-  ticked <- zoomGameState gameTick
+  ticked <- zoomGameStateFromAppState gameTick
   when ticked updateAchievements

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -68,10 +68,10 @@ mainEventHandlers = allHandlers Main $ \case
     )
   HideRobotsEvent -> ("Hide robots for a few ticks", Brick.zoom (playState . uiGameplay) hideRobots)
   ShowCESKDebugEvent -> ("Show active robot CESK machine debugging line", showCESKDebug)
-  PauseEvent -> ("Pause or unpause the game", Brick.zoom playState $ whenRunning' safeTogglePause)
-  RunSingleTickEvent -> ("Run game for a single tick", whenRunning runSingleTick)
-  IncreaseTpsEvent -> ("Double game speed", Brick.zoom playState $ whenRunning' . modify $ adjustTPS (+))
-  DecreaseTpsEvent -> ("Halve game speed", Brick.zoom playState $ whenRunning' . modify $ adjustTPS (-))
+  PauseEvent -> ("Pause or unpause the game", Brick.zoom playState $ whenRunningPlayState safeTogglePause)
+  RunSingleTickEvent -> ("Run game for a single tick", whenRunningAppState runSingleTick)
+  IncreaseTpsEvent -> ("Double game speed", Brick.zoom playState $ whenRunningPlayState . modify $ adjustTPS (+))
+  DecreaseTpsEvent -> ("Halve game speed", Brick.zoom playState $ whenRunningPlayState . modify $ adjustTPS (-))
   FocusWorldEvent -> ("Set focus on the World panel", Brick.zoom playState $ setFocus WorldPanel)
   FocusRobotEvent -> ("Set focus on the Robot panel", Brick.zoom playState $ setFocus RobotPanel)
   FocusREPLEvent -> ("Set focus on the REPL panel", Brick.zoom playState $ setFocus REPLPanel)
@@ -198,11 +198,11 @@ isRunning = do
   mt <- preuse $ uiGameplay . uiDialogs . uiModal . _Just . modalType
   return $ maybe True isRunningModal mt
 
-whenRunning :: EventM Name AppState () -> EventM Name AppState ()
-whenRunning a = Brick.zoom playState isRunning >>= \r -> when r a
+whenRunningAppState :: EventM Name AppState () -> EventM Name AppState ()
+whenRunningAppState a = Brick.zoom playState isRunning >>= \r -> when r a
 
-whenRunning' :: EventM Name PlayState () -> EventM Name PlayState ()
-whenRunning' a = isRunning >>= \r -> when r a
+whenRunningPlayState :: EventM Name PlayState () -> EventM Name PlayState ()
+whenRunningPlayState a = isRunning >>= \r -> when r a
 
 whenDebug :: DebugOption -> EventM Name AppState () -> EventM Name AppState ()
 whenDebug d a = do

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -39,70 +39,57 @@ mainEventHandlers = allHandlers Main $ \case
   QuitEvent -> ("Open quit game dialog", toggleQuitGameDialog)
   ViewHelpEvent ->
     ( "View Help screen"
-    , do
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ toggleModal m HelpModal
+    , playStateWithMenu $ toggleModal HelpModal
     )
   ViewRobotsEvent ->
     ( "View Robots screen"
-    , do
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ toggleModal m RobotsModal
+    , playStateWithMenu $ toggleModal RobotsModal
     )
   ViewRecipesEvent ->
     ( "View Recipes screen"
-    , do
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ toggleDiscoveryNotificationModal m RecipesModal availableRecipes
+    , playStateWithMenu $ toggleDiscoveryNotificationModal RecipesModal availableRecipes
     )
   ViewCommandsEvent ->
     ( "View Commands screen"
-    , do
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ toggleDiscoveryNotificationModal m CommandsModal availableCommands
+    , playStateWithMenu $ toggleDiscoveryNotificationModal CommandsModal availableCommands
     )
   ViewMessagesEvent ->
     ( "View Messages screen"
-    , do
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ toggleMessagesModal m
+    , playStateWithMenu toggleMessagesModal
     )
   ViewStructuresEvent ->
     ( "View Structures screen"
-    , do
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ toggleStructuresModal m StructuresModal (recognizerAutomatons . originalStructureDefinitions)
+    , playStateWithMenu $
+        toggleStructuresModal StructuresModal (recognizerAutomatons . originalStructureDefinitions)
     )
   ViewGoalEvent ->
     ( "View scenario goal description"
-    , do
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ viewGoal m
+    , playStateWithMenu viewGoal
     )
-  HideRobotsEvent -> ("Hide robots for a few ticks", hideRobots)
+  HideRobotsEvent -> ("Hide robots for a few ticks", Brick.zoom (playState . uiGameplay) hideRobots)
   ShowCESKDebugEvent -> ("Show active robot CESK machine debugging line", showCESKDebug)
-  PauseEvent -> ("Pause or unpause the game", whenRunning $ Brick.zoom playState safeTogglePause)
+  PauseEvent -> ("Pause or unpause the game", Brick.zoom playState $ whenRunning' safeTogglePause)
   RunSingleTickEvent -> ("Run game for a single tick", whenRunning runSingleTick)
-  IncreaseTpsEvent -> ("Double game speed", whenRunning . modify $ adjustTPS (+))
-  DecreaseTpsEvent -> ("Halve game speed", whenRunning . modify $ adjustTPS (-))
+  IncreaseTpsEvent -> ("Double game speed", Brick.zoom playState $ whenRunning' . modify $ adjustTPS (+))
+  DecreaseTpsEvent -> ("Halve game speed", Brick.zoom playState $ whenRunning' . modify $ adjustTPS (-))
   FocusWorldEvent -> ("Set focus on the World panel", Brick.zoom playState $ setFocus WorldPanel)
   FocusRobotEvent -> ("Set focus on the Robot panel", Brick.zoom playState $ setFocus RobotPanel)
   FocusREPLEvent -> ("Set focus on the REPL panel", Brick.zoom playState $ setFocus REPLPanel)
   FocusInfoEvent -> ("Set focus on the Info panel", Brick.zoom playState $ setFocus InfoPanel)
   ToggleCreativeModeEvent -> ("Toggle creative mode", whenDebug ToggleCreative $ Brick.zoom playState toggleCreativeMode)
   ToggleWorldEditorEvent -> ("Toggle world editor mode", whenDebug ToggleWorldEditor $ Brick.zoom playState toggleWorldEditor)
-  ToggleREPLVisibilityEvent -> ("Collapse/Expand REPL panel", toggleREPLVisibility)
+  ToggleREPLVisibilityEvent -> ("Collapse/Expand REPL panel", Brick.zoom playState toggleREPLVisibility)
   ViewBaseEvent -> ("View the base robot", Brick.zoom playState viewBase)
   ToggleFPSEvent -> ("Toggle the FPS display", Brick.zoom playState toggleFPS)
 
 toggleQuitGameDialog :: EventM Name AppState ()
 toggleQuitGameDialog = do
   s <- get
-  m <- use $ uiState . uiMenu
-  Brick.zoom playState $ case s ^. playState . gameState . winCondition of
-    WinConditions (Won _ _) _ -> toggleModal m $ ScenarioEndModal WinModal
-    WinConditions (Unwinnable _) _ -> toggleModal m $ ScenarioEndModal LoseModal
-    _ -> toggleModal m QuitModal
+  let whichModal = case s ^. playState . gameState . winCondition of
+        WinConditions (Won _ _) _ -> ScenarioEndModal WinModal
+        WinConditions (Unwinnable _) _ -> ScenarioEndModal LoseModal
+        _ -> QuitModal
+  playStateWithMenu $ toggleModal whichModal
 
 toggleGameModal ::
   Foldable t =>
@@ -115,23 +102,23 @@ toggleGameModal menu m l = do
   let nothingToShow = null $ s ^. gameState . l
 
   unless nothingToShow $
-    toggleModal menu m
+    toggleModal m menu
   return nothingToShow
 
 toggleStructuresModal ::
   Foldable t =>
-  Menu ->
   ModalType ->
   Lens' Landscape (t a) ->
+  Menu ->
   EventM Name PlayState ()
-toggleStructuresModal menu m l = void $ toggleGameModal menu m (landscape . l)
+toggleStructuresModal m l menu = void $ toggleGameModal menu m (landscape . l)
 
 toggleDiscoveryNotificationModal ::
-  Menu ->
   ModalType ->
   Lens' Discovery (Notifications a) ->
+  Menu ->
   EventM Name PlayState ()
-toggleDiscoveryNotificationModal menu m l = do
+toggleDiscoveryNotificationModal m l menu = do
   nothingToShow <- toggleGameModal menu m (discovery . l . notificationsContent)
   unless nothingToShow $ gameState . discovery . l . notificationsCount .= 0
 
@@ -145,11 +132,11 @@ viewGoal :: Menu -> EventM Name PlayState ()
 viewGoal m = do
   s <- get
   if hasAnythingToShow $ s ^. uiGameplay . uiDialogs . uiGoal . goalsContent
-    then toggleModal m GoalModal
+    then toggleModal GoalModal m
     else continueWithoutRedraw
 
-hideRobots :: EventM Name AppState ()
-hideRobots = Brick.zoom (playState . uiGameplay) $ do
+hideRobots :: EventM Name UIGameplay ()
+hideRobots = do
   t <- liftIO $ getTime Monotonic
   h <- use uiHideRobotsUntil
   case h >= t of
@@ -165,7 +152,7 @@ showCESKDebug = do
   s <- get
   let isPaused = s ^. playState . gameState . temporal . paused
   let isCreative = s ^. playState . gameState . creativeMode
-  let hasDebug = hasDebugCapability isCreative s
+  let hasDebug = hasDebugCapability isCreative $ s ^. playState . gameState
   when (isPaused && hasDebug) $ do
     debug <- playState . uiGameplay . uiShowDebug Lens.<%= not
     if debug
@@ -178,8 +165,8 @@ runSingleTick = do
   runGameTickUI
 
 -- | Adjust the ticks per second speed.
-adjustTPS :: (Int -> Int -> Int) -> AppState -> AppState
-adjustTPS (+/-) = playState . uiGameplay . uiTiming . lgTicksPerSecond %~ (+/- 1)
+adjustTPS :: (Int -> Int -> Int) -> PlayState -> PlayState
+adjustTPS (+/-) = uiGameplay . uiTiming . lgTicksPerSecond %~ (+/- 1)
 
 toggleCreativeMode :: EventM Name PlayState ()
 toggleCreativeMode = gameState . creativeMode %= not
@@ -189,10 +176,10 @@ toggleWorldEditor = do
   uiGameplay . uiWorldEditor . worldOverdraw . isWorldEditorEnabled %= not
   setFocus WorldEditorPanel
 
-toggleREPLVisibility :: EventM Name AppState ()
+toggleREPLVisibility :: EventM Name PlayState ()
 toggleREPLVisibility = do
   invalidateCacheEntry WorldCache
-  playState . uiGameplay . uiShowREPL %= not
+  uiGameplay . uiShowREPL %= not
 
 viewBase :: EventM Name PlayState ()
 viewBase = do
@@ -206,13 +193,16 @@ toggleFPS = uiGameplay . uiTiming . uiShowFPS %= not
 --                 HELPER UTILS
 -- ----------------------------------------------
 
-isRunning :: EventM Name AppState Bool
+isRunning :: EventM Name PlayState Bool
 isRunning = do
-  mt <- preuse $ playState . uiGameplay . uiDialogs . uiModal . _Just . modalType
+  mt <- preuse $ uiGameplay . uiDialogs . uiModal . _Just . modalType
   return $ maybe True isRunningModal mt
 
 whenRunning :: EventM Name AppState () -> EventM Name AppState ()
-whenRunning a = isRunning >>= \r -> when r a
+whenRunning a = Brick.zoom playState isRunning >>= \r -> when r a
+
+whenRunning' :: EventM Name PlayState () -> EventM Name PlayState ()
+whenRunning' a = isRunning >>= \r -> when r a
 
 whenDebug :: DebugOption -> EventM Name AppState () -> EventM Name AppState ()
 whenDebug d a = do

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -157,7 +157,7 @@ showCESKDebug = do
     debug <- playState . uiGameplay . uiShowDebug Lens.<%= not
     if debug
       then playState . gameState . temporal . gameStep .= RobotStep SBefore
-      else zoomGameState finishGameTick >> void updateUI
+      else zoomGameStateFromAppState finishGameTick >> void updateUI
 
 runSingleTick :: EventM Name AppState ()
 runSingleTick = do

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/REPL.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/REPL.hs
@@ -29,40 +29,40 @@ import Swarm.TUI.Model.UI.Gameplay
 -- See 'Swarm.TUI.Controller.handleREPLEvent'.
 replEventHandlers :: [B.KeyEventHandler SwarmEvent (EventM Name AppState)]
 replEventHandlers = allHandlers REPL $ \case
-  CancelRunningProgramEvent -> ("Cancel running base robot program", cancelRunningBase)
-  TogglePilotingModeEvent -> ("Toggle piloting mode", onlyCreative togglePilotingMode)
-  ToggleCustomKeyHandlingEvent -> ("Toggle custom key handling mode", toggleCustomKeyHandling)
+  CancelRunningProgramEvent -> ("Cancel running base robot program", Brick.zoom playState cancelRunningBase)
+  TogglePilotingModeEvent -> ("Toggle piloting mode", Brick.zoom playState $ onlyCreative togglePilotingMode)
+  ToggleCustomKeyHandlingEvent -> ("Toggle custom key handling mode", Brick.zoom playState toggleCustomKeyHandling)
 
 -- | Cancel the running base CESK machine and clear REPL input text.
 --
 -- It is handled in top REPL handler so we can always cancel the currently running
 -- base program no matter what REPL control mode we are in.
-cancelRunningBase :: EventM Name AppState ()
+cancelRunningBase :: EventM Name PlayState ()
 cancelRunningBase = do
-  working <- use $ playState . gameState . gameControls . replWorking
-  when working $ playState . gameState . baseRobot . machine %= cancel
-  Brick.zoom (playState . uiGameplay . uiREPL) $ do
+  working <- use $ gameState . gameControls . replWorking
+  when working $ gameState . baseRobot . machine %= cancel
+  Brick.zoom (uiGameplay . uiREPL) $ do
     replPromptType .= CmdPrompt []
     replPromptText .= ""
 
-togglePilotingMode :: EventM Name AppState ()
+togglePilotingMode :: EventM Name PlayState ()
 togglePilotingMode = do
   s <- get
-  let theRepl = s ^. playState . uiGameplay . uiREPL
+  let theRepl = s ^. uiGameplay . uiREPL
       uinput = theRepl ^. replPromptText
       curMode = theRepl ^. replControlMode
   case curMode of
-    Piloting -> playState . uiGameplay . uiREPL . replControlMode .= Typing
+    Piloting -> uiGameplay . uiREPL . replControlMode .= Typing
     _ ->
       if T.null uinput
-        then playState . uiGameplay . uiREPL . replControlMode .= Piloting
+        then uiGameplay . uiREPL . replControlMode .= Piloting
         else do
           addREPLHistItem $ mkREPLError "Please clear the REPL before engaging pilot mode."
           invalidateCacheEntry REPLHistoryCache
 
-toggleCustomKeyHandling :: EventM Name AppState ()
+toggleCustomKeyHandling :: EventM Name PlayState ()
 toggleCustomKeyHandling = do
   s <- get
-  when (isJust (s ^. playState . gameState . gameControls . inputHandler)) $ do
-    curMode <- use $ playState . uiGameplay . uiREPL . replControlMode
-    (playState . uiGameplay . uiREPL . replControlMode) .= case curMode of Handling -> Typing; _ -> Handling
+  when (isJust (s ^. gameState . gameControls . inputHandler)) $ do
+    curMode <- use $ uiGameplay . uiREPL . replControlMode
+    (uiGameplay . uiREPL . replControlMode) .= case curMode of Handling -> Typing; _ -> Handling

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Robot.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Robot.hs
@@ -31,7 +31,6 @@ import Swarm.TUI.Inventory.Sorting (cycleSortDirection, cycleSortOrder)
 import Swarm.TUI.List
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Event
-import Swarm.TUI.Model.UI
 import Swarm.TUI.Model.UI.Gameplay
 import Swarm.TUI.View.Util (generateModal)
 
@@ -53,9 +52,7 @@ robotEventHandlers :: [KeyEventHandler SwarmEvent (EventM Name AppState)]
 robotEventHandlers = nonCustomizableHandlers <> customizableHandlers
  where
   nonCustomizableHandlers =
-    [ onKey V.KEnter "Show entity description" $ do
-        m <- use $ uiState . uiMenu
-        Brick.zoom playState $ showEntityDescription m
+    [ onKey V.KEnter "Show entity description" $ playStateWithMenu showEntityDescription
     ]
   customizableHandlers = allHandlers Robot $ \case
     MakeEntityEvent -> ("Make the selected entity", Brick.zoom playState makeFocusedEntity)
@@ -130,8 +127,7 @@ handleInventorySearchEvent = \case
   -- Enter: return to regular inventory mode, and pop out the selected item
   Key V.KEnter -> do
     zoomInventory $ uiInventorySearch .= Nothing
-    m <- use $ uiState . uiMenu
-    Brick.zoom playState $ showEntityDescription m
+    playStateWithMenu showEntityDescription
   -- Any old character: append to the current search string
   CharKey c -> do
     resetViewport infoScroll

--- a/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
@@ -25,7 +25,7 @@ import Swarm.Game.State.Substate
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Achievements (attainAchievement, attainAchievement')
 import Swarm.TUI.Model.Repl
-import Swarm.TUI.Model.UI
+import Swarm.TUI.Model.UI (uiDebugOptions, uiMenu)
 import Swarm.TUI.Model.UI.Gameplay
 import System.FilePath (splitDirectories)
 

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -67,7 +67,7 @@ updateAndRedrawUI forceRedraw = do
 --   game for some number of ticks.
 updateUI :: EventM Name AppState Bool
 updateUI = do
-  loadVisibleRegion
+  Brick.zoom (playState . gameState) loadVisibleRegion
 
   -- If the game state indicates a redraw is needed, invalidate the
   -- world cache so it will be redrawn.
@@ -108,10 +108,10 @@ updateUI = do
   replUpdated <- case g ^. gameControls . replStatus of
     REPLWorking pty (Just v)
       -- It did, and the result was the unit value or an exception.  Just reset replStatus.
-      | v `elem` [VUnit, VExc] -> do
-          listener <- use $ playState . gameState . gameControls . replListener
+      | v `elem` [VUnit, VExc] -> Brick.zoom playState $ do
+          listener <- use $ gameState . gameControls . replListener
           liftIO $ listener ""
-          playState . gameState . gameControls . replStatus .= REPLDone (Just (pty, v))
+          gameState . gameControls . replStatus .= REPLDone (Just (pty, v))
           pure True
 
       -- It did, and returned some other value.  Create new 'it'
@@ -142,12 +142,12 @@ updateUI = do
   -- automatically switch to the logger and scroll all the way down so
   -- the new message can be seen.
   playState . uiGameplay . uiScrollToEnd .= False
-  logUpdated <- do
+  logUpdated <- Brick.zoom playState $ do
     -- If the inventory or info panels are currently focused, it would
     -- be rude to update them right under the user's nose, so consider
     -- them "sticky".  They will be updated as soon as the player moves
     -- the focus away.
-    fring <- use $ playState . uiGameplay . uiFocusRing
+    fring <- use $ uiGameplay . uiFocusRing
     let sticky = focusGetCurrent fring `elem` map (Just . FocusablePanel) [RobotPanel, InfoPanel]
 
     -- Check if the robot log was updated and we are allowed to change
@@ -156,21 +156,22 @@ updateUI = do
       False -> pure False
       True -> do
         -- Reset the log updated flag
-        zoomGameState $ zoomRobots clearFocusedRobotLogUpdated
+        zoomGameState' $ zoomRobots clearFocusedRobotLogUpdated
 
         -- Find and focus an equipped "logger" device in the inventory list.
         let isLogger (EquippedEntry e) = e ^. entityName == "logger"
             isLogger _ = False
             focusLogger = BL.listFindBy isLogger
 
-        playState . uiGameplay . uiInventory . uiInventoryList . _Just . _2 %= focusLogger
+        uiGameplay . uiInventory . uiInventoryList . _Just . _2 %= focusLogger
 
         -- Now inform the UI that it should scroll the info panel to
         -- the very end.
-        playState . uiGameplay . uiScrollToEnd .= True
+        uiGameplay . uiScrollToEnd .= True
         pure True
 
-  goalOrWinUpdated <- doGoalUpdates
+  menu <- use $ uiState . uiMenu
+  goalOrWinUpdated <- doGoalUpdates menu
 
   newPopups <- generateNotificationPopups
 
@@ -229,28 +230,28 @@ updateRobotDetailsPane robotPayload =
 -- * feedback as to the final goal the player accomplished,
 -- * as a summary of all of the goals of the game
 -- * shows the player more "optional" goals they can continue to pursue
-doGoalUpdates :: EventM Name AppState Bool
-doGoalUpdates = do
+doGoalUpdates :: Menu -> EventM Name AppState Bool
+doGoalUpdates menu = do
   curGoal <- use (playState . uiGameplay . uiDialogs . uiGoal . goalsContent)
   curWinCondition <- use (playState . gameState . winCondition)
   announcementsList <- use (playState . gameState . messageInfo . announcementQueue . to toList)
-
-  menu <- use $ uiState . uiMenu
 
   -- Decide whether we need to update the current goal text and pop
   -- up a modal dialog.
   case curWinCondition of
     NoWinCondition -> return False
     WinConditions (Unwinnable False) x -> do
-      -- This clears the "flag" that the Lose dialog needs to pop up
-      playState . gameState . winCondition .= WinConditions (Unwinnable True) x
-      Brick.zoom playState $ openModal menu $ ScenarioEndModal LoseModal
+      Brick.zoom playState $ do
+        -- This clears the "flag" that the Lose dialog needs to pop up
+        gameState . winCondition .= WinConditions (Unwinnable True) x
+        openModal menu $ ScenarioEndModal LoseModal
       saveScenarioInfoOnFinishNocheat
       return True
     WinConditions (Won False ts) x -> do
-      -- This clears the "flag" that the Win dialog needs to pop up
-      playState . gameState . winCondition .= WinConditions (Won True ts) x
-      Brick.zoom playState $ openModal menu $ ScenarioEndModal WinModal
+      Brick.zoom playState $ do
+        -- This clears the "flag" that the Win dialog needs to pop up
+        gameState . winCondition .= WinConditions (Won True ts) x
+        openModal menu $ ScenarioEndModal WinModal
       saveScenarioInfoOnFinishNocheat
       -- We do NOT advance the New Game menu to the next item here (we
       -- used to!), because we do not know if the user is going to
@@ -273,17 +274,17 @@ doGoalUpdates = do
 
       -- Decide whether to show a pop-up modal congratulating the user on
       -- successfully completing the current challenge.
-      when (goalWasUpdated && not isEnding) $ do
+      when (goalWasUpdated && not isEnding) $ Brick.zoom playState $ do
         -- The "uiGoal" field is necessary at least to "persist" the data that is needed
         -- if the player chooses to later "recall" the goals dialog with CTRL+g.
-        playState . uiGameplay . uiDialogs . uiGoal .= goalDisplay newGoalTracking
+        uiGameplay . uiDialogs . uiGoal .= goalDisplay newGoalTracking
 
         -- This clears the "flag" that indicate that the goals dialog needs to be
         -- automatically popped up.
-        playState . gameState . messageInfo . announcementQueue .= mempty
+        gameState . messageInfo . announcementQueue .= mempty
 
-        showObjectives <- use $ playState . uiGameplay . uiAutoShowObjectives
-        Brick.zoom playState $ when showObjectives $ openModal menu GoalModal
+        showObjectives <- use $ uiGameplay . uiAutoShowObjectives
+        when showObjectives $ openModal menu GoalModal
 
       return goalWasUpdated
  where

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -156,7 +156,7 @@ updateUI = do
       False -> pure False
       True -> do
         -- Reset the log updated flag
-        zoomGameState' $ zoomRobots clearFocusedRobotLogUpdated
+        zoomGameStateFromPlayState $ zoomRobots clearFocusedRobotLogUpdated
 
         -- Find and focus an equipped "logger" device in the inventory list.
         let isLogger (EquippedEntry e) = e ^. entityName == "logger"

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -37,12 +37,13 @@ import Swarm.Language.Capability (Capability (CDebug))
 import Swarm.Language.Syntax hiding (Key)
 import Swarm.TUI.Model (
   AppState,
-  ModalType (..),
+  PlayState,
   gameState,
   modalScroll,
   playState,
   uiGameplay,
  )
+import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.Repl (REPLHistItem, REPLPrompt, REPLState, addREPLItem, replHistory, replPromptText, replPromptType)
 import Swarm.TUI.Model.UI.Gameplay
@@ -73,12 +74,12 @@ pattern BackspaceKey = VtyEvent (V.EvKey V.KBS [])
 pattern FKey :: Int -> BrickEvent n e
 pattern FKey c = VtyEvent (V.EvKey (V.KFun c) [])
 
-openModal :: ModalType -> EventM Name AppState ()
-openModal mt = do
+openModal :: Menu -> ModalType -> EventM Name PlayState ()
+openModal m mt = do
   resetViewport modalScroll
-  newModal <- gets $ flip generateModal mt
+  newModal <- gets $ flip (generateModal m) mt
   ensurePause
-  playState . uiGameplay . uiDialogs . uiModal ?= newModal
+  uiGameplay . uiDialogs . uiModal ?= newModal
   -- Beep
   case mt of
     ScenarioEndModal _ -> do
@@ -88,8 +89,8 @@ openModal mt = do
  where
   -- Set the game to AutoPause if needed
   ensurePause = do
-    pause <- use $ playState . gameState . temporal . paused
-    unless (pause || isRunningModal mt) $ playState . gameState . temporal . runStatus .= AutoPause
+    pause <- use $ gameState . temporal . paused
+    unless (pause || isRunningModal mt) $ gameState . temporal . runStatus .= AutoPause
 
 -- | The running modals do not autopause the game.
 isRunningModal :: ModalType -> Bool
@@ -104,29 +105,29 @@ isRunningModal = \case
 -- doesn't matter; if we are unpausing, this is critical to
 -- ensure the next frame doesn't think it has to catch up from
 -- whenever the game was paused!
-safeTogglePause :: EventM Name AppState ()
+safeTogglePause :: EventM Name PlayState ()
 safeTogglePause = do
   curTime <- liftIO $ getTime Monotonic
-  playState . uiGameplay . uiTiming . lastFrameTime .= curTime
-  playState . uiGameplay . uiShowDebug .= False
-  p <- playState . gameState . temporal . runStatus Lens.<%= toggleRunStatus
-  when (p == Running) $ zoomGameState finishGameTick
+  uiGameplay . uiTiming . lastFrameTime .= curTime
+  uiGameplay . uiShowDebug .= False
+  p <- gameState . temporal . runStatus Lens.<%= toggleRunStatus
+  when (p == Running) $ zoomGameState' finishGameTick
 
 -- | Only unpause the game if leaving autopaused modal.
 --
 -- Note that the game could have been paused before opening
 -- the modal, in that case, leave the game paused.
-safeAutoUnpause :: EventM Name AppState ()
+safeAutoUnpause :: EventM Name PlayState ()
 safeAutoUnpause = do
-  runs <- use $ playState . gameState . temporal . runStatus
+  runs <- use $ gameState . temporal . runStatus
   when (runs == AutoPause) safeTogglePause
 
-toggleModal :: ModalType -> EventM Name AppState ()
-toggleModal mt = do
-  modal <- use $ playState . uiGameplay . uiDialogs . uiModal
+toggleModal :: Menu -> ModalType -> EventM Name PlayState ()
+toggleModal m mt = do
+  modal <- use $ uiGameplay . uiDialogs . uiModal
   case modal of
-    Nothing -> openModal mt
-    Just _ -> playState . uiGameplay . uiDialogs . uiModal .= Nothing >> safeAutoUnpause
+    Nothing -> openModal m mt
+    Just _ -> uiGameplay . uiDialogs . uiModal .= Nothing >> safeAutoUnpause
 
 setFocus :: FocusablePanel -> EventM Name AppState ()
 setFocus name = playState . uiGameplay . uiFocusRing %= focusSetCurrent (FocusablePanel name)
@@ -165,35 +166,49 @@ hasDebugCapability isCreative s =
     s ^? playState . gameState . to focusedRobot . _Just . robotCapabilities
 
 -- | Resets the viewport scroll position
-resetViewport :: ViewportScroll Name -> EventM Name AppState ()
+resetViewport :: ViewportScroll Name -> EventM Name s ()
 resetViewport n = do
   vScrollToBeginning n
   hScrollToBeginning n
 
 -- | Modifies the game state using a fused-effect state action.
-zoomGameState :: (MonadState AppState m, MonadIO m) => Fused.StateC GameState (TimeIOC (Fused.LiftC IO)) a -> m a
+zoomGameState ::
+  (MonadState AppState m, MonadIO m) =>
+  Fused.StateC GameState (TimeIOC (Fused.LiftC IO)) a ->
+  m a
 zoomGameState f = do
   gs <- use $ playState . gameState
   (gs', a) <- liftIO (Fused.runM (runTimeIO (Fused.runState gs f)))
   playState . gameState .= gs'
   return a
 
-onlyCreative :: (MonadState AppState m) => m () -> m ()
+-- | Modifies the game state using a fused-effect state action.
+zoomGameState' ::
+  (MonadState PlayState m, MonadIO m) =>
+  Fused.StateC GameState (TimeIOC (Fused.LiftC IO)) a ->
+  m a
+zoomGameState' f = do
+  gs <- use gameState
+  (gs', a) <- liftIO (Fused.runM (runTimeIO (Fused.runState gs f)))
+  gameState .= gs'
+  return a
+
+onlyCreative :: (MonadState PlayState m) => m () -> m ()
 onlyCreative a = do
-  c <- use $ playState . gameState . creativeMode
+  c <- use $ gameState . creativeMode
   when c a
 
 -- | Create a list of handlers with embedding events and using pattern matching.
 allHandlers ::
   (Ord e2, Enum e1, Bounded e1) =>
   (e1 -> e2) ->
-  (e1 -> (Text, EventM Name AppState ())) ->
-  [KeyEventHandler e2 (EventM Name AppState)]
+  (e1 -> (Text, EventM Name s ())) ->
+  [KeyEventHandler e2 (EventM Name s)]
 allHandlers eEmbed f = map handleEvent1 enumerate
  where
   handleEvent1 e1 = let (n, a) = f e1 in onEvent (eEmbed e1) n a
 
-runBaseTerm :: (MonadState AppState m) => Maybe TSyntax -> m ()
+runBaseTerm :: (MonadState PlayState m) => Maybe TSyntax -> m ()
 runBaseTerm = mapM_ startBaseProgram
  where
   -- The player typed something at the REPL and hit Enter; this
@@ -201,21 +216,21 @@ runBaseTerm = mapM_ startBaseProgram
   -- input is valid) and sets up the base robot to run it.
   startBaseProgram t = do
     -- Set the REPL status to Working
-    playState . gameState . gameControls . replStatus .= REPLWorking (t ^. sType) Nothing
+    gameState . gameControls . replStatus .= REPLWorking (t ^. sType) Nothing
     -- Set up the robot's CESK machine to evaluate/execute the
     -- given term.
-    playState . gameState . baseRobot . machine %= continue t
+    gameState . baseRobot . machine %= continue t
     -- Finally, be sure to activate the base robot.
-    playState . gameState %= execState (zoomRobots $ activateRobot 0)
+    gameState %= execState (zoomRobots $ activateRobot 0)
 
 -- | Set the REPL to the given text and REPL prompt type.
 modifyResetREPL :: Text -> REPLPrompt -> REPLState -> REPLState
 modifyResetREPL t r = (replPromptText .~ t) . (replPromptType .~ r)
 
 -- | Reset the REPL state to the given text and REPL prompt type.
-resetREPL :: MonadState AppState m => Text -> REPLPrompt -> m ()
-resetREPL t p = playState . uiGameplay . uiREPL %= modifyResetREPL t p
+resetREPL :: MonadState PlayState m => Text -> REPLPrompt -> m ()
+resetREPL t p = uiGameplay . uiREPL %= modifyResetREPL t p
 
 -- | Add an item to the REPL history.
-addREPLHistItem :: MonadState AppState m => REPLHistItem -> m ()
-addREPLHistItem item = playState . uiGameplay . uiREPL . replHistory %= addREPLItem item
+addREPLHistItem :: MonadState PlayState m => REPLHistItem -> m ()
+addREPLHistItem item = uiGameplay . uiREPL . replHistory %= addREPLItem item

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -240,6 +240,8 @@ resetREPL t p = uiGameplay . uiREPL %= modifyResetREPL t p
 addREPLHistItem :: MonadState PlayState m => REPLHistItem -> m ()
 addREPLHistItem item = uiGameplay . uiREPL . replHistory %= addREPLItem item
 
+-- | Run an action that only depends on a 'PlayState'
+-- and read-only access to the 'Menu'.
 playStateWithMenu ::
   (Menu -> EventM Name PlayState ()) ->
   EventM Name AppState ()

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -129,23 +129,23 @@ toggleModal m mt = do
     Nothing -> openModal m mt
     Just _ -> uiGameplay . uiDialogs . uiModal .= Nothing >> safeAutoUnpause
 
-setFocus :: FocusablePanel -> EventM Name AppState ()
-setFocus name = playState . uiGameplay . uiFocusRing %= focusSetCurrent (FocusablePanel name)
+setFocus :: FocusablePanel -> EventM Name PlayState ()
+setFocus name = uiGameplay . uiFocusRing %= focusSetCurrent (FocusablePanel name)
 
-immediatelyRedrawWorld :: EventM Name AppState ()
+immediatelyRedrawWorld :: EventM Name GameState ()
 immediatelyRedrawWorld = do
   invalidateCacheEntry WorldCache
   loadVisibleRegion
 
 -- | Make sure all tiles covering the visible part of the world are
 --   loaded.
-loadVisibleRegion :: EventM Name AppState ()
+loadVisibleRegion :: EventM Name GameState ()
 loadVisibleRegion = do
   mext <- lookupExtent WorldExtent
   forM_ mext $ \(Extent _ _ size) -> do
-    gs <- use $ playState . gameState
-    let vr = viewingRegion (gs ^. robotInfo . viewCenter) (over both fromIntegral size)
-    playState . gameState . landscape . multiWorld %= M.adjust (W.loadRegion (vr ^. planar)) (vr ^. subworld)
+    vc <- use $ robotInfo . viewCenter
+    let vr = viewingRegion vc (over both fromIntegral size)
+    landscape . multiWorld %= M.adjust (W.loadRegion (vr ^. planar)) (vr ^. subworld)
 
 mouseLocToWorldCoords :: Brick.Location -> EventM Name GameState (Maybe (Cosmic Coords))
 mouseLocToWorldCoords (Brick.Location mouseLoc) = do

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -53,37 +53,37 @@ activateWorldEditorFunction _ MapSaveButton = saveMapFile
 activateWorldEditorFunction _ ClearEntityButton =
   uiGameplay . uiWorldEditor . entityPaintList . BL.listSelectedL .= Nothing
 
-handleCtrlLeftClick :: B.Location -> EventM Name AppState ()
+handleCtrlLeftClick :: B.Location -> EventM Name PlayState ()
 handleCtrlLeftClick mouseLoc = do
-  worldEditor <- use $ playState . uiGameplay . uiWorldEditor
+  worldEditor <- use $ uiGameplay . uiWorldEditor
   _ <- runMaybeT $ do
     guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     let getSelected x = snd <$> BL.listSelectedElement x
         maybeTerrainType = getSelected $ worldEditor ^. terrainList
         maybeEntityPaint = getSelected $ worldEditor ^. entityPaintList
     terrain <- hoistMaybe maybeTerrainType
-    mouseCoords <- MaybeT $ Brick.zoom (playState . gameState) $ mouseLocToWorldCoords mouseLoc
-    Brick.zoom (playState . uiGameplay . uiWorldEditor) $ do
+    mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
+    Brick.zoom (uiGameplay . uiWorldEditor) $ do
       worldOverdraw . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
       lastWorldEditorMessage .= Nothing
-  immediatelyRedrawWorld
+  Brick.zoom gameState immediatelyRedrawWorld
 
-handleRightClick :: B.Location -> EventM Name AppState ()
+handleRightClick :: B.Location -> EventM Name PlayState ()
 handleRightClick mouseLoc = do
-  worldEditor <- use $ playState . uiGameplay . uiWorldEditor
+  worldEditor <- use $ uiGameplay . uiWorldEditor
   _ <- runMaybeT $ do
     guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
-    mouseCoords <- MaybeT $ Brick.zoom (playState . gameState) $ mouseLocToWorldCoords mouseLoc
-    playState . uiGameplay . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
-  immediatelyRedrawWorld
+    mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
+    uiGameplay . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
+  Brick.zoom gameState immediatelyRedrawWorld
 
 -- | "Eye Dropper" tool:
-handleMiddleClick :: B.Location -> EventM Name AppState ()
+handleMiddleClick :: B.Location -> EventM Name PlayState ()
 handleMiddleClick mouseLoc = do
-  worldEditor <- use $ playState . uiGameplay . uiWorldEditor
+  worldEditor <- use $ uiGameplay . uiWorldEditor
   when (worldEditor ^. worldOverdraw . isWorldEditorEnabled) $ do
-    w <- use $ playState . gameState . landscape . multiWorld
-    tm <- use $ playState . gameState . landscape . terrainAndEntities . terrainMap
+    w <- use $ gameState . landscape . multiWorld
+    tm <- use $ gameState . landscape . terrainAndEntities . terrainMap
     let setTerrainPaint coords = do
           let (terrain, maybeElementPaint) =
                 EU.getEditorContentAt
@@ -91,14 +91,14 @@ handleMiddleClick mouseLoc = do
                   (worldEditor ^. worldOverdraw)
                   w
                   coords
-          playState . uiGameplay . uiWorldEditor . terrainList %= BL.listMoveToElement terrain
+          uiGameplay . uiWorldEditor . terrainList %= BL.listMoveToElement terrain
           forM_ maybeElementPaint $ \elementPaint ->
             let p = case elementPaint of
                   Facade efd -> efd
                   Ref r -> mkFacade r
-             in playState . uiGameplay . uiWorldEditor . entityPaintList %= BL.listMoveToElement p
+             in uiGameplay . uiWorldEditor . entityPaintList %= BL.listMoveToElement p
 
-    mouseCoordsM <- Brick.zoom (playState . gameState) $ mouseLocToWorldCoords mouseLoc
+    mouseCoordsM <- Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
     whenJust mouseCoordsM setTerrainPaint
 
 -- | Handle user input events in the robot panel.
@@ -116,20 +116,20 @@ handleWorldEditorPanelEvent m = \case
   _ -> return ()
 
 -- | Return value: whether the cursor position should be updated
-updateAreaBounds :: Maybe (Cosmic Coords) -> EventM Name AppState Bool
+updateAreaBounds :: Maybe (Cosmic Coords) -> EventM Name PlayState Bool
 updateAreaBounds = \case
   Nothing -> return True
   Just mouseCoords -> do
-    selectorStage <- use $ playState . uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep
+    selectorStage <- use $ uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep
     case selectorStage of
       UpperLeftPending -> do
-        playState . uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep .= LowerRightPending mouseCoords
+        uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep .= LowerRightPending mouseCoords
         return False
       -- TODO (#1152): Validate that the lower-right click is below and to the right of
       -- the top-left coord and that they are within the same subworld
       LowerRightPending upperLeftMouseCoords -> do
         t <- liftIO $ getTime Monotonic
-        Brick.zoom (playState . uiGameplay . uiWorldEditor) $ do
+        Brick.zoom (uiGameplay . uiWorldEditor) $ do
           lastWorldEditorMessage .= Nothing
           Brick.zoom editingBounds $ do
             boundsRect .= Just (fmap (,view planar mouseCoords) upperLeftMouseCoords)

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -102,8 +102,8 @@ handleMiddleClick mouseLoc = do
     whenJust mouseCoordsM setTerrainPaint
 
 -- | Handle user input events in the robot panel.
-handleWorldEditorPanelEvent :: Menu -> BrickEvent Name AppEvent -> EventM Name PlayState ()
-handleWorldEditorPanelEvent m = \case
+handleWorldEditorPanelEvent :: BrickEvent Name AppEvent -> Menu -> EventM Name PlayState ()
+handleWorldEditorPanelEvent e m = case e of
   Key V.KEsc -> uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep .= SelectionComplete
   Key V.KEnter -> do
     fring <- use $ uiGameplay . uiWorldEditor . editorFocusRing

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -356,16 +356,16 @@ runtimeState :: Lens' AppState RuntimeState
 
 -- | Get the currently focused 'InventoryListEntry' from the robot
 --   info panel (if any).
-focusedItem :: AppState -> Maybe InventoryListEntry
+focusedItem :: PlayState -> Maybe InventoryListEntry
 focusedItem s = do
-  list <- s ^? playState . uiGameplay . uiInventory . uiInventoryList . _Just . _2
+  list <- s ^? uiGameplay . uiInventory . uiInventoryList . _Just . _2
   (_, entry) <- BL.listSelectedElement list
   return entry
 
 -- | Get the currently focused entity from the robot info panel (if
 --   any).  This is just like 'focusedItem' but forgets the
 --   distinction between plain inventory items and equipped devices.
-focusedEntity :: AppState -> Maybe Entity
+focusedEntity :: PlayState -> Maybe Entity
 focusedEntity =
   focusedItem >=> \case
     Separator _ -> Nothing

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -447,7 +447,8 @@ drawGameUI s =
                   fr
                   (FocusablePanel InfoPanel)
                   plainBorder
-                  $ drawInfoPanel s
+                  $ drawInfoPanel
+                  $ s ^. playState
               , hCenter
                   . clickable (FocusablePanel WorldEditorPanel)
                   . EV.drawWorldEditor fr
@@ -1095,9 +1096,9 @@ drawItem _ _ _ (EquippedEntry e) = drawLabelledEntityName e <+> padLeft Max (str
 
 -- | Draw the info panel in the bottom-left corner, which shows info
 --   about the currently focused inventory item.
-drawInfoPanel :: AppState -> Widget Name
+drawInfoPanel :: PlayState -> Widget Name
 drawInfoPanel s
-  | Just Far <- s ^. playState . gameState . to focusedRange = blank
+  | Just Far <- s ^. gameState . to focusedRange = blank
   | otherwise =
       withVScrollBars OnRight
         . viewport InfoViewport Vertical
@@ -1106,14 +1107,14 @@ drawInfoPanel s
 
 -- | Display info about the currently focused inventory entity,
 --   such as its description and relevant recipes.
-explainFocusedItem :: AppState -> Widget Name
+explainFocusedItem :: PlayState -> Widget Name
 explainFocusedItem s = case focusedItem s of
   Just (InventoryEntry _ e) -> explainEntry uig gs e
   Just (EquippedEntry e) -> explainEntry uig gs e
   _ -> txt " "
  where
-  gs = s ^. playState . gameState
-  uig = s ^. playState . uiGameplay
+  gs = s ^. gameState
+  uig = s ^. uiGameplay
 
 explainEntry :: UIGameplay -> GameState -> Entity -> Widget Name
 explainEntry uig gs e =

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -902,7 +902,7 @@ drawKeyMenu s =
 
   isReplWorking = gs ^. gameControls . replWorking
   isPaused = gs ^. temporal . paused
-  hasDebug = hasDebugCapability creative s
+  hasDebug = hasDebugCapability creative gs
   creative = gs ^. creativeMode
   showCreative = uis ^. uiDebugOptions . Lens.contains ToggleCreative
   showEditor = uis ^. uiDebugOptions . Lens.contains ToggleWorldEditor

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -441,14 +441,13 @@ drawGameUI s =
                             (txt . (" Search: " <>) . (<> " "))
                             (uig ^. uiInventory . uiInventorySearch)
                     )
-                  $ drawRobotPanel s
+                  $ drawRobotPanel ps
               , panel
                   highlightAttr
                   fr
                   (FocusablePanel InfoPanel)
                   plainBorder
-                  $ drawInfoPanel
-                  $ s ^. playState
+                  $ drawInfoPanel ps
               , hCenter
                   . clickable (FocusablePanel WorldEditorPanel)
                   . EV.drawWorldEditor fr
@@ -458,18 +457,21 @@ drawGameUI s =
         ]
   ]
  where
-  uig = s ^. playState . uiGameplay
+  ps = s ^. playState
+  gs = ps ^. gameState
+  uig = ps ^. uiGameplay
   addCursorPos = bottomLabels . leftLabel ?~ padLeftRight 1 widg
    where
     widg = case uig ^. uiWorldCursor of
-      Nothing -> str $ renderCoordsString $ s ^. playState . gameState . robotInfo . viewCenter
-      Just coord -> clickable WorldPositionIndicator $ drawWorldCursorInfo (uig ^. uiWorldEditor . worldOverdraw) (s ^. playState . gameState) coord
+      Nothing -> str $ renderCoordsString $ gs ^. robotInfo . viewCenter
+      Just coord -> clickable WorldPositionIndicator $ drawWorldCursorInfo (uig ^. uiWorldEditor . worldOverdraw) gs coord
   -- Add clock display in top right of the world view if focused robot
   -- has a clock equipped
-  addClock = topLabels . rightLabel ?~ padLeftRight 1 (drawClockDisplay (uig ^. uiTiming . lgTicksPerSecond) $ s ^. playState . gameState)
+  addClock = topLabels . rightLabel ?~ padLeftRight 1 (drawClockDisplay (uig ^. uiTiming . lgTicksPerSecond) gs)
   fr = uig ^. uiFocusRing
   showREPL = uig ^. uiShowREPL
-  rightPanel = if showREPL then worldPanel ++ replPanel else worldPanel ++ minimizedREPL
+  rightPanelBottom = if showREPL then replPanel else minimizedREPL
+  rightPanel = worldPanel ++ rightPanelBottom
   minimizedREPL = case focusGetCurrent fr of
     (Just (FocusablePanel REPLPanel)) -> [separateBorders $ clickable (FocusablePanel REPLPanel) (forceAttr highlightAttr hBorder)]
     _ -> [separateBorders $ clickable (FocusablePanel REPLPanel) hBorder]
@@ -484,7 +486,7 @@ drawGameUI s =
             & addCursorPos
             & addClock
         )
-        (drawWorldPane uig (s ^. playState . gameState))
+        (drawWorldPane uig gs)
     , drawKeyMenu s
     ]
   replPanel =
@@ -642,7 +644,7 @@ drawModal s = \case
         [ "Condolences!"
         , "This scenario is no longer winnable."
         ]
-  DescriptionModal e -> descriptionWidget s e
+  DescriptionModal e -> descriptionWidget (s ^. playState) e
   QuitModal -> padBottom (Pad 1) $ hCenter $ txt (quitMsg (s ^. uiState . uiMenu))
   GoalModal ->
     GR.renderGoalsDisplay (uig ^. uiDialogs . uiGoal) $
@@ -792,11 +794,11 @@ commandsListWidget gs =
           constCaps cmd
 
 -- | Generate a pop-up widget to display the description of an entity.
-descriptionWidget :: AppState -> Entity -> Widget Name
+descriptionWidget :: PlayState -> Entity -> Widget Name
 descriptionWidget s e = padLeftRight 1 (explainEntry uig gs e)
  where
-  gs = s ^. playState . gameState
-  uig = s ^. playState . uiGameplay
+  gs = s ^. gameState
+  uig = s ^. uiGameplay
 
 -- | Draw a widget with messages to the current robot.
 messagesWidget :: GameState -> [Widget Name]
@@ -837,18 +839,20 @@ colorSeverity = \case
 drawModalMenu :: AppState -> Widget Name
 drawModalMenu s = vLimit 1 . hBox $ map (padLeftRight 1 . drawKeyCmd) globalKeyCmds
  where
+  gs = s ^. playState . gameState
+
   notificationKey :: Getter GameState (Notifications a) -> SE.MainEvent -> Text -> Maybe (KeyHighlight, Text, Text)
   notificationKey notifLens key name
-    | null (s ^. playState . gameState . notifLens . notificationsContent) = Nothing
+    | null (gs ^. notifLens . notificationsContent) = Nothing
     | otherwise =
         let highlight
-              | s ^. playState . gameState . notifLens . notificationsCount > 0 = Alert
+              | gs ^. notifLens . notificationsCount > 0 = Alert
               | otherwise = NoHighlight
          in Just (highlight, keyM key, name)
 
   -- Hides this key if the recognizable structure list is empty
   structuresKey =
-    if null $ s ^. playState . gameState . landscape . recognizerAutomatons . originalStructureDefinitions
+    if null $ gs ^. landscape . recognizerAutomatons . originalStructureDefinitions
       then Nothing
       else Just (NoHighlight, keyM SE.ViewStructuresEvent, "Structures")
 
@@ -894,13 +898,14 @@ drawKeyMenu s =
 
   uig = s ^. playState . uiGameplay
   gs = s ^. playState . gameState
+  uis = s ^. uiState
 
   isReplWorking = gs ^. gameControls . replWorking
   isPaused = gs ^. temporal . paused
   hasDebug = hasDebugCapability creative s
   creative = gs ^. creativeMode
-  showCreative = s ^. uiState . uiDebugOptions . Lens.contains ToggleCreative
-  showEditor = s ^. uiState . uiDebugOptions . Lens.contains ToggleWorldEditor
+  showCreative = uis ^. uiDebugOptions . Lens.contains ToggleCreative
+  showEditor = uis ^. uiDebugOptions . Lens.contains ToggleWorldEditor
   goal = hasAnythingToShow $ uig ^. uiDialogs . uiGoal . goalsContent
   showZero = uig ^. uiInventory . uiShowZero
   inventorySort = uig ^. uiInventory . uiInventorySort
@@ -1041,13 +1046,13 @@ drawWorldPane ui g =
 -- | Draw info about the currently focused robot, such as its name,
 --   position, orientation, and inventory, as long as it is not too
 --   far away.
-drawRobotPanel :: AppState -> Widget Name
+drawRobotPanel :: PlayState -> Widget Name
 drawRobotPanel s
   -- If the focused robot is too far away to communicate, just leave the panel blank.
   -- There should be no way to tell the difference between a robot that is too far
   -- away and a robot that does not exist.
-  | Just r <- s ^. playState . gameState . to focusedRobot
-  , Just (_, lst) <- s ^. playState . uiGameplay . uiInventory . uiInventoryList =
+  | Just r <- s ^. gameState . to focusedRobot
+  , Just (_, lst) <- s ^. uiGameplay . uiInventory . uiInventoryList =
       let drawClickableItem pos selb = clickable (InventoryListItem pos) . drawItem (lst ^. BL.listSelectedL) pos selb
           details =
             [ txt (r ^. robotName)

--- a/src/swarm-tui/Swarm/TUI/View/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Util.hs
@@ -30,7 +30,6 @@ import Swarm.Language.Types (Polytype)
 import Swarm.Pretty (prettyTextLine)
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Event (SwarmEvent)
-import Swarm.TUI.Model.UI
 import Swarm.TUI.Model.UI.Gameplay
 import Swarm.TUI.View.Attribute.Attr
 import Swarm.TUI.View.CellDisplay


### PR DESCRIPTION
Continues toward #2276.

This PR incrementally pushes the state scope to the narrower `PlayState` rather than `AppState` for many utility functions, re-simplifying the code in many cases where an extra `playState` lens layer was added in #2282.  Counting the occurrences of the `playState` lens has been a good metric for the progress on this refactoring.

For functions where this is not yet feasible, common reasons are:
* need access to the `uiState . uiMenu`
    * In particular, `toggleModal`/`openModal` need access to the `Menu` for use by `generateModal`.
        * And more specifically, for the "win", "lose", and "quit" modals, either to determine if it is `NoMenu` or to determine which scenario comes next.
* need access to `uiState . uiDebugOptions`
* need access to the `ScenarioCollection` (by way of `normalizeScenarioPath`) for:
    * `saveScenarioInfoOnFinishNocheat`
    * `saveScenarioInfoOnQuit`
* Need access to `uiState . uiAchievements` for:
    * `runGameTick`
 
This exercise is informative as to which record members we may want to re-organize.