### PR TITLE
Tutorial tweaks

### DIFF
--- a/data/scenarios/Tutorials/move.yaml
+++ b/data/scenarios/Tutorials/move.yaml
@@ -27,11 +27,15 @@ objectives:
 
         `move; move`
 
-        To reuse that command without having to retype it press the upward arrow on your keyboard.
-        This will allow you to select previous commands.
+        To reuse that command without having to retype it, press the up arrow on your keyboard.
+        This will allow you to select previously entered commands.
 
         Ahead of you is a six steps long corridor. Move to its end, i.e. the coordinates `(8,0)` marked
         with the second purple `flower`{=entity}.
+
+        Note that you do not need to type everything in one go; you
+        can enter multiple commands, as long as they eventually get
+        you to the flower.
 
         You can open this popup window at any time to remind yourself of the goal using **Ctrl+G**.
     condition: |
@@ -42,7 +46,7 @@ objectives:
     goal:
       - |
         Well done! In addition to `move`, you can use the `turn` command to turn your robot, for example,
-        `turn right` or `turn east`.
+        `turn right` or (if you have a `compass`{=entity}) `turn east`.
 
         Switch to the inventory view in the upper left (by clicking on it or typing **Alt+E**) and select
         the `treads`{=entity} device to read about the details.

--- a/data/scenarios/Tutorials/world101.yaml
+++ b/data/scenarios/Tutorials/world101.yaml
@@ -10,6 +10,7 @@ objectives:
       - You can see that your base starts out with some key devices equipped and some basic supplies for building robots.  To build more advanced devices and produce more robots, you'll need to explore, gather resources, and set up some automated production pipelines.
       - At this point you may want to create an external `.sw`{=path} file with useful definitions you create.  You can then load it via the `run` command.  See https://github.com/swarm-game/swarm/tree/main/editors for help configuring your editor with support for swarm-lang.
       - Your first task is to collect three or more `tree`{=entity}s. You can remind yourself of the available commands using **F4**.
+      - Since you don't yet have a `compass`{=entity} device, you won't be able to refer to cardinal directions like `north` or `east`, only relative directions like `left`, `right`, or `back`.
     condition: |
       try {
         n <- as base {count "tree"};


### PR DESCRIPTION
A couple tweaks based on my observation of students completing the tutorials:

- Explicitly state in the move tutorial that they don't have to solve the objective all in one go
- Explicitly explain in the "first steps" scenario that they don't have a `compass` so they won't be able to refer to cardinal directions