### PR TITLE
Use off-the-shelf ordered map

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -35,7 +35,7 @@
   - {name: fromJust, within: []}
   - {name: Data.Colour.SRGB.sRGB24read, within: []}
   - {name: Data.IntMap.!, within: []}
-# - {name: Data.Map.!, within: []} # TODO: #1494
+  - {name: Data.Map.!, within: [Swarm.Language.Context.rehydrate, Swarm.Language.Typecheck.check]} # TODO: #1494
 # - {name: error, within: []} # TODO: #1494
 
 # Add custom hints for this project

--- a/src/swarm-lang/Swarm/Language/Syntax/AST.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/AST.hs
@@ -45,7 +45,7 @@ instance Data ty => Plated (Syntax' ty) where
 
 -- | A @let@ expression can be written either as @let x = e1 in e2@ or
 --   as @def x = e1 end; e2@. This enumeration simply records which it
---   was so that we can pretty-print appropriatly.
+--   was so that we can pretty-print appropriately.
 data LetSyntax = LSLet | LSDef
   deriving (Eq, Ord, Show, Bounded, Enum, Generic, Data, Hashable, ToJSON, FromJSON)
 

--- a/src/swarm-tournament/Swarm/Web/Tournament.hs
+++ b/src/swarm-tournament/Swarm/Web/Tournament.hs
@@ -385,7 +385,6 @@ app unitTestFileserver appData =
         -- files there.
         -- Instead, we manually stub the paths that are used as redirects
         -- so that the web API invocation does not 404 when looking for them.
-
           serveDirectoryEmbedded
             [ (TL.unpack defaultRedirectPage, "Hello World!")
             , (TL.unpack defaultSolutionSubmissionRedirectPage, "Hello World!")

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -184,18 +184,18 @@ handleMainMenuEvent menu = \case
 
         -- Extract the first unsolved tutorial challenge
         let tutorialCollection = getTutorials ss
-            tutorials = scOrder tutorialCollection
+            tutorials = scenarioCollectionToList tutorialCollection
             -- Find first unsolved tutorial, or first tutorial if all are solved
-            firstUnsolved :: Maybe FilePath
-            firstUnsolved = (tutorials >>= find unsolved) <|> (tutorials >>= listToMaybe)
-            unsolved t = case M.lookup t (scMap tutorialCollection) of
-              Just (SISingle (_, si)) -> case si ^. scenarioStatus of
+            firstUnsolved :: Maybe ScenarioItem
+            firstUnsolved = find unsolved tutorials <|> listToMaybe tutorials
+            unsolved = \case
+              SISingle (_, si) -> case si ^. scenarioStatus of
                 Played _ _ best
                   | Metric Completed _ <- best ^. scenarioBestByTime -> False
                   | otherwise -> True
                 _ -> True
               _ -> False
-            firstUnsolvedInfo = case firstUnsolved >>= (scMap tutorialCollection M.!?) of
+            firstUnsolvedInfo = case firstUnsolved of
               Just (SISingle siPair) -> siPair
               _ -> error "No first tutorial found!"
             firstUnsolvedName = firstUnsolvedInfo ^. _1 . scenarioMetadata . scenarioName

--- a/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
@@ -81,7 +81,7 @@ saveScenarioInfoOnFinish p = do
       -- There are not currently any subcollections within the
       -- tutorials, but checking subcollections recursively just seems
       -- like the right thing to do
-      isComplete (SICollection _ (SC _ m)) = all isComplete m
+      isComplete (SICollection _ (SC m)) = all isComplete m
 
   when (all isComplete tutorialMap) $
     attainAchievement $

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -17,7 +17,7 @@ import Control.Lens hiding (from, (<.>))
 import Data.List.Extra (enumerate)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
-import Data.Map qualified as M
+import Data.Map.Ordered qualified as OM
 import Data.Text (Text)
 import Data.Vector qualified as V
 import Swarm.Game.Achievement.Definitions
@@ -125,7 +125,7 @@ mkNewGameMenu sc path = fmap NewGameMenu $ NE.nonEmpty =<< go (Just sc) (splitPa
 
     lst = BL.listFindBy hasName (mkScenarioList curSC)
 
-    nextSC = case M.lookup (dropTrailingPathSeparator thing) (scMap curSC) of
+    nextSC = case OM.lookup (dropTrailingPathSeparator thing) (scMap curSC) of
       Just (SICollection _ c) -> Just c
       _ -> Nothing
 

--- a/src/swarm-tui/Swarm/TUI/View/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Util.hs
@@ -80,7 +80,7 @@ generateModal m s mt =
         , [ (nextMsg, Button NextButton, Next scene)
           | Just scene <- [nextScenario m]
           ]
-            ++ [ (stopMsg, Button QuitButton, QuitAction)
+            ++ [ (stopMsg, Button QuitButton, QuitAction) -- TODO(#2376) QuitAction is not used
                , (continueMsg, Button KeepPlayingButton, KeepPlaying)
                ]
         )

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -28,6 +28,7 @@ module Swarm.Util (
   tails1,
   prependList,
   deleteKeys,
+  lookupEither,
   applyWhen,
   applyJust,
   hoistMaybe,
@@ -89,6 +90,7 @@ import Control.Monad (filterM, unless)
 import Control.Monad.Trans.Maybe (MaybeT (..))
 import Data.Bifunctor (Bifunctor (bimap), first)
 import Data.Char (isAlphaNum, toLower)
+import Data.Either.Extra (maybeToEither)
 import Data.Either.Validation
 import Data.Foldable (Foldable (..))
 import Data.Foldable qualified as Foldable
@@ -242,6 +244,11 @@ allEqual (x : xs) = all (== x) xs
 -- https://hackage.haskell.org/package/ghc-9.8.1/docs/GHC-Data-FiniteMap.html#v:deleteList
 deleteKeys :: Ord key => [key] -> Map key elt -> Map key elt
 deleteKeys ks m = foldl' (flip M.delete) m ks
+
+-- | Convenience function to indicate which key
+-- was not found in the map.
+lookupEither :: Ord k => k -> Map k v -> Either k v
+lookupEither k = maybeToEither k . M.lookup k
 
 ------------------------------------------------------------
 -- Backported functions

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -276,6 +276,9 @@ common nonempty-containers
 common optparse-applicative
   build-depends: optparse-applicative >=0.16 && <0.19
 
+common ordered-containers
+  build-depends: ordered-containers >=0.2.4 && <0.2.5
+
 common palette
   build-depends: palette >=0.3 && <0.4
 
@@ -687,6 +690,7 @@ library swarm-engine
     monoidmap,
     mtl,
     nonempty-containers,
+    ordered-containers,
     prettyprinter,
     random,
     servant-docs,
@@ -1013,6 +1017,7 @@ library swarm-tui
     murmur3,
     natural-sort,
     nonempty-containers,
+    ordered-containers,
     palette,
     servant-docs,
     split,


### PR DESCRIPTION
Towards #1494.

Previously, `ScenarioCollection` used a custom implementation of an ordered map.  Furthermore, it used a partial function `M.!` when converting to a list.

We now use `Data.Map.Ordered` instead.