### PR TITLE
Disentangle modal types

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -444,7 +444,7 @@ handleModalEvent = \case
               updateRobotDetailsPane $ snd x
       _ -> do
         mdialog <- preuse $ playState . scenarioState . uiGameplay . uiDialogs . uiModal . _Just . modalDialog
-        scenarioStateWithMenu $ toggleModal $ ScenarioEndModal QuitModal
+        scenarioStateWithMenu $ toggleModal $ EndScenarioModal QuitModal
 
         menu <- use $ uiState . uiMenu
         let isNoMenu = case menu of
@@ -453,7 +453,7 @@ handleModalEvent = \case
 
         case dialogSelection =<< mdialog of
           Just (Button QuitButton, _) -> quitGame isNoMenu
-          Just (Button KeepPlayingButton, _) -> scenarioStateWithMenu $ toggleModal $ ScenarioEndModal KeepPlayingModal
+          Just (Button KeepPlayingButton, _) -> scenarioStateWithMenu $ toggleModal $ EndScenarioModal KeepPlayingModal
           Just (Button StartOverButton, StartOver currentSeed siPair) -> do
             invalidateCache
             restartGame currentSeed siPair
@@ -717,7 +717,7 @@ handleREPLEventTyping m = \case
       ControlChar 'd' -> do
         text <- use $ uiGameplay . uiREPL . replPromptText
         if text == T.empty
-          then toggleModal (ScenarioEndModal QuitModal) m
+          then toggleModal (EndScenarioModal QuitModal) m
           else continueWithoutRedraw
       MetaKey V.KBS ->
         uiGameplay . uiREPL . replPromptEditor %= applyEdit TZ.deletePrevWord

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -101,7 +101,7 @@ toggleQuitGameDialog = do
         WinConditions (Won _ _) _ -> ScenarioFinishModal WinModal
         WinConditions (Unwinnable _) _ -> ScenarioFinishModal LoseModal
         _ -> QuitModal
-  scenarioStateWithMenu $ toggleModal $ ScenarioEndModal whichModal
+  scenarioStateWithMenu $ toggleModal $ EndScenarioModal whichModal
 
 toggleGameModal ::
   Foldable t =>

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Robot.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Robot.hs
@@ -31,6 +31,7 @@ import Swarm.TUI.Inventory.Sorting (cycleSortDirection, cycleSortOrder)
 import Swarm.TUI.List
 import Swarm.TUI.Model
 import Swarm.TUI.Model.Event
+import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.UI.Gameplay
 import Swarm.TUI.View.Util (generateModal)
 
@@ -54,7 +55,7 @@ robotEventHandlers :: [KeyEventHandler SwarmEvent (EventM Name AppState)]
 robotEventHandlers = nonCustomizableHandlers <> customizableHandlers
  where
   nonCustomizableHandlers =
