### PR TITLE
Expand all tydefs in `infer` and `check`

### DIFF
--- a/src/swarm-lang/Swarm/Effect/Unify/Fast.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify/Fast.hs
@@ -39,6 +39,7 @@ import Data.Map.Merge.Lazy qualified as M
 import Data.Monoid (First (..))
 import Data.Set (Set)
 import Data.Set qualified as S
+import Swarm.Util.Effect (withThrow)
 import Swarm.Effect.Unify
 import Swarm.Effect.Unify.Common
 import Swarm.Language.Types hiding (Type)
@@ -253,7 +254,9 @@ unify ty1 ty2 = do
         (UTyRec x ty, _) -> unify (unfoldRec x ty) ty2
         (_, UTyRec x ty) -> unify ty1 (unfoldRec x ty)
         (UTyUser x1 tys, _) -> do
-          ty1' <- expandTydef x1 tys
+          ty1' <- withThrow
+            (\(UnexpandedUserType _) -> UndefinedUserType (UTyUser x1 tys))
+            (expandTydef x1 tys)
           unify ty1' ty2
         (_, UTyUser {}) -> unify ty2 ty1
         (Free t1, Free t2) -> Free <$> unifyF t1 t2

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -76,7 +76,7 @@ import Swarm.Effect.Unify qualified as U
 import Swarm.Effect.Unify.Fast qualified as U
 import Swarm.Language.Context hiding (lookup)
 import Swarm.Language.Context qualified as Ctx
-import Swarm.Language.Kindcheck (KindError, checkKind, checkPolytypeKind)
+import Swarm.Language.Kindcheck (KindError (..), checkKind, checkPolytypeKind)
 import Swarm.Language.Parser.QQ (tyQ)
 import Swarm.Language.Parser.Util (getLocRange)
 import Swarm.Language.Requirements.Analysis (requirements)
@@ -448,11 +448,13 @@ generalize uty = do
 data TypeErr
   = -- | An undefined variable was encountered.
     UnboundVar Var
+  | -- | An undefined type was encountered.
+    UnboundType Var
   | -- | A kind error was encountered.
     KindErr KindError
   | -- | A Skolem variable escaped its local context.
     EscapedSkolem Var
-  | -- | Occurs check failure, i.e. infinite type.
+  | -- | Failure during unification.
     UnificationErr UnificationError
   | -- | Type mismatch caught by 'unify'.  The given term was
     --   expected to have a certain type, but has a different type
@@ -512,6 +514,8 @@ instance PrettyPrec TypeErr where
       "Skolem variable" <+> pretty x <+> "would escape its scope"
     UnboundVar x ->
       "Unbound variable" <+> pretty x
+    UnboundType x ->
+      "Undefined type" <+> pretty x
     DefNotTopLevel t ->
       "Definitions may only be at the top level:" <+> pprCode t
     CantInfer t ->
@@ -710,7 +714,7 @@ decomposeTyConApp1 ::
   Sourced UType ->
   m UType
 decomposeTyConApp1 c t (src, UTyConApp (TCUser u) as) = do
