### PR TITLE
Reset info panel scroll when clicking on an inventory item

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -402,7 +402,9 @@ handleMainEvent forceRedraw ev = do
     MouseUp n _ _mouseLoc ->
       Brick.zoom (playState . scenarioState) $ do
         case n of
-          InventoryListItem pos -> uiGameplay . uiInventory . uiInventoryList . traverse . _2 %= BL.listMoveTo pos
+          InventoryListItem pos -> do
+            uiGameplay . uiInventory . uiInventoryList . traverse . _2 %= BL.listMoveTo pos
+            vScrollToBeginning infoScroll
           x@(WorldEditorPanelControl y) -> do
             uiGameplay . uiWorldEditor . editorFocusRing %= focusSetCurrent x
             EC.activateWorldEditorFunction y


### PR DESCRIPTION
This was suggested by @Mfonism at ZuriHac.  It turns out that we already do reset the info panel scroll when moving between inventory items with arrow keys, but not when clicking on inventory items.