### PR TITLE
Add Swiss Army Robot achievement for equipping all craftable devices in classic game

### DIFF
--- a/src/swarm-doc/Swarm/Doc/Gen.hs
+++ b/src/swarm-doc/Swarm/Doc/Gen.hs
@@ -14,6 +14,9 @@ module Swarm.Doc.Gen (
 
   -- ** Wiki pages
   PageAddress (..),
+
+  -- ** Recipe graph drawing
+  EdgeFilter (..)
 ) where
 
 import Control.Lens (view, (^.))

--- a/src/swarm-doc/Swarm/Doc/Gen.hs
+++ b/src/swarm-doc/Swarm/Doc/Gen.hs
@@ -28,7 +28,6 @@ import Data.Map.Lazy qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.Text (Text, unpack)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Text.Lazy.IO qualified as TL
@@ -147,10 +146,6 @@ filterEdge ef i o = case ef of
   FilterForward -> i <= o
   FilterNext -> i + 1 == o
 
--- | Ignore utility entities that are just used for tutorials and challenges.
-ignoredEntities :: Set Text
-ignoredEntities = Set.fromList ["wall"]
-
 recipesToDot :: RG.RecipeGraph -> EdgeFilter -> Dot ()
 recipesToDot graphData ef = do
   Dot.attribute ("rankdir", "LR")
@@ -160,8 +155,8 @@ recipesToDot graphData ef = do
   -- --------------------------------------------------------------------------
   -- add nodes with for all the known entities
   let enames' = map (view entityName) . toList $ RG.allEntities graphData
-      enames = filter (`Set.notMember` ignoredEntities) enames'
-  ebmap <- Map.fromList . zip enames <$> mapM (box . unpack) enames
+      enames = filter (`Set.notMember` RG.ignoredEntities) enames'
+  ebmap <- Map.fromList . zip enames <$> mapM (box . T.unpack) enames
   -- --------------------------------------------------------------------------
   -- getters for the NodeId based on entity name or the whole entity
   let safeGetEntity m e = fromMaybe (error $ show e <> " is not an entity!?") $ m Map.!? e

--- a/src/swarm-doc/Swarm/Doc/Gen.hs
+++ b/src/swarm-doc/Swarm/Doc/Gen.hs
@@ -164,7 +164,7 @@ filterEdge ef i o = case ef of
 
 -- | Ignore utility entities that are just used for tutorials and challenges.
 ignoredEntities :: Set Text
-ignoredEntities = Set.fromList [ "wall" ]
+ignoredEntities = Set.fromList ["wall"]
 
 recipesToDot :: RecipeGraphData -> EdgeFilter -> Dot ()
 recipesToDot graphData ef = do

--- a/src/swarm-doc/Swarm/Doc/Gen.hs
+++ b/src/swarm-doc/Swarm/Doc/Gen.hs
@@ -14,7 +14,6 @@ module Swarm.Doc.Gen (
 
   -- ** Wiki pages
   PageAddress (..),
-
 ) where
 
 import Control.Lens (view, (^.))

--- a/src/swarm-doc/Swarm/Doc/Gen.hs
+++ b/src/swarm-doc/Swarm/Doc/Gen.hs
@@ -16,7 +16,7 @@ module Swarm.Doc.Gen (
   PageAddress (..),
 
   -- ** Recipe graph drawing
-  EdgeFilter (..)
+  EdgeFilter (..),
 ) where
 
 import Control.Lens (view, (^.))

--- a/src/swarm-doc/Swarm/Doc/Util.hs
+++ b/src/swarm-doc/Swarm/Doc/Util.hs
@@ -8,13 +8,8 @@
 module Swarm.Doc.Util where
 
 import Control.Effect.Throw (Has, Throw, throwError)
-import Control.Lens (view)
-import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Swarm.Failure (SystemFailure (CustomFailure))
-import Swarm.Game.Robot (Robot)
-import Swarm.Game.Scenario (ScenarioLandscape, scenarioRobots)
 import Swarm.Language.Syntax (Const (..))
 import Swarm.Language.Syntax qualified as Syntax
 