-  ty2 <- expandTydef u as
+  ty2 <- adaptToTypeErr NoLoc (UnboundType . getUnexpanded) $ expandTydef u as
   decomposeTyConApp1 c t (src, ty2)
 decomposeTyConApp1 c _ (_, UTyConApp c' [a])
   | c == c' = return a
@@ -757,7 +761,7 @@ decomposeRcdTy ms = \case
   ty@(UTyConApp tc as) -> case tc of
     -- User-defined type: expand it
     TCUser u -> do
-      ty2 <- expandTydef u as
+      ty2 <- adaptToTypeErr NoLoc (UnboundType . getUnexpanded) $ expandTydef u as
       decomposeRcdTy ms ty2
     -- Any other type constructor application is definitely not a record type
     _ -> throwTypeErr (maybe NoLoc (view sLoc) ms) $ MismatchRcd ms ty
@@ -782,7 +786,7 @@ decomposeTyConApp2 ::
   Sourced UType ->
   m (UType, UType)
 decomposeTyConApp2 c t (src, UTyConApp (TCUser u) as) = do
-  ty2 <- expandTydef u as
+  ty2 <- adaptToTypeErr NoLoc (UnboundType . getUnexpanded) $ expandTydef u as
   decomposeTyConApp2 c t (src, ty2)
 decomposeTyConApp2 c _ (_, UTyConApp c' [ty1, ty2])
   | c == c' = return (ty1, ty2)
@@ -818,7 +822,10 @@ inferTop ctx reqCtx tdCtx = runTC ctx reqCtx tdCtx Ctx.empty . infer
 checkTop :: TCtx -> ReqCtx -> TDCtx -> Syntax -> Type -> Either ContextualTypeErr TSyntax
 checkTop ctx reqCtx tdCtx t ty = runTC ctx reqCtx tdCtx Ctx.empty $ check t (toU ty)
 
--- | Infer the type of a term, returning a type-annotated term.
+-- | Infer the type of a term, returning a type-annotated term.  It is
+--   guaranteed that all user-defined types have been completely
+--   expanded away; no user-defined type names will show up in any
+--   annotations.
 --
 --   The only cases explicitly handled in 'infer' are those where
 --   pushing an expected type down into the term can't possibly help,
@@ -879,9 +886,11 @@ infer s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
   -- type.
   SLam x (Just argTy) body -> do
     adaptToTypeErr l KindErr $ checkKind argTy
-    let uargTy = toU argTy
+    -- Make sure we expand user-defined types
+    argTy' <- adaptToTypeErr l (UnboundType . getUnexpanded) $ expandTydefs argTy
+    let uargTy = toU argTy'
     body' <- withBinding @UPolytype (lvVar x) (mkTrivPoly uargTy) $ infer body
-    return $ Syntax' l (SLam x (Just argTy) body') cs (UTyFun uargTy (body' ^. sType))
+    return $ Syntax' l (SLam x (Just argTy') body') cs (UTyFun uargTy (body' ^. sType))
 
   -- Need special case here for applying 'atomic' or 'instant' so we
   -- don't handle it with the case for generic type application.
@@ -999,8 +1008,10 @@ infer s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
     -- Free variables should be able to unify with anything in
     -- following typechecking steps.
     iuty <- instantiate upty
-    c' <- check c iuty
-    return $ Syntax' l (SAnnotate c' (forgetQ qpty)) cs iuty
+    -- Make sure to expand tydefs so none end up in the result.
+    iuty' <- adaptToTypeErr l (UnboundType . getUnexpanded) $ expandTydefs iuty
+    c' <- check c iuty'
+    return $ Syntax' l (SAnnotate c' (forgetQ qpty)) cs iuty'
 
   -- Fallback: to infer the type of anything else, make up a fresh unification
   -- variable for its type and check against it.
@@ -1128,7 +1139,9 @@ inferConst c = run . runReader @TVCtx Ctx.empty . quantify $ case c of
   arithBinT = [tyQ| Int -> Int -> Int |]
 
 -- | @check t ty@ checks that @t@ has type @ty@, returning a
---   type-annotated AST if so.
+--   type-annotated AST if so. It is guaranteed that all user-defined
+--   types have been completely expanded away; no user-defined type
+--   names will show up in any annotations.
 --
 --   We try to stay in checking mode as far as possible, decomposing
 --   the expected type as we go and pushing it through the recursion.
