### PR TITLE
Single authoritative source for ScenarioInfo

### DIFF
--- a/src/swarm-doc/Swarm/Doc/Pedagogy.hs
+++ b/src/swarm-doc/Swarm/Doc/Pedagogy.hs
@@ -53,8 +53,8 @@ import Swarm.Game.ScenarioInfo (
   flatten,
   getTutorials,
   loadScenarios,
+  pathifyCollection,
   scenarioCollectionToList,
-  scenarioPath,
  )
 import Swarm.Game.World.Load (loadWorlds)
 import Swarm.Language.Syntax
@@ -164,7 +164,7 @@ computeCommandIntroductions =
 -- and derive their command coverage info.
 generateIntroductionsSequence :: ScenarioCollection ScenarioInfo -> [CoverageInfo]
 generateIntroductionsSequence =
-  computeCommandIntroductions . zipFrom 0 . getTuts . fmap (ScenarioPath . view scenarioPath)
+  computeCommandIntroductions . zipFrom 0 . getTuts . pathifyCollection
  where
   getTuts =
     concatMap flatten

--- a/src/swarm-doc/Swarm/Doc/Pedagogy.hs
+++ b/src/swarm-doc/Swarm/Doc/Pedagogy.hs
@@ -47,6 +47,7 @@ import Swarm.Game.Scenario (
 import Swarm.Game.Scenario.Objective (objectiveGoal)
 import Swarm.Game.ScenarioInfo (
   ScenarioCollection,
+  ScenarioInfo,
   ScenarioInfoPair,
   flatten,
   getTutorials,
@@ -81,7 +82,7 @@ data CoverageInfo = CoverageInfo
 -- introduced in their solution and descriptions
 -- having been extracted
 data TutorialInfo = TutorialInfo
-  { scenarioPair :: ScenarioInfoPair
+  { scenarioPair :: ScenarioInfoPair ScenarioInfo
   , tutIndex :: Int
   , solutionCommands :: Map Const [SrcLoc]
   , descriptionCommands :: Set Const
@@ -96,7 +97,7 @@ data CommandAccum = CommandAccum
 -- * Functions
 
 -- | Extract commands from both goal descriptions and solution code.
-extractCommandUsages :: Int -> ScenarioInfoPair -> TutorialInfo
+extractCommandUsages :: Int -> ScenarioInfoPair ScenarioInfo -> TutorialInfo
 extractCommandUsages idx siPair@(s, _si) =
   TutorialInfo siPair idx solnCommands $ getDescCommands s
  where
@@ -142,13 +143,13 @@ getCommands (Just tsyn) =
 
 -- | "fold" over the tutorials in sequence to determine which
 -- commands are novel to each tutorial's solution.
-computeCommandIntroductions :: [(Int, ScenarioInfoPair)] -> [CoverageInfo]
+computeCommandIntroductions :: [(Int, ScenarioInfoPair ScenarioInfo)] -> [CoverageInfo]
 computeCommandIntroductions =
   reverse . tuts . foldl' f initial
  where
   initial = CommandAccum mempty mempty
 
-  f :: CommandAccum -> (Int, ScenarioInfoPair) -> CommandAccum
+  f :: CommandAccum -> (Int, ScenarioInfoPair ScenarioInfo) -> CommandAccum
   f (CommandAccum encounteredPreviously xs) (idx, siPair) =
     CommandAccum updatedEncountered $ CoverageInfo usages novelCommands : xs
    where
@@ -160,7 +161,7 @@ computeCommandIntroductions =
 
 -- | Extract the tutorials from the complete scenario collection
 -- and derive their command coverage info.
-generateIntroductionsSequence :: ScenarioCollection -> [CoverageInfo]
+generateIntroductionsSequence :: ScenarioCollection ScenarioInfo -> [CoverageInfo]
 generateIntroductionsSequence =
   computeCommandIntroductions . zipFrom 0 . getTuts
  where
@@ -173,7 +174,7 @@ generateIntroductionsSequence =
 
 -- | Helper for standalone rendering.
 -- For unit tests, can instead access the scenarios via the GameState.
-loadScenarioCollection :: IO ScenarioCollection
+loadScenarioCollection :: IO (ScenarioCollection ScenarioInfo)
 loadScenarioCollection = simpleErrorHandle $ do
   tem <- loadEntitiesAndTerrain
 

--- a/src/swarm-engine/Swarm/Game/Scenario/Status.hs
+++ b/src/swarm-engine/Swarm/Game/Scenario/Status.hs
@@ -80,6 +80,14 @@ newtype ScenarioPath = ScenarioPath
   { getScenarioPath :: FilePath
   }
 
+data ScenarioWith a = ScenarioWith
+  { _getScenario :: Scenario
+  , _getScenarioInfo :: a
+  }
+  deriving (Generic, Functor)
+
+makeLenses ''ScenarioWith
+
 -- | A 'ScenarioInfo' record stores metadata about a scenario: its
 -- canonical path and status.
 -- By way of the 'ScenarioStatus' record, it stores the
@@ -96,8 +104,6 @@ instance FromJSON ScenarioInfo where
 instance ToJSON ScenarioInfo where
   toEncoding = genericToEncoding scenarioOptions
   toJSON = genericToJSON scenarioOptions
-
-type ScenarioInfoPair a = (Scenario, a)
 
 makeLensesNoSigs ''ScenarioInfo
 

--- a/src/swarm-engine/Swarm/Game/Scenario/Status.hs
+++ b/src/swarm-engine/Swarm/Game/Scenario/Status.hs
@@ -75,6 +75,11 @@ getLaunchParams = \case
   NotStarted -> emptyLaunchParams
   Played x _ _ -> x
 
+-- | The normalized path to a scenario, amenable to lookup
+newtype ScenarioPath = ScenarioPath
+  { getScenarioPath :: FilePath
+  }
+
 -- | A 'ScenarioInfo' record stores metadata about a scenario: its
 -- canonical path and status.
 -- By way of the 'ScenarioStatus' record, it stores the

--- a/src/swarm-engine/Swarm/Game/Scenario/Status.hs
+++ b/src/swarm-engine/Swarm/Game/Scenario/Status.hs
@@ -92,7 +92,7 @@ instance ToJSON ScenarioInfo where
   toEncoding = genericToEncoding scenarioOptions
   toJSON = genericToJSON scenarioOptions
 
-type ScenarioInfoPair = (Scenario, ScenarioInfo)
+type ScenarioInfoPair a = (Scenario, a)
 
 makeLensesNoSigs ''ScenarioInfo
 

--- a/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
+++ b/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
@@ -286,10 +286,16 @@ loadScenarioInfo p = do
     then do
       return $
         ScenarioInfo path NotStarted
-    else
-      withThrow (AssetNotLoaded (Data Scenarios) infoPath . CanNotParseYaml)
-        . (liftEither <=< sendIO)
-        $ decodeFileEither infoPath
+    else do
+      ScenarioInfo _storedPath status <-
+        withThrow (AssetNotLoaded (Data Scenarios) infoPath . CanNotParseYaml)
+          . (liftEither <=< sendIO)
+          $ decodeFileEither infoPath
+      -- We discard the path that was saved inside the yaml file, so that there
+      -- is only a single authoritative path "key": the original scenario path.
+      --
+      -- TODO(#2390) Maybe we shouldn't store that path.
+      return $ ScenarioInfo path status
 
 -- | Save info about played scenario to XDG data directory.
 saveScenarioInfo ::

--- a/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
+++ b/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
@@ -26,6 +26,7 @@ module Swarm.Game.ScenarioInfo (
   ScenarioItem (..),
   scenarioItemName,
   _SISingle,
+  pathifyCollection,
 
   -- ** Tutorials
   tutorialsDirname,
@@ -127,6 +128,9 @@ newtype ScenarioCollection a = SC
   { scMap :: OMap FilePath (ScenarioItem a)
   }
   deriving (Functor)
+
+pathifyCollection :: Functor f => f ScenarioInfo -> f ScenarioPath
+pathifyCollection = fmap (ScenarioPath . view scenarioPath)
 
 -- | Access and modify 'ScenarioItem's in collection based on their path.
 scenarioItemByPath :: FilePath -> Traversal' (ScenarioCollection a) (ScenarioItem a)

--- a/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
+++ b/src/swarm-engine/Swarm/Game/ScenarioInfo.hs
@@ -111,6 +111,7 @@ fromMapOM = OM.fromList . M.toList
 -- | A scenario item is either a specific scenario, or a collection of
 --   scenarios (/e.g./ the scenarios contained in a subdirectory).
 data ScenarioItem a = SISingle (ScenarioInfoPair a) | SICollection Text (ScenarioCollection a)
+  deriving (Functor)
 
 -- | Retrieve the name of a scenario item.
 scenarioItemName :: ScenarioItem a -> Text
@@ -125,6 +126,7 @@ scenarioItemName (SICollection name _) = name
 newtype ScenarioCollection a = SC
   { scMap :: OMap FilePath (ScenarioItem a)
   }
+  deriving (Functor)
 
 -- | Access and modify 'ScenarioItem's in collection based on their path.
 scenarioItemByPath :: FilePath -> Traversal' (ScenarioCollection a) (ScenarioItem a)

--- a/src/swarm-engine/Swarm/Game/State/Runtime.hs
+++ b/src/swarm-engine/Swarm/Game/State/Runtime.hs
@@ -36,7 +36,7 @@ import Swarm.Failure (SystemFailure)
 import Swarm.Game.Land
 import Swarm.Game.Recipe (loadRecipes)
 import Swarm.Game.Scenario (GameStateInputs (..), ScenarioInputs (..))
-import Swarm.Game.ScenarioInfo (ScenarioCollection, loadScenarios)
+import Swarm.Game.ScenarioInfo (ScenarioCollection, ScenarioInfo, loadScenarios)
 import Swarm.Game.State.Substate
 import Swarm.Game.World.Load (loadWorlds)
 import Swarm.Log
@@ -47,7 +47,7 @@ data RuntimeState = RuntimeState
   { _webPort :: Maybe Int
   , _upstreamRelease :: Either (Severity, Text) String
   , _eventLog :: Notifications LogEntry
-  , _scenarios :: ScenarioCollection
+  , _scenarios :: ScenarioCollection ScenarioInfo
   , _stdGameConfigInputs :: GameStateConfig
   , _appData :: Map Text Text
   }
@@ -131,7 +131,7 @@ upstreamRelease :: Lens' RuntimeState (Either (Severity, Text) String)
 eventLog :: Lens' RuntimeState (Notifications LogEntry)
 
 -- | The collection of scenarios that comes with the game.
-scenarios :: Lens' RuntimeState ScenarioCollection
+scenarios :: Lens' RuntimeState (ScenarioCollection ScenarioInfo)
 
 -- | Built-in resources for loading games
 stdGameConfigInputs :: Lens' RuntimeState GameStateConfig

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -287,7 +287,7 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
   showLaunchDialog = case snd <$> BL.listSelectedElement curMenu of
     Just (SISingle (s, ScenarioPath p)) -> do
       ss <- use $ runtimeState . scenarios
-      let si = loadScenarioInfoFromPath ss p
+      let si = getScenarioInfoFromPath ss p
       Brick.zoom (uiState . uiLaunchConfig) $ prepareLaunchDialog (s, si)
     _ -> pure ()
 

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -518,7 +518,7 @@ quitGame isNoMenu = do
   liftIO $ (`T.appendFile` T.unlines hist) =<< getSwarmHistoryPath True
 
   -- Save scenario status info.
-  saveScenarioInfoOnQuit isNoMenu
+  saveScenarioInfoOnQuit
 
   -- Automatically advance the menu to the next scenario iff the
   -- player has won the current one.

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -65,7 +65,7 @@ import Swarm.Game.Robot.Concrete
 import Swarm.Game.Scenario (scenarioMetadata, scenarioName)
 import Swarm.Game.Scenario.Scoring.Best (scenarioBestByTime)
 import Swarm.Game.Scenario.Scoring.GenericMetrics
-import Swarm.Game.Scenario.Status (ScenarioPath (..))
+import Swarm.Game.Scenario.Status (ScenarioPath (..), ScenarioWith (..), getScenario)
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
@@ -190,7 +190,7 @@ handleMainMenuEvent menu = \case
             firstUnsolved :: Maybe (ScenarioItem ScenarioInfo)
             firstUnsolved = find unsolved tutorials <|> listToMaybe tutorials
             unsolved = \case
-              SISingle (_, si) -> case si ^. scenarioStatus of
+              SISingle (ScenarioWith _ si) -> case si ^. scenarioStatus of
                 Played _ _ best
                   | Metric Completed _ <- best ^. scenarioBestByTime -> False
                   | otherwise -> True
@@ -199,7 +199,7 @@ handleMainMenuEvent menu = \case
             firstUnsolvedInfo = case firstUnsolved of
               Just (SISingle siPair) -> siPair
               _ -> error "No first tutorial found!"
-            firstUnsolvedName = firstUnsolvedInfo ^. _1 . scenarioMetadata . scenarioName
+            firstUnsolvedName = firstUnsolvedInfo ^. getScenario . scenarioMetadata . scenarioName
 
         -- Now set up the menu stack as if the user had chosen "New Game > Tutorials > t"
         -- where t is the tutorial scenario we identified as the first unsolved one
@@ -285,10 +285,10 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
   _ -> pure ()
  where
   showLaunchDialog = case snd <$> BL.listSelectedElement curMenu of
-    Just (SISingle (s, ScenarioPath p)) -> do
+    Just (SISingle (ScenarioWith s (ScenarioPath p))) -> do
       ss <- use $ runtimeState . scenarios
       let si = getScenarioInfoFromPath ss p
-      Brick.zoom (uiState . uiLaunchConfig) $ prepareLaunchDialog (s, si)
+      Brick.zoom (uiState . uiLaunchConfig) $ prepareLaunchDialog $ ScenarioWith s si
     _ -> pure ()
 
 exitNewGameMenu ::

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -179,7 +179,7 @@ handleMainMenuEvent menu = \case
     forM_ (snd <$> BL.listSelectedElement menu) $ \case
       NewGame -> do
         ss <- use $ runtimeState . scenarios
-        uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList $ fmap (ScenarioPath . view scenarioPath) ss)
+        uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList $ pathifyCollection ss)
       Tutorial -> do
         ss <- use $ runtimeState . scenarios
 
@@ -203,8 +203,7 @@ handleMainMenuEvent menu = \case
 
         -- Now set up the menu stack as if the user had chosen "New Game > Tutorials > t"
         -- where t is the tutorial scenario we identified as the first unsolved one
-        let pathifyCollection = fmap (ScenarioPath . view scenarioPath)
-            topMenu =
+        let topMenu =
               BL.listFindBy
                 ((== tutorialsDirname) . T.unpack . scenarioItemName)
                 (mkScenarioList $ pathifyCollection ss)
@@ -216,7 +215,7 @@ handleMainMenuEvent menu = \case
 
         -- Finally, set the menu stack, and start the scenario!
         uiState . uiMenu .= NewGameMenu menuStack
-        startGame (fmap (ScenarioPath . view scenarioPath) firstUnsolvedInfo) Nothing
+        startGame (pathifyCollection firstUnsolvedInfo) Nothing
       Achievements -> uiState . uiMenu .= AchievementsMenu (BL.list AchievementList (V.fromList listAchievements) 1)
       Messages -> do
         runtimeState . eventLog . notificationsCount .= 0

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -186,7 +186,7 @@ handleMainMenuEvent menu = \case
         let tutorialCollection = getTutorials ss
             tutorials = scenarioCollectionToList tutorialCollection
             -- Find first unsolved tutorial, or first tutorial if all are solved
-            firstUnsolved :: Maybe ScenarioItem
+            firstUnsolved :: Maybe (ScenarioItem ScenarioInfo)
             firstUnsolved = find unsolved tutorials <|> listToMaybe tutorials
             unsolved = \case
               SISingle (_, si) -> case si ^. scenarioStatus of
@@ -264,7 +264,7 @@ handleMainMessagesEvent = \case
 
 -- TODO: #2010 Finish porting Controller to KeyEventHandlers
 handleNewGameMenuEvent ::
-  NonEmpty (BL.List Name ScenarioItem) ->
+  NonEmpty (BL.List Name (ScenarioItem ScenarioInfo)) ->
   BrickEvent Name AppEvent ->
   EventM Name AppState ()
 handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
@@ -287,7 +287,9 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
     Just (SISingle siPair) -> Brick.zoom (uiState . uiLaunchConfig) $ prepareLaunchDialog siPair
     _ -> pure ()
 
-exitNewGameMenu :: NonEmpty (BL.List Name ScenarioItem) -> EventM Name AppState ()
+exitNewGameMenu ::
+  NonEmpty (BL.List Name (ScenarioItem ScenarioInfo)) ->
+  EventM Name AppState ()
 exitNewGameMenu stk = do
   uiState
     . uiMenu

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -65,6 +65,7 @@ import Swarm.Game.Robot.Concrete
 import Swarm.Game.Scenario (scenarioMetadata, scenarioName)
 import Swarm.Game.Scenario.Scoring.Best (scenarioBestByTime)
 import Swarm.Game.Scenario.Scoring.GenericMetrics
+import Swarm.Game.Scenario.Status (ScenarioPath (..))
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
@@ -178,7 +179,7 @@ handleMainMenuEvent menu = \case
     forM_ (snd <$> BL.listSelectedElement menu) $ \case
       NewGame -> do
         ss <- use $ runtimeState . scenarios
-        uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList ss)
+        uiState . uiMenu .= NewGameMenu (pure $ mkScenarioList $ fmap (ScenarioPath . view scenarioPath) ss)
       Tutorial -> do
         ss <- use $ runtimeState . scenarios
 
@@ -202,19 +203,20 @@ handleMainMenuEvent menu = \case
 
         -- Now set up the menu stack as if the user had chosen "New Game > Tutorials > t"
         -- where t is the tutorial scenario we identified as the first unsolved one
-        let topMenu =
+        let pathifyCollection = fmap (ScenarioPath . view scenarioPath)
+            topMenu =
               BL.listFindBy
                 ((== tutorialsDirname) . T.unpack . scenarioItemName)
-                (mkScenarioList ss)
+                (mkScenarioList $ pathifyCollection ss)
             tutorialMenu =
               BL.listFindBy
                 ((== firstUnsolvedName) . scenarioItemName)
-                (mkScenarioList tutorialCollection)
+                (mkScenarioList $ pathifyCollection tutorialCollection)
             menuStack = tutorialMenu :| pure topMenu
 
         -- Finally, set the menu stack, and start the scenario!
         uiState . uiMenu .= NewGameMenu menuStack
-        startGame firstUnsolvedInfo Nothing
+        startGame (fmap (ScenarioPath . view scenarioPath) firstUnsolvedInfo) Nothing
       Achievements -> uiState . uiMenu .= AchievementsMenu (BL.list AchievementList (V.fromList listAchievements) 1)
       Messages -> do
         runtimeState . eventLog . notificationsCount .= 0
@@ -264,7 +266,7 @@ handleMainMessagesEvent = \case
 
 -- TODO: #2010 Finish porting Controller to KeyEventHandlers
 handleNewGameMenuEvent ::
-  NonEmpty (BL.List Name (ScenarioItem ScenarioInfo)) ->
+  NonEmpty (BL.List Name (ScenarioItem ScenarioPath)) ->
   BrickEvent Name AppEvent ->
   EventM Name AppState ()
 handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
@@ -284,11 +286,14 @@ handleNewGameMenuEvent scenarioStack@(curMenu :| rest) = \case
   _ -> pure ()
  where
   showLaunchDialog = case snd <$> BL.listSelectedElement curMenu of
-    Just (SISingle siPair) -> Brick.zoom (uiState . uiLaunchConfig) $ prepareLaunchDialog siPair
+    Just (SISingle (s, ScenarioPath p)) -> do
+      ss <- use $ runtimeState . scenarios
+      let si = loadScenarioInfoFromPath ss p
+      Brick.zoom (uiState . uiLaunchConfig) $ prepareLaunchDialog (s, si)
     _ -> pure ()
 
 exitNewGameMenu ::
-  NonEmpty (BL.List Name (ScenarioItem ScenarioInfo)) ->
+  NonEmpty (BL.List Name (ScenarioItem ScenarioPath)) ->
   EventM Name AppState ()
 exitNewGameMenu stk = do
   uiState

--- a/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
@@ -32,7 +32,7 @@ import System.FilePath (splitDirectories)
 getNormalizedCurrentScenarioPath ::
   MonadIO m =>
   GameState ->
-  ScenarioCollection ->
+  ScenarioCollection a ->
   m (Maybe FilePath)
 getNormalizedCurrentScenarioPath gs sc = do
   -- the path should be normalized and good to search in scenario collection

--- a/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
@@ -52,9 +52,6 @@ saveScenarioInfoOnFinish p = do
   ts <- use $ playState . gameState . temporal . ticks
   saved <- use $ playState . gameState . completionStatsSaved
 
-  -- NOTE: This traversal is apparently not the same one as used by
-  -- the scenario selection menu, so the menu needs to be updated separately.
-  -- See Note [scenario menu update]
   let currentScenarioInfo :: Traversal' AppState ScenarioInfo
       currentScenarioInfo = runtimeState . scenarios . scenarioItemByPath p . _SISingle . _2
 

--- a/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
@@ -17,7 +17,7 @@ import Control.Monad.State (MonadState)
 import Data.Maybe (listToMaybe)
 import Data.Time (getZonedTime)
 import Swarm.Game.Achievement.Definitions
-import Swarm.Game.Scenario.Status (scenarioIsCompleted, updateScenarioInfoOnFinish)
+import Swarm.Game.Scenario.Status
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.State
 import Swarm.Game.State.Runtime
@@ -53,7 +53,7 @@ saveScenarioInfoOnFinish p = do
   saved <- use $ playState . gameState . completionStatsSaved
 
   let currentScenarioInfo :: Traversal' AppState ScenarioInfo
-      currentScenarioInfo = runtimeState . scenarios . scenarioItemByPath p . _SISingle . _2
+      currentScenarioInfo = runtimeState . scenarios . scenarioItemByPath p . _SISingle . getScenarioInfo
 
   replHist <- use $ playState . uiGameplay . uiREPL . replHistory
   let determinator = CodeSizeDeterminators initialRunCode $ replHist ^. replHasExecutedManualInput
@@ -74,7 +74,7 @@ saveScenarioInfoOnFinish p = do
 
   -- Check if all tutorials have been completed
   tutorialMap <- use $ runtimeState . scenarios . to getTutorials . to scMap
-  let isComplete (SISingle (_, s)) = scenarioIsCompleted s
+  let isComplete (SISingle (ScenarioWith _ s)) = scenarioIsCompleted s
       -- There are not currently any subcollections within the
       -- tutorials, but checking subcollections recursively just seems
       -- like the right thing to do

--- a/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/SaveScenario.hs
@@ -10,24 +10,22 @@ module Swarm.TUI.Controller.SaveScenario (
 
 -- See Note [liftA2 re-export from Prelude]
 
-import Brick.Widgets.List qualified as BL
 import Control.Lens as Lens
-import Control.Monad (forM_, unless, void, when)
+import Control.Monad (forM_, unless, when)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.State (MonadState)
 import Data.Maybe (listToMaybe)
 import Data.Time (getZonedTime)
 import Swarm.Game.Achievement.Definitions
-import Swarm.Game.Scenario.Status (ScenarioPath (..), scenarioIsCompleted, updateScenarioInfoOnFinish)
+import Swarm.Game.Scenario.Status (scenarioIsCompleted, updateScenarioInfoOnFinish)
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.State
 import Swarm.Game.State.Runtime
 import Swarm.Game.State.Substate
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Achievements (attainAchievement, attainAchievement')
-import Swarm.TUI.Model.Menu (mkNewGameMenu)
 import Swarm.TUI.Model.Repl
-import Swarm.TUI.Model.UI (uiDebugOptions, uiMenu)
+import Swarm.TUI.Model.UI (uiDebugOptions)
 import Swarm.TUI.Model.UI.Gameplay
 import System.FilePath (splitDirectories)
 
@@ -43,7 +41,7 @@ getNormalizedCurrentScenarioPath gs sc = do
 saveScenarioInfoOnFinish ::
   (MonadIO m, MonadState AppState m) =>
   FilePath ->
-  m (Maybe ScenarioInfo)
+  m ()
 saveScenarioInfoOnFinish p = do
   initialRunCode <- use $ playState . gameState . gameControls . initiallyRunCode
   t <- liftIO getZonedTime
@@ -91,8 +89,6 @@ saveScenarioInfoOnFinish p = do
 
   playState . gameState . completionStatsSaved .= won
 
-  return status
-
 -- | Don't save progress for developers or cheaters.
 unlessCheating :: MonadState AppState m => m () -> m ()
 unlessCheating a = do
@@ -110,27 +106,9 @@ saveScenarioInfoOnFinishNocheat = do
     getNormalizedCurrentScenarioPath gs sc >>= mapM_ saveScenarioInfoOnFinish
 
 -- | Write the @ScenarioInfo@ out to disk when exiting a game.
-saveScenarioInfoOnQuit :: (MonadIO m, MonadState AppState m) => Bool -> m ()
-saveScenarioInfoOnQuit isNoMenu = do
+saveScenarioInfoOnQuit :: (MonadIO m, MonadState AppState m) => m ()
+saveScenarioInfoOnQuit = do
   sc <- use $ runtimeState . scenarios
   gs <- use $ playState . gameState
   unlessCheating $
-    getNormalizedCurrentScenarioPath gs sc >>= mapM_ go
- where
-  go p = do
-    void $ saveScenarioInfoOnFinish p
-
-    -- See what scenario is currently focused in the menu.  Depending on how the
-    -- previous scenario ended (via quit vs. via win), it might be the same as
-    -- currentScenarioPath or it might be different.
-    curPath <- preuse $ uiState . uiMenu . _NewGameMenu . ix 0 . BL.listSelectedElementL . _SISingle . _2
-
-    -- If the menu is NoMenu, it means we skipped showing the
-    -- menu at startup, so leave it alone; we simply want to
-    -- exit the entire app.
-    -- Otherwise, rebuild the NewGameMenu so it gets the updated
-    -- ScenarioInfo, being sure to preserve the same focused
-    -- scenario.
-    unless isNoMenu $ do
-      sc <- use $ runtimeState . scenarios
-      forM_ (mkNewGameMenu sc (maybe p getScenarioPath curPath)) (uiState . uiMenu .=)
+    getNormalizedCurrentScenarioPath gs sc >>= mapM_ saveScenarioInfoOnFinish

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -17,6 +17,7 @@ import Data.Map qualified as M
 import Data.Yaml qualified as Y
 import Graphics.Vty qualified as V
 import Swarm.Game.Land
+import Swarm.Game.Scenario.Status
 import Swarm.Game.Scenario.Topography.EntityFacade
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
@@ -155,6 +156,6 @@ saveMapFile = do
       fp = worldEditor ^. outputFilePath
       maybeScenarioPair = uig ^. scenarioRef
 
-  liftIO $ Y.encodeFile fp $ constructScenario (fst <$> maybeScenarioPair) mapCellGrid
+  liftIO $ Y.encodeFile fp $ constructScenario (view getScenario <$> maybeScenarioPair) mapCellGrid
 
   uiGameplay . uiWorldEditor . lastWorldEditorMessage .= Just "Saved."

--- a/src/swarm-tui/Swarm/TUI/Editor/View.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/View.hs
@@ -10,6 +10,7 @@ import Control.Lens hiding (Const, from)
 import Data.List qualified as L
 import Swarm.Game.Land
 import Swarm.Game.Scenario
+import Swarm.Game.Scenario.Status
 import Swarm.Game.Scenario.Topography.Area qualified as EA
 import Swarm.Game.Scenario.Topography.EntityFacade
 import Swarm.Game.Terrain (TerrainMap, TerrainType)
@@ -28,7 +29,7 @@ import Swarm.Util (applyWhen)
 
 extractTerrainMap :: UIGameplay -> TerrainMap
 extractTerrainMap uig =
-  maybe mempty (view (scenarioLandscape . scenarioTerrainAndEntities . terrainMap) . fst) $
+  maybe mempty (view $ getScenario . scenarioLandscape . scenarioTerrainAndEntities . terrainMap) $
     uig ^. scenarioRef
 
 drawWorldEditor :: FocusRing Name -> UIGameplay -> Widget Name

--- a/src/swarm-tui/Swarm/TUI/Launch/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Launch/Controller.hs
@@ -117,7 +117,7 @@ handleFBEvent ev = do
     cacheValidatedInputs
 
 handleLaunchOptionsEvent ::
-  ScenarioInfoPair ->
+  ScenarioInfoPair ScenarioInfo ->
   BrickEvent Name AppEvent ->
   EventM Name AppState ()
 handleLaunchOptionsEvent siPair = \case

--- a/src/swarm-tui/Swarm/TUI/Launch/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Launch/Controller.hs
@@ -117,7 +117,7 @@ handleFBEvent ev = do
     cacheValidatedInputs
 
 handleLaunchOptionsEvent ::
-  ScenarioInfoPair ScenarioInfo ->
+  ScenarioWith ScenarioInfo ->
   BrickEvent Name AppEvent ->
   EventM Name AppState ()
 handleLaunchOptionsEvent siPair = \case

--- a/src/swarm-tui/Swarm/TUI/Launch/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Launch/Model.hs
@@ -16,7 +16,7 @@ import Control.Lens (makeLenses)
 import Data.Functor.Identity (Identity (Identity))
 import Data.Text (Text)
 import Swarm.Failure (SystemFailure)
-import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (LaunchParams), ScenarioInfoPair, SerializableLaunchParams)
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (LaunchParams), ScenarioInfo, ScenarioInfoPair, SerializableLaunchParams)
 import Swarm.Game.State (LaunchParams, ValidatedLaunchParams, getRunCodePath, parseCodeFile)
 import Swarm.Pretty (prettyText)
 import Swarm.TUI.Model.Name
@@ -50,7 +50,7 @@ data LaunchControls = LaunchControls
   { _fileBrowser :: FileBrowserControl
   , _seedValueEditor :: Editor Text Name
   , _scenarioConfigFocusRing :: Focus.FocusRing Name
-  , _isDisplayedFor :: Maybe ScenarioInfoPair
+  , _isDisplayedFor :: Maybe (ScenarioInfoPair ScenarioInfo)
   }
 
 makeLenses ''LaunchControls

--- a/src/swarm-tui/Swarm/TUI/Launch/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Launch/Model.hs
@@ -16,7 +16,7 @@ import Control.Lens (makeLenses)
 import Data.Functor.Identity (Identity (Identity))
 import Data.Text (Text)
 import Swarm.Failure (SystemFailure)
-import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (LaunchParams), ScenarioInfo, ScenarioInfoPair, SerializableLaunchParams)
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (LaunchParams), ScenarioInfo, ScenarioWith, SerializableLaunchParams)
 import Swarm.Game.State (LaunchParams, ValidatedLaunchParams, getRunCodePath, parseCodeFile)
 import Swarm.Pretty (prettyText)
 import Swarm.TUI.Model.Name
@@ -50,7 +50,7 @@ data LaunchControls = LaunchControls
   { _fileBrowser :: FileBrowserControl
   , _seedValueEditor :: Editor Text Name
   , _scenarioConfigFocusRing :: Focus.FocusRing Name
-  , _isDisplayedFor :: Maybe (ScenarioInfoPair ScenarioInfo)
+  , _isDisplayedFor :: Maybe (ScenarioWith ScenarioInfo)
   }
 
 makeLenses ''LaunchControls

--- a/src/swarm-tui/Swarm/TUI/Launch/Prep.hs
+++ b/src/swarm-tui/Swarm/TUI/Launch/Prep.hs
@@ -20,7 +20,7 @@ import Data.Functor.Identity (runIdentity)
 import Data.List.Extra (enumerate)
 import Data.Text qualified as T
 import Swarm.Failure (SystemFailure)
-import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (..), ScenarioInfo, ScenarioInfoPair, getLaunchParams, scenarioStatus)
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (..), ScenarioInfo, ScenarioWith (..), getLaunchParams, scenarioStatus)
 import Swarm.Game.State (ValidatedLaunchParams, getRunCodePath, parseCodeFile)
 import Swarm.Game.World.Gen (Seed)
 import Swarm.Pretty (prettyText)
