### PR TITLE
Restore the fix for robot modal leak by only rendering when visible

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -189,7 +189,10 @@ updateUI = do
 
   newPopups <- Brick.zoom playState generateNotificationPopups
 
-  Brick.zoom (playState . scenarioState) $ doRobotListUpdate dOps g
+  -- Update the robots modal only when it is enabled.  See #2370.
+  curModal <- use $ playState . scenarioState . uiGameplay . uiDialogs . uiModal
+  when ((view modalType <$> curModal) == Just (MidScenarioModal RobotsModal)) $ do
+    Brick.zoom (playState . scenarioState) $ doRobotListUpdate dOps g
 
   let redraw =
         g ^. needsRedraw


### PR DESCRIPTION
The fix in #2379 was mistakenly deleted in #2382.

Part of #2440.