@@ -1144,180 +1157,184 @@ check ::
   Syntax ->
   UType ->
   m (Syntax' UType)
-check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
-  -- Once we're typechecking, we don't need to keep around explicit
-  -- parens any more
-  SParens t1 -> check t1 expected
-  -- If t : ty, then  {t} : {ty}.
-  SDelay s1 -> do
-    ty1 <- decomposeDelayTy s (Expected, expected)
-    s1' <- check s1 ty1
-    return $ Syntax' l (SDelay s1') cs (UTyDelay ty1)
+check s@(CSyntax l t cs) expectedRaw = addLocToTypeErr l $ do
+  expected <- adaptToTypeErr l (UnboundType . getUnexpanded) $ expandTydefs expectedRaw
+  case t of
+    -- Once we're typechecking, we don't need to keep around explicit
+    -- parens any more
+    SParens t1 -> check t1 expected
+    -- If t : ty, then  {t} : {ty}.
+    SDelay s1 -> do
+      ty1 <- decomposeDelayTy s (Expected, expected)
+      s1' <- check s1 ty1
+      return $ Syntax' l (SDelay s1') cs (UTyDelay ty1)
 
-  -- To check the type of a pair, make sure the expected type is a
-  -- product type, and push the two types down into the left and right.
-  SPair s1 s2 -> do
-    (ty1, ty2) <- decomposeProdTy s (Expected, expected)
-    s1' <- check s1 ty1
-    s2' <- check s2 ty2
-    return $ Syntax' l (SPair s1' s2') cs (UTyProd ty1 ty2)
+    -- To check the type of a pair, make sure the expected type is a
+    -- product type, and push the two types down into the left and right.
+    SPair s1 s2 -> do
+      (ty1, ty2) <- decomposeProdTy s (Expected, expected)
+      s1' <- check s1 ty1
+      s2' <- check s2 ty2
+      return $ Syntax' l (SPair s1' s2') cs (UTyProd ty1 ty2)
 
-  -- To check a lambda, make sure the expected type is a function type.
-  SLam x mxTy body -> do
-    (argTy, resTy) <- decomposeFunTy s (Expected, expected)
-    traverse_ (adaptToTypeErr l KindErr . checkKind) mxTy
-    forM_ (toU mxTy) $ \xTy -> do
-      res <- argTy U.=:= xTy
-      case res of
-        -- Generate a special error when the explicit type annotation
-        -- on a lambda doesn't match the expected type,
-        -- e.g. (\x:Int. x + 2) : Text -> Int, since the usual
-        -- "expected/but got" language would probably be confusing.
-        Left _ -> throwTypeErr l $ LambdaArgMismatch (joined argTy xTy)
-        Right _ -> return ()
+    -- To check a lambda, make sure the expected type is a function type.
+    SLam x mxTy body -> do
+      (argTy, resTy) <- decomposeFunTy s (Expected, expected)
+      traverse_ (adaptToTypeErr l KindErr . checkKind) mxTy
+      forM_ (toU mxTy) $ \xTy -> do
+        res <- argTy U.=:= xTy
+        case res of
+          -- Generate a special error when the explicit type annotation
+          -- on a lambda doesn't match the expected type,
+          -- e.g. (\x:Int. x + 2) : Text -> Int, since the usual
+          -- "expected/but got" language would probably be confusing.
+          Left _ -> throwTypeErr l $ LambdaArgMismatch (joined argTy xTy)
+          Right _ -> return ()
 
-    body' <- withBinding @UPolytype (lvVar x) (mkTrivPoly argTy) $ check body resTy
-    return $ Syntax' l (SLam x mxTy body') cs (UTyFun argTy resTy)
+      body' <- withBinding @UPolytype (lvVar x) (mkTrivPoly argTy) $ check body resTy
+      return $ Syntax' l (SLam x mxTy body') cs (UTyFun argTy resTy)
 
-  -- Special case for checking the argument to 'atomic' (or
-  -- 'instant').  'atomic t' has the same type as 't', which must have
-  -- a type of the form 'Cmd a' for some 'a'.
+    -- Special case for checking the argument to 'atomic' (or
+    -- 'instant').  'atomic t' has the same type as 't', which must have
+    -- a type of the form 'Cmd a' for some 'a'.
 