@@ -116,9 +116,9 @@ initFileBrowserWidget maybePlayedScript = do
 -- * The "marked file" is persisted outside of the 'FB.FileBrowser' state, and the
 --   "initial directory" is set upon instantiation from that external state.
 prepareLaunchDialog ::
-  ScenarioInfoPair ScenarioInfo ->
+  ScenarioWith ScenarioInfo ->
   EventM Name LaunchOptions ()
-prepareLaunchDialog siPair@(_, si) = do
+prepareLaunchDialog siPair@(ScenarioWith _ si) = do
   let serializableLaunchParams = getLaunchParams $ si ^. scenarioStatus
   launchEditingParams <- liftIO $ fromSerializableParams serializableLaunchParams
   editingParams .= launchEditingParams

--- a/src/swarm-tui/Swarm/TUI/Launch/Prep.hs
+++ b/src/swarm-tui/Swarm/TUI/Launch/Prep.hs
@@ -20,7 +20,7 @@ import Data.Functor.Identity (runIdentity)
 import Data.List.Extra (enumerate)
 import Data.Text qualified as T
 import Swarm.Failure (SystemFailure)
-import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (..), ScenarioInfoPair, getLaunchParams, scenarioStatus)
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (..), ScenarioInfo, ScenarioInfoPair, getLaunchParams, scenarioStatus)
 import Swarm.Game.State (ValidatedLaunchParams, getRunCodePath, parseCodeFile)
 import Swarm.Game.World.Gen (Seed)
 import Swarm.Pretty (prettyText)
