### PR TITLE
narrower state for saving progression

### DIFF
--- a/src/swarm-engine/Swarm/Game/Popup.hs
+++ b/src/swarm-engine/Swarm/Game/Popup.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Swarm.TUI.Model.Dialog.Popup (
+module Swarm.Game.Popup (
   -- * Popup types
   Popup (..),
 

--- a/src/swarm-engine/Swarm/Game/State/Runtime.hs
+++ b/src/swarm-engine/Swarm/Game/State/Runtime.hs
@@ -21,6 +21,7 @@ module Swarm.Game.State.Runtime (
   appData,
   stdGameConfigInputs,
   attainedAchievements,
+  uiPopups,
 
   -- ** Utility
   initScenarioInputs,
@@ -42,6 +43,7 @@ import Swarm.Game.Achievement.Attainment
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
 import Swarm.Game.Land
+import Swarm.Game.Popup
 import Swarm.Game.Recipe (loadRecipes)
 import Swarm.Game.Scenario (GameStateInputs (..), ScenarioInputs (..))
 import Swarm.Game.ScenarioInfo (ScenarioCollection, ScenarioInfo, loadScenarios)
@@ -60,6 +62,7 @@ import Swarm.Util.Lens (makeLensesNoSigs)
 data ProgressionState = ProgressionState
   { _scenarios :: ScenarioCollection ScenarioInfo
   , _attainedAchievements :: Map CategorizedAchievement Attainment
+  , _uiPopups :: PopupState
   }
 
 makeLensesNoSigs ''ProgressionState
@@ -69,6 +72,9 @@ attainedAchievements :: Lens' ProgressionState (Map CategorizedAchievement Attai
 
 -- | The collection of scenarios that comes with the game.
 scenarios :: Lens' ProgressionState (ScenarioCollection ScenarioInfo)
+
+-- | Queue of popups to display
+uiPopups :: Lens' ProgressionState PopupState
 
 data RuntimeState = RuntimeState
   { _webPort :: Maybe Int
@@ -145,6 +151,7 @@ initRuntimeState opts = do
           ProgressionState
             { _scenarios = s
             , _attainedAchievements = M.fromList $ map (view achievement &&& id) achievements
+            , _uiPopups = initPopupState
             }
       }
 

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -137,7 +137,7 @@ handleEvent e = do
       -- quitting a game, moving around the menu, the popup
       -- display will continue as normal.
       upd <- case e of
-        AppEvent Frame -> Brick.zoom (uiState . uiPopups) progressPopups
+        AppEvent Frame -> Brick.zoom (runtimeState . progression . uiPopups) progressPopups
         _ -> pure False
       if playing
         then handleMainEvent upd e
@@ -222,7 +222,9 @@ handleMainMenuEvent menu = \case
         uiState . uiMenu .= MessagesMenu
       About -> do
         uiState . uiMenu .= AboutMenu
-        attainAchievement $ GlobalAchievement LookedAtAboutScreen
+        Brick.zoom (runtimeState . progression) $
+          attainAchievement $
+            GlobalAchievement LookedAtAboutScreen
       Quit -> halt
   CharKey 'q' -> halt
   ControlChar 'q' -> halt

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -178,10 +178,10 @@ handleMainMenuEvent menu = \case
   Key V.KEnter ->
     forM_ (snd <$> BL.listSelectedElement menu) $ \case
       NewGame -> do
-        ss <- use $ runtimeState . scenarios
+        ss <- use $ runtimeState . progression . scenarios
         uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList $ pathifyCollection ss)
       Tutorial -> do
-        ss <- use $ runtimeState . scenarios
+        ss <- use $ runtimeState . progression . scenarios
 
         -- Extract the first unsolved tutorial challenge
         let tutorialCollection = getTutorials ss
@@ -286,7 +286,7 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
  where
   showLaunchDialog = case snd <$> BL.listSelectedElement curMenu of
     Just (SISingle (ScenarioWith s (ScenarioPath p))) -> do
-      ss <- use $ runtimeState . scenarios
+      ss <- use $ runtimeState . progression . scenarios
       let si = getScenarioInfoFromPath ss p
       Brick.zoom (uiState . uiLaunchConfig) $ prepareLaunchDialog $ ScenarioWith s si
     _ -> pure ()

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -20,13 +20,13 @@ import Swarm.Game.Achievement.Attainment (achievement)
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
 import Swarm.Game.State
+import Swarm.Game.State.Runtime
 import Swarm.Game.State.Substate
 import Swarm.Game.Step (gameTick)
 import Swarm.TUI.Controller.UpdateUI
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Achievements (popupAchievement)
-import Swarm.TUI.Model.UI
 import Swarm.TUI.Model.UI.Gameplay
 import System.Clock
 
@@ -149,15 +149,15 @@ updateAchievements = do
   achievementsFromGame <- use $ playState . gameState . discovery . gameAchievements
   let wrappedGameAchievements = M.mapKeys GameplayAchievement achievementsFromGame
 
-  oldMasterAchievementsList <- use $ uiState . uiAchievements
-  uiState . uiAchievements %= M.unionWith (<>) wrappedGameAchievements
+  oldMasterAchievementsList <- use $ runtimeState . progression . uiAchievements
+  runtimeState . progression . uiAchievements %= M.unionWith (<>) wrappedGameAchievements
 
   -- Don't save to disk unless there was a change in the attainment list.
   let incrementalAchievements = wrappedGameAchievements `M.difference` oldMasterAchievementsList
   unless (null incrementalAchievements) $ do
     mapM_ (popupAchievement . view achievement) incrementalAchievements
 
-    newAchievements <- use $ uiState . uiAchievements
+    newAchievements <- use $ runtimeState . progression . uiAchievements
     liftIO $ saveAchievementsInfo $ M.elems newAchievements
 
 -- | Run the game for a single tick (/without/ updating the UI).

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -154,10 +154,10 @@ updateAchievements = do
 
   -- Don't save to disk unless there was a change in the attainment list.
   let incrementalAchievements = wrappedGameAchievements `M.difference` oldMasterAchievementsList
-  unless (null incrementalAchievements) $ do
+  unless (null incrementalAchievements) $ Brick.zoom (runtimeState . progression) $ do
     mapM_ (popupAchievement . view achievement) incrementalAchievements
 
-    newAchievements <- use $ runtimeState . progression . attainedAchievements
+    newAchievements <- use attainedAchievements
     liftIO $ saveAchievementsInfo $ M.elems newAchievements
 
 -- | Run the game for a single tick (/without/ updating the UI).

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -149,15 +149,15 @@ updateAchievements = do
   achievementsFromGame <- use $ playState . gameState . discovery . gameAchievements
   let wrappedGameAchievements = M.mapKeys GameplayAchievement achievementsFromGame
 
-  oldMasterAchievementsList <- use $ runtimeState . progression . uiAchievements
-  runtimeState . progression . uiAchievements %= M.unionWith (<>) wrappedGameAchievements
+  oldMasterAchievementsList <- use $ runtimeState . progression . attainedAchievements
+  runtimeState . progression . attainedAchievements %= M.unionWith (<>) wrappedGameAchievements
 
   -- Don't save to disk unless there was a change in the attainment list.
   let incrementalAchievements = wrappedGameAchievements `M.difference` oldMasterAchievementsList
   unless (null incrementalAchievements) $ do
     mapM_ (popupAchievement . view achievement) incrementalAchievements
 
-    newAchievements <- use $ runtimeState . progression . uiAchievements
+    newAchievements <- use $ runtimeState . progression . attainedAchievements
     liftIO $ saveAchievementsInfo $ M.elems newAchievements
 
 -- | Run the game for a single tick (/without/ updating the UI).

--- a/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
@@ -53,7 +53,7 @@ saveScenarioInfoOnFinish p = do
   saved <- use $ playState . gameState . completionStatsSaved
 
   let currentScenarioInfo :: Traversal' AppState ScenarioInfo
-      currentScenarioInfo = runtimeState . scenarios . scenarioItemByPath p . _SISingle . getScenarioInfo
+      currentScenarioInfo = runtimeState . progression . scenarios . scenarioItemByPath p . _SISingle . getScenarioInfo
 
   replHist <- use $ playState . uiGameplay . uiREPL . replHistory
   let determinator = CodeSizeDeterminators initialRunCode $ replHist ^. replHasExecutedManualInput
@@ -73,7 +73,7 @@ saveScenarioInfoOnFinish p = do
     liftIO $ saveScenarioInfo p si
 
   -- Check if all tutorials have been completed
-  tutorialMap <- use $ runtimeState . scenarios . to getTutorials . to scMap
+  tutorialMap <- use $ runtimeState . progression . scenarios . to getTutorials . to scMap
   let isComplete (SISingle (ScenarioWith _ s)) = scenarioIsCompleted s
       -- There are not currently any subcollections within the
       -- tutorials, but checking subcollections recursively just seems
@@ -96,7 +96,7 @@ unlessCheating a = do
 -- | Write the @ScenarioInfo@ out to disk when finishing a game (i.e. on winning or exit).
 saveScenarioInfoOnFinishNocheat :: (MonadIO m, MonadState AppState m) => m ()
 saveScenarioInfoOnFinishNocheat = do
-  sc <- use $ runtimeState . scenarios
+  sc <- use $ runtimeState . progression . scenarios
   gs <- use $ playState . gameState
   unlessCheating $
     -- the path should be normalized and good to search in scenario collection
@@ -105,7 +105,7 @@ saveScenarioInfoOnFinishNocheat = do
 -- | Write the @ScenarioInfo@ out to disk when exiting a game.
 saveScenarioInfoOnQuit :: (MonadIO m, MonadState AppState m) => m ()
 saveScenarioInfoOnQuit = do
-  sc <- use $ runtimeState . scenarios
+  sc <- use $ runtimeState . progression . scenarios
   gs <- use $ playState . gameState
   unlessCheating $
     getNormalizedCurrentScenarioPath gs sc >>= mapM_ saveScenarioInfoOnFinish

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -28,11 +28,13 @@ import Data.String (fromString)
 import Data.Text qualified as T
 import Data.Vector qualified as V
 import Swarm.Game.Entity hiding (empty)
+import Swarm.Game.Popup (Popup (..), addPopup)
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Activity
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
+import Swarm.Game.State.Runtime
 import Swarm.Game.State.Substate
 import Swarm.Language.Typed (Typed (..))
 import Swarm.Language.Types
@@ -43,7 +45,6 @@ import Swarm.TUI.Controller.Util
 import Swarm.TUI.Model
 import Swarm.TUI.Model.DebugOption (DebugOption (..))
 import Swarm.TUI.Model.Dialog.Goal
-import Swarm.TUI.Model.Dialog.Popup (Popup (..), addPopup)
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.UI
@@ -328,14 +329,14 @@ generateNotificationPopups = do
   rs <- use $ playState . gameState . discovery . availableRecipes
   let newRecipes = rs ^. notificationsShouldAlert
   when newRecipes $ do
-    uiState . uiPopups %= addPopup RecipesPopup
+    runtimeState . progression . uiPopups %= addPopup RecipesPopup
     playState . gameState . discovery . availableRecipes . notificationsShouldAlert .= False
 
   cs <- use $ playState . gameState . discovery . availableCommands
   let alertCommands = cs ^. notificationsShouldAlert
   when alertCommands $ do
     let newCommands = take (cs ^. notificationsCount) (cs ^. notificationsContent)
-    uiState . uiPopups %= addPopup (CommandsPopup newCommands)
+    runtimeState . progression . uiPopups %= addPopup (CommandsPopup newCommands)
     playState . gameState . discovery . availableCommands . notificationsShouldAlert .= False
 
   return $ newRecipes || alertCommands

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -152,7 +152,8 @@ logEvent src sev who msg el =
  where
   l = LogEntry (TickNumber 0) src sev who msg
 
--- | This encapsulates both game and UI state for an actively-playing scenario.
+-- | This encapsulates both game and UI state for an actively-playing scenario, as well
+-- as state that evolves as a result of playing a scenario.
 data PlayState = PlayState
   { _gameState :: GameState
   , _uiGameplay :: UIGameplay

--- a/src/swarm-tui/Swarm/TUI/Model/Achievements.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Achievements.hs
@@ -36,15 +36,15 @@ attainAchievement' ::
   CategorizedAchievement ->
   m ()
 attainAchievement' t p a = do
-  mAttainment <- use $ runtimeState . progression . uiAchievements . at a
+  mAttainment <- use $ runtimeState . progression . attainedAchievements . at a
   when (isNothing mAttainment) $ popupAchievement a
 
-  (runtimeState . progression . uiAchievements)
+  (runtimeState . progression . attainedAchievements)
     %= M.insertWith
       (<>)
       a
       (Attainment a (getScenarioPath <$> p) t)
-  newAchievements <- use $ runtimeState . progression . uiAchievements
+  newAchievements <- use $ runtimeState . progression . attainedAchievements
   liftIO $ saveAchievementsInfo $ M.elems newAchievements
 
 -- | Generate a popup for an achievement.

--- a/src/swarm-tui/Swarm/TUI/Model/Achievements.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Achievements.hs
@@ -19,6 +19,7 @@ import Swarm.Game.Achievement.Attainment
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Persistence
 import Swarm.Game.Scenario.Status (ScenarioPath (..))
+import Swarm.Game.State.Runtime
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Dialog.Popup (Popup (AchievementPopup), addPopup)
 import Swarm.TUI.Model.UI
@@ -35,15 +36,15 @@ attainAchievement' ::
   CategorizedAchievement ->
   m ()
 attainAchievement' t p a = do
-  mAttainment <- use $ uiState . uiAchievements . at a
+  mAttainment <- use $ runtimeState . progression . uiAchievements . at a
   when (isNothing mAttainment) $ popupAchievement a
 
-  (uiState . uiAchievements)
+  (runtimeState . progression . uiAchievements)
     %= M.insertWith
       (<>)
       a
       (Attainment a (getScenarioPath <$> p) t)
-  newAchievements <- use $ uiState . uiAchievements
+  newAchievements <- use $ runtimeState . progression . uiAchievements
   liftIO $ saveAchievementsInfo $ M.elems newAchievements
 
 -- | Generate a popup for an achievement.

--- a/src/swarm-tui/Swarm/TUI/Model/Dialog.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Dialog.hs
@@ -1,9 +1,9 @@
 module Swarm.TUI.Model.Dialog (
   module Swarm.TUI.Model.Dialog.Goal,
-  module Swarm.TUI.Model.Dialog.Popup,
+  module Swarm.Game.Popup,
   module Swarm.TUI.Model.Dialog.Structure,
 ) where
 
+import Swarm.Game.Popup
 import Swarm.TUI.Model.Dialog.Goal
-import Swarm.TUI.Model.Dialog.Popup
 import Swarm.TUI.Model.Dialog.Structure

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -187,7 +187,7 @@ constructAppState rs ui key opts@(AppOpts {..}) = do
             return $ CodeToRun ScenarioSuggested soln
           codeToRun = maybeAutoplay <|> maybeRunScript
 
-      let si = getScenarioInfoFromPath (rs ^. scenarios) path
+      let si = getScenarioInfoFromPath (rs ^. progression . scenarios) path
 
       sendIO $
         execStateT
@@ -249,7 +249,7 @@ startGame ::
   Maybe CodeToRun ->
   m ()
 startGame (ScenarioWith s (ScenarioPath p)) c = do
-  ss <- use $ runtimeState . scenarios
+  ss <- use $ runtimeState . progression . scenarios
   let si = getScenarioInfoFromPath ss p
   startGameWithSeed (ScenarioWith s si) . LaunchParams (pure Nothing) $ pure c
 
@@ -268,7 +268,7 @@ restartGame ::
   ScenarioWith ScenarioPath ->
   m ()
 restartGame currentSeed (ScenarioWith s (ScenarioPath p)) = do
-  ss <- use $ runtimeState . scenarios
+  ss <- use $ runtimeState . progression . scenarios
   let si = getScenarioInfoFromPath ss p
   startGameWithSeed (ScenarioWith s si) $ LaunchParams (pure (Just currentSeed)) (pure Nothing)
 
@@ -281,10 +281,11 @@ startGameWithSeed ::
   m ()
 startGameWithSeed siPair@(ScenarioWith _scene si) lp = do
   t <- liftIO getZonedTime
-  ss <- use $ runtimeState . scenarios
+  ss <- use $ runtimeState . progression . scenarios
   p <- liftIO $ normalizeScenarioPath ss $ si ^. scenarioPath
 
   runtimeState
+    . progression
     . scenarios
     . scenarioItemByPath p
     . _SISingle

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -302,7 +302,7 @@ startGameWithSeed siPair@(ScenarioWith _scene si) lp = do
   -- will not be saved.
   debugging <- use $ uiState . uiDebugOptions
   unless (null debugging) $
-    uiState . uiPopups %= addPopup DebugWarningPopup
+    runtimeState . progression . uiPopups %= addPopup DebugWarningPopup
  where
   prevBest t = case si ^. scenarioStatus of
     NotStarted -> emptyBest t

--- a/src/swarm-tui/Swarm/TUI/Model/UI.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI.hs
@@ -12,7 +12,6 @@ module Swarm.TUI.Model.UI (
   uiPlaying,
   uiDebugOptions,
   uiLaunchConfig,
-  uiAchievements,
   uiAttrMap,
   uiPopups,
 
@@ -25,19 +24,13 @@ module Swarm.TUI.Model.UI (
 
 import Brick (AttrMap)
 import Brick.Focus
-import Control.Arrow ((&&&))
 import Control.Effect.Accum
 import Control.Effect.Lift
 import Control.Lens hiding (from, (<.>))
 import Data.List.Extra (enumerate)
-import Data.Map (Map)
-import Data.Map qualified as M
 import Data.Sequence (Seq)
 import Data.Set (Set)
 import Swarm.Failure (SystemFailure)
-import Swarm.Game.Achievement.Attainment
-import Swarm.Game.Achievement.Definitions
-import Swarm.Game.Achievement.Persistence
 import Swarm.TUI.Launch.Model
 import Swarm.TUI.Launch.Prep
 import Swarm.TUI.Model.DebugOption (DebugOption)
@@ -57,7 +50,6 @@ data UIState = UIState
   , _uiPlaying :: Bool
   , _uiDebugOptions :: Set DebugOption
   , _uiLaunchConfig :: LaunchOptions
-  , _uiAchievements :: Map CategorizedAchievement Attainment
   , _uiAttrMap :: AttrMap
   , _uiPopups :: PopupState
   }
@@ -82,9 +74,6 @@ uiDebugOptions :: Lens' UIState (Set DebugOption)
 
 -- | Configuration modal when launching a scenario
 uiLaunchConfig :: Lens' UIState LaunchOptions
-
--- | Map of achievements that were attained
-uiAchievements :: Lens' UIState (Map CategorizedAchievement Attainment)
 
 -- | Attribute map
 uiAttrMap :: Lens' UIState AttrMap
@@ -123,7 +112,6 @@ initUIState ::
   UIInitOptions ->
   m UIState
 initUIState UIInitOptions {..} = do
-  achievements <- loadAchievementsInfo
   launchConfigPanel <- sendIO initConfigPanel
   return
     UIState
@@ -131,7 +119,6 @@ initUIState UIInitOptions {..} = do
       , _uiPlaying = not showMainMenu
       , _uiDebugOptions = debugOptions
       , _uiLaunchConfig = launchConfigPanel
-      , _uiAchievements = M.fromList $ map (view achievement &&& id) achievements
       , _uiAttrMap = swarmAttrMap
       , _uiPopups = initPopupState
       }

--- a/src/swarm-tui/Swarm/TUI/Model/UI.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI.hs
@@ -13,7 +13,6 @@ module Swarm.TUI.Model.UI (
   uiDebugOptions,
   uiLaunchConfig,
   uiAttrMap,
-  uiPopups,
 
   -- ** Initialization
   initFocusRing,
@@ -34,7 +33,6 @@ import Swarm.Failure (SystemFailure)
 import Swarm.TUI.Launch.Model
 import Swarm.TUI.Launch.Prep
 import Swarm.TUI.Model.DebugOption (DebugOption)
-import Swarm.TUI.Model.Dialog
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
 import Swarm.TUI.View.Attribute.Attr (swarmAttrMap)
@@ -51,7 +49,6 @@ data UIState = UIState
   , _uiDebugOptions :: Set DebugOption
   , _uiLaunchConfig :: LaunchOptions
   , _uiAttrMap :: AttrMap
-  , _uiPopups :: PopupState
   }
 
 -- * Lenses for UIState
@@ -77,9 +74,6 @@ uiLaunchConfig :: Lens' UIState LaunchOptions
 
 -- | Attribute map
 uiAttrMap :: Lens' UIState AttrMap
-
--- | Queue of popups to display
-uiPopups :: Lens' UIState PopupState
 
 -- * UIState initialization
 
@@ -120,5 +114,4 @@ initUIState UIInitOptions {..} = do
       , _uiDebugOptions = debugOptions
       , _uiLaunchConfig = launchConfigPanel
       , _uiAttrMap = swarmAttrMap
-      , _uiPopups = initPopupState
       }

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -247,7 +247,7 @@ drawNewGameMenuUI appState (l :| ls) launchOptions = case displayedFor of
         [] -> withAttr cyanAttr $ txt " ◉ "
         _ -> withAttr yellowAttr $ txt " ◎ "
    where
-    currentScenarioInfo = appState ^? runtimeState . scenarios . scenarioItemByPath sPath . _SISingle . getScenarioInfo
+    currentScenarioInfo = appState ^? runtimeState . progression . scenarios . scenarioItemByPath sPath . _SISingle . getScenarioInfo
 
   isCompleted :: BestRecords -> Bool
   isCompleted best = best ^. scenarioBestByTime . metricProgress == Completed
@@ -277,7 +277,7 @@ drawNewGameMenuUI appState (l :| ls) launchOptions = case displayedFor of
    where
     vc = determineStaticViewCenter (s ^. scenarioLandscape) worldTuples
 
-    currentScenarioInfo = appState ^? runtimeState . scenarios . scenarioItemByPath sPath . _SISingle . getScenarioInfo
+    currentScenarioInfo = appState ^? runtimeState . progression . scenarios . scenarioItemByPath sPath . _SISingle . getScenarioInfo
 
     worldTuples = buildWorldTuples $ s ^. scenarioLandscape
     theWorlds =

--- a/src/swarm-tui/Swarm/TUI/View/Achievement.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Achievement.hs
@@ -44,7 +44,7 @@ drawAchievementsMenuUI s l =
           ]
     ]
  where