-  TConst c :$: at
-    | c `elem` [Atomic, Instant] -> do
-        argTy <- decomposeCmdTy s (Expected, expected)
-        at' <- check at (UTyCmd argTy)
-        atomic' <- infer (Syntax l (TConst c))
-        -- It's important that we typecheck the subterm @at@ *before* we
-        -- check that it is a valid argument to @atomic@: this way we can
-        -- ensure that we have already inferred the types of any variables
-        -- referenced.
-        --
-        -- When c is Atomic we validate that the argument to atomic is
-        -- guaranteed to operate within a single tick.  When c is Instant
-        -- we skip this check.
-        when (c == Atomic) $ validAtomic at
-        return $ Syntax' l (SApp atomic' at') cs (UTyCmd argTy)
+    TConst c :$: at
+      | c `elem` [Atomic, Instant] -> do
+          argTy <- decomposeCmdTy s (Expected, expected)
+          at' <- check at (UTyCmd argTy)
+          atomic' <- infer (Syntax l (TConst c))
+          -- It's important that we typecheck the subterm @at@ *before* we
+          -- check that it is a valid argument to @atomic@: this way we can
+          -- ensure that we have already inferred the types of any variables
+          -- referenced.
+          --
+          -- When c is Atomic we validate that the argument to atomic is
+          -- guaranteed to operate within a single tick.  When c is Instant
+          -- we skip this check.
+          when (c == Atomic) $ validAtomic at
+          return $ Syntax' l (SApp atomic' at') cs (UTyCmd argTy)
 
