### PR TITLE
Ignore profiling outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ docs/ott/*.tex
 node_modules/
 package-lock.json
 package.json
+
+*.hp
+*.eventlog
+*.eventlog.html
+*.prof


### PR DESCRIPTION
Add some file types produced by profiling to `.gitignore`.