-  attainedMap = s ^. runtimeState . progression . uiAchievements
+  attainedMap = s ^. runtimeState . progression . attainedAchievements
 
 drawAchievementListItem ::
   Map CategorizedAchievement Attainment ->

--- a/src/swarm-tui/Swarm/TUI/View/Achievement.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Achievement.hs
@@ -15,8 +15,8 @@ import Data.Time.Format (defaultTimeLocale, formatTime)
 import Swarm.Game.Achievement.Attainment
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Achievement.Description
+import Swarm.Game.State.Runtime
 import Swarm.TUI.Model
-import Swarm.TUI.Model.UI
 import Swarm.TUI.View.Attribute.Attr
 import Swarm.TUI.View.Util (drawMarkdown)
 import Text.Wrap
@@ -44,7 +44,7 @@ drawAchievementsMenuUI s l =
           ]
     ]
  where
-  attainedMap = s ^. uiState . uiAchievements
+  attainedMap = s ^. runtimeState . progression . uiAchievements
 
 drawAchievementListItem ::
   Map CategorizedAchievement Attainment ->

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -13,12 +13,12 @@ import Brick.Widgets.Core (emptyWidget, hBox, withAttr)
 import Control.Lens ((^.))
 import Swarm.Game.Achievement.Definitions (title)
 import Swarm.Game.Achievement.Description (describe)
