### PR TITLE
Explicit term-level type argument to `read` command

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -366,9 +366,9 @@
     - |
       When equipped as a device, parsley enables the `read` command, which can be used to turn text into values:
       ```
-      read : Text -> a
+      read : Type -> Text -> a
       ```
-      If the given `Text`{=type} represents a value of the expected type, the value will be returned; otherwise, an exception is thrown.  For example, `(read "3" : Int) == 3`, but `read "hello" : Int` crashes.
+      If the given `Text`{=type} represents a value of the given `Type`{=type} (written using `@`{=snippet} syntax), the value will be returned; otherwise, an exception is thrown.  For example, `(read @Int "3") == 3`, but `read @Int "hello"` crashes.
     - Note that `read`, unlike `format`, is unable to deal with function, delay, or command types.
   properties: [pickable, growable]
   capabilities: [read]

--- a/data/scenarios/Challenges/_flower-count/judge.sw
+++ b/data/scenarios/Challenges/_flower-count/judge.sw
@@ -19,7 +19,7 @@ def judgeCount : Int -> Cmd Unit = \actual.
     (\_. pure ())
     (\p.
       try {
-        let c = (read p : Int) in
+        let c = read @Int p in
         if (c == actual) { win } {}
       } {}
     )

--- a/data/scenarios/Challenges/_flower-count/solution.sw
+++ b/data/scenarios/Challenges/_flower-count/solution.sw
@@ -81,7 +81,7 @@ def countAndReport : Int * Int -> Int * Int -> Cmd Unit = \size. \ll.
   cnt <- countFlowers size ll;
   goto (0,0);
   paper <- acquire;
-  let soFar = (read paper : Int) in
+  let soFar = read @Int paper in
   erase paper;
   newPaper <- print "paper" (format (soFar + cnt));
   place newPaper;

--- a/data/scenarios/Challenges/_telephone/photocopier.sw
+++ b/data/scenarios/Challenges/_telephone/photocopier.sw
@@ -16,7 +16,7 @@ end
 
 def followInstructions : Text -> Cmd Unit = \paper.
   try {
-    let res = (read paper : ((Int * Int) * Text))
+    let res = read @((Int * Int) * Text) paper
     in  pixel res
   } {}
 end

--- a/src/swarm-lang/Swarm/Language/Elaborate.hs
+++ b/src/swarm-lang/Swarm/Language/Elaborate.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause

--- a/src/swarm-lang/Swarm/Language/Elaborate.hs
+++ b/src/swarm-lang/Swarm/Language/Elaborate.hs
@@ -9,7 +9,6 @@ module Swarm.Language.Elaborate where
 
 import Control.Lens (transform, (^.))
 import Swarm.Language.Syntax
-import Swarm.Language.Types
 
 -- | Perform some elaboration / rewriting on a fully type-annotated
 --   term.  This currently performs such operations as rewriting @if@
@@ -25,10 +24,7 @@ elaborate :: TSyntax -> TSyntax
 elaborate = transform rewrite
  where
   rewrite :: TSyntax -> TSyntax
-  rewrite = \case
-    syn@(Syntax' l (TConst Read) cs pty@(ptBody -> TyText :->: outTy)) ->
-      Syntax' l (SApp syn (Syntax' NoLoc (TType outTy) mempty (mkTrivPoly TyUnit))) cs pty
-    Syntax' l t cs ty -> Syntax' l (rewriteTerm t) cs ty
+  rewrite (Syntax' l t cs ty) = Syntax' l (rewriteTerm t) cs ty
 
   rewriteTerm :: TTerm -> TTerm
   rewriteTerm = \case

--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -107,6 +107,7 @@ parseTermAtom2 =
           <*> pure Nothing
           <*> (optional (symbol ";") *> (parseTerm <|> (eof $> sNoop)))
         <|> SRcd <$> brackets (parseRecord (optional (symbol "=" *> parseTerm)))
+        <|> TType <$> (symbol "@" *> parseTypeAtom)
     )
     <|> parseLoc (mkTuple <$> parens (parseTerm `sepBy` symbol ","))
     <|> parseLoc (TDelay (TConst Noop) <$ try (symbol "{" *> symbol "}"))

--- a/src/swarm-lang/Swarm/Language/Requirements/Analysis.hs
+++ b/src/swarm-lang/Swarm/Language/Requirements/Analysis.hs
@@ -66,6 +66,7 @@ requirements tdCtx ctx =
     TAntiText _ -> pure ()
     TBool _ -> pure ()
     TSuspend {} -> pure ()
