### PR TITLE
Destroy base if it has `life support system` unequipped for 256 ticks

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -432,6 +432,13 @@ execConst runChildProg c vs s k = do
         equippedDevices %= delete item
         robotInventory %= insert item
 
+        when (myID == 0 && itemName == "life support system") $ do
+          -- If the base unequips the life support system, you die!
+          -- This is one of only two (known) ways to get the
+          -- `DestroyedBase` achievement.
+          selfDestruct .= True
+          when (myID == 0) $ grantAchievementForRobot DestroyedBase
+
         -- Now check whether being on the current cell would still be
         -- allowed.
         loc <- use robotLocation
@@ -448,7 +455,7 @@ execConst runChildProg c vs s k = do
           PathLiquid _ -> do
             -- Unequipping a device that gives the Float capability in
             -- the middle of liquid results in drowning, EVEN for
-            -- base!  This is currently the only (known) way to get
+            -- base!  This is currently the other known way to get
             -- the `DestroyedBase` achievement.
             selfDestruct .= True
             when (myID == 0) $ grantAchievementForRobot DestroyedBase

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -562,6 +562,40 @@ seedProgram minTime randTime seedlingCount seedlingRadius thing =
     selfdestruct
   |]
 
+-- | XXX
+addAsphyxiateBot :: Has (State GameState) sig m => TimeSpec -> Cosmic Location -> m ()
+addAsphyxiateBot ts loc =
+  zoomRobots . addTRobot (initMachine asphyxiateProg) $
+    mkRobot
+      Nothing
+      "life support monitor"
+      (Markdown.fromText $ T.unwords ["A life support monitor."])
+      (Just loc)
+      zero
+      (defaultEntityDisplay ' ' & invisible .~ True)
+      Nothing
+      []
+      []
+      True
+      False
+      emptyExceptions
+      ts
+
+asphyxiateProg :: TSyntax
+asphyxiateProg =
+  [tmQ|
+    def countdown : Int -> Cmd Unit = \n.
+      if (n == 0)
+        {destroy base}
+        { wait 1;
+          life <- as base {equipped "life support system"};
+          if life {selfdestruct} {countdown (n-1)}
+        }
+    end;
+
+    countdown 256
+  |]
+
 ------------------------------------------------------------
 -- Some utility functions
 ------------------------------------------------------------

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -562,7 +562,8 @@ seedProgram minTime randTime seedlingCount seedlingRadius thing =
     selfdestruct
   |]
 
--- | XXX
+-- | Create an "asphyxiation robot" to monitor time with "life support
+--   system" unequipped.
 addAsphyxiateBot :: Has (State GameState) sig m => TimeSpec -> Cosmic Location -> m ()
 addAsphyxiateBot ts loc =
   zoomRobots . addTRobot (initMachine asphyxiateProg) $
@@ -581,6 +582,10 @@ addAsphyxiateBot ts loc =
       emptyExceptions
       ts
 
+-- | Count down from 256 ticks.  If at any point during the countdown
+--   we detect that the base has the life support system re-equipped,
+--   stop the countdown and self-destruct.  Otherwise, at the end of
+--   the countdown, destroy the base.
 asphyxiateProg :: TSyntax
 asphyxiateProg =
   [tmQ|

--- a/src/swarm-lang/Swarm/Language/Capability.hs
+++ b/src/swarm-lang/Swarm/Language/Capability.hs
@@ -137,6 +137,7 @@ constCaps = \case
   RobotNamed -> Just CGod
   RobotNumbered -> Just CGod
   Surveil -> Just CGod
+  Destroy -> Just CGod
   -- ----------------------------------------------------------------
   -- type-level arithmetic
   Inl -> Just CSum

--- a/src/swarm-lang/Swarm/Language/Syntax/Constants.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Constants.hs
@@ -321,6 +321,8 @@ data Const
     RobotNumbered
   | -- | Check if an entity is known.
     Knows
+  | -- | Destroy another robot.
+    Destroy
   deriving (Eq, Ord, Enum, Bounded, Data, Show, Generic, Hashable, FromJSON, ToJSON, FromJSONKey, ToJSONKey)
 
 instance PrettyPrec Const where
@@ -882,6 +884,7 @@ constInfo c = case c of
   RobotNamed -> command 1 Intangible $ shortDoc (Set.singleton $ Query $ Sensing RobotSensing) "Find an actor by name."
   RobotNumbered -> command 1 Intangible $ shortDoc (Set.singleton $ Query $ Sensing RobotSensing) "Find an actor by number."
   Knows -> command 1 Intangible $ shortDoc (Set.singleton $ Query $ Sensing RobotSensing) "Check if the robot knows about an entity."
+  Destroy -> command 1 short $ shortDoc (Set.singleton $ Mutation $ RobotChange ExistenceChange) "Destroy another robot."
  where
   doc e b ls = ConstDoc e b (T.unlines ls)
   shortDoc e b = ConstDoc e b ""

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -1145,6 +1145,7 @@ inferConst c = run . runReader @TVCtx Ctx.empty . quantify $ case c of
   RobotNamed -> [tyQ| Text -> Cmd Actor |]
   RobotNumbered -> [tyQ| Int -> Cmd Actor |]
   Knows -> [tyQ| Text -> Cmd Bool |]
+  Destroy -> [tyQ| Actor -> Cmd Unit |]
  where
   cmpBinT = [tyQ| a -> a -> Bool |]
   arithBinT = [tyQ| Int -> Int -> Int |]


### PR DESCRIPTION
When the `base` unequips the `life support system`:
- Log a dire warning
- Spawn a system robot that counts down from 256
    - If the base re-equips the `life support system` at any point, cancel the countdown
    - Otherwise, destroy the base at the end of the countdown (and grant `DestroyedBase` achievement)

This PR also adds a new command `destroy :: Actor -> Cmd Unit` which destroys another robot.  For obvious reasons, this requires `God` capability.

Closes #1388.