@@ -116,7 +116,7 @@ initFileBrowserWidget maybePlayedScript = do
 -- * The "marked file" is persisted outside of the 'FB.FileBrowser' state, and the
 --   "initial directory" is set upon instantiation from that external state.
 prepareLaunchDialog ::
-  ScenarioInfoPair ->
+  ScenarioInfoPair ScenarioInfo ->
   EventM Name LaunchOptions ()
 prepareLaunchDialog siPair@(_, si) = do
   let serializableLaunchParams = getLaunchParams $ si ^. scenarioStatus

--- a/src/swarm-tui/Swarm/TUI/Launch/View.hs
+++ b/src/swarm-tui/Swarm/TUI/Launch/View.hs
@@ -20,7 +20,7 @@ import Data.Either (isRight)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Game.Scenario (scenarioLandscape, scenarioSeed)
-import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (..))
+import Swarm.Game.Scenario.Status (ParameterizableLaunchParams (..), getScenario)
 import Swarm.Game.State (getRunCodePath)
 import Swarm.TUI.Launch.Model
 import Swarm.TUI.Launch.Prep
@@ -103,7 +103,7 @@ drawLaunchConfigPanel (LaunchOptions lc launchParams) =
 
   scenarioSeedText =
     maybe "random" show $
-      view (scenarioLandscape . scenarioSeed) . fst =<< displayedFor
+      view (getScenario . scenarioLandscape . scenarioSeed) =<< displayedFor
 
   mkSeedEntryWidget seedEntryContent =
     if isFocused SeedSelector

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -33,7 +33,6 @@ module Swarm.TUI.Model (
   Menu (..),
   _NewGameMenu,
   mkScenarioList,
-  mkNewGameMenu,
 
   -- * UI state
 
@@ -313,7 +312,7 @@ defaultAppOpts =
 --   currently selected scenario (if any).  Can return @Nothing@ if
 --   either we are not in the @NewGameMenu@, or the current scenario
 --   is the last among its siblings.
-nextScenario :: Menu -> Maybe (ScenarioInfoPair ScenarioInfo)
+nextScenario :: Menu -> Maybe (ScenarioInfoPair ScenarioPath)
 nextScenario = \case
   NewGameMenu (curMenu :| _) ->
     let nextMenuList = BL.listMoveDown curMenu

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -313,7 +313,7 @@ defaultAppOpts =
 --   currently selected scenario (if any).  Can return @Nothing@ if
 --   either we are not in the @NewGameMenu@, or the current scenario
 --   is the last among its siblings.
-nextScenario :: Menu -> Maybe ScenarioInfoPair
+nextScenario :: Menu -> Maybe (ScenarioInfoPair ScenarioInfo)
 nextScenario = \case
   NewGameMenu (curMenu :| _) ->
     let nextMenuList = BL.listMoveDown curMenu

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -312,7 +312,7 @@ defaultAppOpts =
 --   currently selected scenario (if any).  Can return @Nothing@ if
 --   either we are not in the @NewGameMenu@, or the current scenario
 --   is the last among its siblings.
-nextScenario :: Menu -> Maybe (ScenarioInfoPair ScenarioPath)
+nextScenario :: Menu -> Maybe (ScenarioWith ScenarioPath)
 nextScenario = \case
   NewGameMenu (curMenu :| _) ->
     let nextMenuList = BL.listMoveDown curMenu

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -24,8 +24,8 @@ import Swarm.Game.Ingredients
 import Swarm.Game.Scenario.Status (ScenarioPath (..))
 import Swarm.Game.ScenarioInfo (
   ScenarioCollection,
-  ScenarioInfoPair,
   ScenarioItem (..),
+  ScenarioWith,
   scenarioCollectionToList,
  )
 import Swarm.Game.World.Gen (Seed)
@@ -57,9 +57,9 @@ data ModalType
 data ButtonAction
   = Cancel
   | KeepPlaying
-  | StartOver Seed (ScenarioInfoPair ScenarioPath)
+  | StartOver Seed (ScenarioWith ScenarioPath)
   | QuitAction
-  | Next (ScenarioInfoPair ScenarioPath)
+  | Next (ScenarioWith ScenarioPath)
 
 data Modal = Modal
   { _modalType :: ModalType

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -62,9 +62,9 @@ data ModalType
 data ButtonAction
   = Cancel
   | KeepPlaying
-  | StartOver Seed ScenarioInfoPair
+  | StartOver Seed (ScenarioInfoPair ScenarioInfo)
   | QuitAction
-  | Next ScenarioInfoPair
+  | Next (ScenarioInfoPair ScenarioInfo)
 
 data Modal = Modal
   { _modalType :: ModalType
@@ -90,7 +90,7 @@ data Menu
     -- menu item is ALWAYS the same as the scenario currently being played.
     -- See https://github.com/swarm-game/swarm/issues/1064 and
     -- https://github.com/swarm-game/swarm/pull/1065.
-    NewGameMenu (NonEmpty (BL.List Name ScenarioItem))
+    NewGameMenu (NonEmpty (BL.List Name (ScenarioItem ScenarioInfo)))
   | AchievementsMenu (BL.List Name CategorizedAchievement)
   | MessagesMenu
   | AboutMenu
@@ -101,25 +101,25 @@ mainMenu e = BL.list MenuList (V.fromList enumerate) 1 & BL.listMoveToElement e
 makePrisms ''Menu
 
 -- | Create a brick 'BL.List' of scenario items from a 'ScenarioCollection'.
-mkScenarioList :: ScenarioCollection -> BL.List Name ScenarioItem
+mkScenarioList :: ScenarioCollection ScenarioInfo -> BL.List Name (ScenarioItem ScenarioInfo)
 mkScenarioList = flip (BL.list ScenarioList) 1 . V.fromList . scenarioCollectionToList
 
 -- | Given a 'ScenarioCollection' and a 'FilePath' which is the canonical
 --   path to some folder or scenario, construct a 'NewGameMenu' stack
 --   focused on the given item, if possible.
-mkNewGameMenu :: ScenarioCollection -> FilePath -> Maybe Menu
+mkNewGameMenu :: ScenarioCollection ScenarioInfo -> FilePath -> Maybe Menu
 mkNewGameMenu sc path = fmap NewGameMenu $ NE.nonEmpty =<< go (Just sc) (splitPath path) []
  where
   go ::
-    Maybe ScenarioCollection ->
+    Maybe (ScenarioCollection ScenarioInfo) ->
     [FilePath] ->
-    [BL.List Name ScenarioItem] ->
-    Maybe [BL.List Name ScenarioItem]
+    [BL.List Name (ScenarioItem ScenarioInfo)] ->
+    Maybe [BL.List Name (ScenarioItem ScenarioInfo)]
   go _ [] stk = Just stk
   go Nothing _ _ = Nothing
   go (Just curSC) (thing : rest) stk = go nextSC rest (lst : stk)
    where
-    hasName :: ScenarioItem -> Bool
+    hasName :: ScenarioItem ScenarioInfo -> Bool
     hasName (SISingle (_, ScenarioInfo pth _)) = takeFileName pth == thing
     hasName (SICollection nm _) = nm == into @Text (dropTrailingPathSeparator thing)
 

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -16,26 +16,20 @@ import Brick.Widgets.List qualified as BL
 import Control.Lens hiding (from, (<.>))
 import Data.List.Extra (enumerate)
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.List.NonEmpty qualified as NE
-import Data.Map.Ordered qualified as OM
 import Data.Text (Text)
 import Data.Vector qualified as V
 import Swarm.Game.Achievement.Definitions
 import Swarm.Game.Entity as E
 import Swarm.Game.Ingredients
-import Swarm.Game.Scenario.Status (ScenarioPath (..), scenarioPath)
+import Swarm.Game.Scenario.Status (ScenarioPath (..))
 import Swarm.Game.ScenarioInfo (
   ScenarioCollection,
-  ScenarioInfo (..),
   ScenarioInfoPair,
   ScenarioItem (..),
-  scMap,
   scenarioCollectionToList,
  )
 import Swarm.Game.World.Gen (Seed)
 import Swarm.TUI.Model.Name
-import System.FilePath (dropTrailingPathSeparator, splitPath, takeFileName)
-import Witch (into)
 
 ------------------------------------------------------------
 -- Menus and dialogs
@@ -107,31 +101,6 @@ mkScenarioList =
   flip (BL.list ScenarioList) 1
     . V.fromList
     . scenarioCollectionToList
-
--- | Given a 'ScenarioCollection' and a 'FilePath' which is the canonical
---   path to some folder or scenario, construct a 'NewGameMenu' stack
---   focused on the given item, if possible.
-mkNewGameMenu :: ScenarioCollection ScenarioInfo -> FilePath -> Maybe Menu
-mkNewGameMenu sc path = fmap NewGameMenu $ NE.nonEmpty =<< go (Just sc) (splitPath path) []
- where
-  go ::
-    Maybe (ScenarioCollection ScenarioInfo) ->
-    [FilePath] ->
-    [BL.List Name (ScenarioItem ScenarioPath)] ->
-    Maybe [BL.List Name (ScenarioItem ScenarioPath)]
-  go _ [] stk = Just stk
-  go Nothing _ _ = Nothing
-  go (Just curSC) (thing : rest) stk = go nextSC rest (lst : stk)
-   where
-    hasName :: ScenarioItem ScenarioPath -> Bool
-    hasName (SISingle (_, ScenarioPath pth)) = takeFileName pth == thing
-    hasName (SICollection nm _) = nm == into @Text (dropTrailingPathSeparator thing)
-
-    lst = BL.listFindBy hasName (mkScenarioList $ fmap (ScenarioPath . view scenarioPath) curSC)
-
-    nextSC = case OM.lookup (dropTrailingPathSeparator thing) (scMap curSC) of
-      Just (SICollection _ c) -> Just c
-      _ -> Nothing
 
 ------------------------------------------------------------
 -- Inventory list entries

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -236,7 +236,7 @@ constructAppState rs ui key opts@(AppOpts {..}) = do
       }
 
 -- | Load a 'Scenario' and start playing the game.
-startGame :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair -> Maybe CodeToRun -> m ()
+startGame :: (MonadIO m, MonadState AppState m) => ScenarioInfoPair ScenarioInfo -> Maybe CodeToRun -> m ()
 startGame siPair = startGameWithSeed siPair . LaunchParams (pure Nothing) . pure
 
 -- | Re-initialize the game from the stored reference to the current scenario.
@@ -248,14 +248,19 @@ startGame siPair = startGameWithSeed siPair . LaunchParams (pure Nothing) . pure
 --
 -- Since scenarios are stored as a Maybe in the UI state, we handle the Nothing
 -- case upstream so that the Scenario passed to this function definitely exists.
-restartGame :: (MonadIO m, MonadState AppState m) => Seed -> ScenarioInfoPair -> m ()
-restartGame currentSeed siPair = startGameWithSeed siPair $ LaunchParams (pure (Just currentSeed)) (pure Nothing)
+restartGame ::
+  (MonadIO m, MonadState AppState m) =>
+  Seed ->
+  ScenarioInfoPair ScenarioInfo ->
+  m ()
+restartGame currentSeed siPair =
+  startGameWithSeed siPair $ LaunchParams (pure (Just currentSeed)) (pure Nothing)
 
 -- | Load a 'Scenario' and start playing the game, with the
 --   possibility for the user to override the seed.
 startGameWithSeed ::
   (MonadIO m, MonadState AppState m) =>
-  ScenarioInfoPair ->
+  ScenarioInfoPair ScenarioInfo ->
   ValidatedLaunchParams ->
   m ()
 startGameWithSeed siPair@(_scene, si) lp = do
@@ -290,7 +295,7 @@ startGameWithSeed siPair@(_scene, si) lp = do
 -- | Modify the 'AppState' appropriately when starting a new scenario.
 scenarioToAppState ::
   (MonadIO m, MonadState AppState m) =>
-  ScenarioInfoPair ->
+  ScenarioInfoPair ScenarioInfo ->
   ValidatedLaunchParams ->
   m ()
 scenarioToAppState siPair@(scene, _) lp = do
@@ -318,7 +323,7 @@ setUIGameplay ::
   GameState ->
   TimeSpec ->
   Bool ->
-  ScenarioInfoPair ->
+  ScenarioInfoPair ScenarioInfo ->
   UIGameplay ->
   UIGameplay
 setUIGameplay gs curTime isAutoplaying siPair@(scenario, _) uig =
@@ -356,7 +361,7 @@ setUIGameplay gs curTime isAutoplaying siPair@(scenario, _) uig =
 
 -- | Modify the UI state appropriately when starting a new scenario.
 scenarioToUIState ::
-  ScenarioInfoPair ->
+  ScenarioInfoPair ScenarioInfo ->
   UIState ->
   IO UIState
 scenarioToUIState siPair u = do

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -63,6 +63,7 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Type (originalStruct
 import Swarm.Game.ScenarioInfo (
   ScenarioCollection,
   normalizeScenarioPath,
+  pathifyCollection,
   scenarioItemByPath,
   _SISingle,
  )
@@ -294,7 +295,7 @@ startGameWithSeed siPair@(_scene, si) lp = do
       (Metric Attempted $ ProgressStats t emptyAttemptMetric)
       (prevBest t)
 
-  scenarioToAppState (fmap (ScenarioPath . view scenarioPath) siPair) lp
+  scenarioToAppState (pathifyCollection siPair) lp
   -- Beware: currentScenarioPath must be set so that progress/achievements can be saved.
   -- It has just been cleared in scenarioToAppState.
   playState . gameState . currentScenarioPath .= Just p

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -14,7 +14,7 @@ module Swarm.TUI.Model.StateUpdate (
   restartGame,
   attainAchievement,
   attainAchievement',
-  loadScenarioInfoFromPath,
+  getScenarioInfoFromPath,
   scenarioToAppState,
 ) where
 
@@ -146,11 +146,11 @@ initPersistentState opts@(AppOpts {..}) = do
   let initRS' = addWarnings initRS (F.toList warnings)
   return (initRS', initUI, initKs)
 
-loadScenarioInfoFromPath ::
+getScenarioInfoFromPath ::
   ScenarioCollection ScenarioInfo ->
   FilePath ->
   ScenarioInfo
-loadScenarioInfoFromPath ss path =
+getScenarioInfoFromPath ss path =
   fromMaybe (ScenarioInfo path NotStarted) currentScenarioInfo
  where
   currentScenarioInfo = ss ^? scenarioItemByPath path . _SISingle . _2
@@ -187,7 +187,7 @@ constructAppState rs ui key opts@(AppOpts {..}) = do
             return $ CodeToRun ScenarioSuggested soln
           codeToRun = maybeAutoplay <|> maybeRunScript
 
-      let si = loadScenarioInfoFromPath (rs ^. scenarios) path
+      let si = getScenarioInfoFromPath (rs ^. scenarios) path
 
       sendIO $
         execStateT
@@ -250,7 +250,7 @@ startGame ::
   m ()
 startGame (s, ScenarioPath p) c = do
   ss <- use $ runtimeState . scenarios
-  let si = loadScenarioInfoFromPath ss p
+  let si = getScenarioInfoFromPath ss p
   startGameWithSeed (s, si) . LaunchParams (pure Nothing) $ pure c
 
 -- | Re-initialize the game from the stored reference to the current scenario.
@@ -269,7 +269,7 @@ restartGame ::
   m ()
 restartGame currentSeed (s, ScenarioPath p) = do
   ss <- use $ runtimeState . scenarios
-  let si = loadScenarioInfoFromPath ss p
+  let si = getScenarioInfoFromPath ss p
   startGameWithSeed (s, si) $ LaunchParams (pure (Just currentSeed)) (pure Nothing)
 
 -- | Load a 'Scenario' and start playing the game, with the

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -283,10 +283,6 @@ startGameWithSeed siPair@(_scene, si) lp = do
   ss <- use $ runtimeState . scenarios
   p <- liftIO $ normalizeScenarioPath ss $ si ^. scenarioPath
 
-  let prevBest = case si ^. scenarioStatus of
-        NotStarted -> emptyBest t
-        Played _ _ b -> b
-
   runtimeState
     . scenarios
     . scenarioItemByPath p
@@ -296,7 +292,7 @@ startGameWithSeed siPair@(_scene, si) lp = do
     .= Played
       (toSerializableParams lp)
       (Metric Attempted $ ProgressStats t emptyAttemptMetric)
-      prevBest
+      (prevBest t)
 
   scenarioToAppState (fmap (ScenarioPath . view scenarioPath) siPair) lp
   -- Beware: currentScenarioPath must be set so that progress/achievements can be saved.
@@ -308,6 +304,10 @@ startGameWithSeed siPair@(_scene, si) lp = do
   debugging <- use $ uiState . uiDebugOptions
   unless (null debugging) $
     uiState . uiPopups %= addPopup DebugWarningPopup
+ where
+  prevBest t = case si ^. scenarioStatus of
+    NotStarted -> emptyBest t
+    Played _ _ b -> b
 
 -- | Modify the 'AppState' appropriately when starting a new scenario.
 scenarioToAppState ::

--- a/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
@@ -56,8 +56,8 @@ import Brick.Widgets.List qualified as BL
 import Control.Lens hiding (from, (<.>))
 import Data.Bits (FiniteBits (finiteBitSize))
 import Data.Text (Text)
+import Swarm.Game.Scenario.Status (ScenarioPath)
 import Swarm.Game.ScenarioInfo (
-  ScenarioInfo,
   ScenarioInfoPair,
  )
 import Swarm.Game.Universe
@@ -213,7 +213,7 @@ data UIGameplay = UIGameplay
   , _uiShowDebug :: Bool
   , _uiHideRobotsUntil :: TimeSpec
   , _uiTiming :: UITiming
-  , _scenarioRef :: Maybe (ScenarioInfoPair ScenarioInfo)
+  , _scenarioRef :: Maybe (ScenarioInfoPair ScenarioPath)
   }
 
 -- * Lenses for UIGameplay
@@ -270,4 +270,4 @@ uiShowRobots :: Getter UIGameplay Bool
 uiShowRobots = to (\ui -> ui ^. uiTiming . lastFrameTime > ui ^. uiHideRobotsUntil)
 
 -- | The currently active Scenario description, useful for starting over.
-scenarioRef :: Lens' UIGameplay (Maybe (ScenarioInfoPair ScenarioInfo))
+scenarioRef :: Lens' UIGameplay (Maybe (ScenarioInfoPair ScenarioPath))

--- a/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
@@ -58,7 +58,7 @@ import Data.Bits (FiniteBits (finiteBitSize))
 import Data.Text (Text)
 import Swarm.Game.Scenario.Status (ScenarioPath)
 import Swarm.Game.ScenarioInfo (
-  ScenarioInfoPair,
+  ScenarioWith,
  )
 import Swarm.Game.Universe
 import Swarm.Game.World.Coords
@@ -213,7 +213,7 @@ data UIGameplay = UIGameplay
   , _uiShowDebug :: Bool
   , _uiHideRobotsUntil :: TimeSpec
   , _uiTiming :: UITiming
-  , _scenarioRef :: Maybe (ScenarioInfoPair ScenarioPath)
+  , _scenarioRef :: Maybe (ScenarioWith ScenarioPath)
   }
 
 -- * Lenses for UIGameplay
@@ -270,4 +270,4 @@ uiShowRobots :: Getter UIGameplay Bool
 uiShowRobots = to (\ui -> ui ^. uiTiming . lastFrameTime > ui ^. uiHideRobotsUntil)
 
 -- | The currently active Scenario description, useful for starting over.
-scenarioRef :: Lens' UIGameplay (Maybe (ScenarioInfoPair ScenarioPath))
+scenarioRef :: Lens' UIGameplay (Maybe (ScenarioWith ScenarioPath))

--- a/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
@@ -57,6 +57,7 @@ import Control.Lens hiding (from, (<.>))
 import Data.Bits (FiniteBits (finiteBitSize))
 import Data.Text (Text)
 import Swarm.Game.ScenarioInfo (
+  ScenarioInfo,
   ScenarioInfoPair,
  )
 import Swarm.Game.Universe
@@ -212,7 +213,7 @@ data UIGameplay = UIGameplay
   , _uiShowDebug :: Bool
   , _uiHideRobotsUntil :: TimeSpec
   , _uiTiming :: UITiming
-  , _scenarioRef :: Maybe ScenarioInfoPair
+  , _scenarioRef :: Maybe (ScenarioInfoPair ScenarioInfo)
   }
 
 -- * Lenses for UIGameplay
@@ -269,4 +270,4 @@ uiShowRobots :: Getter UIGameplay Bool
 uiShowRobots = to (\ui -> ui ^. uiTiming . lastFrameTime > ui ^. uiHideRobotsUntil)
 
 -- | The currently active Scenario description, useful for starting over.
-scenarioRef :: Lens' UIGameplay (Maybe ScenarioInfoPair)
+scenarioRef :: Lens' UIGameplay (Maybe (ScenarioInfoPair ScenarioInfo))

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -199,7 +199,7 @@ newVersionWidget = \case
 -- | When launching a game, a modal prompt may appear on another layer
 -- to input seed and/or a script to run.
 drawNewGameMenuUI ::
-  NonEmpty (BL.List Name ScenarioItem) ->
+  NonEmpty (BL.List Name (ScenarioItem ScenarioInfo)) ->
   LaunchOptions ->
   [Widget Name]
 drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
@@ -249,14 +249,14 @@ drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
     NotStarted -> withAttr cyanAttr $ txt "not started"
     Played _initialScript pm _best -> describeProgress pm
 
-  breadcrumbs :: [BL.List Name ScenarioItem] -> Text
+  breadcrumbs :: [BL.List Name (ScenarioItem ScenarioInfo)] -> Text
   breadcrumbs =
     T.intercalate " > "
       . ("Scenarios" :)
       . reverse
       . mapMaybe (fmap (scenarioItemName . snd) . BL.listSelectedElement)
 
-  drawDescription :: ScenarioItem -> Widget Name
+  drawDescription :: ScenarioItem ScenarioInfo -> Widget Name
   drawDescription (SICollection _ _) = txtWrap " "
   drawDescription (SISingle (s, si)) =
     vBox

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -100,7 +100,9 @@ import Swarm.Game.Scenario.Topography.Center
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.ScenarioInfo (
   ScenarioItem (..),
+  scenarioItemByPath,
   scenarioItemName,
+  _SISingle,
  )
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
@@ -166,7 +168,7 @@ drawMenuUI s = case s ^. uiState . uiMenu of
   -- quit the app instead.  But just in case, we display the main menu anyway.
   NoMenu -> [drawMainMenuUI s (mainMenu NewGame)]
   MainMenu l -> [drawMainMenuUI s l]
-  NewGameMenu stk -> drawNewGameMenuUI stk $ s ^. uiState . uiLaunchConfig
+  NewGameMenu stk -> drawNewGameMenuUI s stk $ s ^. uiState . uiLaunchConfig
   AchievementsMenu l -> [drawAchievementsMenuUI s l]
   MessagesMenu -> [drawMainMessages s]
   AboutMenu -> [drawAboutMenuUI (s ^. runtimeState . appData . at "about")]
@@ -199,10 +201,11 @@ newVersionWidget = \case
 -- | When launching a game, a modal prompt may appear on another layer
 -- to input seed and/or a script to run.
 drawNewGameMenuUI ::
-  NonEmpty (BL.List Name (ScenarioItem ScenarioInfo)) ->
+  AppState ->
+  NonEmpty (BL.List Name (ScenarioItem ScenarioPath)) ->
   LaunchOptions ->
   [Widget Name]
-drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
+drawNewGameMenuUI appState (l :| ls) launchOptions = case displayedFor of
   Nothing -> pure mainWidget
   Just _ -> drawLaunchConfigPanel launchOptions <> pure mainWidget
  where
@@ -232,14 +235,19 @@ drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
     (Nothing, Just (SISingle _)) -> hCenter $ txt "Press 'o' for launch options, or 'Enter' to launch with defaults"
     _ -> txt " "
 
-  drawScenarioItem (SISingle (s, si)) = padRight (Pad 1) (drawStatusInfo s si) <+> txt (s ^. scenarioMetadata . scenarioName)
+  drawScenarioItem (SISingle (s, ScenarioPath sPath)) = padRight (Pad 1) (drawStatusInfo s sPath) <+> txt (s ^. scenarioMetadata . scenarioName)
   drawScenarioItem (SICollection nm _) = padRight (Pad 1) (withAttr boldAttr $ txt " > ") <+> txt nm
-  drawStatusInfo s si = case si ^. scenarioStatus of
-    NotStarted -> txt " ○ "
-    Played _script _latestMetric best | isCompleted best -> withAttr greenAttr $ txt " ● "
-    Played {} -> case s ^. scenarioOperation . scenarioObjectives of
-      [] -> withAttr cyanAttr $ txt " ◉ "
-      _ -> withAttr yellowAttr $ txt " ◎ "
+
+  drawStatusInfo s sPath = case currentScenarioInfo of
+    Nothing -> emptyWidget
+    Just si -> case si ^. scenarioStatus of
+      NotStarted -> txt " ○ "
+      Played _script _latestMetric best | isCompleted best -> withAttr greenAttr $ txt " ● "
+      Played {} -> case s ^. scenarioOperation . scenarioObjectives of
+        [] -> withAttr cyanAttr $ txt " ◉ "
+        _ -> withAttr yellowAttr $ txt " ◎ "
+   where
+    currentScenarioInfo = appState ^? runtimeState . scenarios . scenarioItemByPath sPath . _SISingle . _2
 
   isCompleted :: BestRecords -> Bool
   isCompleted best = best ^. scenarioBestByTime . metricProgress == Completed
@@ -249,25 +257,27 @@ drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
     NotStarted -> withAttr cyanAttr $ txt "not started"
     Played _initialScript pm _best -> describeProgress pm
 
-  breadcrumbs :: [BL.List Name (ScenarioItem ScenarioInfo)] -> Text
+  breadcrumbs :: [BL.List Name (ScenarioItem ScenarioPath)] -> Text
   breadcrumbs =
     T.intercalate " > "
       . ("Scenarios" :)
       . reverse
       . mapMaybe (fmap (scenarioItemName . snd) . BL.listSelectedElement)
 
-  drawDescription :: ScenarioItem ScenarioInfo -> Widget Name
+  drawDescription :: ScenarioItem ScenarioPath -> Widget Name
   drawDescription (SICollection _ _) = txtWrap " "
-  drawDescription (SISingle (s, si)) =
+  drawDescription (SISingle (s, ScenarioPath sPath)) =
     vBox
       [ drawMarkdown (nonBlank (s ^. scenarioOperation . scenarioDescription))
-      , cached (ScenarioPreview $ si ^. scenarioPath) $
+      , cached (ScenarioPreview sPath) $
           hCenter . padTop (Pad 1) . vLimit 6 $
             hLimitPercent 60 worldPeek
       , padTop (Pad 1) table
       ]
    where
     vc = determineStaticViewCenter (s ^. scenarioLandscape) worldTuples
+
+    currentScenarioInfo = appState ^? runtimeState . scenarios . scenarioItemByPath sPath . _SISingle . _2
 
     worldTuples = buildWorldTuples $ s ^. scenarioLandscape
     theWorlds =
@@ -295,15 +305,19 @@ drawNewGameMenuUI (l :| ls) launchOptions = case displayedFor of
       )
     secondRow =
       ( txt "last:"
-      , Just $ describeStatus $ si ^. scenarioStatus
+      , stat
       )
