### PR TITLE
Dependency updates

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,10 +25,10 @@ queue_rules:
           - or:
             - check-success=HLint
             - -files~=\.hs$
+          - check-success=Haskell-CI - Linux - ghc-9.12.1
           - check-success=Haskell-CI - Linux - ghc-9.10.1
           - check-success=Haskell-CI - Linux - ghc-9.8.2
           - check-success=Haskell-CI - Linux - ghc-9.6.6
-          - check-success=Haskell-CI - Linux - ghc-9.4.8
           - check-success=Haskell-CI - windows-latest - ghc-9.8.2
 
 pull_request_rules:
@@ -57,10 +57,10 @@ pull_request_rules:
       - or:
         - check-success=HLint
         - -files~=\.hs$
+      - check-success=Haskell-CI - Linux - ghc-9.12.1
       - check-success=Haskell-CI - Linux - ghc-9.10.1
       - check-success=Haskell-CI - Linux - ghc-9.8.2
       - check-success=Haskell-CI - Linux - ghc-9.6.6
-      - check-success=Haskell-CI - Linux - ghc-9.4.8
       - check-success=Haskell-CI - windows-latest - ghc-9.8.2
   - label=merge me
   - ! '#approved-reviews-by>=1'

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -1,6 +1,6 @@
 #####################################################################
 ## NOTE:                                                            #
-## When changing versions, do not forget to update .mergify.yaml    #
+## When changing versions, also update .github/mergify.yaml         #
 ##                                                                  #
 ## WARNING:                                                         #
 ## Hand-edited to add filter in on.push and on.pull_request.        #
@@ -58,6 +58,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.1
+            compilerKind: ghc
+            compilerVersion: 9.12.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
@@ -71,11 +76,6 @@ jobs:
           - compiler: ghc-9.6.6
             compilerKind: ghc
             compilerVersion: 9.6.6
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-9.4.8
-            compilerKind: ghc
-            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
       fail-fast: false

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -19,7 +19,6 @@
 -- See <https://github.com/swarm-game/swarm/issues/495>.
 module Swarm.Game.Step where
 
-import Control.Applicative (Applicative (..))
 import Control.Carrier.Error.Either (ErrorC, runError)
 import Control.Carrier.State.Lazy
 import Control.Carrier.Throw.Either (runThrow)
@@ -75,7 +74,7 @@ import Swarm.Util hiding (both)
 import Swarm.Util.WindowedCounter qualified as WC
 import System.Clock (TimeSpec)
 import Witch (From (from))
-import Prelude hiding (Applicative (..), lookup)
+import Prelude hiding (lookup)
 
 -- | The main function to do one game tick.
 --

--- a/src/swarm-engine/Swarm/Game/Step/Arithmetic.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Arithmetic.hs
@@ -9,7 +9,6 @@
 -- Arithmetic and Comparison commands
 module Swarm.Game.Step.Arithmetic where
 
-import Control.Applicative (Applicative (..))
 import Control.Carrier.State.Lazy
 import Control.Effect.Error
 import Control.Monad (zipWithM)
@@ -21,7 +20,7 @@ import Swarm.Game.Step.Util
 import Swarm.Language.Syntax
 import Swarm.Language.Value
 import Witch (From (from))
-import Prelude hiding (Applicative (..), lookup)
+import Prelude hiding (lookup)
 
 ------------------------------------------------------------
 -- Comparison

--- a/src/swarm-engine/Swarm/Game/Step/Combustion.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Combustion.hs
@@ -16,7 +16,6 @@
 -- well as to initiate the delayed combustion of its neighbors.
 module Swarm.Game.Step.Combustion where
 
-import Control.Applicative (Applicative (..))
 import Control.Carrier.State.Lazy
 import Control.Effect.Lens
 import Control.Lens as Lens hiding (Const, distrib, from, parts, use, uses, view, (%=), (+=), (.=), (<+=), (<>=))
