### PR TITLE
Use Brick.Animation to implement popup notifications

### DIFF
--- a/app/game/Swarm/App.hs
+++ b/app/game/Swarm/App.hs
@@ -65,7 +65,7 @@ app eventHandler =
 appMain :: AppOpts -> IO ()
 appMain opts = do
   chan <- createChannel
-  res <- runM . runThrow $ initAppState opts chan
+  res <- runM . runThrow $ initAppState opts (Just chan)
   case res of
     Left err -> do
       T.hPutStrLn stderr (prettyText @SystemFailure err)
@@ -105,7 +105,7 @@ demoWeb = do
   let demoPort = 8080
   chan <- createChannel
   res <-
-    runM . runThrow $ initAppState (defaultAppOpts {userScenario = demoScenario}) chan
+    runM . runThrow $ initAppState (defaultAppOpts {userScenario = demoScenario}) (Just chan)
   case res of
     Left err -> T.putStrLn (prettyText @SystemFailure err)
     Right s -> do

--- a/src/swarm-engine/Swarm/Game/Popup.hs
+++ b/src/swarm-engine/Swarm/Game/Popup.hs
@@ -19,7 +19,6 @@ module Swarm.Game.Popup (
 
 import Control.Lens (makeLenses, use, (%~), (.=))
 import Control.Monad.State (MonadState)
-import Data.Maybe (isJust)
 import Data.Sequence (Seq, (|>), pattern (:<|))
 import Data.Sequence qualified as Seq
 import Swarm.Game.Achievement.Definitions (CategorizedAchievement)
@@ -59,19 +58,12 @@ popupFrames :: Int
 popupFrames = 100
 
 -- | Move the next popup (if any) from the queue to the
---   currently displayed popup.  Return True if there was any
---   popup to move.
-nextPopup :: MonadState PopupState m => m Bool
+--   currently displayed popup.
+nextPopup :: MonadState PopupState m => m ()
 nextPopup = do
   q <- use popupQueue
-  cur <- use currentPopup
   case q of
-    Seq.Empty
-      | isJust cur -> do
-          currentPopup .= Nothing
-          pure True
-      | otherwise -> pure False
+    Seq.Empty -> currentPopup .= Nothing
     n :<| ns -> do
       currentPopup .= Just n
       popupQueue .= ns
-      pure True

--- a/src/swarm-engine/Swarm/Game/Popup.hs
+++ b/src/swarm-engine/Swarm/Game/Popup.hs
@@ -12,9 +12,6 @@ module Swarm.Game.Popup (
   initPopupState,
   addPopup,
   nextPopup,
-
-  -- * Popup animation
-  popupFrames,
 ) where
 
 import Control.Lens (makeLenses, use, (%~), (.=))
@@ -52,10 +49,6 @@ initPopupState =
 -- | Add a popup to the end of the queue.
 addPopup :: Popup -> PopupState -> PopupState
 addPopup notif = popupQueue %~ (|> notif)
-
--- | The number of frames for which to display a popup.
-popupFrames :: Int
-popupFrames = 100
 
 -- | Move the next popup (if any) from the queue to the
 --   currently displayed popup.

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -120,7 +120,7 @@ handleEvent e = do
     -- the query for upstream version could finish at any time, so we have to handle it here
     AppEvent (UpstreamVersion ev) -> handleUpstreamVersionResponse ev
     AppEvent (Web (RunWebCode {..})) | not playing -> liftIO . webReply $ Rejected NoActiveGame
-    AppEvent (PopupEvent event) -> event
+    AppEvent (PopupEvent event) -> event >> continueWithoutRedraw
     _ -> do
       -- Handle popup display at the very top level, so it is
       -- unaffected by any other state, e.g. even when starting or

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -142,6 +142,8 @@ startPopupIfNeeded = do
   mPopup <- use $ playState . progression . uiPopups . currentPopup
   case mPopup of
     Just popup -> do
+      -- Ensures we don't grab another popup while waiting for the animation manager to start the event.
+      -- The animation state will be set to AnimActive when the animation manager actually starts the animation
       playState . progression . uiPopupAnimationState .= AnimScheduled
       animMgr <- use animationMgr
       startPopupAnimation animMgr popup

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -120,8 +120,7 @@ handleEvent e = do
     -- the query for upstream version could finish at any time, so we have to handle it here
     AppEvent (UpstreamVersion ev) -> handleUpstreamVersionResponse ev
     AppEvent (Web (RunWebCode {..})) | not playing -> liftIO . webReply $ Rejected NoActiveGame
-    AppEvent (PopupEvent event) -> do
-      event
+    AppEvent (PopupEvent event) -> event
     _ -> do
       -- Handle popup display at the very top level, so it is
       -- unaffected by any other state, e.g. even when starting or

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -142,7 +142,6 @@ import Text.Fuzzy qualified as Fuzzy
 -- | 'Swarm.TUI.Model.AppEvent' represents a type for custom event types our app can
 --   receive. The primary custom event 'Frame' is sent by a separate thread as fast as
 --   it can, telling the TUI to render a new frame.
--- TODO Expand on the custom event PopupEvent
 data AppEvent
   = Frame
   | Web WebCommand

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -141,7 +141,9 @@ import Text.Fuzzy qualified as Fuzzy
 
 -- | 'Swarm.TUI.Model.AppEvent' represents a type for custom event types our app can
 --   receive. The primary custom event 'Frame' is sent by a separate thread as fast as
---   it can, telling the TUI to render a new frame.
+--   it can, telling the TUI to render a new frame. The custom event 'PopupEvent' is sent
+--   by the animation manager and contains an event that starts, stops, or updates a
+--   popup notification.
 data AppEvent
   = Frame
   | Web WebCommand

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -172,11 +172,7 @@ initPersistentState opts@(AppOpts {..}) = do
         (loadTestScenarios $ mkRuntimeOptions opts)
     achievements <- loadAchievementsInfo
 
-    let animState =
-          AnimationState
-            { _runningAnimation = Nothing
-            , _animationScheduled = False
-            }
+    let animState = AnimInactive
     let progState =
           ProgressionState
             { _scenarios = s

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -208,7 +208,7 @@ constructAppState (PersistentState rs ui key progState) opts@(AppOpts {..}) mCha
   historyT <- sendIO $ readFileMayT =<< getSwarmHistoryPath False
   let history = maybe [] (map mkREPLSubmission . T.lines) historyT
   startTime <- sendIO $ getTime Monotonic
-  chan <- sendIO $ maybe initNullChan pure mChan
+  chan <- sendIO $ maybe initTestChan pure mChan
   animMgr <- sendIO $ startAnimationManager animMgrTickDuration chan PopupEvent
 
   let gsc = rs ^. stdGameConfigInputs
@@ -440,10 +440,10 @@ scenarioToUIState siPair u = do
           )
           swarmAttrMap
 
--- | Create a BChan that cannot hold any events.
+-- | Create a BChan that holds only one event.
 --   This should only be used in unit tests, integration tests, and benchmarks
-initNullChan :: IO (BChan AppEvent)
-initNullChan = newBChan 0
+initTestChan :: IO (BChan AppEvent)
+initTestChan = newBChan 1
 
 -- | Create an initial app state for a specific scenario.  Note that
 --   this function is used only for unit tests, integration tests, and

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -111,7 +111,7 @@ import System.Clock
 
 -- | The resolution at which the animation manager checks animations for updates, in miliseconds
 animMgrTickDuration :: Int
-animMgrTickDuration = 250
+animMgrTickDuration = 33
 
 -- | Initialize the 'AppState' from scratch.
 initAppState ::

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -30,16 +30,16 @@ import Swarm.TUI.View.Attribute.Attr (notifAttr)
 import Swarm.TUI.View.Util (bindingText)
 import Swarm.Util (commaList, squote)
 
--- | The number of frames taken by each step of the notification popup
+-- | The number of animation frames taken by each step of the notification popup
 --   animation.
 animFrames :: Int
 animFrames = 3
 
--- | The number of milliseconds taken by each frame of the notification popup
+-- | The number of milliseconds taken by each animation frame of the notification popup
 popupFrameDuration :: Integer
 popupFrameDuration = 25
 
--- | The number of frames for which to display a popup.
+-- | The number of animation frames for which to display a popup.
 popupFrames :: Int
 popupFrames = 125
 
@@ -90,18 +90,16 @@ drawPopup s = \case
   keyConf = s ^. keyEventHandling . keyConfig
 
 -- | Compute the number of rows of the notification popup we should be
---   showing, based on the number of frames the popup has existed.
+--   showing, based on the number of animation frames the popup has existed.
 --   This is what causes the popup to animate in and out of existence.
 popupRows :: Int -> Int
 popupRows f
-  -- If we're less than halfway through the lifetime of the popup,
-  -- divide the number of frames by the number of frames for each step
-  -- of the animation (rounded up).  This will become much larger than
-  -- the actual number of rows in the popup, but the 'cropTopTo' function
-  -- simply has no effect when given any value equal to or larger than the
-  -- number of rows of a widget.  This way the animation will continue to
-  -- work for popups with any (reasonable) number of rows.
-  | f <= popupFrames `div` 2 = (f + animFrames - 1) `div` animFrames
-  -- Otherwise, divide the number of frames remaining by the number of
-  -- frames for each step of the animation (rounded up).
-  | otherwise = (popupFrames - f + animFrames - 1) `div` animFrames
+  -- If we're less than halfway through the lifetime of the popup, use
+  -- the number of animation frames elapsed since the beginning of the popup animation.
+  -- This will become much larger than the actual number of rows in the
+  -- popup, but the 'cropTopTo' function simply has no effect when given any value
+  -- equal to or larger than the number of rows of a widget. This way the animation
+  -- will continue to work for popups with any (reasonable) number of rows.
+  | f <= popupFrames `div` 2 = f
+  -- Otherwise, use the number of frames remaining.
+  | otherwise = popupFrames - f

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -51,7 +51,10 @@ drawPopups s = renderAnimation (const emptyWidget) s mAnim
 
 -- | Signal the animation manager to start the popup animation.
 startPopupAnimation :: MonadIO m => AnimationManager AppState AppEvent Name -> Popup -> m ()
-startPopupAnimation mgr p = startAnimation mgr (makePopupClip p) popupFrameDuration Once (playState . progression . uiPopupAnimationState . animTraversal)
+startPopupAnimation mgr p = startAnimation mgr (makePopupClip p) popupFrameDuration Once trav
+ where
+  trav :: Traversal' AppState (Maybe (Animation AppState Name))
+  trav = playState . progression . uiPopupAnimationState . animTraversal
 
 makePopupClip :: Popup -> Clip AppState Name
 makePopupClip p = newClip $ map drawPopupFrame [0 .. popupFrames]

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -4,7 +4,10 @@
 -- SPDX-License-Identifier: BSD-3-Clause
 --
 -- Rendering (& animating) notification popups.
-module Swarm.TUI.View.Popup where
+module Swarm.TUI.View.Popup (
+  drawPopups,
+  startPopupAnimation,
+) where
 
 import Brick (Widget (..), cropTopTo, padLeftRight, txt, vBox)
 import Brick.Animation (AnimationManager, Clip, RunMode (..), newClip, renderAnimation, startAnimation)
@@ -27,7 +30,7 @@ import Swarm.Util (commaList, squote)
 -- | The number of frames taken by each step of the notification popup
 --   animation.
 animFrames :: Int
-animFrames = 1 -- 3
+animFrames = 1
 
 -- | The number of milliseconds taken by each frame of the notification popup
 popupFrameDuration :: Integer
@@ -35,12 +38,11 @@ popupFrameDuration = 50
 
 -- | Draw the current notification popup (if any).
 drawPopups :: AppState -> Widget Name
-drawPopups s = renderAnimation (const defaultWidget) s mAnim
+drawPopups s = renderAnimation (const emptyWidget) s mAnim
  where
-  defaultWidget = emptyWidget
   mAnim = s ^? playState . progression . uiPopupAnimationState . _AnimActive
 
--- TODO
+-- | Signal the animation manager to start the popup animation.
 startPopupAnimation :: MonadIO m => AnimationManager AppState AppEvent Name -> Popup -> m ()
 startPopupAnimation mgr p = startAnimation mgr (makePopupClip p) popupFrameDuration Once (playState . progression . uiPopupAnimationState . animTraversal)
 

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -13,11 +13,11 @@ module Swarm.TUI.View.Popup (
 ) where
 
 import Brick (Widget (..), cropTopTo, padLeftRight, txt, vBox)
-import Brick.Animation (AnimationManager, Clip, RunMode (..), newClip, renderAnimation, startAnimation)
+import Brick.Animation (Animation, AnimationManager, Clip, RunMode (..), newClip, renderAnimation, startAnimation)
 import Brick.Widgets.Border (border)
 import Brick.Widgets.Center (hCenterLayer)
 import Brick.Widgets.Core (emptyWidget, hBox, withAttr)
-import Control.Lens ((^.), (^?))
+import Control.Lens (Traversal', (^.), (^?))
 import Control.Monad.IO.Class (MonadIO)
 import Swarm.Game.Achievement.Definitions (title)
 import Swarm.Game.Achievement.Description (describe)
@@ -33,15 +33,15 @@ import Swarm.Util (commaList, squote)
 -- | The number of frames taken by each step of the notification popup
 --   animation.
 animFrames :: Int
-animFrames = 1
+animFrames = 3
 
 -- | The number of milliseconds taken by each frame of the notification popup
 popupFrameDuration :: Integer
-popupFrameDuration = 50
+popupFrameDuration = 25
 
 -- | The number of frames for which to display a popup.
 popupFrames :: Int
-popupFrames = 100
+popupFrames = 125
 
 -- | Draw the current notification popup (if any).
 drawPopups :: AppState -> Widget Name

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -7,6 +7,9 @@
 module Swarm.TUI.View.Popup (
   drawPopups,
   startPopupAnimation,
+  animFrames,
+  popupFrameDuration,
+  popupFrames,
 ) where
 
 import Brick (Widget (..), cropTopTo, padLeftRight, txt, vBox)
@@ -18,7 +21,7 @@ import Control.Lens ((^.), (^?))
 import Control.Monad.IO.Class (MonadIO)
 import Swarm.Game.Achievement.Definitions (title)
 import Swarm.Game.Achievement.Description (describe)
-import Swarm.Game.Popup (Popup (..), popupFrames)
+import Swarm.Game.Popup (Popup (..))
 import Swarm.Language.Syntax (constInfo, syntax)
 import Swarm.TUI.Model (AppEvent, AppState, animTraversal, keyConfig, keyEventHandling, playState, progression, uiPopupAnimationState, _AnimActive)
 import Swarm.TUI.Model.Event qualified as SE
@@ -35,6 +38,10 @@ animFrames = 1
 -- | The number of milliseconds taken by each frame of the notification popup
 popupFrameDuration :: Integer
 popupFrameDuration = 50
+
+-- | The number of frames for which to display a popup.
+popupFrames :: Int
+popupFrames = 100
 
 -- | Draw the current notification popup (if any).
 drawPopups :: AppState -> Widget Name

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -7,7 +7,6 @@
 module Swarm.TUI.View.Popup (
   drawPopups,
   startPopupAnimation,
-  animFrames,
   popupFrameDuration,
   popupFrames,
 ) where
@@ -30,14 +29,9 @@ import Swarm.TUI.View.Attribute.Attr (notifAttr)
 import Swarm.TUI.View.Util (bindingText)
 import Swarm.Util (commaList, squote)
 
--- | The number of animation frames taken by each step of the notification popup
---   animation.
-animFrames :: Int
-animFrames = 3
-
 -- | The number of milliseconds taken by each animation frame of the notification popup
 popupFrameDuration :: Integer
-popupFrameDuration = 25
+popupFrameDuration = 50
 
 -- | The number of animation frames for which to display a popup.
 popupFrames :: Int

--- a/src/swarm-tui/Swarm/TUI/View/Popup.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Popup.hs
@@ -11,13 +11,13 @@ import Brick.Animation (AnimationManager, Clip, RunMode (..), newClip, renderAni
 import Brick.Widgets.Border (border)
 import Brick.Widgets.Center (hCenterLayer)
 import Brick.Widgets.Core (emptyWidget, hBox, withAttr)
-import Control.Lens ((^.))
+import Control.Lens ((^.), (^?))
 import Control.Monad.IO.Class (MonadIO)
 import Swarm.Game.Achievement.Definitions (title)
 import Swarm.Game.Achievement.Description (describe)
 import Swarm.Game.Popup (Popup (..), popupFrames)
 import Swarm.Language.Syntax (constInfo, syntax)
-import Swarm.TUI.Model (AppEvent, AppState, keyConfig, keyEventHandling, playState, progression, runningAnimation, uiPopupAnimationState)
+import Swarm.TUI.Model (AppEvent, AppState, animTraversal, keyConfig, keyEventHandling, playState, progression, uiPopupAnimationState, _AnimActive)
 import Swarm.TUI.Model.Event qualified as SE
 import Swarm.TUI.Model.Name
 import Swarm.TUI.View.Attribute.Attr (notifAttr)
@@ -38,11 +38,11 @@ drawPopups :: AppState -> Widget Name
 drawPopups s = renderAnimation (const defaultWidget) s mAnim
  where
   defaultWidget = emptyWidget
-  mAnim = s ^. playState . progression . uiPopupAnimationState . runningAnimation
+  mAnim = s ^? playState . progression . uiPopupAnimationState . _AnimActive
 
 -- TODO
 startPopupAnimation :: MonadIO m => AnimationManager AppState AppEvent Name -> Popup -> m ()
-startPopupAnimation mgr p = startAnimation mgr (makePopupClip p) popupFrameDuration Once (playState . progression . uiPopupAnimationState . runningAnimation)
+startPopupAnimation mgr p = startAnimation mgr (makePopupClip p) popupFrameDuration Once (playState . progression . uiPopupAnimationState . animTraversal)
 
 makePopupClip :: Popup -> Clip AppState Name
 makePopupClip p = newClip $ map drawPopupFrame [0 .. popupFrames]

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -81,7 +81,7 @@ import Swarm.TUI.Model (
   userScenario,
  )
 import Swarm.TUI.Model.DebugOption (DebugOption (LoadTestingScenarios))
-import Swarm.TUI.Model.StateUpdate (PersistentState (..), constructAppState, initPersistentState)
+import Swarm.TUI.Model.StateUpdate (PersistentState (..), constructAppState, initNullChan, initPersistentState)
 import Swarm.Util (applyWhen, findAllWithExt)
 import Swarm.Util.RingBuffer qualified as RB
 import Swarm.Util.Yaml (decodeFileEitherE)
@@ -539,7 +539,8 @@ testScenarioSolutions ps =
     (GameState -> Assertion) ->
     TestTree
   testSolution' s p shouldCheckBadErrors verify = testCase p $ do
-    out <- runM . runThrow @SystemFailure $ constructAppState ps $ defaultAppOpts {userScenario = Just p}
+    nullChan <- initNullChan
+    out <- runM . runThrow @SystemFailure $ constructAppState ps (defaultAppOpts {userScenario = Just p}) nullChan
     case out of
       Left err -> assertFailure $ prettyString err
       Right appState -> case appState ^. playState . scenarioState . gameState . winSolution of

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -81,7 +81,7 @@ import Swarm.TUI.Model (
   userScenario,
  )
 import Swarm.TUI.Model.DebugOption (DebugOption (LoadTestingScenarios))
-import Swarm.TUI.Model.StateUpdate (PersistentState (..), constructAppState, initNullChan, initPersistentState)
+import Swarm.TUI.Model.StateUpdate (PersistentState (..), constructAppState, initPersistentState)
 import Swarm.Util (applyWhen, findAllWithExt)
 import Swarm.Util.RingBuffer qualified as RB
 import Swarm.Util.Yaml (decodeFileEitherE)
@@ -539,8 +539,7 @@ testScenarioSolutions ps =
     (GameState -> Assertion) ->
     TestTree
   testSolution' s p shouldCheckBadErrors verify = testCase p $ do
-    nullChan <- initNullChan
-    out <- runM . runThrow @SystemFailure $ constructAppState ps (defaultAppOpts {userScenario = Just p}) nullChan
+    out <- runM . runThrow @SystemFailure $ constructAppState ps (defaultAppOpts {userScenario = Just p}) Nothing
     case out of
       Left err -> assertFailure $ prettyString err
       Right appState -> case appState ^. playState . scenarioState . gameState . winSolution of


### PR DESCRIPTION
This PR refactors the code to use `Brick.Animation` to implement notification popups. The only user-facing change this PR makes is making it so that notification popups slide in more quickly, last longer at full size, then slide out more quickly.

As part of the implementation, this PR adds a field to `AppState` to store the animation manager and adds a field to `ProgressionState` to store the state of the popup animation (including the animation itself if it is running). 

Closes #2422 