### PR TITLE
Clarify backstory tutorial

### DIFF
--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -25,7 +25,7 @@ entities:
   - name: TIPS
     display:
       attr: device
-      char: 'R'
+      char: '?'
     description:
       - |
         When you're ready for your first tutorial challenge, type at the prompt:

--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -73,7 +73,7 @@ robots:
       forever {
         try {
           m <- listen;
-          if (m == "Ready!" || m == "ready!" || m == "ready") {
+          if (m == "Ready!" || m == "Ready" || m == "ready!" || m == "ready") {
             create "TIPS";
             log "The player is ready!"
           } {

--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -22,7 +22,7 @@ objectives:
 solution: |
   say "Ready!"
 entities:
-  - name: READY
+  - name: TIPS
     display:
       attr: device
       char: 'R'
@@ -36,6 +36,17 @@ entities:
       - |
         To open the full goal text again, you can hit **Ctrl+G**.
     properties: [known, pickable]
+  - name: logger
+    display:
+      attr: device
+      char: 'l'
+    description:
+      - |
+        Allows a robot to generate and store messages for later viewing.
+      - |
+        For this scenario it shows errors and tips.
+    properties: [pickable]
+    capabilities: [log, listen]
 robots:
   - name: base
     display:
@@ -54,7 +65,7 @@ robots:
     loc: [0, 0]
     dir: [0, 0]
     inventory:
-      - [0, READY]
+      - [0, TIPS]
     devices:
       - logger
     program: |
@@ -66,12 +77,11 @@ robots:
             create "READY";
             log "The player is ready!"
           } {
-            say $ "Wrong message: " ++ format m
+            say $ "Wrong message: " ++ format m ++ " you should say \"Ready!\""
           }
         } {log "Something bad happened!"}
       }
 seed: 0
-creative: true
 world:
   scrollable: false
   dsl: |

--- a/data/scenarios/Tutorials/backstory.yaml
+++ b/data/scenarios/Tutorials/backstory.yaml
@@ -17,7 +17,7 @@ objectives:
     condition: |
       try {
         l <- robotNamed "listener";
-        as l {has "READY"}
+        as l {has "TIPS"}
       } { pure false }
 solution: |
   say "Ready!"
@@ -55,7 +55,7 @@ robots:
     dir: east
     loc: [0, 0]
     inventory:
-      - [1, READY]
+      - [1, TIPS]
     devices:
       - logger
   - name: listener
@@ -74,10 +74,10 @@ robots:
         try {
           m <- listen;
           if (m == "Ready!" || m == "ready!" || m == "ready") {
-            create "READY";
+            create "TIPS";
             log "The player is ready!"
           } {
-            say $ "Wrong message: " ++ format m ++ " you should say \"Ready!\""
+            say $ "Wrong message " ++ format m ++ ", you should say \"Ready!\""
           }
         } {log "Something bad happened!"}
       }


### PR DESCRIPTION
* add `say "Ready!"` to the hint in  logger too
* allow `say "Ready"`
* make backstory not creative, so that README and logger stand out

Based on feedback from players on ZuriHack. 🙂 