-  -- Checking the type of a let- or def-expression.
-  SLet ls r x mxTy _ _ t1 t2 -> withFrame l (TCLet (lvVar x)) $ do
-    mqxTy <- traverse quantify mxTy
-    (skolems, upty, t1') <- case mqxTy of
-      -- No type annotation was provided for the let binding, so infer its type.
-      Nothing -> do
-        -- The let could be recursive, so we must generate a fresh
-        -- unification variable for the type of x and infer the type
-        -- of t1 with x in the context.
-        xTy <- fresh
-        t1' <- withBinding @UPolytype (lvVar x) (mkTrivPoly xTy) $ infer t1
-        let uty = t1' ^. sType
-        uty' <- unify (Just t1) (joined xTy uty)
-        upty <- generalize uty'
-        return ([], upty, t1')
-      -- An explicit polytype annotation has been provided. Perform
-      -- implicit quantification, kind checking, and skolemization,
-      -- then check definition and body under an extended context.
-      Just pty -> do
-        _ <- adaptToTypeErr l KindErr . checkPolytypeKind $ pty
-        let upty = toU pty
-        (ss, uty) <- skolemize upty
-        t1' <- withBinding (lvVar x) upty . withBindings ss $ check t1 uty
-        return (Ctx.vars ss, upty, t1')
+    -- Checking the type of a let- or def-expression.
+    SLet ls r x mxTy _ _ t1 t2 -> withFrame l (TCLet (lvVar x)) $ do
+      mqxTy <- traverse quantify mxTy
+      (skolems, upty, t1') <- case mqxTy of
+        -- No type annotation was provided for the let binding, so infer its type.
+        Nothing -> do
+          -- The let could be recursive, so we must generate a fresh
+          -- unification variable for the type of x and infer the type
+          -- of t1 with x in the context.
+          xTy <- fresh
+          t1' <- withBinding @UPolytype (lvVar x) (mkTrivPoly xTy) $ infer t1
+          let uty = t1' ^. sType
+          uty' <- unify (Just t1) (joined xTy uty)
+          upty <- generalize uty'
+          return ([], upty, t1')
+        -- An explicit polytype annotation has been provided. Perform
+        -- implicit quantification, kind checking, and skolemization,
+        -- then check definition and body under an extended context.
+        Just pty -> do
+          _ <- adaptToTypeErr l KindErr . checkPolytypeKind $ pty
+          let upty = toU pty
+          -- Expand any user types in the provided type annotation
+          upty' <- adaptToTypeErr l (UnboundType . getUnexpanded) $ mapM expandTydefs upty
+          (ss, uty) <- skolemize upty'
+          t1' <- withBinding (lvVar x) upty' . withBindings ss $ check t1 uty
+          return (Ctx.vars ss, upty', t1')
 
-    -- Check the requirements of t1.
-    tdCtx <- ask @TDCtx
-    reqCtx <- ask @ReqCtx
-    let Syntax' _ tt1 _ _ = t1
-        reqs = requirements tdCtx reqCtx tt1
+      -- Check the requirements of t1.
+      tdCtx <- ask @TDCtx
+      reqCtx <- ask @ReqCtx
+      let Syntax' _ tt1 _ _ = t1
+          reqs = requirements tdCtx reqCtx tt1
 
-    -- If we are checking a 'def', ensure t2 has a command type.  This ensures that
-    -- something like 'def ... end; x + 3' is not allowed, since this
-    -- would result in the whole thing being wrapped in pure, like
-    -- 'pure (def ... end; x + 3)', which means the def would be local and
-    -- not persist to the next REPL input, which could be surprising.
+      -- If we are checking a 'def', ensure t2 has a command type.  This ensures that
+      -- something like 'def ... end; x + 3' is not allowed, since this
+      -- would result in the whole thing being wrapped in pure, like
+      -- 'pure (def ... end; x + 3)', which means the def would be local and
+      -- not persist to the next REPL input, which could be surprising.
+      --
+      -- On the other hand, 'let x = y in x + 3' is perfectly fine.
+      when (ls == LSDef) $ void $ decomposeCmdTy t2 (Expected, expected)
+
+      -- Now check the type of the body, under a context extended with
+      -- the type and requirements of the bound variable.
+      t2' <-
+        withBinding (lvVar x) upty $
+          withBinding (lvVar x) reqs $
+            check t2 expected
+
+      -- Make sure none of the generated skolem variables have escaped.
+      ask @UCtx >>= mapM_ (noSkolems l skolems)
+
+      -- Annotate a 'def' with requirements, but not 'let'.  The reason
+      -- is so that let introduces truly "local" bindings which never
+      -- persist, but def introduces "global" bindings.  Variables bound
+      -- in the environment can only be used to typecheck future REPL
+      -- terms if the environment holds not only a value but also a type
+      -- + requirements for them.  For example:
+      --
+      -- > def x : Int = 3 end; pure (x + 2)
+      -- 5
+      -- > x
+      -- 3
+      -- > let y : Int = 3 in y + 2
+      -- 5
+      -- > y
+      -- 1:1: Unbound variable y
+      -- > let y = 3 in def x = 5 end; pure (x + y)
+      -- 8
+      -- > y
+      -- 1:1: Unbound variable y
+      -- > x
+      -- 5
+      let mreqs = case ls of
+            LSDef -> Just reqs
+            LSLet -> Nothing
+
+      -- Return the annotated let.
+      return $ Syntax' l (SLet ls r x mxTy mqxTy mreqs t1' t2') cs expected
+
+    -- Kind-check a type definition and then check the body under an
+    -- extended context.
+    STydef x pty _ t1 -> do
+      tydef <- adaptToTypeErr l KindErr $ checkPolytypeKind pty
+      t1' <- withBinding (lvVar x) tydef (check t1 expected)
+      -- Eliminate the type alias in the reported type, since it is not
+      -- in scope in the ambient context to which we report back the type.
+      expected' <- elimTydef (lvVar x) tydef <$> applyBindings expected
+      return $ Syntax' l (STydef x pty (Just tydef) t1') cs expected'
+
+    -- To check a record, ensure the expected type is a record type,
+    -- ensure all the right fields are present, and push the expected
+    -- types of all the fields down into recursive checks.
     --
-    -- On the other hand, 'let x = y in x + 3' is perfectly fine.
-    when (ls == LSDef) $ void $ decomposeCmdTy t2 (Expected, expected)
+    -- We have to be careful here --- if the expected type is not
+    -- manifestly a record type but might unify with one (i.e. if the
+    -- expected type is a variable) then we can't generate type
+    -- variables for its subparts and push them, we have to switch
+    -- completely into inference mode.  See Note [Checking and inference
+    -- for record literals].
+    SRcd fields
+      | UTyRcd tyMap <- expected -> do
+          let expectedFields = M.keysSet tyMap
+              actualFields = M.keysSet fields
+          when (actualFields /= expectedFields) $
+            throwTypeErr l $
+              FieldsMismatch (joined expectedFields actualFields)
+          m' <- itraverse (\x ms -> check (fromMaybe (STerm (TVar x)) ms) (tyMap ! x)) fields
+          return $ Syntax' l (SRcd (Just <$> m')) cs expected
 
-    -- Now check the type of the body, under a context extended with
-    -- the type and requirements of the bound variable.
-    t2' <-
-      withBinding (lvVar x) upty $
-        withBinding (lvVar x) reqs $
-          check t2 expected
+    -- The type of @suspend t@ is @Cmd T@ if @t : T@.
+    SSuspend s1 -> do
+      argTy <- decomposeCmdTy s (Expected, expected)
+      s1' <- check s1 argTy
+      return $ Syntax' l (SSuspend s1') cs expected
 
-    -- Make sure none of the generated skolem variables have escaped.
-    ask @UCtx >>= mapM_ (noSkolems l skolems)
-
-    -- Annotate a 'def' with requirements, but not 'let'.  The reason
-    -- is so that let introduces truly "local" bindings which never
-    -- persist, but def introduces "global" bindings.  Variables bound
-    -- in the environment can only be used to typecheck future REPL
-    -- terms if the environment holds not only a value but also a type
-    -- + requirements for them.  For example:
-    --
-    -- > def x : Int = 3 end; pure (x + 2)
-    -- 5
-    -- > x
-    -- 3
-    -- > let y : Int = 3 in y + 2
-    -- 5
-    -- > y
-    -- 1:1: Unbound variable y
-    -- > let y = 3 in def x = 5 end; pure (x + y)
-    -- 8
-    -- > y
-    -- 1:1: Unbound variable y
-    -- > x
-    -- 5
-    let mreqs = case ls of
-          LSDef -> Just reqs
-          LSLet -> Nothing
-
-    -- Return the annotated let.
-    return $ Syntax' l (SLet ls r x mxTy mqxTy mreqs t1' t2') cs expected
-
-  -- Kind-check a type definition and then check the body under an
-  -- extended context.
-  STydef x pty _ t1 -> do
-    tydef <- adaptToTypeErr l KindErr $ checkPolytypeKind pty
-    t1' <- withBinding (lvVar x) tydef (check t1 expected)
-    -- Eliminate the type alias in the reported type, since it is not
-    -- in scope in the ambient context to which we report back the type.
-    expected' <- elimTydef (lvVar x) tydef <$> applyBindings expected
-    return $ Syntax' l (STydef x pty (Just tydef) t1') cs expected'
-
-  -- To check a record, ensure the expected type is a record type,
-  -- ensure all the right fields are present, and push the expected
-  -- types of all the fields down into recursive checks.
-  --
-  -- We have to be careful here --- if the expected type is not
-  -- manifestly a record type but might unify with one (i.e. if the
-  -- expected type is a variable) then we can't generate type
-  -- variables for its subparts and push them, we have to switch
-  -- completely into inference mode.  See Note [Checking and inference
-  -- for record literals].
-  SRcd fields
-    | UTyRcd tyMap <- expected -> do
-        let expectedFields = M.keysSet tyMap
-            actualFields = M.keysSet fields
-        when (actualFields /= expectedFields) $
-          throwTypeErr l $
-            FieldsMismatch (joined expectedFields actualFields)
-        m' <- itraverse (\x ms -> check (fromMaybe (STerm (TVar x)) ms) (tyMap ! x)) fields
-        return $ Syntax' l (SRcd (Just <$> m')) cs expected
-
-  -- The type of @suspend t@ is @Cmd T@ if @t : T@.
-  SSuspend s1 -> do
-    argTy <- decomposeCmdTy s (Expected, expected)
-    s1' <- check s1 argTy
-    return $ Syntax' l (SSuspend s1') cs expected
-
-  -- Fallback: switch into inference mode, and check that the type we
-  -- get is what we expected.
-  _ -> do
-    Syntax' l' t' _ actual <- infer s
-    Syntax' l' t' cs <$> unify (Just s) (joined expected actual)
+    -- Fallback: switch into inference mode, and check that the type we
+    -- get is what we expected.
+    _ -> do
+      Syntax' l' t' _ actual <- infer s
+      Syntax' l' t' cs <$> unify (Just s) (joined expected actual)
 
 -- ~~~~ Note [Checking and inference for record literals]
 --