+import Swarm.Game.Popup (Popup (..), currentPopup, popupFrames)
+import Swarm.Game.State.Runtime
 import Swarm.Language.Syntax (constInfo, syntax)
-import Swarm.TUI.Model (AppState, keyConfig, keyEventHandling, uiState)
-import Swarm.TUI.Model.Dialog.Popup (Popup (..), currentPopup, popupFrames)
+import Swarm.TUI.Model (AppState, keyConfig, keyEventHandling, runtimeState)
 import Swarm.TUI.Model.Event qualified as SE
 import Swarm.TUI.Model.Name
-import Swarm.TUI.Model.UI (uiPopups)
 import Swarm.TUI.View.Attribute.Attr (notifAttr)
 import Swarm.TUI.View.Util (bindingText)
 import Swarm.Util (commaList, squote)
@@ -31,7 +31,7 @@ animFrames = 3
 -- | Draw the current notification popup (if any).
 drawPopups :: AppState -> Widget Name
 drawPopups s = hCenterLayer $
-  case s ^. uiState . uiPopups . currentPopup of
+  case s ^. runtimeState . progression . uiPopups . currentPopup of
     Just (notif, f) ->
       cropTopTo (popupRows f) . border . padLeftRight 2 $ drawPopup s notif
     _ -> emptyWidget

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -712,6 +712,7 @@ library swarm-engine
     Swarm.Game.Achievement.Persistence
     Swarm.Game.CESK
     Swarm.Game.Exception
