### PR TITLE
Don't re-validate REPL input when moving the cursor left or right

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -693,7 +693,12 @@ handleREPLEventTyping = \case
         uiState . uiGameplay . uiREPL . replPromptType %= \case
           CmdPrompt _ -> CmdPrompt [] -- reset completions on any event passed to editor
           SearchPrompt a -> SearchPrompt a
-        modify validateREPLForm
+
+        -- Now re-validate the input, unless only the cursor moved.
+        case ev of
+          Key V.KLeft -> pure ()
+          Key V.KRight -> pure ()
+          _ -> modify validateREPLForm
 
 insertMatchingPair :: Char -> EventM Name (Editor Text Name) ()
 insertMatchingPair c = modify . applyEdit $ TZ.insertChar c >>> TZ.insertChar (close c) >>> TZ.moveLeft


### PR DESCRIPTION
Moving the cursor L/R within the REPL input now feels much snappier.  There's no need to re-validate the entire input when only moving the cursor.  Closes #2364.