+     where
+      stat = case currentScenarioInfo of
+        Nothing -> Nothing
+        Just si -> Just $ describeStatus $ si ^. scenarioStatus
 
     padTopLeft = padTop (Pad 1) . padLeft (Pad 1)
 
     tableRows =
       map (map padTopLeft . pairToList) $
         mapMaybe sequenceA $
-          firstRow : secondRow : makeBestScoreRows (si ^. scenarioStatus)
+          firstRow : secondRow : maybe [] (makeBestScoreRows . view scenarioStatus) currentScenarioInfo
     table =
       BT.renderTable
         . BT.surroundingBorder False

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -235,7 +235,7 @@ drawNewGameMenuUI appState (l :| ls) launchOptions = case displayedFor of
     (Nothing, Just (SISingle _)) -> hCenter $ txt "Press 'o' for launch options, or 'Enter' to launch with defaults"
     _ -> txt " "
 
-  drawScenarioItem (SISingle (s, ScenarioPath sPath)) = padRight (Pad 1) (drawStatusInfo s sPath) <+> txt (s ^. scenarioMetadata . scenarioName)
+  drawScenarioItem (SISingle (ScenarioWith s (ScenarioPath sPath))) = padRight (Pad 1) (drawStatusInfo s sPath) <+> txt (s ^. scenarioMetadata . scenarioName)
   drawScenarioItem (SICollection nm _) = padRight (Pad 1) (withAttr boldAttr $ txt " > ") <+> txt nm
 
   drawStatusInfo s sPath = case currentScenarioInfo of
