### PR TITLE
Disentangle more state parameters

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -235,6 +235,7 @@ doGoalUpdates menu = do
   curGoal <- use (playState . uiGameplay . uiDialogs . uiGoal . goalsContent)
   curWinCondition <- use (playState . gameState . winCondition)
   announcementsList <- use (playState . gameState . messageInfo . announcementQueue . to toList)
+  showHiddenGoals <- use $ uiState . uiDebugOptions . Lens.contains ShowHiddenGoals
 
   -- Decide whether we need to update the current goal text and pop
   -- up a modal dialog.
@@ -262,7 +263,6 @@ doGoalUpdates menu = do
       -- advance the menu at that point.
       return True
     WinConditions _ oc -> do
-      showHiddenGoals <- use $ uiState . uiDebugOptions . Lens.contains ShowHiddenGoals
       currentModal <- preuse $ playState . uiGameplay . uiDialogs . uiModal . _Just . modalType
       let newGoalTracking = GoalTracking announcementsList $ constructGoalMap showHiddenGoals oc
           -- The "uiGoal" field is initialized with empty members, so we know that

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -12,7 +12,7 @@ import Brick.Keybindings
 import Control.Carrier.Lift qualified as Fused
 import Control.Carrier.State.Lazy qualified as Fused
 import Control.Lens as Lens
-import Control.Monad (forM_, unless, when)
+import Control.Monad (forM, forM_, unless, when)
 import Control.Monad.IO.Class (MonadIO (liftIO), liftIO)
 import Control.Monad.State (MonadState, execState)
 import Data.List.Extra (enumerate)
@@ -152,15 +152,13 @@ loadVisibleRegion = do
 mouseLocToWorldCoords :: Brick.Location -> EventM Name GameState (Maybe (Cosmic Coords))
 mouseLocToWorldCoords (Brick.Location mouseLoc) = do
   mext <- lookupExtent WorldExtent
-  case mext of
-    Nothing -> pure Nothing
-    Just ext -> do
-      region <- gets $ flip viewingRegion (bimap fromIntegral fromIntegral (extentSize ext)) . view (robotInfo . viewCenter)
-      let regionStart = unCoords (fst $ region ^. planar)
-          mouseLoc' = bimap fromIntegral fromIntegral mouseLoc
-          mx = snd mouseLoc' + fst regionStart
-          my = fst mouseLoc' + snd regionStart
-       in pure . Just $ Cosmic (region ^. subworld) $ Coords (mx, my)
+  forM mext $ \ext -> do
+    region <- gets $ flip viewingRegion (bimap fromIntegral fromIntegral (extentSize ext)) . view (robotInfo . viewCenter)
+    let regionStart = unCoords (fst $ region ^. planar)
+        mouseLoc' = bimap fromIntegral fromIntegral mouseLoc
+        mx = snd mouseLoc' + fst regionStart
+        my = fst mouseLoc' + snd regionStart
+     in pure $ Cosmic (region ^. subworld) $ Coords (mx, my)
 
 hasDebugCapability :: Bool -> GameState -> Bool
 hasDebugCapability isCreative s =

--- a/src/swarm-tui/Swarm/TUI/Model/UI.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI.hs
@@ -49,6 +49,9 @@ import Swarm.Util.Lens (makeLensesNoSigs)
 
 -- * Toplevel UIState definition
 
+-- | UI state independent of an actively-playing scenario.
+-- Compare to 'UIGameplay', which contains UI state for an
+-- active scenario.
 data UIState = UIState
   { _uiMenu :: Menu
   , _uiPlaying :: Bool

--- a/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
@@ -193,8 +193,11 @@ uiStructure :: Lens' UIDialogs StructureDisplay
 -- | Definition and status of a recognizable structure
 uiRobot :: Lens' UIDialogs RobotDisplay
 
--- | The main record holding the gameplay UI state.  For access to the fields,
--- see the lenses below.
+-- | UI state specific to an actively-playing scenario.
+-- Compare to 'UIState', which contains UI state independent of an
+-- active scenario.
+--
+-- For access to the fields, see the lenses below.
 data UIGameplay = UIGameplay
   { _uiFocusRing :: FocusRing Name
   , _uiWorldCursor :: Maybe (Cosmic Coords)

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -14,7 +14,7 @@ import Control.Lens ((^.))
 import Swarm.Game.Achievement.Definitions (title)
 import Swarm.Game.Achievement.Description (describe)
 import Swarm.Language.Syntax (constInfo, syntax)
-import Swarm.TUI.Model (AppState, uiState)
+import Swarm.TUI.Model (AppState, keyConfig, keyEventHandling, uiState)
 import Swarm.TUI.Model.Dialog.Popup (Popup (..), currentPopup, popupFrames)
 import Swarm.TUI.Model.Event qualified as SE
 import Swarm.TUI.Model.Name
@@ -46,7 +46,7 @@ drawPopup s = \case
   RecipesPopup ->
     hBox
       [ withAttr notifAttr (txt "New recipes unlocked! ")
-      , txt $ bindingText s (SE.Main SE.ViewRecipesEvent) <> " to view."
+      , txt $ bindingText keyConf (SE.Main SE.ViewRecipesEvent) <> " to view."
       ]
   CommandsPopup cmds ->
     vBox
@@ -54,13 +54,15 @@ drawPopup s = \case
           [ withAttr notifAttr (txt "New commands unlocked: ")
           , txt . commaList $ map (squote . syntax . constInfo) cmds
           ]
-      , txt $ "Hit " <> bindingText s (SE.Main SE.ViewCommandsEvent) <> " to view all available commands."
+      , txt $ "Hit " <> bindingText keyConf (SE.Main SE.ViewCommandsEvent) <> " to view all available commands."
       ]
   DebugWarningPopup ->
     hBox
       [ withAttr notifAttr (txt "Warning: ")
       , txt "No progress will be saved, since debugging flags are in use."
       ]
+ where
+  keyConf = s ^. keyEventHandling . keyConfig
 
 -- | Compute the number of rows of the notification popup we should be
 --   showing, based on the number of frames the popup has existed.


### PR DESCRIPTION
Toward #2276.


# In this PR
* Decompose `updateUI` into smaller functions
* add documentation for `UIGameplay` and `UIState` records
* As described in #2362, the `uiState . uiMenu` is used in a number of places, often just to check whether it is set to `NoMenu`.  We instead precompute this condition and pass it as a parameter.
* Instead of retrieving from the implicit `AppState`, we pass the `ScenarioCollection` ( `runtimeState . scenarios` ) explicitly to `getNormalizedCurrentScenarioPath`.

# Long-term goal

The "main layers" of the UI can either comprise the active playfield (`drawGameUI`) or the out-of-game menu (`drawMenuUI`):

https://github.com/swarm-game/swarm/blob/68e57fc040283b0d2659a6336ed6521b20c684f5/src/swarm-tui/Swarm/TUI/View.hs#L150-L154

Since these are mutually exclusive, we should extricate the state needed for either one, rather than passing the complete `AppState` to both.

In fact there are a couple of places in the code that describe "unreachable combinations" of state:

https://github.com/swarm-game/swarm/blob/68e57fc040283b0d2659a6336ed6521b20c684f5/src/swarm-tui/Swarm/TUI/View.hs#L158-L160

and

https://github.com/swarm-game/swarm/blob/68e57fc040283b0d2659a6336ed6521b20c684f5/src/swarm-tui/Swarm/TUI/Controller.hs#L155-L158

As part of the deconflation of state, we should also be able to solve this: https://github.com/swarm-game/swarm/issues/1064#issuecomment-1410915316