-    [ onKey V.KEnter "Show entity description" $ playStateWithMenu showEntityDescription
+    [ onKey V.KEnter "Show entity description" $ scenarioStateWithMenu showEntityDescription
     ]
   customizableHandlers = allHandlers Robot $ \case
     MakeEntityEvent -> ("Make the selected entity", Brick.zoom (playState . scenarioState) makeFocusedEntity)
@@ -71,7 +72,7 @@ showEntityDescription m = gets focusedEntity >>= maybe continueWithoutRedraw des
   descriptionModal e = do
     s <- get
     resetViewport modalScroll
-    uiGameplay . uiDialogs . uiModal ?= generateModal m s (DescriptionModal e)
+    uiGameplay . uiDialogs . uiModal ?= generateModal m s (MidScenarioModal $ DescriptionModal e)
 
 -- | Attempt to make an entity selected from the inventory, if the
 --   base is not currently busy.
@@ -129,7 +130,7 @@ handleInventorySearchEvent = \case
   -- Enter: return to regular inventory mode, and pop out the selected item
   Key V.KEnter -> do
     zoomInventory $ uiInventorySearch .= Nothing
-    playStateWithMenu showEntityDescription
+    scenarioStateWithMenu showEntityDescription
   -- Any old character: append to the current search string
   CharKey c -> do
     resetViewport infoScroll

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -11,6 +11,7 @@ module Swarm.TUI.Controller.UpdateUI (
 ) where
 
 -- See Note [liftA2 re-export from Prelude]
+
 import Brick hiding (Direction, Location, on)
 import Brick.Focus
 import Brick.Widgets.List qualified as BL
@@ -45,6 +46,7 @@ import Swarm.TUI.Controller.Util
 import Swarm.TUI.Model
 import Swarm.TUI.Model.DebugOption (DebugOption (..))
 import Swarm.TUI.Model.Dialog.Goal
+import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.Repl
 import Swarm.TUI.Model.UI
@@ -258,14 +260,14 @@ doGoalUpdates dOpts menu = do
       Brick.zoom scenarioState $ do
         -- This clears the "flag" that the Lose dialog needs to pop up
         gameState . winCondition .= WinConditions (Unwinnable True) x
-        openModal menu $ ScenarioEndModal LoseModal
+        openModal menu $ ScenarioEndModal $ ScenarioFinishModal LoseModal
       saveScenarioInfoOnFinishNocheat dOpts
       return True
     WinConditions (Won False ts) x -> do
       Brick.zoom scenarioState $ do
         -- This clears the "flag" that the Win dialog needs to pop up
         gameState . winCondition .= WinConditions (Won True ts) x
-        openModal menu $ ScenarioEndModal WinModal
+        openModal menu $ ScenarioEndModal $ ScenarioFinishModal WinModal
       saveScenarioInfoOnFinishNocheat dOpts
       -- We do NOT advance the New Game menu to the next item here (we
       -- used to!), because we do not know if the user is going to
@@ -297,7 +299,7 @@ doGoalUpdates dOpts menu = do
         gameState . messageInfo . announcementQueue .= mempty
 
         showObjectives <- use $ uiGameplay . uiAutoShowObjectives
-        when showObjectives $ openModal menu GoalModal
+        when showObjectives $ openModal menu $ MidScenarioModal GoalModal
 
       return goalWasUpdated
  where
@@ -317,9 +319,7 @@ doGoalUpdates dOpts menu = do
 
   isEndingModal :: ModalType -> Bool
   isEndingModal = \case
-    ScenarioEndModal {} -> True
-    QuitModal -> True
-    KeepPlayingModal -> True
+    ScenarioEndModal _ -> True
     _ -> False
 
 -- | Pops up notifications when new recipes or commands are unlocked.

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -260,14 +260,14 @@ doGoalUpdates dOpts menu = do
       Brick.zoom scenarioState $ do
         -- This clears the "flag" that the Lose dialog needs to pop up
         gameState . winCondition .= WinConditions (Unwinnable True) x
-        openModal menu $ ScenarioEndModal $ ScenarioFinishModal LoseModal
+        openModal menu $ EndScenarioModal $ ScenarioFinishModal LoseModal
       saveScenarioInfoOnFinishNocheat dOpts
       return True
     WinConditions (Won False ts) x -> do
       Brick.zoom scenarioState $ do
         -- This clears the "flag" that the Win dialog needs to pop up
         gameState . winCondition .= WinConditions (Won True ts) x
-        openModal menu $ ScenarioEndModal $ ScenarioFinishModal WinModal
+        openModal menu $ EndScenarioModal $ ScenarioFinishModal WinModal
       saveScenarioInfoOnFinishNocheat dOpts
       -- We do NOT advance the New Game menu to the next item here (we
       -- used to!), because we do not know if the user is going to
@@ -319,7 +319,7 @@ doGoalUpdates dOpts menu = do
 
   isEndingModal :: ModalType -> Bool
   isEndingModal = \case
-    ScenarioEndModal _ -> True
+    EndScenarioModal _ -> True
     _ -> False
 
 -- | Pops up notifications when new recipes or commands are unlocked.

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -257,17 +257,17 @@ doGoalUpdates dOpts menu = do
   case curWinCondition of
     NoWinCondition -> return False
     WinConditions (Unwinnable False) x -> do
-      Brick.zoom scenarioState $ do
-        -- This clears the "flag" that the Lose dialog needs to pop up
-        gameState . winCondition .= WinConditions (Unwinnable True) x
-        openModal menu $ EndScenarioModal $ ScenarioFinishModal LoseModal
+      -- This clears the "flag" that the Lose dialog needs to pop up
+      scenarioState . gameState . winCondition .= WinConditions (Unwinnable True) x
+      openEndScenarioModal menu $ ScenarioFinishModal LoseModal
+
       saveScenarioInfoOnFinishNocheat dOpts
       return True
     WinConditions (Won False ts) x -> do
-      Brick.zoom scenarioState $ do
-        -- This clears the "flag" that the Win dialog needs to pop up
-        gameState . winCondition .= WinConditions (Won True ts) x
-        openModal menu $ EndScenarioModal $ ScenarioFinishModal WinModal
+      -- This clears the "flag" that the Win dialog needs to pop up
+      scenarioState . gameState . winCondition .= WinConditions (Won True ts) x
+      openEndScenarioModal menu $ ScenarioFinishModal WinModal
+
       saveScenarioInfoOnFinishNocheat dOpts
       -- We do NOT advance the New Game menu to the next item here (we
       -- used to!), because we do not know if the user is going to
@@ -299,7 +299,7 @@ doGoalUpdates dOpts menu = do
         gameState . messageInfo . announcementQueue .= mempty
 
         showObjectives <- use $ uiGameplay . uiAutoShowObjectives
-        when showObjectives $ openModal menu $ MidScenarioModal GoalModal
+        when showObjectives $ openMidScenarioModal GoalModal
 
       return goalWasUpdated
  where

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -81,7 +81,7 @@ pattern FKey c = VtyEvent (V.EvKey (V.KFun c) [])
 openEndScenarioModal :: Menu -> EndScenarioModalType -> EventM Name PlayState ()
 openEndScenarioModal m mt = do
   resetViewport modalScroll
-  newModal <- Brick.zoom scenarioState $ gets (flip (generateScenarioEndModal m) mt)
+  newModal <- gets $ flip (generateScenarioEndModal m) mt
   Brick.zoom scenarioState ensurePause
   scenarioState . uiGameplay . uiDialogs . uiModal ?= newModal
   -- Beep

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -86,7 +86,7 @@ openModal m mt = do
   uiGameplay . uiDialogs . uiModal ?= newModal
   -- Beep
   case mt of
-    ScenarioEndModal _ -> do
+    ScenarioEndModal (ScenarioFinishModal _) -> do
       vty <- getVtyHandle
       liftIO $ V.ringTerminalBell $ V.outputIface vty
     _ -> return ()
@@ -99,8 +99,8 @@ openModal m mt = do
 -- | The running modals do not autopause the game.
 isRunningModal :: ModalType -> Bool
 isRunningModal = \case
-  RobotsModal -> True
-  MessagesModal -> True
+  MidScenarioModal RobotsModal -> True
+  MidScenarioModal MessagesModal -> True
   _ -> False
 
 -- | Set the game to Running if it was (auto) paused otherwise to paused.
@@ -253,9 +253,9 @@ addREPLHistItem item = uiGameplay . uiREPL . replHistory %= addREPLItem item
 
 -- | Run an action that only depends on a 'ScenarioState'
 -- and read-only access to the 'Menu'.
-playStateWithMenu ::
+scenarioStateWithMenu ::
   (Menu -> EventM Name ScenarioState ()) ->
   EventM Name AppState ()
-playStateWithMenu f = do
+scenarioStateWithMenu f = do
   m <- use $ uiState . uiMenu
   Brick.zoom (playState . scenarioState) $ f m

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -44,12 +44,10 @@ import Swarm.TUI.Model (
   playState,
   scenarioState,
   uiGameplay,
-  uiState,
  )
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.Repl (REPLHistItem, REPLPrompt, REPLState, addREPLItem, replHistory, replPromptText, replPromptType)
-import Swarm.TUI.Model.UI
 import Swarm.TUI.Model.UI.Gameplay
 import Swarm.TUI.View.Util (generateModal, generateScenarioEndModal)
 import System.Clock (Clock (..), getTime)
@@ -269,12 +267,3 @@ resetREPL t p = uiGameplay . uiREPL %= modifyResetREPL t p
 -- | Add an item to the REPL history.
 addREPLHistItem :: MonadState ScenarioState m => REPLHistItem -> m ()
 addREPLHistItem item = uiGameplay . uiREPL . replHistory %= addREPLItem item
-
--- | Run an action that only depends on a 'ScenarioState'
--- and read-only access to the 'Menu'.
-scenarioStateWithMenu ::
-  (Menu -> EventM Name ScenarioState ()) ->
-  EventM Name AppState ()
-scenarioStateWithMenu f = do
-  m <- use $ uiState . uiMenu
-  Brick.zoom (playState . scenarioState) $ f m

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -28,6 +28,7 @@ import Swarm.TUI.Editor.Model
 import Swarm.TUI.Editor.Palette
 import Swarm.TUI.Editor.Util qualified as EU
 import Swarm.TUI.Model
+import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.UI.Gameplay
 import Swarm.Util (hoistMaybe)
@@ -39,8 +40,8 @@ import System.Clock
 ------------------------------------------------------------
 
 activateWorldEditorFunction :: Menu -> WorldEditorFocusable -> EventM Name ScenarioState ()
-activateWorldEditorFunction m BrushSelector = openModal m TerrainPaletteModal
-activateWorldEditorFunction m EntitySelector = openModal m EntityPaletteModal
+activateWorldEditorFunction m BrushSelector = openModal m $ MidScenarioModal TerrainPaletteModal
+activateWorldEditorFunction m EntitySelector = openModal m $ MidScenarioModal EntityPaletteModal
 activateWorldEditorFunction _ AreaSelector =
   Brick.zoom (uiGameplay . uiWorldEditor . editingBounds) $ do
     selectorStage <- use boundsSelectionStep

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -39,20 +39,20 @@ import System.Clock
 -- World Editor panel events
 ------------------------------------------------------------
 
-activateWorldEditorFunction :: Menu -> WorldEditorFocusable -> EventM Name ScenarioState ()
-activateWorldEditorFunction m BrushSelector = openModal m $ MidScenarioModal TerrainPaletteModal
-activateWorldEditorFunction m EntitySelector = openModal m $ MidScenarioModal EntityPaletteModal
-activateWorldEditorFunction _ AreaSelector =
+activateWorldEditorFunction :: WorldEditorFocusable -> EventM Name ScenarioState ()
+activateWorldEditorFunction BrushSelector = openMidScenarioModal TerrainPaletteModal
+activateWorldEditorFunction EntitySelector = openMidScenarioModal EntityPaletteModal
+activateWorldEditorFunction AreaSelector =
   Brick.zoom (uiGameplay . uiWorldEditor . editingBounds) $ do
     selectorStage <- use boundsSelectionStep
     case selectorStage of
       SelectionComplete -> boundsSelectionStep .= UpperLeftPending
       _ -> return ()
-activateWorldEditorFunction _ OutputPathSelector =
+activateWorldEditorFunction OutputPathSelector =
   -- TODO: #1371
   liftIO $ putStrLn "File selection"
-activateWorldEditorFunction _ MapSaveButton = saveMapFile
-activateWorldEditorFunction _ ClearEntityButton =
+activateWorldEditorFunction MapSaveButton = saveMapFile
+activateWorldEditorFunction ClearEntityButton =
   uiGameplay . uiWorldEditor . entityPaintList . BL.listSelectedL .= Nothing
 
 handleCtrlLeftClick :: B.Location -> EventM Name ScenarioState ()
@@ -104,13 +104,13 @@ handleMiddleClick mouseLoc = do
     whenJust mouseCoordsM setTerrainPaint
 
 -- | Handle user input events in the robot panel.
-handleWorldEditorPanelEvent :: BrickEvent Name AppEvent -> Menu -> EventM Name ScenarioState ()
-handleWorldEditorPanelEvent e m = case e of
+handleWorldEditorPanelEvent :: BrickEvent Name AppEvent -> EventM Name ScenarioState ()
+handleWorldEditorPanelEvent = \case
   Key V.KEsc -> uiGameplay . uiWorldEditor . editingBounds . boundsSelectionStep .= SelectionComplete
   Key V.KEnter -> do
     fring <- use $ uiGameplay . uiWorldEditor . editorFocusRing
     case focusGetCurrent fring of
-      Just (WorldEditorPanelControl x) -> activateWorldEditorFunction m x
+      Just (WorldEditorPanelControl x) -> activateWorldEditorFunction x
       _ -> return ()
   ControlChar 's' -> saveMapFile
   CharKey '\t' -> uiGameplay . uiWorldEditor . editorFocusRing %= focusNext

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -91,7 +91,6 @@ import Control.Lens hiding (from, (<.>))
 import Control.Monad ((>=>))
 import Control.Monad.State (MonadState)
 import Data.List (findIndex)
-import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
@@ -107,7 +106,7 @@ import Swarm.Game.Ingredients
 import Swarm.Game.Popup
 import Swarm.Game.Robot
 import Swarm.Game.Scenario.Status
-import Swarm.Game.ScenarioInfo (ScenarioCollection, _SISingle)
+import Swarm.Game.ScenarioInfo (ScenarioCollection)
 import Swarm.Game.State
 import Swarm.Game.State.Runtime
 import Swarm.Game.State.Substate

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -67,7 +67,7 @@ data ButtonAction
   | KeepPlaying
   | StartOver Seed (ScenarioWith ScenarioPath)
   | QuitAction
-  | Next (ScenarioWith ScenarioPath)
+  | Next (ScenarioWith ScenarioPath) [ScenarioWith ScenarioPath]
 
 data Modal = Modal
   { _modalType :: ModalType

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -51,7 +51,7 @@ data MidScenarioModalType
   | GoalModal
   deriving (Show, Eq)
 
-data ScenarioEndModalType
+data EndScenarioModalType
   = ScenarioFinishModal ScenarioOutcome
   | QuitModal
   | KeepPlayingModal
@@ -59,7 +59,7 @@ data ScenarioEndModalType
 
 data ModalType
   = MidScenarioModal MidScenarioModalType
-  | ScenarioEndModal ScenarioEndModalType
+  | EndScenarioModal EndScenarioModalType
   deriving (Show, Eq)
 
 data ButtonAction

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -38,7 +38,7 @@ import Swarm.TUI.Model.Name
 data ScenarioOutcome = WinModal | LoseModal
   deriving (Show, Eq)
 
-data ModalType
+data MidScenarioModalType
   = HelpModal
   | RecipesModal
   | CommandsModal
@@ -47,11 +47,19 @@ data ModalType
   | EntityPaletteModal
   | TerrainPaletteModal
   | RobotsModal
-  | ScenarioEndModal ScenarioOutcome
-  | QuitModal
-  | KeepPlayingModal
   | DescriptionModal Entity
   | GoalModal
+  deriving (Show, Eq)
+
+data ScenarioEndModalType
+  = ScenarioFinishModal ScenarioOutcome
+  | QuitModal
+  | KeepPlayingModal
+  deriving (Show, Eq)
+
+data ModalType
+  = MidScenarioModal MidScenarioModalType
+  | ScenarioEndModal ScenarioEndModalType
   deriving (Show, Eq)
 
 data ButtonAction

--- a/src/swarm-tui/Swarm/TUI/Model/Menu.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Menu.hs
@@ -67,7 +67,7 @@ data ButtonAction
   | KeepPlaying
   | StartOver Seed (ScenarioWith ScenarioPath)
   | QuitAction
-  | Next (ScenarioWith ScenarioPath) [ScenarioWith ScenarioPath]
+  | Next (NonEmpty (ScenarioWith ScenarioPath))
 
 data Modal = Modal
   { _modalType :: ModalType

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -281,8 +281,10 @@ startGame ::
   (MonadIO m, MonadState AppState m) =>
   ScenarioWith ScenarioPath ->
   Maybe CodeToRun ->
+  [ScenarioWith ScenarioPath] ->
   m ()
-startGame (ScenarioWith s (ScenarioPath p)) c = do
+startGame (ScenarioWith s (ScenarioPath p)) c remaining = do
+  playState . progression . scenarioSequence .= remaining
   ss <- use $ playState . progression . scenarios
   let si = getScenarioInfoFromPath ss p
   startGameWithSeed (ScenarioWith s si) . LaunchParams (pure Nothing) $ pure c

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -37,6 +37,7 @@ import Data.Bifunctor (first)
 import Data.Foldable qualified as F
 import Data.List qualified as List
 import Data.List.Extra (enumerate)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe, isJust)
@@ -279,11 +280,10 @@ constructAppState (PersistentState rs ui key progState) opts@(AppOpts {..}) = do
 -- | Load a 'Scenario' and start playing the game.
 startGame ::
   (MonadIO m, MonadState AppState m) =>
-  ScenarioWith ScenarioPath ->
+  NonEmpty (ScenarioWith ScenarioPath) ->
   Maybe CodeToRun ->
-  [ScenarioWith ScenarioPath] ->
   m ()
-startGame (ScenarioWith s (ScenarioPath p)) c remaining = do
+startGame (ScenarioWith s (ScenarioPath p) :| remaining) c = do
   playState . progression . scenarioSequence .= remaining
   ss <- use $ playState . progression . scenarios
   let si = getScenarioInfoFromPath ss p

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -168,6 +168,7 @@ initPersistentState opts@(AppOpts {..}) = do
             { _scenarios = s
             , _attainedAchievements = M.fromList $ map (view achievement &&& id) achievements
             , _uiPopups = initPopupState
+            , _scenarioSequence = mempty
             }
     return $ PersistentState rs ui ks progState
   let initRS' = addWarnings initRS (F.toList warnings)

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -663,37 +663,39 @@ drawModal ::
   ModalType ->
   Widget Name
 drawModal h ps isNoMenu = \case
-  MidScenarioModal HelpModal -> helpWidget h $ gs ^. randomness . seed
-  MidScenarioModal RobotsModal -> drawRobotsModal $ uig ^. uiDialogs . uiRobot
-  MidScenarioModal RecipesModal -> availableListWidget gs RecipeList
-  MidScenarioModal CommandsModal -> commandsListWidget gs
-  MidScenarioModal MessagesModal -> availableListWidget gs MessageList
-  MidScenarioModal StructuresModal -> SR.renderStructuresDisplay gs $ uig ^. uiDialogs . uiStructure
-  ScenarioEndModal (ScenarioFinishModal outcome) ->
-    padBottom (Pad 1) $
-      vBox $
-        map
-          (hCenter . txt)
-          content
-   where
-    content = case outcome of
-      WinModal -> ["Congratulations!"]
-      LoseModal ->
-        [ "Condolences!"
-        , "This scenario is no longer winnable."
-        ]
-  MidScenarioModal (DescriptionModal e) -> descriptionWidget ps e
-  ScenarioEndModal QuitModal -> padBottom (Pad 1) $ hCenter $ txt (quitMsg isNoMenu)
-  MidScenarioModal GoalModal ->
-    GR.renderGoalsDisplay (uig ^. uiDialogs . uiGoal) $
-      view (getScenario . scenarioOperation . scenarioDescription) <$> uig ^. scenarioRef
-  ScenarioEndModal KeepPlayingModal ->
-    padLeftRight 1 $
-      displayParagraphs $
-        pure
-          "Have fun!  Hit Ctrl-Q whenever you're ready to proceed to the next challenge or return to the menu."
-  MidScenarioModal TerrainPaletteModal -> EV.drawTerrainSelector uig
-  MidScenarioModal EntityPaletteModal -> EV.drawEntityPaintSelector uig
+  MidScenarioModal x -> case x of
+    HelpModal -> helpWidget h $ gs ^. randomness . seed
+    RobotsModal -> drawRobotsModal $ uig ^. uiDialogs . uiRobot
+    RecipesModal -> availableListWidget gs RecipeList
+    CommandsModal -> commandsListWidget gs
+    MessagesModal -> availableListWidget gs MessageList
+    StructuresModal -> SR.renderStructuresDisplay gs $ uig ^. uiDialogs . uiStructure
+    DescriptionModal e -> descriptionWidget ps e
+    GoalModal ->
+      GR.renderGoalsDisplay (uig ^. uiDialogs . uiGoal) $
+        view (getScenario . scenarioOperation . scenarioDescription) <$> uig ^. scenarioRef
+    TerrainPaletteModal -> EV.drawTerrainSelector uig
+    EntityPaletteModal -> EV.drawEntityPaintSelector uig
+  EndScenarioModal x -> case x of
+    ScenarioFinishModal outcome ->
+      padBottom (Pad 1) $
+        vBox $
+          map
+            (hCenter . txt)
+            content
+     where
+      content = case outcome of
+        WinModal -> ["Congratulations!"]
+        LoseModal ->
+          [ "Condolences!"
+          , "This scenario is no longer winnable."
+          ]
+    QuitModal -> padBottom (Pad 1) $ hCenter $ txt (quitMsg isNoMenu)
+    KeepPlayingModal ->
+      padLeftRight 1 $
+        displayParagraphs $
+          pure
+            "Have fun!  Hit Ctrl-Q whenever you're ready to proceed to the next challenge or return to the menu."
  where
   gs = ps ^. gameState
   uig = ps ^. uiGameplay

--- a/src/swarm-tui/Swarm/TUI/View/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Util.hs
@@ -58,8 +58,8 @@ generateScenarioEndModal m s mt =
     ( ""
     , Just
         ( Button NextButton
-        , [ (nextMsg, Button NextButton, Next scene remainingScenarios)
-          | Just (scene :| remainingScenarios) <- [NE.nonEmpty scenarioList]
+        , [ (nextMsg, Button NextButton, Next remainingScenarios)
+          | Just remainingScenarios <- [NE.nonEmpty scenarioList]
           ]
             ++ [ (stopMsg, Button QuitButton, QuitAction) -- TODO(#2376) QuitAction is not used
                , (continueMsg, Button KeepPlayingButton, KeepPlaying)

--- a/src/swarm-tui/Swarm/TUI/View/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Util.hs
@@ -21,7 +21,7 @@ import Swarm.Game.Entity as E
 import Swarm.Game.Land
 import Swarm.Game.Scenario (scenarioMetadata, scenarioName)
 import Swarm.Game.Scenario.Status
-import Swarm.Game.ScenarioInfo (scenarioItemName, _SISingle)
+import Swarm.Game.ScenarioInfo (scenarioItemName)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
 import Swarm.Game.State.Substate
@@ -280,17 +280,3 @@ bindingText keyConf e = maybe "" ppBindingShort b
     Binding V.KLeft m | null m -> "←"
     Binding V.KRight m | null m -> "→"
     bi -> ppBinding bi
-
---- | Extract the scenario which would come next in the menu from the
----   currently selected scenario (if any).  Can return @Nothing@ if
----   either we are not in the @NewGameMenu@, or the current scenario
----   is the last among its siblings.
-nextScenario :: Menu -> Maybe (ScenarioWith ScenarioPath)
-nextScenario = \case
-  NewGameMenu (curMenu :| _) ->
-    let nextMenuList = BL.listMoveDown curMenu
-        isLastScenario = BL.listSelected curMenu == Just (length (BL.listElements curMenu) - 1)
-     in if isLastScenario
-          then Nothing
-          else BL.listSelectedElement nextMenuList >>= preview _SISingle . snd
-  _ -> Nothing


### PR DESCRIPTION
Closes #2408.

There are two distinct categories of modals which both go through the same function for toggling/generating/opening.  However, one of these categories requires access to more state than the other.

By introducing an additional layer of sum types, we can simplify the code path for one of these categories which requires less state access.

# Test procedure

## Test case 1

1. `rm ~/.local/share/swarm/saves/Tutorials_*`
1. Launch game
2. Select "Tutorials" from toplevel menu
3. Complete first tutorial, select "Next challenge!" in popup dialog
4. Complete second tutorial, select "Next challenge!" in popup dialog
5. Observe that we are now playing the "Crafting" tutorial.

## Test case 2

1. Launch game
2. Select "New game"
3. Select "Tutorials" category
4. Select an arbitrary tutorial
5. Complete two in sequence, using "Next challenge!" each time
6. Observe correct sequence was followed