@@ -46,7 +45,7 @@ import Swarm.Language.Syntax.Direction (Direction)
 import Swarm.Language.Text.Markdown qualified as Markdown
 import Swarm.Util hiding (both)
 import System.Clock (TimeSpec)
-import Prelude hiding (Applicative (..), lookup)
+import Prelude hiding (lookup)
 
 igniteCommand :: (HasRobotStepState sig m, Has Effect.Time sig m) => Const -> Direction -> m ()
 igniteCommand c d = do

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -13,7 +13,6 @@ module Swarm.Game.Step.Const where
 
 import Swarm.Game.Scenario (RecognizableStructureContent)
 
-import Control.Applicative (Applicative (..))
 import Control.Arrow ((&&&))
 import Control.Carrier.State.Lazy
 import Control.Effect.Error
@@ -105,7 +104,7 @@ import Swarm.Util.Effect (throwToMaybe)
 import Swarm.Util.Lens (inherit)
 import Text.Megaparsec (runParser)
 import Witch (From (from), into)
-import Prelude hiding (Applicative (..), lookup)
+import Prelude hiding (lookup)
 
 -- | How to handle failure, for example when moving into liquid or
 --   attempting to move to a blocked location

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -9,7 +9,6 @@
 -- Utilities for implementing robot commands.
 module Swarm.Game.Step.Util where
 
-import Control.Applicative (Applicative (..))
 import Control.Carrier.State.Lazy
 import Control.Effect.Error
 import Control.Effect.Lens
@@ -48,7 +47,7 @@ import Swarm.Language.Syntax.Direction (Direction)
 import Swarm.ResourceLoading (NameGenerator (..))
 import Swarm.Util hiding (both)
 import System.Random (UniformRange, uniformR)
-import Prelude hiding (Applicative (..), lookup)
+import Prelude hiding (lookup)
 
 deriveHeading :: HasRobotStepState sig m => Direction -> m Heading
 deriveHeading d = do

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -12,7 +12,6 @@
 -- Helper functions for "Swarm.Game.Step.Const" commands
 module Swarm.Game.Step.Util.Command where
 
-import Control.Applicative (Applicative (..))
 import Control.Carrier.State.Lazy
 import Control.Carrier.Throw.Either (ThrowC, runThrow)
 import Control.Effect.Error
@@ -67,7 +66,7 @@ import Swarm.Language.Text.Markdown qualified as Markdown
 import Swarm.Log
 import Swarm.Util (applyWhen)
 import System.Clock (TimeSpec)
-import Prelude hiding (Applicative (..), lookup)
+import Prelude hiding (lookup)
 
 data GrabbingCmd
   = Grab'

--- a/src/swarm-lang/Swarm/Language/Context.hs
+++ b/src/swarm-lang/Swarm/Language/Context.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE OverloadedStrings #-}
 

--- a/src/swarm-lang/Swarm/Language/Syntax/Comments.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Comments.hs
@@ -27,7 +27,7 @@ import Data.Aeson.Types hiding (Key)
 import Data.Data (Data)
 import Data.Hashable (Hashable)
 import Data.Sequence (Seq)
-import Data.Text hiding (filter, length, map)
+import Data.Text (Text)
 import GHC.Generics (Generic)
 import Prettyprinter (pretty)
 import Swarm.Language.Syntax.Loc

--- a/src/swarm-lang/Swarm/Language/Syntax/Constants.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Constants.hs
@@ -34,7 +34,7 @@ import Data.Int (Int32)
 import Data.List.Extra (enumerate)
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.Text hiding (filter, length, map)
+import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Prettyprinter (pretty)
@@ -919,7 +919,7 @@ constInfo c = case c of
       }
 
   lowShow :: Show a => a -> Text
-  lowShow = toLower . showT
+  lowShow = T.toLower . showT
 
 -- | Maximum perception distance for
 -- 'Chirp' and 'Sniff' commands