@@ -247,7 +247,7 @@ drawNewGameMenuUI appState (l :| ls) launchOptions = case displayedFor of
         [] -> withAttr cyanAttr $ txt " ◉ "
         _ -> withAttr yellowAttr $ txt " ◎ "
    where
-    currentScenarioInfo = appState ^? runtimeState . scenarios . scenarioItemByPath sPath . _SISingle . _2
+    currentScenarioInfo = appState ^? runtimeState . scenarios . scenarioItemByPath sPath . _SISingle . getScenarioInfo
 
   isCompleted :: BestRecords -> Bool
   isCompleted best = best ^. scenarioBestByTime . metricProgress == Completed
@@ -266,7 +266,7 @@ drawNewGameMenuUI appState (l :| ls) launchOptions = case displayedFor of
 
   drawDescription :: ScenarioItem ScenarioPath -> Widget Name
   drawDescription (SICollection _ _) = txtWrap " "
-  drawDescription (SISingle (s, ScenarioPath sPath)) =
+  drawDescription (SISingle (ScenarioWith s (ScenarioPath sPath))) =
     vBox
       [ drawMarkdown (nonBlank (s ^. scenarioOperation . scenarioDescription))
       , cached (ScenarioPreview sPath) $
@@ -277,7 +277,7 @@ drawNewGameMenuUI appState (l :| ls) launchOptions = case displayedFor of
    where
     vc = determineStaticViewCenter (s ^. scenarioLandscape) worldTuples
 
-    currentScenarioInfo = appState ^? runtimeState . scenarios . scenarioItemByPath sPath . _SISingle . _2
+    currentScenarioInfo = appState ^? runtimeState . scenarios . scenarioItemByPath sPath . _SISingle . getScenarioInfo
 
     worldTuples = buildWorldTuples $ s ^. scenarioLandscape
     theWorlds =
@@ -685,7 +685,7 @@ drawModal h ps isNoMenu = \case
   QuitModal -> padBottom (Pad 1) $ hCenter $ txt (quitMsg isNoMenu)
   GoalModal ->
     GR.renderGoalsDisplay (uig ^. uiDialogs . uiGoal) $
-      view (scenarioOperation . scenarioDescription) . fst <$> uig ^. scenarioRef
+      view (getScenario . scenarioOperation . scenarioDescription) <$> uig ^. scenarioRef
   KeepPlayingModal ->
     padLeftRight 1 $
       displayParagraphs $

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -308,9 +308,7 @@ drawNewGameMenuUI appState (l :| ls) launchOptions = case displayedFor of
       , stat
       )
      where