--- a/src/swarm-util/Swarm/Failure.hs
+++ b/src/swarm-util/Swarm/Failure.hs
@@ -78,7 +78,7 @@ data SystemFailure
   | ScenarioNotFound FilePath
   | OrderFileWarning FilePath OrderFileWarning
   | CanNotParseMegaparsec (ParseErrorBundle Text Void)
-  | DoesNotTypecheck Text -- See Note [Typechecking errors]
+  | DoesNotTypecheck Text -- See Note [Pretty-printing typechecking errors]
   | CustomFailure Text
   deriving (Show)
 

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -401,6 +401,14 @@ testEval g =
             ( "read \"\\\"hi: there\\\"\" : Text"
                 `evaluatesToV` ("hi: there" :: Text)
             )
+        , testCase
+            "read at user-defined type works #2223"
+            ( "tydef Foo = Int end; read \"3\" : Foo" `evaluatesToV` (3 :: Integer) )
+        , testCase
+            "read at wrong user-defined type fails normally #2223"
+            ( "tydef Foo = Bool end; read \"3\" : Foo"
+                `throwsError` ("Could not read \"3\" at type Bool" `T.isInfixOf`)
+            )
         ]
     , testGroup
         "records - #1093"

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -629,6 +629,12 @@ testLanguagePipeline =
                 "tydef Unbound a b = a + b + c end"
                 "1:34:\n  |\n1 | tydef Unbound a b = a + b + c end\n  |                                  ^\nUndefined type variable(s) on right-hand side of tydef: c\n"
             )