--- a/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
@@ -39,7 +39,7 @@ module Swarm.Language.Syntax.Pattern (
 
 import Control.Lens (makeLenses, pattern Empty)
 import Data.Map.Strict (Map)
-import Data.Text hiding (filter, length, map)
+import Data.Text (Text)
 import Swarm.Language.Requirements.Type (Requirements)
 import Swarm.Language.Syntax.AST
 import Swarm.Language.Syntax.Comments

--- a/src/swarm-scenario/Swarm/Game/World/Interpret.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Interpret.hs
@@ -11,7 +11,6 @@ module Swarm.Game.World.Interpret (
   interpConst,
 ) where
 
-import Control.Applicative (Applicative (..))
 import Data.ByteString (ByteString)
 import Data.Hash.Murmur (murmur3)
 import Data.Tagged (unTagged)
@@ -24,7 +23,6 @@ import Swarm.Game.World.Syntax (Axis (..))
 import Swarm.Game.World.Typecheck (Const (..), Empty (..), Over (..))
 import Witch (from)
 import Witch.Encoding qualified as Encoding
-import Prelude hiding (Applicative (..))
 
 -- | Interpret an abstracted term into the host language.
 interpBTerm :: Seed -> BTerm a -> a

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -26,8 +26,6 @@ module Swarm.TUI.Controller (
   handleInfoPanelEvent,
 ) where
 
--- See Note [liftA2 re-export from Prelude]
-
 import Brick hiding (Direction, Location)
 import Brick.Focus
 import Brick.Keybindings qualified as B
@@ -36,7 +34,7 @@ import Brick.Widgets.Edit (Editor, applyEdit, editContentsL, handleEditorEvent)
 import Brick.Widgets.List (handleListEvent, listElements)
 import Brick.Widgets.List qualified as BL
 import Brick.Widgets.TabularList.Mixed
-import Control.Applicative (pure, (<|>))
+import Control.Applicative ((<|>))
 import Control.Category ((>>>))
 import Control.Lens as Lens
 import Control.Monad (forM_, unless, void, when)
@@ -111,18 +109,6 @@ import Swarm.TUI.Model.UI.Gameplay
 import Swarm.TUI.View.Robot (getList)
 import Swarm.TUI.View.Robot.Type
 import Swarm.Util hiding (both, (<<.=))
-import Prelude hiding (Applicative (..))
-
--- ~~~~ Note [liftA2 re-export from Prelude]
---
--- As of base-4.18 (GHC 9.6), liftA2 is re-exported from Prelude.  See
--- https://github.com/haskell/core-libraries-committee/issues/50 .  In
--- order to compile warning-free on both GHC 9.6 and older versions,
--- we hide the import of Applicative functions from Prelude and import
--- explicitly from Control.Applicative.  In theory, if at some point
--- in the distant future we end up dropping support for GHC < 9.6 then
--- we could get rid of both explicit imports and just get liftA2 and
--- pure implicitly from Prelude.
 
 -- | The top-level event handler for the TUI.
 handleEvent :: BrickEvent Name AppEvent -> EventM Name AppState ()

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -15,7 +15,6 @@ module Swarm.TUI.Controller.UpdateUI (
 import Brick hiding (Direction, Location, on)
 import Brick.Focus
 import Brick.Widgets.List qualified as BL
-import Control.Applicative (liftA2, pure)
 import Control.Lens as Lens
 import Control.Monad (forM_, unless, when)
 import Control.Monad.IO.Class (liftIO)
@@ -56,7 +55,6 @@ import Swarm.TUI.View.Robot
 import Swarm.TUI.View.Robot.Type
 import Swarm.Util (applyJust)
 import Witch (into)
-import Prelude hiding (Applicative (..))
 
 -- | Update the UI and redraw if needed.
 --

--- a/src/swarm-tui/Swarm/TUI/Model/Repl.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Repl.hs
@@ -58,7 +58,6 @@ module Swarm.TUI.Model.Repl (
 ) where
 
 import Brick.Widgets.Edit (Editor, applyEdit, editorText, getEditContents)
-import Control.Applicative (Applicative (liftA2))
 import Control.Lens hiding (from, (.=), (<.>))
 import Data.Aeson (ToJSON, object, toJSON, (.=))
 import Data.Foldable (toList)
@@ -75,7 +74,6 @@ import Swarm.Language.Types
 import Swarm.TUI.Model.Name
 import Swarm.Util (applyWhen)
 import Swarm.Util.Lens (makeLensesNoSigs)
-import Prelude hiding (Applicative (..))
 
 ------------------------------------------------------------
 -- REPL History

--- a/src/swarm-util/Swarm/Language/Syntax/Direction.hs
+++ b/src/swarm-util/Swarm/Language/Syntax/Direction.hs
@@ -27,7 +27,7 @@ import Data.Data (Data)
 import Data.Hashable (Hashable)
 import Data.List qualified as L (drop)
 import Data.List.Extra (enumerate)
-import Data.Text hiding (filter, length, map)
+import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Prettyprinter (pretty)

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -380,6 +380,9 @@ failT :: MonadFail m => [Text] -> m a
 failT = fail . from @Text . T.unwords
 
 -- | Show a value, but as Text.
+--
+--   Note: Data.Text.show was added in text-2.1.2.  Eventually we can
+--   require that version of text and get rid of showT.
 showT :: Show a => a -> Text
 showT = from @String . show
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -121,7 +121,7 @@ common ghc2021-extensions
     TypeOperators
 
 common base
-  build-depends: base >=4.14 && <4.21
+  build-depends: base >=4.14 && <4.22
 
 common AhoCorasick
   build-depends: AhoCorasick >=0.0.4 && <0.0.5
@@ -148,7 +148,7 @@ common boolexpr
   build-depends: boolexpr >=0.2 && <0.3
 
 common brick
-  build-depends: brick >=2.1.1 && <2.5
+  build-depends: brick >=2.1.1 && <2.9
 
 common brick-list-skip
   build-depends: brick-list-skip >=0.1.1.2 && <0.2
@@ -220,7 +220,7 @@ common githash
   build-depends: githash >=0.1.6 && <0.2
 
 common hashable
-  build-depends: hashable >=1.3.4 && <1.5
+  build-depends: hashable >=1.3.4 && <1.6
 
 common hsnoise
   build-depends: hsnoise >=0.0.3 && <0.1
@@ -244,7 +244,7 @@ common lsp
   build-depends: lsp >=2.4 && <2.8
 
 common megaparsec
-  build-depends: megaparsec >=9.6.1 && <9.7
+  build-depends: megaparsec >=9.6.1 && <9.8
 
 common minimorph
   build-depends: minimorph >=0.3 && <0.4
@@ -283,7 +283,7 @@ common palette
   build-depends: palette >=0.3 && <0.4
 
 common pandoc
-  build-depends: pandoc >=3.0 && <3.6
+  build-depends: pandoc >=3.0 && <3.7
 
 common pandoc-types
   build-depends: pandoc-types >=1.23 && <1.24
@@ -298,7 +298,7 @@ common quickcheck-instances
   build-depends: quickcheck-instances >=0.3.17 && <0.4
 
 common random
-  build-depends: random >=1.2.0 && <1.3
+  build-depends: random >=1.2.0 && <1.4
 
 common scientific
   build-depends: scientific >=0.3.6 && <0.3.9
@@ -334,7 +334,7 @@ common tasty
   build-depends: tasty >=0.10 && <1.6
 
 common tasty-bench
-  build-depends: tasty-bench >=0.3.1 && <0.4
+  build-depends: tasty-bench >=0.3.1 && <0.5
 
 common tasty-expected-failure
   build-depends: tasty-expected-failure >=0.12 && <0.13
@@ -343,10 +343,10 @@ common tasty-hunit
   build-depends: tasty-hunit >=0.10 && <0.11
 
 common tasty-quickcheck
-  build-depends: tasty-quickcheck >=0.10 && <0.11
+  build-depends: tasty-quickcheck >=0.10 && <0.12
 
 common template-haskell
-  build-depends: template-haskell >=2.16 && <2.23
+  build-depends: template-haskell >=2.16 && <2.24
 
 common terminal-size
   build-depends: terminal-size >=0.3 && <1.0
@@ -355,7 +355,7 @@ common text
   build-depends: text >=1.2.4 && <2.2
 
 common text-rope
-  build-depends: text-rope >=0.2 && <0.3
+  build-depends: text-rope >=0.2 && <0.4
 
 common text-zipper
   build-depends: text-zipper >=0.10 && <0.14
@@ -379,7 +379,7 @@ common vector
   build-depends: vector >=0.12 && <0.14
 
 common vty
-  build-depends: vty >=6.1 && <6.3
+  build-depends: vty >=6.1 && <6.5
 
 common vty-crossplatform
   build-depends: vty-crossplatform >=0.4 && <0.5
@@ -397,10 +397,10 @@ common warp
   build-depends: warp >=3.2 && <3.5
 
 common witch
-  build-depends: witch >=1.1.1.0 && <1.3
+  build-depends: witch >=1.1.1.0 && <1.4
 
 common witherable
-  build-depends: witherable >=0.4 && <0.5
+  build-depends: witherable >=0.4 && <0.6
 
 common word-wrap
   build-depends: word-wrap >=0.5 && <0.6

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -38,7 +38,7 @@ maintainer: byorgey@gmail.com
 bug-reports: https://github.com/swarm-game/swarm/issues
 copyright: Brent Yorgey 2021
 category: Game
-tested-with: ghc ==9.4.8 || ==9.6.6 || ==9.8.2 || ==9.10.1
+tested-with: ghc ==9.6.6 || ==9.8.2 || ==9.10.1 || ==9.12.1
 extra-doc-files:
   CHANGELOG.md
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -121,7 +121,7 @@ common ghc2021-extensions
     TypeOperators
 
 common base
-  build-depends: base >=4.14 && <4.22
+  build-depends: base >=4.18 && <4.22
 
 common AhoCorasick
   build-depends: AhoCorasick >=0.0.4 && <0.0.5

--- a/test/standalone-topography/src/Main.hs
+++ b/test/standalone-topography/src/Main.hs
@@ -5,14 +5,13 @@
 module Main where
 
 import Data.Proxy
-import Data.Typeable (Typeable)
 import Lib (compareToReferenceImage)
 import Test.Tasty
 import Test.Tasty.HUnit (testCase)
 import Test.Tasty.Options
 
 newtype UpdateGoldenTests = UpdateGoldenTests Bool
-  deriving (Eq, Ord, Typeable)
+  deriving (Eq, Ord)
 
 instance IsOption UpdateGoldenTests where
   parseValue = fmap UpdateGoldenTests . safeRead


### PR DESCRIPTION
- Add support for GHC 9.12
- Remove support for GHC 9.4
- Clean up `Data.Text` imports to avoid ambiguity with new `Data.Text.show` in `text-2.1.2`
- Bump upper bounds to allow:
  - `base-4.21` (GHC 9.12)
  - `brick-2.8`
  - `hashable-1.5`
  - `megaparsec-9.7`
  - `pandoc-3.6`
  - `random-1.3`
  - `tasty-bench-0.4`
  - `tasty-quickcheck-0.11`
  - `template-haskell-2.23`
  - `text-rope-0.3`
  - `vty-6.4`
  - `witch-1.3`
  - `witherable-0.5`
- Require `base >= 4.18` and use `Applicative` re-exported from `base`