### PR TITLE
Optional `chars` palette field to specify auto-generated character entities

### DIFF
--- a/data/scenarios/Testing/2193-text-entities.yaml
+++ b/data/scenarios/Testing/2193-text-entities.yaml
@@ -1,0 +1,27 @@
+version: 1
+name: Automatic character entities
+description: |
+  Demo writing text in a world with auto-generated character entities
+robots:
+  - name: base
+    dir: east
+    devices:
+      - treads
+      - logger
+      - grabber
+      - scanner
+world:
+  dsl: |
+    {grass}
+  palette:
+    # These characters will exist in the palette mapped to default
+    # auto-generated character entities, unless explicitly overridden.
+    chars: "A-Za-z0-9! "
+    # 'D' in the palette maps to [stone, null, base], even though it
+    # exists in the range A-Z above.
+    'D': [stone, null, base]
+    '.': [stone]
+  map: |-
+    .......................................................................
+    ...Hello world! This is a Demo! 1234098765abcdefghijklmnopqrstuvwxyz...
+    .......................................................................

--- a/data/schema/world.json
+++ b/data/schema/world.json
@@ -57,8 +57,8 @@
         },
         "palette": {
             "type": "object",
-            "examples": [{"T": ["grass", "tree"]}],
-            "description": "The palette maps single character keys to tuples representing contents of cells in the world, so that a world containing entities and robots can be drawn graphically. See [Cells](#cells) for the contents of the tuples representing a cell."
+            "examples": [{"T": ["grass", "tree"]}, {"chars": "A-Z0-9!? "}],
+            "description": "The palette maps single character keys to tuples representing contents of cells in the world, so that a world containing entities and robots can be drawn graphically. See [Cells](#cells) for the contents of the tuples representing a cell.  Optionally, a special 'chars' key can be specified, mapped to a string of characters and character ranges.  These characters will be available in the palette as default auto-generated entities that look like themselves, to be used for writing text or purely cosmetic designs."
         },
         "portals": {
             "description": "A list of portal definitions that reference waypoints.",

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldDescription.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldDescription.hs
@@ -7,14 +7,18 @@
 -- SPDX-License-Identifier: BSD-3-Clause
 module Swarm.Game.Scenario.Topography.WorldDescription where
 
+import Control.Arrow ((&&&))
 import Control.Carrier.Reader (runReader)
 import Control.Carrier.Throw.Either
 import Control.Monad (forM)
 import Data.Coerce
 import Data.Functor.Identity
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Yaml as Y
-import Swarm.Game.Entity (Entity)
+import Swarm.Game.Cosmetic.Display (defaultEntityDisplay)
+import Swarm.Game.Entity (Entity, EntityProperty (Known), mkEntity)
 import Swarm.Game.Land
 import Swarm.Game.Location
 import Swarm.Game.Scenario.RobotLookup (RobotMap)
@@ -25,8 +29,9 @@ import Swarm.Game.Scenario.Topography.Navigation.Waypoint (
   Parentage (Root),
   WaypointName,
  )
-import Swarm.Game.Scenario.Topography.ProtoCell (
+import Swarm.Game.Scenario.Topography.Palette (
   StructurePalette (StructurePalette),
+  SignpostableCell (..)
  )
 import Swarm.Game.Scenario.Topography.Structure (
   MergedStructure (MergedStructure),
@@ -39,11 +44,15 @@ import Swarm.Game.Scenario.Topography.Structure.Overlay (
  )
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Static (LocatedStructure)
 import Swarm.Game.Scenario.Topography.WorldPalette
+import Swarm.Game.Terrain (TerrainType (..))
 import Swarm.Game.Universe (SubworldName (DefaultRootSubworld))
 import Swarm.Game.World.Parse ()
 import Swarm.Game.World.Syntax
 import Swarm.Game.World.Typecheck
+import Swarm.Language.Syntax (Syntax)
+import Swarm.Language.Text.Markdown (Document, fromText)
 import Swarm.Pretty (prettyString)
+import Swarm.Util.Erasable (Erasable (..))
 import Swarm.Util.Yaml
 
 ------------------------------------------------------------
@@ -78,14 +87,29 @@ data WorldParseDependencies
       -- | last for the benefit of partial application
       TerrainEntityMaps
 
+-- | Generate default character entities for characters in 'paletteChars'.
+generateCharEntities :: WorldPalette Entity -> WorldPalette Entity
+generateCharEntities (StructurePalette charSet pal) = StructurePalette charSet (pal <> charPal)
+  where
+    charPal = M.fromList . map (id &&& mkCharCell) . S.toList $ charSet
+
+    mkCharCell :: Char -> SignpostableCell (PCell Entity)
+    mkCharCell c = SignpostableCell Nothing Nothing (Cell BlankT (EJust (mkCharEntity c)) [])
+
+    mkCharEntity :: Char -> Entity
+    mkCharEntity c = mkEntity (defaultEntityDisplay c) (T.pack [c]) (mkCharDesc c) [Known] mempty
+
+    mkCharDesc :: Char -> Document Syntax
+    mkCharDesc c = fromText $ "The letter " <> T.pack [c] <> "."
+
 instance FromJSONE WorldParseDependencies WorldDescription where
   parseJSONE = withObjectE "world description" $ \v -> do
     WorldParseDependencies worldMap scenarioLevelStructureDefs rm tem <- getE
 
     let withDeps = localE (const (tem, rm))
     palette <-
-      withDeps $
-        v ..:? "palette" ..!= StructurePalette mempty
+      fmap generateCharEntities . withDeps $
+        v ..:? "palette" ..!= StructurePalette mempty mempty
     subworldLocalStructureDefs <-
       withDeps $
         v ..:? "structures" ..!= []

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldPalette.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldPalette.hs
@@ -13,7 +13,7 @@ import Swarm.Game.Entity
 import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.EntityFacade
 import Swarm.Game.Scenario.Topography.Grid
-import Swarm.Game.Scenario.Topography.ProtoCell
+import Swarm.Game.Scenario.Topography.Palette
 import Swarm.Game.Terrain (TerrainType)
 import Swarm.Util.Erasable
 
@@ -99,7 +99,7 @@ prepForJson ::
   PaletteAndMaskChar ->
   Grid (Maybe CellPaintDisplay) ->
   (String, KM.KeyMap CellPaintDisplay)
-prepForJson (PaletteAndMaskChar (StructurePalette suggestedPalette) maybeMaskChar) cellGrid =
+prepForJson (PaletteAndMaskChar (StructurePalette _ suggestedPalette) maybeMaskChar) cellGrid =
   (constructWorldMap mappedPairs maskCharacter cellGrid, constructPalette mappedPairs)
  where
   preassignments :: [(Char, TerrainWith EntityFacade)]

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Palette.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Palette.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+module Swarm.Game.Scenario.Topography.Palette (
+  SignpostableCell (..),
+  StructureMarker (..),
+  StructurePalette (..),
+) where
+
+import Data.Aeson.Key qualified as K
+import Data.Aeson.KeyMap qualified as KM
+import Data.Map (Map)
+import Data.Map qualified as M
+import Data.Set (Set)
+import Data.Set qualified as S
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Void (Void)
+import Data.Tuple (swap)
+import Swarm.Game.Scenario.Topography.ProtoCell
+import Swarm.Util (quote)
+import Swarm.Util.Yaml
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
+data StructurePalette e = StructurePalette
+  { paletteChars :: Set Char
+      -- ^ List of characters that can be used as special character
+      --   entities that just look like themselves, for use in labelling
+      --   things in the world with text
+  , unPalette :: Map Char (SignpostableCell e)
+  }
+  deriving (Eq, Show)
+
+instance (FromJSONE e a) => FromJSONE e (StructurePalette a) where
+  parseJSONE =
+    withObjectE "palette" $ \km -> do
+      -- Try parsing special 'chars' key
+      chars <- case KM.lookup "chars" km of
+        Nothing -> pure S.empty
+        Just charsVal -> withTextE "charset" readCharSet charsVal
+
+      m <- mapM parseJSONE (KM.delete "chars" km)
+      -- We swap the tuples twice so we can traverse over the second
+      -- element of the tuple in between.
+      swappedPairs <- mapM (verifyChar . swap) $ M.toList $ KM.toMap m
+      return . StructurePalette chars . M.fromList $ map swap swappedPairs
+   where
+    verifyChar = traverse $ ensureSingleChar . K.toString
+    ensureSingleChar [x] = return x
+    ensureSingleChar x =
+      fail $
+        T.unpack $
+          T.unwords
+            [ "Palette entry is not a single character:"
+            , quote $ T.pack x
+            ]
+
+------------------------------------------------------------
+-- Parsing character sets
+
+-- | Parse a character set, which consists of a sequence of items;
+--   each item is either a single character, or a character range of
+--   the form @x-y@ where @x@ and @y@ are characters.  For example,
+--   @A-Z1-9!?@ corresponds to all uppercase letters, all nonzero
+--   digits, and exclamation point or question mark.
+readCharSet :: Text -> ParserE e (Set Char)
+readCharSet t = case runParser parseCharSet "" t of
+  Left err -> fail (errorBundlePretty err)
+  Right s -> pure s
+
+type Parser = Parsec Void Text
+
+--   <charset> ::= <item>+
+--   <item> ::= <single> | <range>
+--   <single> ::= <char> (not '-')
+--   <range> ::= <single> '-' <single>
+
+parseCharSet :: Parser (Set Char)
+parseCharSet = S.unions <$> many parseItem
+
+parseItem :: Parser (Set Char)
+parseItem = try parseRange <|> S.singleton <$> parseSingle
+
+parseRange :: Parser (Set Char)
+parseRange = mkRange <$> parseSingle <*> (char '-' *> parseSingle)
+
+mkRange :: Char -> Char -> Set Char
+mkRange x y = S.fromList [x .. y]
+
+parseSingle :: Parser Char
+parseSingle = anySingleBut '-' <?> "non-hyphen character"

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/ProtoCell.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/ProtoCell.hs
@@ -5,7 +5,6 @@
 -- SPDX-License-Identifier: BSD-3-Clause
 module Swarm.Game.Scenario.Topography.ProtoCell (
   SignpostableCell (..),
-  StructurePalette (..),
   StructureMarker (..),
 ) where
 
@@ -13,6 +12,9 @@ import Control.Applicative ((<|>))
 import Data.Aeson.Key qualified as K
 import Data.Aeson.KeyMap qualified as KM
 import Data.Map (Map, fromList, toList)
+import Data.Set (Set)
+import Data.Set qualified as S
+import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Tuple (swap)
 import Data.Yaml as Y
@@ -22,29 +24,6 @@ import Swarm.Game.Scenario.Topography.Placement
 import Swarm.Game.Scenario.Topography.Structure.Named (StructureName)
 import Swarm.Util (quote)
 import Swarm.Util.Yaml
-
-newtype StructurePalette e = StructurePalette
-  {unPalette :: Map Char (SignpostableCell e)}
-  deriving (Eq, Show)
-
-instance (FromJSONE e a) => FromJSONE e (StructurePalette a) where
-  parseJSONE =
-    withObjectE "palette" $ \v -> do
-      m <- mapM parseJSONE v
-      -- We swap the tuples twice so we can traverse over the second
-      -- element of the tuple in between.
-      swappedPairs <- mapM (verifyChar . swap) $ toList $ KM.toMap m
-      return . StructurePalette . fromList $ map swap swappedPairs
-   where
-    verifyChar = traverse $ ensureSingleChar . K.toString
-    ensureSingleChar [x] = return x
-    ensureSingleChar x =
-      fail $
-        T.unpack $
-          T.unwords
-            [ "Palette entry is not a single character:"
-            , quote $ T.pack x
-            ]
 
 data StructureMarker = StructureMarker
   { name :: StructureName

--- a/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure.hs
+++ b/src/swarm-topography/Swarm/Game/Scenario/Topography/Structure.hs
@@ -21,7 +21,7 @@ import Swarm.Game.Location
 import Swarm.Game.Scenario.Topography.Grid
 import Swarm.Game.Scenario.Topography.Navigation.Waypoint
 import Swarm.Game.Scenario.Topography.Placement
-import Swarm.Game.Scenario.Topography.ProtoCell
+import Swarm.Game.Scenario.Topography.Palette
 import Swarm.Game.Scenario.Topography.Structure.Named
 import Swarm.Game.Scenario.Topography.Structure.Overlay
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Static
@@ -85,7 +85,7 @@ parseStructure pal structures v = do
 
 instance (FromJSONE e a) => FromJSONE e (PStructure (Maybe a)) where
   parseJSONE = withObjectE "structure definition" $ \v -> do
-    pal <- v ..:? "palette" ..!= StructurePalette mempty
+    pal <- v ..:? "palette" ..!= StructurePalette mempty mempty
     structures <- v ..:? "structures" ..!= []
     liftE $ parseStructure pal structures v
 
@@ -138,7 +138,7 @@ paintMap maskChar pal g = do
 
   usedChars = Set.fromList $ allMembers g
   paletteKeys = M.keysSet $ unPalette pal
-  unusedPaletteChars = Set.difference paletteKeys usedChars
+  unusedPaletteChars = Set.difference paletteKeys (usedChars <> paletteChars pal)
 
   toCell c =
     if Just c == maskChar

--- a/src/swarm-tui/Swarm/TUI/Editor/Palette.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Palette.hs
@@ -26,7 +26,7 @@ import Swarm.Game.Scenario.Topography.Cell
 import Swarm.Game.Scenario.Topography.EntityFacade
 import Swarm.Game.Scenario.Topography.Grid
 import Swarm.Game.Scenario.Topography.Navigation.Portal (Navigation (..))
-import Swarm.Game.Scenario.Topography.ProtoCell
+import Swarm.Game.Scenario.Topography.Palette
 import Swarm.Game.Scenario.Topography.Structure.Overlay
 import Swarm.Game.Scenario.Topography.WorldDescription
 import Swarm.Game.Scenario.Topography.WorldPalette
@@ -135,7 +135,7 @@ constructScenario maybeOriginalScenario cellGrid =
   wd =
     WorldDescription
       { scrollable = True
-      , palette = StructurePalette suggestedPalette
+      , palette = StructurePalette mempty suggestedPalette
       , area = PositionedGrid upperLeftCoord cellGrid
       , navigation = Navigation mempty mempty
       , placedStructures = mempty

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -519,6 +519,7 @@ library swarm-topography
     hashable,
     lens,
     linear,
+    megaparsec,
     nonempty-containers,
     servant-docs,
     split,
@@ -536,6 +537,7 @@ library swarm-topography
     Swarm.Game.Scenario.Topography.Grid
     Swarm.Game.Scenario.Topography.Modify
     Swarm.Game.Scenario.Topography.Navigation.Waypoint
+    Swarm.Game.Scenario.Topography.Palette
     Swarm.Game.Scenario.Topography.Placement
     Swarm.Game.Scenario.Topography.ProtoCell
     Swarm.Game.Scenario.Topography.Rasterize


### PR DESCRIPTION
Adds an optional `chars` field to the `palette` specification of a world, which expects a string like `A-Za-f0-9!?` specifying a set of characters that can be used to stand for auto-generated default entities that just look like themselves.  Can be used to write text or create strictly cosmetic designs in a world.

Closes #2193 .  In the immediate future, I plan to use it for https://github.com/swarm-game/swarm/pull/2492#discussion_r2153283183 .