--- a/src/swarm-doc/Swarm/Doc/Util.hs
+++ b/src/swarm-doc/Swarm/Doc/Util.hs
@@ -14,7 +14,6 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Failure (SystemFailure (CustomFailure))
 import Swarm.Game.Robot (Robot)
-import Swarm.Game.Robot.Concrete (instantiateRobot)
 import Swarm.Game.Scenario (ScenarioLandscape, scenarioRobots)
 import Swarm.Language.Syntax (Const (..))
 import Swarm.Language.Syntax qualified as Syntax
@@ -45,8 +44,3 @@ commands = filter Syntax.isCmd Syntax.allConst
 
 constSyntax :: Const -> Text
 constSyntax = Syntax.syntax . Syntax.constInfo
-
-instantiateBaseRobot :: Has (Throw SystemFailure) sig m => ScenarioLandscape -> m Robot
-instantiateBaseRobot sLandscape = case listToMaybe $ view scenarioRobots sLandscape of
-  Just r -> pure $ instantiateRobot Nothing 0 r
-  Nothing -> throwError $ CustomFailure "Scenario contains no robots"

--- a/src/swarm-doc/Swarm/Doc/Util.hs
+++ b/src/swarm-doc/Swarm/Doc/Util.hs
@@ -7,7 +7,6 @@
 -- Utilities for generating doc markup
 module Swarm.Doc.Util where
 
-import Control.Effect.Throw (Has, Throw, throwError)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Swarm.Language.Syntax (Const (..))

--- a/src/swarm-engine/Swarm/Game/Achievement/Description.hs
+++ b/src/swarm-engine/Swarm/Game/Achievement/Description.hs
@@ -103,6 +103,13 @@ describe = \case
       "`give` something to your`self`."
       Easy
       True
+  GameplayAchievement EquippedAllDevices ->
+    AchievementInfo
+      "Swiss Army Robot"
+      (Just $ Freeform "You never know when that might come in handy...")
+      "`equip` all craftable devices simultaneously."
+      Gruelling
+      True
 
 -- | Validity conditions are required if-and-only-if the achievement
 -- category is 'GameplayAchievement'.
@@ -116,3 +123,4 @@ getValidityRequirements = \case
   GetDisoriented -> ValidityConditions OnlyPlayerRobot ExcludesCreativeMode
   SwapSame -> ValidityConditions OnlyPlayerRobot ExcludesCreativeMode
   GaveToSelf -> ValidityConditions OnlyPlayerRobot ExcludesCreativeMode
+  EquippedAllDevices -> ValidityConditions OnlyPlayerRobot ExcludesCreativeMode

--- a/src/swarm-engine/Swarm/Game/Scenario/Status.hs
+++ b/src/swarm-engine/Swarm/Game/Scenario/Status.hs
@@ -16,7 +16,7 @@ import Data.Aeson (
   genericToJSON,
  )
 import Data.Function (on)
-import Data.String (IsString(..))
+import Data.String (IsString (..))
 import Data.Time (ZonedTime, diffUTCTime, zonedTimeToUTC)
 import Data.Yaml as Y
 import GHC.Generics (Generic)

--- a/src/swarm-engine/Swarm/Game/Scenario/Status.hs
+++ b/src/swarm-engine/Swarm/Game/Scenario/Status.hs
@@ -16,6 +16,7 @@ import Data.Aeson (
   genericToJSON,
  )
 import Data.Function (on)
+import Data.String (IsString(..))
 import Data.Time (ZonedTime, diffUTCTime, zonedTimeToUTC)
 import Data.Yaml as Y
 import GHC.Generics (Generic)
@@ -79,6 +80,10 @@ getLaunchParams = \case
 newtype ScenarioPath = ScenarioPath
   { getScenarioPath :: FilePath
   }
