### PR TITLE
Make entities in bind2 tutorial known

### DIFF
--- a/data/scenarios/Tutorials/bind2.yaml
+++ b/data/scenarios/Tutorials/bind2.yaml
@@ -93,6 +93,7 @@ robots:
       - [1, treads]
       - [1, grabber]
       - [1, compass]
+known: [Hastur, pedestal]
 world:
   palette:
     'Ω': [stone, null, base]


### PR DESCRIPTION
The entities in the `bind2` tutorial (`Hastur` and the `pedestal`) ought to be marked as `known` so they will not display as question marks.