### PR TITLE
Remove data step from release

### DIFF
--- a/.github/workflows/haskell-release.yml
+++ b/.github/workflows/haskell-release.yml
@@ -108,12 +108,6 @@ jobs:
             name: swarm-Darwin-arm64
             path: artifacts/swarm-Darwin-arm64
 
-        - name: Download Swarm data
-          uses: actions/download-artifact@v4
-          with:
-            name: swarm-data.zip
-            path: artifacts/swarm-Darwin-arm64
-
         - name: Rename executables
           run: |
               mv artifacts/swarm-Linux-x86_64/swarm  swarm-Linux-x86_64


### PR DESCRIPTION
There is another step creating the ZIP file afterwards, so I think this additional step was a mistake.

See #2046.