+  deriving (Eq, Show)
+
+instance IsString ScenarioPath where
+  fromString = ScenarioPath
 
 data ScenarioWith a = ScenarioWith
   { _getScenario :: Scenario

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -33,7 +33,7 @@ import Swarm.Game.Recipe (
   inRecipeMap,
   outRecipeMap,
  )
-import Swarm.Game.Recipe.Graph (scenarioRecipeGraph, RecipeGraph(..))
+import Swarm.Game.Recipe.Graph (RecipeGraph (..), scenarioRecipeGraph)
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.Scenario

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -33,7 +33,7 @@ import Swarm.Game.Recipe (
   inRecipeMap,
   outRecipeMap,
  )
-import Swarm.Game.Recipe.Graph (RecipeGraph (..), scenarioRecipeGraph)
+import Swarm.Game.Recipe.Graph qualified as RG
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.Scenario
@@ -119,9 +119,9 @@ pureScenarioToGameState (ScenarioWith scenario fp) theSeed now toRun gsc =
   -- Get the names of all devices (i.e. entities that provide at least
   -- one capability) which can be recursively crafted from the
   -- starting inventory + entities available in the world
-  craftable = S.map (view entityName) . S.filter isDevice $ S.unions (rgLevels recipeGraph)
+  craftable = S.map (view entityName) . S.filter isDevice $ S.unions (RG.levels recipeGraph)
    where
-    recipeGraph = scenarioRecipeGraph scenario (initState gsc)
+    recipeGraph = RG.scenarioRecipeGraph scenario (initState gsc)
     isDevice :: Entity -> Bool
     isDevice = not . M.null . getMap . view entityCapabilities
 

--- a/src/swarm-engine/Swarm/Game/State/Substate.hs
+++ b/src/swarm-engine/Swarm/Game/State/Substate.hs
@@ -66,6 +66,7 @@ module Swarm.Game.State.Substate (
   availableRecipes,
   availableCommands,
   knownEntities,
+  craftableDevices,
   gameAchievements,
   structureRecognition,
   tagMembers,
@@ -339,6 +340,7 @@ data Discovery = Discovery
   , _availableRecipes :: Notifications (Recipe Entity)
   , _availableCommands :: Notifications Const
   , _knownEntities :: S.Set EntityName
+  , _craftableDevices :: S.Set EntityName
   , _gameAchievements :: Map GameplayAchievement Attainment
   , _structureRecognition :: RecognitionState RecognizableStructureContent Entity
   , _tagMembers :: Map Text (NonEmpty EntityName)
@@ -358,6 +360,10 @@ availableCommands :: Lens' Discovery (Notifications Const)
 -- | The names of entities that should be considered \"known\", that is,
 --   robots know what they are without having to scan them.
 knownEntities :: Lens' Discovery (S.Set EntityName)
+
+-- | The set of all entities that can be crafted in the current
+--   scenario.
+craftableDevices :: Lens' Discovery (S.Set EntityName)
 
 -- | Map of in-game achievements that were obtained
 gameAchievements :: Lens' Discovery (Map GameplayAchievement Attainment)
@@ -441,6 +447,7 @@ initDiscovery =
     , _availableCommands = mempty
     , _allDiscoveredEntities = empty
     , _knownEntities = mempty
+    , _craftableDevices = mempty
     , -- This does not need to be initialized with anything,
       -- since the master list of achievements is stored in UIState
       _gameAchievements = mempty

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -11,8 +11,6 @@
 -- Implementation of robot commands
 module Swarm.Game.Step.Const where
 
-import Swarm.Game.Scenario (RecognizableStructureContent)
-
 import Control.Arrow ((&&&))
 import Control.Carrier.State.Lazy
 import Control.Effect.Error
@@ -61,6 +59,7 @@ import Swarm.Game.Robot
 import Swarm.Game.Robot.Activity
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.Robot.Walk (emptyExceptions)
+import Swarm.Game.Scenario (RecognizableStructureContent)
 import Swarm.Game.Scenario.Topography.Area (getNEGridDimensions, rectHeight)
 import Swarm.Game.Scenario.Topography.Navigation.Portal (Navigation (..))
 import Swarm.Game.Scenario.Topography.Navigation.Util
@@ -408,6 +407,13 @@ execConst runChildProg c vs s k = do
         unless already $ do
           equippedDevices %= insert item
           robotInventory %= delete item
+
+          -- Check whether we should bestow the 'EquippedAllDevices' achievement
+          curScenario <- use currentScenarioPath
+          when (curScenario == Just "classic.yaml") $ do
+            equipped <- S.fromList . map (view entityName) . nonzeroEntities <$> use equippedDevices
+            equippable <- use $ discovery . craftableDevices
+            when (equippable `S.isSubsetOf` equipped) $ grantAchievementForRobot EquippedAllDevices
 
           -- Flag the UI for a redraw if we are currently showing our inventory
           when (focusedID == myID) flagRedraw

--- a/src/swarm-scenario/Swarm/Game/Achievement/Definitions.hs
+++ b/src/swarm-scenario/Swarm/Game/Achievement/Definitions.hs
@@ -126,6 +126,7 @@ data GameplayAchievement
   | GetDisoriented
   | SwapSame
   | GaveToSelf
+  | EquippedAllDevices
   deriving (Eq, Ord, Show, Bounded, Enum, Generic)
 
 instance FromJSON GameplayAchievement

--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -75,6 +75,7 @@ module Swarm.Game.Entity (
   contains,
   contains0plus,
   elems,
+  nonzeroEntities,
   isSubsetOf,
   isEmpty,
   inventoryCapabilities,

--- a/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
@@ -16,7 +16,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Tuple (swap)
 import Swarm.Failure (simpleErrorHandle)
-import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityProperties, entityYields, EntityProperty(Pickable))
+import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), EntityProperty (Pickable), entityProperties, entityYields)
 import Swarm.Game.Entity qualified as E
 import Swarm.Game.Land
 import Swarm.Game.Recipe (Recipe, recipeCatalysts, recipeInputs, recipeOutputs)

