### PR TITLE
Ignore cabal haddock-project output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 dist-newstyle/
+haddocks/
 TAGS
 
 .vscode/


### PR DESCRIPTION
Ignore the default output path for `cabal haddock-project` command introduced in Cabal 3.10:
https://cabal.readthedocs.io/en/stable/cabal-commands.html#cabal-haddock-project