### PR TITLE
Use `hoistMaybe` from `transformers 0.6`

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Path/Finding.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Finding.hs
@@ -30,7 +30,7 @@ import Control.Effect.Lens
 import Control.Lens ((^.))
 import Control.Monad (filterM, guard)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Control.Monad.Trans.Maybe (MaybeT (..), hoistMaybe, runMaybeT)
 import Data.Graph.AStar (aStarM)
 import Data.HashSet (HashSet)
 import Data.HashSet qualified as HashSet
@@ -49,7 +49,6 @@ import Swarm.Game.Step.Util.Inspect
 import Swarm.Game.Universe
 import Swarm.Language.Syntax
 import Swarm.Language.Syntax.Direction
-import Swarm.Util (hoistMaybe)
 
 -- | Swarm command arguments are converted to idiomatic Haskell
 -- types before invoking this function, and conversely the callsite

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -14,7 +14,7 @@ import Control.Effect.Error
 import Control.Effect.Lens
 import Control.Monad (forM_, guard, when)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Control.Monad.Trans.Maybe (MaybeT (..), hoistMaybe, runMaybeT)
 import Control.Monad.Trans.State.Strict qualified as TS
 import Data.Array (bounds, (!))
 import Data.IntMap qualified as IM

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -12,7 +12,7 @@ import Control.Lens
 import Control.Monad (forM_, guard, when)
 import Control.Monad.Extra (whenJust)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Control.Monad.Trans.Maybe (MaybeT (..), hoistMaybe, runMaybeT)
 import Data.Map qualified as M
 import Data.Yaml qualified as Y
 import Graphics.Vty qualified as V
@@ -31,7 +31,6 @@ import Swarm.TUI.Model
 import Swarm.TUI.Model.Menu
 import Swarm.TUI.Model.Name
 import Swarm.TUI.Model.UI.Gameplay
-import Swarm.Util (hoistMaybe)
 import Swarm.Util.Erasable (maybeToErasable)
 import System.Clock
 

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -30,7 +30,6 @@ module Swarm.Util (
   lookupEither,
   applyWhen,
   applyJust,
-  hoistMaybe,
   unsnocNE,
 
   -- * Directory utilities
@@ -86,7 +85,6 @@ import Control.Carrier.Throw.Either
 import Control.Effect.State (State, modify, state)
 import Control.Lens (ASetter', Lens', LensLike, LensLike', Over, lens, (<&>), (<>~))
 import Control.Monad (filterM, unless)
-import Control.Monad.Trans.Maybe (MaybeT (..))
 import Data.Bifunctor (Bifunctor (bimap), first)
 import Data.Char (isAlphaNum, toLower)
 import Data.Either.Extra (maybeToEither)
@@ -283,12 +281,6 @@ applyWhen False _ x = x
 applyJust :: Maybe (a -> a) -> a -> a
 applyJust Nothing x = x
 applyJust (Just f) x = f x
-
--- | Convert a 'Maybe' computation to 'MaybeT'.
---
--- TODO (#1151): Use implementation from "transformers" package v0.6.0.0
-hoistMaybe :: (Applicative m) => Maybe b -> MaybeT m b
-hoistMaybe = MaybeT . pure
 
 -- | Like 'unsnoc', but for 'NonEmpty' so without the 'Maybe'
 --

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -364,7 +364,7 @@ common time
   build-depends: time >=1.9 && <1.15
 
 common transformers
-  build-depends: transformers >=0.5 && <0.7
+  build-depends: transformers >=0.6 && <0.7
 
 common unicode-show
   build-depends: unicode-show >=0.1 && <0.2


### PR DESCRIPTION
Require `transformers >= 0.6`, get rid of `Swarm.Util.hoistMaybe`, and use `hoistMaybe` from `transformers`.  Closes #1151.