--- a/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+-- Description: calculate the graph of craftable entities
+-- and their dependencies via recipes.
+module Swarm.Game.Recipe.Graph (
+  RecipeGraph (..),
+  classicScenarioRecipeGraph,
+  scenarioRecipeGraph,
+) where
+
+import Control.Lens (view, (^.))
+import Data.Map.Lazy (Map)
+import Data.Map.Lazy qualified as Map
+import Data.Maybe (catMaybes, listToMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Tuple (swap)
+import Swarm.Failure (simpleErrorHandle)
+import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityYields)
+import Swarm.Game.Entity qualified as E
+import Swarm.Game.Land
+import Swarm.Game.Recipe (Recipe, recipeCatalysts, recipeInputs, recipeOutputs)
+import Swarm.Game.Robot (TRobot, tequippedDevices, trobotInventory)
+import Swarm.Game.Scenario (GameStateInputs (..), Scenario, ScenarioInputs (..), ScenarioLandscape, loadStandaloneScenario, scenarioLandscape, scenarioRobots, scenarioWorlds)
+import Swarm.Game.Scenario.Topography.Cell (PCell (..))
+import Swarm.Game.Scenario.Topography.Grid
+import Swarm.Game.Scenario.Topography.Structure.Overlay (gridContent)
+import Swarm.Game.Scenario.Topography.WorldDescription
+import Swarm.Game.World.Gen (extractEntities)
+import Swarm.Util (both)
+import Swarm.Util.Erasable (erasableToMaybe)
+
+-- | A description of a recipe graph for a given scenario.
+data RecipeGraph = RecipeGraph
+  { rgWorldEntities :: Set Entity
+  -- ^ Entities available in the world
+  , rgStartingDevices :: Set Entity
+  -- ^ Which devices the base starts with
+  , rgStartingInventory :: Set Entity
+  -- ^ What inventory the base starts with
+  , rgLevels :: [Set Entity]
+  -- ^ Recursively craftable entities, organized by distance from
+  -- starting inventory (i.e. number of crafting steps needed)
+  , rgAllEntities :: Set Entity
+  -- ^ All known entities
+  , rgRecipes :: [Recipe Entity]
+  -- ^ All known recipes
+  }
+
+baseRobotTemplate :: ScenarioLandscape -> Maybe TRobot
+baseRobotTemplate = listToMaybe . view scenarioRobots
+
+-- | Load the recipe graph corresponding to the classic scenario.
+classicScenarioRecipeGraph :: IO RecipeGraph
+classicScenarioRecipeGraph = simpleErrorHandle $ do
+  (classic, gsi) <- loadStandaloneScenario "data/scenarios/classic.yaml"
+  pure $ scenarioRecipeGraph classic gsi
+
+-- baseRobot <- baseRobotTemplate (classic ^. scenarioLandscape)
+-- let classicTerm = worlds ! "classic"
+-- let devs = startingDevices baseRobot
+-- let inv = Map.keysSet $ startingInventory baseRobot
+-- let worldEntities = case classicTerm of Some _ t -> extractEntities t
+-- return
+--   RecipeGraph
+--     { rgStartingDevices = devs
+--     , rgStartingInventory = inv
+--     , rgWorldEntities = worldEntities
+--     , rgLevels = recipeLevels emap recipes (Set.unions [worldEntities, devs, inv])
+--     , rgAllEntities = Set.fromList . Map.elems $ entitiesByName emap
+--     , rgRecipes = recipes
+--     }
+
+scenarioRecipeGraph :: Scenario -> GameStateInputs -> RecipeGraph
+scenarioRecipeGraph scenario (GameStateInputs (ScenarioInputs _ (TerrainEntityMaps _ emap)) recipes) =
+  RecipeGraph
+    { rgStartingDevices = devs
+    , rgStartingInventory = inv
+    , rgWorldEntities = worldEntities
+    , rgLevels = recipeLevels emap recipes (Set.unions [worldEntities, devs, inv])
+    , rgAllEntities = Set.fromList . Map.elems $ entitiesByName emap
+    , rgRecipes = recipes
+    }
+ where
+  landscape = scenario ^. scenarioLandscape
+  -- Run Throw computation + turn into Either
+  baseRobot = baseRobotTemplate landscape
+  worldEntities = landscapeEntities landscape
+  devs = maybe Set.empty startingDevices baseRobot
+  inv = maybe Set.empty (Map.keysSet . startingInventory) baseRobot
+
+-- | Get the set of all entities which can be harvested from the world.
+landscapeEntities :: ScenarioLandscape -> Set Entity
+landscapeEntities = foldMap harvestable . view scenarioWorlds
+ where
+  harvestable :: WorldDescription -> Set Entity
+  harvestable wd = Set.fromList (static wd) <> dynamic wd
+   where
+    -- XXX filter by which can be picked up?
+
+    static :: WorldDescription -> [Entity]
+    static =
+      catMaybes
+        . map (erasableToMaybe . cellEntity)
+        . catMaybes
+        . allMembers
+        . gridContent
+        . area
+
+    dynamic :: WorldDescription -> Set Entity
+    dynamic = maybe Set.empty extractEntities . worldProg
+
+-------------------------------------------------------------------------------
+-- RECIPE LEVELS
+-------------------------------------------------------------------------------
+
+-- | Order entities in sets depending on how soon it is possible to obtain them.
+--
+-- So:
+--  * Level 0 - starting entities (for example those obtainable in the world)
+--  * Level N+1 - everything possible to make (or drill or harvest) from Level N
+--
+-- This is almost a BFS, but the requirement is that the set of entities
+-- required for recipe is subset of the entities known in Level N.
+--
+-- If we ever depend on some graph library, this could be rewritten
+-- as some BFS-like algorithm with added recipe nodes, but you would
+-- need to enforce the condition that recipes need ALL incoming edges.
+recipeLevels :: EntityMap -> [Recipe Entity] -> Set Entity -> [Set Entity]
+recipeLevels emap recipes start = levels
+ where
+  recipeParts r = ((r ^. recipeInputs) <> (r ^. recipeCatalysts), r ^. recipeOutputs)
+  m :: [(Set Entity, Set Entity)]
+  m = map (both (Set.fromList . map snd) . recipeParts) recipes
+  levels :: [Set Entity]
+  levels = reverse $ go [start] start
+   where
+    isKnown known (i, _o) = null $ i Set.\\ known
+    lookupYield e = case view entityYields e of
+      Nothing -> e
+      Just yn -> case E.lookupEntityName yn emap of
+        Nothing -> error "unknown yielded entity"
+        Just ye -> ye
+    yielded = Set.map lookupYield
+    nextLevel known = Set.unions $ yielded known : map snd (filter (isKnown known) m)
+    go ls known =
+      let n = nextLevel known Set.\\ known
+       in if null n
+            then ls
+            else go (n : ls) (Set.union n known)
+
+startingDevices :: TRobot -> Set Entity
+startingDevices = Set.fromList . map snd . E.elems . view tequippedDevices
+
+startingInventory :: TRobot -> Map Entity Int
+startingInventory = Map.fromList . map swap . E.elems . view trobotInventory