-      stat = case currentScenarioInfo of
-        Nothing -> Nothing
-        Just si -> Just $ describeStatus $ si ^. scenarioStatus
+      stat = describeStatus . view scenarioStatus <$> currentScenarioInfo
 
     padTopLeft = padTop (Pad 1) . padLeft (Pad 1)
 

--- a/src/swarm-tui/Swarm/TUI/View/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Util.hs
@@ -19,6 +19,7 @@ import Graphics.Vty qualified as V
 import Swarm.Game.Entity as E
 import Swarm.Game.Land
 import Swarm.Game.Scenario (scenarioMetadata, scenarioName)
+import Swarm.Game.Scenario.Status
 import Swarm.Game.ScenarioInfo (scenarioItemName)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
@@ -63,7 +64,7 @@ generateModal m s mt =
       GoalModal ->
         let goalModalTitle = case currentScenario of
               Nothing -> "Goal"
-              Just (scenario, _) -> scenario ^. scenarioMetadata . scenarioName
+              Just (ScenarioWith scenario _) -> scenario ^. scenarioMetadata . scenarioName
          in (" " <> T.unpack goalModalTitle <> " ", Nothing, descriptionWidth)
       KeepPlayingModal -> ("", Just (Button CancelButton, [("OK", Button CancelButton, Cancel)]), 80)
       TerrainPaletteModal -> ("Terrain", Nothing, w)