+        , testCase
+            "redefinition of user type does not break type soundness #2437"
+            (process
+               "tydef Foo = Int end; def f : Int -> Foo = \\x. x + 1 end; tydef Foo = Bool end; if (f 3) {} {}"
+               "1:84: Type mismatch:\n  From context, expected `f 3` to have type `Bool`"
+            )
         ]
     , testGroup
         "recursive types"


### PR DESCRIPTION
This PR does two related things:

1. Immediately expand all user tydefs in `infer` and `check`, so inferred types are always fully expanded and will never contain user tydefs.  This is a bit annoying, especially in the case of tydefs created to abbreviate long, complicated types, but seems necessary to solve soundness issues like #2437.
    - This closes #2223, since now any type annotation on `read` will be immediately expanded, so no user-defined types will be encountered when evaluating the `read` at runtime.
    - This also closes #2437, since the inferred type of a function stored in the context can no longer contain a user-defined type, and so we cannot confuse the type system by redefining one.
2. Throw a proper error in case an undefined type constructor is encountered in `expandTydef`.
    - In #2431 we got rid of a call to `error`.
    - However, instead we just returned the same, unchanged and unexpanded type, which caused its own issues: when doing unification, if we see the same pair of types a second time, we assume by coinduction that the types unify.  This doesn't work if a type can expand to itself, and was the cause of the fatal CESK error in #2223.
    - This PR handles things properly, by throwing an exception which will be propagated appropriately in case anything like this ever happens again.