--- a/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 -- Description: calculate the graph of craftable entities
@@ -15,12 +11,12 @@ module Swarm.Game.Recipe.Graph (
 import Control.Lens (view, (^.))
 import Data.Map.Lazy (Map)
 import Data.Map.Lazy qualified as Map
-import Data.Maybe (catMaybes, listToMaybe)
+import Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Tuple (swap)
 import Swarm.Failure (simpleErrorHandle)
-import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityYields)
+import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), entityProperties, entityYields, EntityProperty(Pickable))
 import Swarm.Game.Entity qualified as E
 import Swarm.Game.Land
 import Swarm.Game.Recipe (Recipe, recipeCatalysts, recipeInputs, recipeOutputs)
@@ -103,8 +99,7 @@ landscapeEntities = foldMap harvestable . view scenarioWorlds
     static :: WorldDescription -> [Entity]
     static =
       filter (Set.member Pickable . view entityProperties)
-        . catMaybes
-        . map (erasableToMaybe . cellEntity)
+        . mapMaybe (erasableToMaybe . cellEntity)
         . catMaybes
         . allMembers
         . gridContent

--- a/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 -- Description: calculate the graph of craftable entities
@@ -6,6 +8,7 @@ module Swarm.Game.Recipe.Graph (
   RecipeGraph (..),
   classicScenarioRecipeGraph,
   scenarioRecipeGraph,
+  ignoredEntities,
 ) where
 
 import Control.Lens (view, (^.))
