### PR TITLE
Fix robot modal memory leak by only rendering modal when it is displayed

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -185,8 +185,11 @@ updateUI = do
 
   newPopups <- generateNotificationPopups
 
-  dOps <- use $ uiState . uiDebugOptions
-  Brick.zoom playState $ doRobotListUpdate dOps g
+  -- Update the robots modal only when it is enabled.  See #2370.
+  curModal <- use $ playState . uiGameplay . uiDialogs . uiModal
+  when ((view modalType <$> curModal) == Just RobotsModal) $ do
+    dOps <- use $ uiState . uiDebugOptions
+    Brick.zoom playState $ doRobotListUpdate dOps g
 
   let redraw =
         g ^. needsRedraw


### PR DESCRIPTION
Fixes #2370 .  Only rerender the robots modal dialog when it is actively being displayed.  This does indeed seem to get rid of the memory leak; here's a heap profile with this fix included:

![robotDisplay-heap-fixed](https://github.com/user-attachments/assets/55913af0-a46e-4140-b6e6-1c2bffddabce)

The only downside is that it now takes a noticeable fraction of a second for the robots dialog to be updated each time it is displayed.  However, I consider this a much better alternative to a memory leak.  I suppose we could try to update the robots modal immediately when it is toggled on, but personally I'd rather leave that as a future improvement.