--- a/src/swarm-tui/Swarm/TUI/View/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Util.hs
@@ -91,6 +91,10 @@ generateModal m s mt =
     stopMsg = fromMaybe "Return to the menu" haltingMessage
     continueMsg = "Keep playing"
 
+  maybeStartOver = do
+    cs <- currentScenario
+    return ("Start over", Button StartOverButton, StartOver currentSeed cs)
+
   mkLoseModal =
     ( ""
     , Just
@@ -106,9 +110,6 @@ generateModal m s mt =
    where
     stopMsg = fromMaybe "Return to the menu" haltingMessage
     continueMsg = "Keep playing"
-    maybeStartOver = do
-      cs <- currentScenario
-      return ("Start over", Button StartOverButton, StartOver currentSeed cs)
 
   isNoMenu = case m of
     NoMenu -> True
@@ -128,9 +129,6 @@ generateModal m s mt =
     )
    where
     stopMsg = fromMaybe ("Quit to" ++ maybe "" (" " ++) (into @String <$> curMenuName m) ++ " menu") haltingMessage
-    maybeStartOver = do
-      cs <- currentScenario
-      return ("Start over", Button StartOverButton, StartOver currentSeed cs)
 
 -- | Render the type of the current REPL input to be shown to the user.
 drawType :: Polytype -> Widget Name