@@ -14,6 +17,7 @@ import Data.Map.Lazy qualified as Map
 import Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Text (Text)
 import Data.Tuple (swap)
 import Swarm.Failure (simpleErrorHandle)
 import Swarm.Game.Entity (Entity, EntityMap (entitiesByName), EntityProperty (Pickable), entityProperties, entityYields)
@@ -29,6 +33,10 @@ import Swarm.Game.Scenario.Topography.WorldDescription
 import Swarm.Game.World.Gen (extractEntities)
 import Swarm.Util (both)
 import Swarm.Util.Erasable (erasableToMaybe)
+
+-- | Ignore utility entities that are just used for tutorials and challenges.
+ignoredEntities :: Set Text
+ignoredEntities = Set.fromList ["wall"]
 
 -- | A description of a recipe graph for a given scenario.
 data RecipeGraph = RecipeGraph

--- a/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
@@ -100,11 +100,10 @@ landscapeEntities = foldMap harvestable . view scenarioWorlds
   harvestable :: WorldDescription -> Set Entity
   harvestable wd = Set.fromList (static wd) <> dynamic wd
    where
-    -- XXX filter by which can be picked up?
-
     static :: WorldDescription -> [Entity]
     static =
-      catMaybes
+      filter (Set.member Pickable . view entityProperties)
+        . catMaybes
         . map (erasableToMaybe . cellEntity)
         . catMaybes
         . allMembers