+    Swarm.Game.Popup
     Swarm.Game.Robot.Activity
     Swarm.Game.Robot.Concrete
     Swarm.Game.Scenario.Objective.WinCheck
@@ -1064,7 +1065,6 @@ library swarm-tui
     Swarm.TUI.Model.DebugOption
     Swarm.TUI.Model.Dialog
     Swarm.TUI.Model.Dialog.Goal
-    Swarm.TUI.Model.Dialog.Popup
     Swarm.TUI.Model.Dialog.Structure
     Swarm.TUI.Model.Event
     Swarm.TUI.Model.KeyBindings

--- a/test/unit/TestPedagogy.hs
+++ b/test/unit/TestPedagogy.hs
@@ -10,7 +10,7 @@ import Control.Lens (view)
 import Data.Map qualified as M
 import Swarm.Doc.Pedagogy
 import Swarm.Game.Scenario.Status (ScenarioPath (..), ScenarioWith (..))
-import Swarm.Game.State.Runtime (RuntimeState, scenarios)
+import Swarm.Game.State.Runtime (RuntimeState, progression, scenarios)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -23,7 +23,7 @@ testPedagogy rs =
         testList
     ]
  where
-  tutorialInfos = generateIntroductionsSequence $ view scenarios rs
+  tutorialInfos = generateIntroductionsSequence $ view (progression . scenarios) rs
 
   testFromTut :: Int -> CoverageInfo -> TestTree
   testFromTut idx (CoverageInfo (TutorialInfo (ScenarioWith _s (ScenarioPath scPath)) _ _ descCommands) novelCommands) =


### PR DESCRIPTION
* Introduce new `ProgressionState` record for out-of-scenario progression
* `Popup.hs` is moved from `swarm-tui` to `swarm-engine`

I was not able to get either `Brick.zoom` or `Lens.zoom` to work with the `MonadState` typeclass constraint, so I converted a few type signatures to the concrete `EventM Name AppState ()` type and was then able to use `Brick.zoom`.