--- a/src/swarm-web/Swarm/Web.hs
+++ b/src/swarm-web/Swarm/Web.hs
@@ -69,6 +69,7 @@ import Swarm.Game.Robot
 import Swarm.Game.Scenario.Objective
 import Swarm.Game.Scenario.Objective.Graph
 import Swarm.Game.Scenario.Objective.WinCheck
+import Swarm.Game.Scenario.Status
 import Swarm.Game.Scenario.Topography.Area (AreaDimensions (..))
 import Swarm.Game.Scenario.Topography.Navigation.Portal
 import Swarm.Game.Scenario.Topography.Structure.Recognition
@@ -311,7 +312,7 @@ replHistHandler appStateRef = do
 mapViewHandler :: IO AppState -> AreaDimensions -> Handler GridResponse
 mapViewHandler appStateRef areaSize = do
   appState <- liftIO appStateRef
-  let maybeScenario = fst <$> appState ^. playState . uiGameplay . scenarioRef
+  let maybeScenario = appState ^? playState . uiGameplay . scenarioRef . _Just . getScenario
   pure $ case maybeScenario of
     Just s ->
       GridResponse True

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -1017,7 +1017,6 @@ library swarm-tui
     murmur3,
     natural-sort,
     nonempty-containers,
-    ordered-containers,
     palette,
     servant-docs,
     split,

--- a/test/unit/TestPedagogy.hs
+++ b/test/unit/TestPedagogy.hs
@@ -9,7 +9,7 @@ module TestPedagogy where
 import Control.Lens (view)
 import Data.Map qualified as M
 import Swarm.Doc.Pedagogy
-import Swarm.Game.ScenarioInfo (scenarioPath)
+import Swarm.Game.Scenario.Status (ScenarioPath (..))
 import Swarm.Game.State.Runtime (RuntimeState, scenarios)
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -26,7 +26,7 @@ testPedagogy rs =
   tutorialInfos = generateIntroductionsSequence $ view scenarios rs
 
   testFromTut :: Int -> CoverageInfo -> TestTree
-  testFromTut idx (CoverageInfo (TutorialInfo (_s, si) _ _ descCommands) novelCommands) =
+  testFromTut idx (CoverageInfo (TutorialInfo (_s, ScenarioPath scPath) _ _ descCommands) novelCommands) =
     testCase
       (unwords [show idx, scPath])
       $ assertBool errMsg allCommandsCovered
@@ -38,7 +38,6 @@ testPedagogy rs =
         , show $ M.keysSet missingCmds
         ]
 
-    scPath = view scenarioPath si
     allCommandsCovered = M.null missingCmds
 
   testList = zipWith testFromTut [0 ..] tutorialInfos

--- a/test/unit/TestPedagogy.hs
+++ b/test/unit/TestPedagogy.hs
@@ -9,7 +9,7 @@ module TestPedagogy where
 import Control.Lens (view)
 import Data.Map qualified as M
 import Swarm.Doc.Pedagogy
-import Swarm.Game.Scenario.Status (ScenarioPath (..))
+import Swarm.Game.Scenario.Status (ScenarioPath (..), ScenarioWith (..))
 import Swarm.Game.State.Runtime (RuntimeState, scenarios)
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -26,7 +26,7 @@ testPedagogy rs =
   tutorialInfos = generateIntroductionsSequence $ view scenarios rs
 
   testFromTut :: Int -> CoverageInfo -> TestTree
-  testFromTut idx (CoverageInfo (TutorialInfo (_s, ScenarioPath scPath) _ _ descCommands) novelCommands) =
+  testFromTut idx (CoverageInfo (TutorialInfo (ScenarioWith _s (ScenarioPath scPath)) _ _ descCommands) novelCommands) =
     testCase
       (unwords [show idx, scPath])
       $ assertBool errMsg allCommandsCovered


### PR DESCRIPTION
Currently, the `ScenarioInfo` records for each `Scenario` are stored in two places:
* The list inside `RuntimeInfo`
* The `Menu`

This has been the source of multiple bugs: see https://github.com/swarm-game/swarm/pull/1243#pullrequestreview-1411539743, https://github.com/swarm-game/swarm/issues/1064#issuecomment-1410915316

In this PR we consolidate on the `RuntimeState` as the single authoritative source for this information and retrieve it from there at all sites that used to reference the `Menu` (in the UI).

# Implementation details

We use the `ScenarioCollection` type to represent the hierarchical structure of scenarios.  Until now this has included `ScenarioInfo` for each leaf node.  We want to re-use this type for the UI menu, but without duplicating each `ScenarioInfo`.  Therefore, we parameterize `ScenarioCollection` (and likewise `ScenarioItem`/`ScenarioInfoPair`) with a payload, which can be either a `ScenarioInfo` (for the authoritative information source) or a `ScenarioPath` (for referencing the authoritative source).

## Conversion

We can "downgrade" a `ScenarioCollection ScenarioInfo` to a `ScenarioCollection ScenarioPath` via its functor instance:
```
fmap (ScenarioPath . view scenarioPath)
```

From a `ScenarioCollection ScenarioPath`, we can recover the `ScenarioInfo` using the `loadScenarioInfoFromPath` function.

# Impact

Although the refactoring touches all type signatures involving `ScenarioInfo`, much complexity was eliminated, including:
* Deletion of the `mkNewGameMenu` function
* Removed most of the code in the `saveScenarioInfoOnQuit` function
* Eliminates a reload from disk in `constructAppState`

# Test procedure

1. Remove tutorial progress:
    ```rm ~/.local/share/swarm/saves/Tutorials_*```
2. Start the game:
    ```./scripts/play.sh```
4. Select "New game".  Observe that no tutorials show indication of progress.
5. Start the first tutorial
6. Use <kbd>Ctrl</kbd>+<kbd>q</kbd> to exit the tutorial back to the Tutorials menu
7. Observe that the tutorial entry shows an indication of progress.