+    TType {} -> pure ()
     -- It doesn't require any special capability to *inquire* about
     -- the requirements of a term.
     TRequirements _ _ -> pure ()

--- a/src/swarm-lang/Swarm/Language/Syntax/Pretty.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Pretty.hs
@@ -142,7 +142,7 @@ instance PrettyPrec (Term' ty) where
       pparens (p > 10) $
         "suspend" <+> prettyPrec 11 t
     SParens t -> pparens True (ppr t)
-    TType ty -> prettyPrec p ty
+    TType ty -> "@" <> prettyPrec 11 ty
 
 prettyDefinition :: Doc ann -> Var -> Maybe (Poly q Type) -> Syntax' ty -> Doc ann
 prettyDefinition defName x mty t1 =

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -896,7 +896,7 @@ infer s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
     | c `elem` [Atomic, Instant] -> fresh >>= check s
   -- Special case for applying 'read' to a type argument, since we need to make
   -- sure the type propagates to the inferred output type of 'read'.
-  TConst Read :$: (STerm (TType argTy))  -> do
+  TConst Read :$: (STerm (TType argTy)) -> do
     r' <- infer $ Syntax l (TConst Read)
     argTy' <- adaptToTypeErr l (UnboundType . getUnexpanded) $ expandTydefs argTy
     arg' <- check (STerm (TType argTy')) UTyType

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -894,6 +894,13 @@ infer s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
   -- This must come BEFORE the SApp case.
   TConst c :$: _
     | c `elem` [Atomic, Instant] -> fresh >>= check s
