### PR TITLE
Throw proper exceptions when encountering unbound user-defined types in `expandTydef` + related functions

### DIFF
--- a/src/swarm-lang/Swarm/Effect/Unify/Fast.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify/Fast.hs
@@ -39,10 +39,10 @@ import Data.Map.Merge.Lazy qualified as M
 import Data.Monoid (First (..))
 import Data.Set (Set)
 import Data.Set qualified as S
-import Swarm.Util.Effect (withThrow)
 import Swarm.Effect.Unify
 import Swarm.Effect.Unify.Common
 import Swarm.Language.Types hiding (Type)
+import Swarm.Util.Effect (withThrow)
 import Prelude hiding (lookup)
 
 ------------------------------------------------------------
@@ -254,9 +254,10 @@ unify ty1 ty2 = do
         (UTyRec x ty, _) -> unify (unfoldRec x ty) ty2
         (_, UTyRec x ty) -> unify ty1 (unfoldRec x ty)
         (UTyUser x1 tys, _) -> do
-          ty1' <- withThrow
-            (\(UnexpandedUserType _) -> UndefinedUserType (UTyUser x1 tys))
-            (expandTydef x1 tys)
+          ty1' <-
+            withThrow
+              (\(UnexpandedUserType _) -> UndefinedUserType (UTyUser x1 tys))
+              (expandTydef x1 tys)
           unify ty1' ty2
         (_, UTyUser {}) -> unify ty2 ty1
         (Free t1, Free t2) -> Free <$> unifyF t1 t2

--- a/src/swarm-lang/Swarm/Effect/Unify/Fast.hs
+++ b/src/swarm-lang/Swarm/Effect/Unify/Fast.hs
@@ -39,6 +39,7 @@ import Data.Map.Merge.Lazy qualified as M
 import Data.Monoid (First (..))
 import Data.Set (Set)
 import Data.Set qualified as S
+import Swarm.Util.Effect (withThrow)
 import Swarm.Effect.Unify
 import Swarm.Effect.Unify.Common
 import Swarm.Language.Types hiding (Type)
@@ -253,7 +254,9 @@ unify ty1 ty2 = do
         (UTyRec x ty, _) -> unify (unfoldRec x ty) ty2
         (_, UTyRec x ty) -> unify ty1 (unfoldRec x ty)
         (UTyUser x1 tys, _) -> do
-          ty1' <- expandTydef x1 tys
+          ty1' <- withThrow
+            (\(UnexpandedUserType _) -> UndefinedUserType (UTyUser x1 tys))
+            (expandTydef x1 tys)
           unify ty1' ty2
         (_, UTyUser {}) -> unify ty2 ty1
         (Free t1, Free t2) -> Free <$> unifyF t1 t2

--- a/src/swarm-lang/Swarm/Language/Kindcheck.hs
+++ b/src/swarm-lang/Swarm/Language/Kindcheck.hs
@@ -126,14 +126,17 @@ checkRecTy x ty = do
 --   variable.
 containsVar ::
   (Has (Reader TDCtx) sig m, Has (Throw KindError) sig m) =>
-  Nat -> Type -> m Bool
+  Nat ->
+  Type ->
+  m Bool
 containsVar i ty@(Fix tyF) = case tyF of
   TyRecVarF j -> pure (i == j)
   TyVarF {} -> pure False
   TyConF (TCUser u) tys -> do
-    ty' <- withThrow
-      (\(UnexpandedUserType _) -> UndefinedTyCon (TCUser u) ty)
-      (expandTydef u tys)
+    ty' <-
+      withThrow
+        (\(UnexpandedUserType _) -> UndefinedTyCon (TCUser u) ty)
+        (expandTydef u tys)
     containsVar i ty'
   TyConF _ tys -> or <$> mapM (containsVar i) tys
   TyRcdF m -> or <$> mapM (containsVar i) m
@@ -150,16 +153,19 @@ containsVar i ty@(Fix tyF) = case tyF of
 --   @tydef Id a = a@, the type @rec x. rec y. Id x@ is also vacuous.
 nonVacuous ::
   (Has (Reader TDCtx) sig m, Has (Throw KindError) sig m) =>
-  Nat -> Type -> m Bool
+  Nat ->
+  Type ->
+  m Bool
 nonVacuous i ty@(Fix tyF) = case tyF of
   -- The type simply consists of a variable bound by some @rec@.
   -- Check if it's the variable we're currently looking for.
   TyRecVarF j -> pure (i /= j)
   -- Expand a user-defined type and keep looking.
   TyConF (TCUser u) tys -> do
-    ty' <- withThrow
-      (\(UnexpandedUserType _) -> UndefinedTyCon (TCUser u) ty)
-      (expandTydef u tys)
+    ty' <-
+      withThrow
+        (\(UnexpandedUserType _) -> UndefinedTyCon (TCUser u) ty)
+        (expandTydef u tys)
     nonVacuous i ty'
   -- Increment the variable we're looking for when going under a @rec@
   -- binder.

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -849,7 +849,8 @@ expandTydef userTyCon tys = do
 --   everywhere in a type.
 expandTydefs ::
   (Has (Reader TDCtx) sig m, Has (Throw ExpandTydefErr) sig m, Typical t, Plated t) =>
-  t -> m t
+  t ->
+  m t
 expandTydefs = rewriteM expand
  where
   -- expand :: t -> m (Maybe t)

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -819,7 +819,7 @@ makeLenses ''TydefInfo
 --   to their definitions and arities/kinds.
 type TDCtx = Ctx TydefInfo
 
-data ExpandTydefErr = UnexpandedUserType { getUnexpanded :: Var }
+newtype ExpandTydefErr = UnexpandedUserType {getUnexpanded :: Var}
   deriving (Eq, Show)
 
 -- | Expand an application "T ty1 ty2 ... tyn" by looking up the

--- a/src/swarm-util/Swarm/Failure.hs
+++ b/src/swarm-util/Swarm/Failure.hs
@@ -78,7 +78,7 @@ data SystemFailure
   | ScenarioNotFound FilePath
   | OrderFileWarning FilePath OrderFileWarning
   | CanNotParseMegaparsec (ParseErrorBundle Text Void)
-  | DoesNotTypecheck Text -- See Note [Typechecking errors]
+  | DoesNotTypecheck Text -- See Note [Pretty-printing typechecking errors]
   | CustomFailure Text
   deriving (Show)
 


### PR DESCRIPTION
Throw a proper error in case an undefined type constructor is encountered in `expandTydef`:

- In #2431 we got rid of a call to `error`.
- However, instead we just returned the same, unchanged and unexpanded type, which caused its own issues: when doing unification, if we see the same pair of types a second time, we assume by coinduction that the types unify.  This doesn't work if a type can expand to itself, and was the cause of the fatal CESK error in #2223.
- This PR handles things properly, by throwing an exception which will be propagated appropriately in case anything like this ever happens again.
- Also, make `expandTydefs` more polymorphic.

This PR is split out from #2438: I am not sure whether we actually want to greedily expand all tydefs as in #2438, but this PR represents the subset of that one which I think we want to do regardless.