--- a/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
@@ -25,7 +25,7 @@ import Swarm.Game.Entity qualified as E
 import Swarm.Game.Land
 import Swarm.Game.Recipe (Recipe, recipeCatalysts, recipeInputs, recipeOutputs)
 import Swarm.Game.Robot (TRobot, tequippedDevices, trobotInventory)
-import Swarm.Game.Scenario (GameStateInputs (..), Scenario, ScenarioInputs (..), ScenarioLandscape, loadStandaloneScenario, scenarioLandscape, scenarioRobots, scenarioWorlds)
+import Swarm.Game.Scenario
 import Swarm.Game.Scenario.Topography.Cell (PCell (..))
 import Swarm.Game.Scenario.Topography.Grid
 import Swarm.Game.Scenario.Topography.Structure.Overlay (gridContent)
@@ -70,11 +70,12 @@ scenarioRecipeGraph scenario (GameStateInputs (ScenarioInputs _ (TerrainEntityMa
     { startingDevices = devs
     , startingInventory = inv
     , worldEntities = ents
-    , levels = recipeLevels emap recipeList (Set.unions [ents, devs, inv])
-    , allEntities = Set.fromList . Map.elems $ entitiesByName emap
-    , recipes = recipeList
+    , levels = recipeLevels scenarioEMap recipeList (Set.unions [ents, devs, inv])
+    , allEntities = Set.fromList . Map.elems $ entitiesByName scenarioEMap
+    , recipes = recipeList ++ (scenario ^. scenarioOperation . scenarioRecipes)
     }
  where
+  scenarioEMap = (scenario ^. scenarioLandscape . scenarioTerrainAndEntities . entityMap) <> emap
   landscape = scenario ^. scenarioLandscape
   baseRobot = baseRobotTemplate landscape
   devs = maybe Set.empty robotStartingDevices baseRobot

--- a/src/swarm-scenario/Swarm/Game/Robot.hs
+++ b/src/swarm-scenario/Swarm/Game/Robot.hs
@@ -42,7 +42,9 @@ module Swarm.Game.Robot (
   trobotLocation,
   robotOrientation,
   robotInventory,
+  trobotInventory,
   equippedDevices,
+  tequippedDevices,
   inventoryHash,
   robotCapabilities,
   walkabilityContext,
@@ -239,6 +241,10 @@ robotOrientation = robotEntity . entityOrientation
 robotInventory :: Lens' Robot Inventory
 robotInventory = robotEntity . entityInventory
 
+-- | A robot template's inventory.
+trobotInventory :: Lens' TRobot Inventory
+trobotInventory = robotEntity . entityInventory
+
 -- | The (unique) ID number of the robot.  This is only a Getter since
 --   the robot ID is immutable.
 robotID :: Getter Robot RID
@@ -266,6 +272,10 @@ equippedDevices = lens _equippedDevices setEquipped
       { _equippedDevices = inst
       , _robotCapabilities = inventoryCapabilities inst
       }
+
+-- | A robot template's equipped devices.
+tequippedDevices :: Getter TRobot Inventory
+tequippedDevices = to _equippedDevices
 
 -- | A hash of a robot's entity record and equipped devices, to
 --   facilitate quickly deciding whether we need to redraw the robot

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -620,6 +620,7 @@ library swarm-scenario
     Swarm.Game.Ingredients
     Swarm.Game.Land
     Swarm.Game.Recipe
+    Swarm.Game.Recipe.Graph
     Swarm.Game.Robot
     Swarm.Game.Robot.Walk
     Swarm.Game.Scenario

--- a/test/integration/TestRecipeCoverage.hs
+++ b/test/integration/TestRecipeCoverage.hs
@@ -10,7 +10,7 @@ import Control.Lens (view)
 import Data.List qualified as List
 import Data.Set qualified as Set
 import Data.Text qualified as T
-import Swarm.Doc.Gen
+import Swarm.Game.Recipe.Graph qualified as RG
 import Swarm.Game.Entity (Entity, EntityName, entityName)
 import Swarm.Util (applyWhen, quote)
 import Test.Tasty
@@ -26,9 +26,9 @@ import Test.Tasty.HUnit
 -- the dot graph of entity recipes in 'Swarm.Doc.Gen' that this test uses.
 testRecipeCoverage :: IO TestTree
 testRecipeCoverage = do
-  graphData <- classicScenarioRecipeGraphData
+  graphData <- RG.classicScenarioRecipeGraph
   let sortE = List.sortOn (T.unpack . view entityName)
-      allEntities = sortE . Set.toList $ rgAllEntities graphData
+      allEntities = sortE . Set.toList $ RG.allEntities graphData
       nonCovered = getNonCoveredEntities graphData
   return . testGroup "Ensure all entities have recipes" $
     map (\e -> expectNonCovered e $ checkCoverage nonCovered e) allEntities
@@ -37,7 +37,7 @@ testRecipeCoverage = do
   checkCoverage s e =
     let name = view entityName e
      in testCase (T.unpack name) $ do
-          assertBool (errMessage name) (name `elem` ignoredEntities || e `Set.notMember` s)
+          assertBool (errMessage name) (name `elem` RG.ignoredEntities || e `Set.notMember` s)
    where
     errMessage missing = T.unpack $ "Can not make " <> quote missing <> " from starting entities."
 
@@ -60,5 +60,5 @@ nonCoveredList =
     , "wedge"
     ]
 
-getNonCoveredEntities :: RecipeGraphData -> Set.Set Entity
-getNonCoveredEntities graphData = rgAllEntities graphData `Set.difference` Set.unions (rgLevels graphData)
+getNonCoveredEntities :: RG.RecipeGraph -> Set.Set Entity
+getNonCoveredEntities graphData = RG.allEntities graphData `Set.difference` Set.unions (RG.levels graphData)

--- a/test/integration/TestRecipeCoverage.hs
+++ b/test/integration/TestRecipeCoverage.hs
@@ -10,8 +10,8 @@ import Control.Lens (view)
 import Data.List qualified as List
 import Data.Set qualified as Set
 import Data.Text qualified as T
-import Swarm.Game.Recipe.Graph qualified as RG
 import Swarm.Game.Entity (Entity, EntityName, entityName)
+import Swarm.Game.Recipe.Graph qualified as RG
 import Swarm.Util (applyWhen, quote)
 import Test.Tasty
 import Test.Tasty.ExpectedFailure (expectFailBecause)


### PR DESCRIPTION
Closes #1030.

- Adds new `EquippedAllDevices` achievement
- Moves the recipe graph analysis code from `swarm-doc` to a new module `Swarm.Game.Recipe.Graph` in `swarm-scenario`.
- Adds a new field `craftableDevices` to the `discovery` subrecord in `gameState`, containing a set of entity names which are available in the world or recursively craftable from what is available.
- Grant the achievement when the player's equipped devices become a superset of the craftable devices, and the current scenario is `classic.yaml`.

This achievement is extremely difficult!  I have not actually been able to test it directly.  Here is a way to test that it seems to be working:

- Temporarily remove the check whether the current scenario is `classic.yaml`
- Load `Tutorials/equip`
- `equip "solar panel"`
- Grab the 3D printer and equip it
- You should be granted the achievement.

For now I have restricted the achievement only to classic mode, but am open to arguments that we should somehow open it up more.