+
+  TConst Read :$: arg@(STerm (TType argTy))  -> do
+    r' <- infer $ Syntax l (TConst Read)
+    arg' <- check arg UTyType
+    -- XXX expand type
+    pure $ Syntax' l (SApp r' arg') cs (UTyFun UTyText (toU argTy))
+
   -- It works better to handle applications in *inference* mode.
   -- Knowing the expected result type of an application does not
   -- really help much.  In the typical case, the function being

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -1007,9 +1007,7 @@ infer s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
     iuty <- instantiate upty
     c' <- check c iuty
     return $ Syntax' l (SAnnotate c' (forgetQ qpty')) cs iuty
-
   TType ty -> pure $ Syntax' l (TType ty) cs UTyType
-
   -- Fallback: to infer the type of anything else, make up a fresh unification
   -- variable for its type and check against it.
   _ -> do

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -579,6 +579,7 @@ baseTyNounPhrase = \case
   BBool -> "a boolean"
   BActor -> "an actor"
   BKey -> "a key"
+  BType -> "a type"
 
 -- | Generate an appropriate message when the sets of fields in two
 --   record types do not match, explaining which fields are extra and
@@ -1007,6 +1008,8 @@ infer s@(CSyntax l t cs) = addLocToTypeErr l $ case t of
     c' <- check c iuty
     return $ Syntax' l (SAnnotate c' (forgetQ qpty')) cs iuty
 
+  TType ty -> pure $ Syntax' l (TType ty) cs UTyType
+
   -- Fallback: to infer the type of anything else, make up a fresh unification
   -- variable for its type and check against it.
   _ -> do
@@ -1108,7 +1111,7 @@ inferConst c = run . runReader @TVCtx Ctx.empty . quantify $ case c of
   Div -> arithBinT
   Exp -> arithBinT
   Format -> [tyQ| a -> Text |]
-  Read -> [tyQ| Text -> a |]
+  Read -> [tyQ| Type -> Text -> a |]
   Print -> [tyQ| Text -> Text -> Cmd Text |]
   Erase -> [tyQ| Text -> Cmd Text |]
   Concat -> [tyQ| Text -> Text -> Text |]

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -44,6 +44,7 @@ module Swarm.Language.Types (
   pattern TyBool,
   pattern TyActor,
   pattern TyKey,
+  pattern TyType,
   pattern (:+:),
   pattern (:*:),
   pattern (:->:),
@@ -68,6 +69,7 @@ module Swarm.Language.Types (
   pattern UTyBool,
   pattern UTyActor,
   pattern UTyKey,
+  pattern UTyType,
   pattern UTySum,
   pattern UTyProd,
   pattern UTyFun,
@@ -199,6 +201,8 @@ data BaseTy
     BActor
   | -- | Keys, i.e. things that can be pressed on the keyboard
     BKey
+  | -- | The type of types
+    BType
   deriving (Eq, Ord, Show, Bounded, Enum, Data, Generic, Hashable, FromJSON, ToJSON)
 
 baseTyName :: BaseTy -> Text
@@ -676,6 +680,9 @@ pattern TyActor = TyBase BActor
 pattern TyKey :: Type
 pattern TyKey = TyBase BKey
 
+pattern TyType :: Type
+pattern TyType = TyBase BType
+
 infixr 5 :+:
 
 pattern (:+:) :: Type -> Type -> Type
@@ -746,6 +753,9 @@ pattern UTyActor = UTyBase BActor
 
 pattern UTyKey :: UType
 pattern UTyKey = UTyBase BKey
+
+pattern UTyType :: UType
+pattern UTyType = UTyBase BType
 
 pattern UTySum :: UType -> UType -> UType
 pattern UTySum ty1 ty2 = UTyConApp TCSum [ty1, ty2]

--- a/src/swarm-lang/Swarm/Language/Value.hs
+++ b/src/swarm-lang/Swarm/Language/Value.hs
@@ -257,4 +257,4 @@ valueToTerm = \case
   VSuspend t _ -> TSuspend t
   VExc -> TConst Undefined
   VBlackhole -> TConst Undefined
-  VType _ -> TConst Undefined
+  VType ty -> TType ty

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -276,129 +276,129 @@ testEval g =
         "read"
         [ testCase
             "read Unit"
-            ("read \"()\" : Unit" `evaluatesToV` ())
+            ("read @Unit \"()\"" `evaluatesToV` ())
         , testCase
             "read Unit with spaces"
-            ("read \"   ()    \" : Unit" `evaluatesToV` ())
+            ("read @Unit \"   ()    \"" `evaluatesToV` ())
         , testCase
             "no read Unit"
-            ("read \"xyz\" : Unit" `throwsError` ("Could not read" `T.isInfixOf`))
+            ("read @Unit \"xyz\"" `throwsError` ("Could not read" `T.isInfixOf`))
         , testCase
             "read Int"
-            ("read \"32\" : Int" `evaluatesToV` (32 :: Integer))
+            ("read @Int \"32\"" `evaluatesToV` (32 :: Integer))
         , testCase
             "read negative Int"
-            ("read \"-32\" : Int" `evaluatesToV` (-32 :: Integer))
+            ("read @Int \"-32\"" `evaluatesToV` (-32 :: Integer))
         , testCase
             "read Int with spaces"
-            ("read \"   -  32   \" : Int" `evaluatesToV` (-32 :: Integer))
+            ("read @Int \"   -  32   \"" `evaluatesToV` (-32 :: Integer))
         , testCase
             "no read Int"
-            ("read \"32.0\" : Int" `throwsError` ("Could not read" `T.isInfixOf`))
+            ("read @Int \"32.0\"" `throwsError` ("Could not read" `T.isInfixOf`))
         , testCase
             "read false"
-            ("read \"false\" : Bool" `evaluatesToV` False)
+            ("read @Bool \"false\"" `evaluatesToV` False)
         , testCase
             "read true"
-            ("read \"true\" : Bool" `evaluatesToV` True)
+            ("read @Bool \"true\"" `evaluatesToV` True)
         , testCase
             "read forward"
-            ( "read \"forward\" : Dir"
+            ( "read @Dir \"forward\""
                 `evaluatesTo` VDir (DRelative (DPlanar DForward))
             )
         , testCase
             "read east"
-            ("read \"east\" : Dir" `evaluatesTo` VDir (DAbsolute DEast))
+            ("read @Dir \"east\"" `evaluatesTo` VDir (DAbsolute DEast))
         , testCase
             "read down"
-            ("read \"down\" : Dir" `evaluatesTo` VDir (DRelative DDown))
+            ("read @Dir \"down\"" `evaluatesTo` VDir (DRelative DDown))
         , testCase
             "read text"
-            ("read \"\\\"hi\\\"\" : Text" `evaluatesToV` ("hi" :: Text))
+            ("read @Text \"\\\"hi\\\"\"" `evaluatesToV` ("hi" :: Text))
         , testCase
             "read sum inl"
-            ( "read \"inl 3\" : (Int + Bool)"
+            ( "read @(Int + Bool) \"inl 3\""
                 `evaluatesToV` Left @Integer @Bool 3
             )
         , testCase
             "read sum inr"
-            ( "read \"inr true\" : (Int + Bool)"
+            ( "read @(Int + Bool) \"inr true\""
                 `evaluatesToV` Right @Integer True
             )
         , testCase
             "read nested sum"
-            ( "read \"inl (inr true)\" : ((Int + Bool) + Unit)"
+            ( "read @((Int + Bool) + Unit) \"inl (inr true)\""
                 `evaluatesToV` Left @_ @() (Right @Integer True)
             )
         , testCase
             "read pair"
-            ( "read \"(3, true)\" : Int * Bool"
+            ( "read @(Int * Bool) \"(3, true)\""
                 `evaluatesToV` (3 :: Integer, True)
             )
         , testCase
             "read pair with non-atomic value"
-            ( "read \"(3, inr true)\" : Int * (Unit + Bool)"
+            ( "read @(Int * (Unit + Bool)) \"(3, inr true)\""
                 `evaluatesToV` (3 :: Integer, Right @() True)
             )
         , testCase
             "read nested pair"
-            ( "read \"(3, true, ())\" : Int * Bool * Unit"
+            ( "read @(Int * Bool * Unit) \"(3, true, ())\""
                 `evaluatesToV` (3 :: Integer, (True, ()))
             )
         , testCase
             "read left-nested pair"
-            ( "read \"((3, true), ())\" : ((Int * Bool) * Unit)"
+            ( "read @((Int * Bool) * Unit) \"((3, true), ())\""
                 `evaluatesToV` ((3 :: Integer, True), ())
             )
         , testCase
             "read empty record"
-            ("read \"[]\" : []" `evaluatesTo` VRcd M.empty)
+            ("read @[] \"[]\"" `evaluatesTo` VRcd M.empty)
         , testCase
             "read singleton record"
-            ( "read \"[x = 2]\" : [x : Int]"
+            ( "read @[x : Int] \"[x = 2]\""
                 `evaluatesTo` VRcd (M.singleton "x" (VInt 2))
             )
         , testCase
             "read doubleton record"
-            ( "read \"[x = 2, y = inr ()]\" : [x : Int, y : Bool + Unit]"
+            ( "read @[x : Int, y : Bool + Unit] \"[x = 2, y = inr ()]\""
                 `evaluatesTo` (VRcd . M.fromList $ [("x", VInt 2), ("y", VInj True VUnit)])
             )
         , testCase
             "read permuted doubleton record"
-            ( "read \"[y = inr (), x = 2]\" : [x : Int, y : Bool + Unit]"
+            ( "read @[x : Int, y : Bool + Unit] \"[y = inr (), x = 2]\""
                 `evaluatesTo` (VRcd . M.fromList $ [("x", VInt 2), ("y", VInj True VUnit)])
             )
         , testCase
             "no read record with repeated fields"
-            ( "read \"[x = 2, x = 3]\" : [x : Int]"
+            ( "read @[x : Int] \"[x = 2, x = 3]\""
                 `throwsError` ("Could not read" `T.isInfixOf`)
             )
         , testCase
             "read key"
-            ( "read \"key \\\"M-C-F5\\\"\" : Key"
+            ( "read @Key \"key \\\"M-C-F5\\\"\""
                 `evaluatesTo` VKey (mkKeyCombo [V.MCtrl, V.MMeta] (V.KFun 5))
             )
         , testCase
             "read recursive list"
-            ( "read \"inr (3, inr (5, inl ()))\" : rec l. Unit + (Int * l)"
+            ( "read @(rec l. Unit + (Int * l)) \"inr (3, inr (5, inl ()))\""
                 `evaluatesToV` [3 :: Integer, 5]
             )
         , testCase
             "read paper with int"
-            ("read \"paper: 52\" : Int" `evaluatesToV` (52 :: Integer))
+            ("read @Int \"paper: 52\"" `evaluatesToV` (52 :: Integer))
         , testCase
             "read paper with tuple"
-            ( "read \"paper: (3, false, ())\" : Int * Bool * Unit"
+            ( "read @(Int * Bool * Unit) \"paper: (3, false, ())\""
                 `evaluatesToV` (3 :: Integer, (False, ()))
             )
         , testCase
             "read random entity with tuple"
-            ( "read \"foo: (3, false, ())\" : Int * Bool * Unit"
+            ( "read @(Int * Bool * Unit) \"foo: (3, false, ())\""
                 `evaluatesToV` (3 :: Integer, (False, ()))
             )
         , testCase
             "read Text value containing colon"
-            ( "read \"\\\"hi: there\\\"\" : Text"
+            ( "read @Text \"\\\"hi: there\\\"\""
                 `evaluatesToV` ("hi: there" :: Text)
             )
         ]

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -401,6 +401,21 @@ testEval g =
             ( "read @Text \"\\\"hi: there\\\"\""
                 `evaluatesToV` ("hi: there" :: Text)
             )
+        , testCase
+            "read at user-defined type Foo = Int"
+            ( "tydef Foo = Int end; read @Foo \"3\""
+                `evaluatesToV` (3 :: Integer)
+            )
+        , testCase
+            "read at user-defined recursive type"
+            ( "tydef List a = rec l. Unit + a * l end; read @(List(Int)) \"inr (1, inl ())\""
+                `evaluatesToV` [1 :: Integer]
+            )
+        , testCase
+            "read at complex type with user-defined types"
+            ( "tydef Foo = Int end; read @(Bool * Foo) \"(True, 3)\""
+                `evaluatesToV` (True, 3 :: Integer)
+            )
         ]
     , testGroup
         "records - #1093"

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -755,6 +755,12 @@ testLanguagePipeline =
                 "(read @Int \"3\") 4"
                 "1:1: Type mismatch:\n  From context, expected `(read @Int \"3\")` to be a function,\n  but it actually has type `Int`"
             )
+        , testCase
+            "read at type stored in a variable"
+            ( process
+                "def T : Type = @(Bool * Int) end; read T \"(True, 3)\""
+                "1:35: The `read` command must be given a literal type as its first argument (Swarm does not have dependent types); found `T` instead."
+            )
         ]
     ]
  where

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -747,6 +747,15 @@ testLanguagePipeline =
                 "3:15:\n  |\n3 |  def z = 3 end\n  |               ^\nunexpected end of input\nexpecting \"!=\", \"&&\", \"()\", \"++\", \"<=\", \"==\", \">=\", \"def\", \"false\", \"let\", \"require\", \"requirements\", \"stock\", \"true\", \"tydef\", \"||\", '\"', '$', '(', '*', '+', '-', '.', '/', ':', ';', '<', '>', '@', '[', '\\', '^', 'end' keyword for definition of 'x', '{', built-in user function, direction constant, integer literal, or variable name\n"
             )
         ]
+    , testGroup
+        "Typechecking for read #2461"
+        [ testCase
+            "read type argument propagates"
+            ( process
+                "(read @Int \"3\") 4"
+                "1:1: Type mismatch:\n  From context, expected `(read @Int \"3\")` to be a function,\n  but it actually has type `Int`"
+            )
+        ]
     ]
  where
   valid = flip process ""

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -744,7 +744,7 @@ testLanguagePipeline =
             "missing end"
             ( process
                 "def x = 3;\n def y = 3 end;\n def z = 3 end"
-                "3:15:\n  |\n3 |  def z = 3 end\n  |               ^\nunexpected end of input\nexpecting \"!=\", \"&&\", \"()\", \"++\", \"<=\", \"==\", \">=\", \"def\", \"false\", \"let\", \"require\", \"requirements\", \"stock\", \"true\", \"tydef\", \"||\", '\"', '$', '(', '*', '+', '-', '.', '/', ':', ';', '<', '>', '[', '\\', '^', 'end' keyword for definition of 'x', '{', built-in user function, direction constant, integer literal, or variable name\n"
+                "3:15:\n  |\n3 |  def z = 3 end\n  |               ^\nunexpected end of input\nexpecting \"!=\", \"&&\", \"()\", \"++\", \"<=\", \"==\", \">=\", \"def\", \"false\", \"let\", \"require\", \"requirements\", \"stock\", \"true\", \"tydef\", \"||\", '\"', '$', '(', '*', '+', '-', '.', '/', ':', ';', '<', '>', '@', '[', '\\', '^', 'end' keyword for definition of 'x', '{', built-in user function, direction constant, integer literal, or variable name\n"
             )
         ]
     ]


### PR DESCRIPTION
- Add `@` syntax for writing types as terms.
- Add a type of types, `Type`.
- Give the `read` command the type `Type -> Text -> a`, and a special typechecking rule such that the type argument (which must be a type literal) becomes the output type.  In other words it really should have a dependent type like `(tau : Type) -> Text -> tau` but I'm not about to add actual dependent types to Swarm. :smile:
- Eagerly expand any user-defined types in an argument to `read`.  Fixes #2223.
- Add some tests.