### PR TITLE
View chunk caching for fast world drawing

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -44,6 +44,7 @@
       , TestLanguagePipeline
       ]
     }
+  - {name: Data.List.NonEmpty.fromList, within: [Swarm.Util.chunksOfNE, Swarm.Util.rangeNE]}
 
 # Add custom hints for this project
 #

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -26,6 +26,7 @@
 #
 - functions:
   - {name: Data.List.head, within: []}
+  - {name: Data.List.NonEmpty.fromList, within: [Swarm.Util]}
   - {name: Prelude.head, within: [Swarm.Web.Tournament.Database.Query]}
   - {name: Prelude.tail, within: []}
   - {name: Prelude.maximum, within: [Swarm.Util]}
@@ -44,7 +45,6 @@
       , TestLanguagePipeline
       ]
     }
-  - {name: Data.List.NonEmpty.fromList, within: [Swarm.Util.chunksOfNE, Swarm.Util.rangeNE]}
 
 # Add custom hints for this project
 #

--- a/src/swarm-engine/Swarm/Game/State/Redraw.hs
+++ b/src/swarm-engine/Swarm/Game/State/Redraw.hs
@@ -64,8 +64,4 @@ resetRedraw = const initRedraw
 -- | Does the world pane need redrawing at all?
 needsRedraw :: Redraw -> Bool
 needsRedraw r =
-  or
-    [ r ^. redrawWorld
-    , r ^. drawFrame
-    , not (S.null $ r ^. dirtyCells)
-    ]
+  r ^. redrawWorld || r ^. drawFrame || not (S.null $ r ^. dirtyCells)

--- a/src/swarm-engine/Swarm/Game/State/Redraw.hs
+++ b/src/swarm-engine/Swarm/Game/State/Redraw.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- A subrecord containing state specific to deciding when and which
+-- parts of the world view to redraw.
+module Swarm.Game.State.Redraw (
+
+  Redraw,
+
+  -- * Lenses
+
+  dirtyCells,
+  redrawWorld,
+  drawFrame,
+
+  -- * Utility
+
+  initRedraw,
+  resetRedraw,
+  needsRedraw
+
+) where
+
+import Control.Lens ((^.), Lens')
+import Data.Set (Set)
+import Data.Set qualified as S
+import Swarm.Game.Location (Location)
+import Swarm.Game.Universe (Cosmic)
+import Swarm.Util.Lens (makeLensesNoSigs)
+
+-- | Subrecord of state relating to whether (and which parts of) the
+--   world view needs to redrawn.
+data Redraw = Redraw
+  { _dirtyCells :: Set (Cosmic Location)
+  , _redrawWorld :: Bool
+  , _drawFrame :: Bool
+  }
+
+makeLensesNoSigs ''Redraw
+
+-- | Which locations have changed since the previous frame?  We will
+--   need to be sure to redraw the view chunks containing these
+--   locations.
+dirtyCells :: Lens' Redraw (Set (Cosmic Location))
+
+-- | Should we redraw the entire world (i.e. invalidate the entire
+--   view chunk cache) next frame?
+redrawWorld :: Lens' Redraw Bool
+
+-- | Should we make sure that we redraw the world pane, even if the
+--   world view itself has not changed?  This might be relevant
+--   e.g. for things displayed around the border of the world pane.
+drawFrame :: Lens' Redraw Bool
+
+-- | Initial 'Redraw' state, indicating that nothing needs to be
+--   redrawn.
+initRedraw :: Redraw
+initRedraw = Redraw S.empty False False
+
+-- | Reset the redraw state, by setting it to 'initRedraw'.  Typically
+--   this should be called right after drawing each frame, to be ready
+--   to collect redrawing information for the next frame.
+resetRedraw :: Redraw -> Redraw
+resetRedraw = const initRedraw
+
+-- | Does the world pane need redrawing at all?
+needsRedraw :: Redraw -> Bool
+needsRedraw r = or
+  [ r ^. redrawWorld
+  , r ^. drawFrame
+  , not (S.null $ r ^. dirtyCells)
+  ]

--- a/src/swarm-engine/Swarm/Game/State/Redraw.hs
+++ b/src/swarm-engine/Swarm/Game/State/Redraw.hs
@@ -21,7 +21,7 @@ module Swarm.Game.State.Redraw (
   redrawWorld,
 ) where
 
-import Control.Lens (Lens', Getter)
+import Control.Lens (Getter, Lens')
 import Data.Set (Set)
 import Data.Set qualified as S
 import Swarm.Game.Location (Location)

--- a/src/swarm-engine/Swarm/Game/State/Redraw.hs
+++ b/src/swarm-engine/Swarm/Game/State/Redraw.hs
@@ -6,24 +6,20 @@
 -- A subrecord containing state specific to deciding when and which
 -- parts of the world view to redraw.
 module Swarm.Game.State.Redraw (
-
   Redraw,
 
   -- * Lenses
-
   dirtyCells,
   redrawWorld,
   drawFrame,
 
   -- * Utility
-
   initRedraw,
   resetRedraw,
-  needsRedraw
-
+  needsRedraw,
 ) where
 
-import Control.Lens ((^.), Lens')
+import Control.Lens (Lens', (^.))
 import Data.Set (Set)
 import Data.Set qualified as S
 import Swarm.Game.Location (Location)
@@ -67,8 +63,9 @@ resetRedraw = const initRedraw
 
 -- | Does the world pane need redrawing at all?
 needsRedraw :: Redraw -> Bool
-needsRedraw r = or
-  [ r ^. redrawWorld
-  , r ^. drawFrame
-  , not (S.null $ r ^. dirtyCells)
-  ]
+needsRedraw r =
+  or
+    [ r ^. redrawWorld
+    , r ^. drawFrame
+    , not (S.null $ r ^. dirtyCells)
+    ]

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -371,13 +371,14 @@ wakeWatchingRobots myID currentTick loc = do
         Waiting _ c -> Waiting newWakeTime c
         x -> x
 
-deleteRobot :: (Has (State Robots) sig m) => RID -> m ()
+deleteRobot :: (Has (State Robots) sig m) => RID -> m (Maybe (Cosmic Location))
 deleteRobot rn = do
   internalActiveRobots %= IS.delete rn
   mrobot <- robotMap . at rn <<.= Nothing
   mrobot `forM_` \robot -> do
     -- Delete the robot from the index of robots by location.
     removeRobotFromLocationMap (robot ^. robotLocation) rn
+  pure (view robotLocation <$> mrobot)
 
 -- | Makes sure empty sets don't hang around in the
 -- 'robotsByLocation' map.  We don't want a key with an

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -171,18 +171,17 @@ finishGameTick =
 insertBackRobot :: Has (State GameState) sig m => RID -> Robot -> m ()
 insertBackRobot rn rob = do
   time <- use $ temporal . ticks
-  zoomRobots $
-    if rob ^. selfDestruct
-      then deleteRobot rn
-      else do
-        robotMap %= IM.insert rn rob
-        case waitingUntil rob of
-          Just wakeUpTime
-            -- if w=2 t=1 then we do not needlessly put robot to waiting queue
-            | wakeUpTime <= addTicks 2 time -> return ()
-            | otherwise -> sleepUntil rn wakeUpTime
-          Nothing ->
-            unless (isActive rob) (sleepForever rn)
+  if rob ^. selfDestruct
+    then deleteRobotAndFlag rn
+    else zoomRobots $ do
+      robotMap %= IM.insert rn rob
+      case waitingUntil rob of
+        Just wakeUpTime
+          -- if w=2 t=1 then we do not needlessly put robot to waiting queue
+          | wakeUpTime <= addTicks 2 time -> return ()
+          | otherwise -> sleepUntil rn wakeUpTime
+        Nothing ->
+          unless (isActive rob) (sleepForever rn)
 
 -- | Run a set of robots - this is used to run robots before/after the focused one.
 --

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -124,7 +124,7 @@ gameTick = measureCpuTimeInSec runTick >>= updateMetrics
     ticked <- runActiveRobots
     updateBaseReplState
     -- Possibly update the view center.
-    modify recalcViewCenterAndRedraw
+    modify (robotInfo %~ recalcViewCenter)
     -- On new tick see if the winning condition for the current objective is met
     when ticked hypotheticalWinCheck'
     return ticked

--- a/src/swarm-engine/Swarm/Game/Step/Combustion.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Combustion.hs
@@ -60,7 +60,6 @@ igniteCommand c d = do
 
   -- Remove the entity from the world.
   updateEntityAt loc (const Nothing)
-  flagRedraw
 
   -- Start burning process
   let selfCombustibility = (e ^. entityCombustion) ? defaultCombustibility

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -412,7 +412,6 @@ execConst runChildProg c vs s k = do
             -- world, since question marks may change to something else.
             focus <- use (robotInfo . focusedRobotID)
             when (focus == otherID && not knew) flagCompleteRedraw
-
           else grantAchievementForRobot GaveToSelf
 
         return $ mkReturn ()

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -159,12 +159,14 @@ execConst runChildProg c vs s k = do
     Destroy -> case vs of
       [VRobot rid] -> do
         myID <- use robotID
+        rm <- use (robotInfo . robotMap)
+        let loc = rm ^? ix rid . robotLocation
         if myID == rid
           then destroyIfNotBase $ \case False -> Just AttemptSelfDestructBase; _ -> Nothing
           else do
-            zoomRobots $ deleteRobot rid
+            _ <- zoomRobots $ deleteRobot rid
             when (rid == 0) $ grantAchievement DestroyedBase
-        flagRedraw
+        maybe (pure ()) flagRedraw loc
         return $ mkReturn ()
       _ -> badConst
     Move -> do

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -71,7 +71,8 @@ adaptGameState f = do
   put newGS
   return newRecognizer
 
--- | Modify the entity (if any) at a given location.
+-- | Modify the entity (if any) at a given location, and mark the cell
+--   dirty (i.e. needing to be redrawn) if anything changes.
 updateEntityAt ::
   (Has (State Robot) sig m, Has (State GameState) sig m) =>
   Cosmic Location ->
@@ -94,6 +95,8 @@ updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
 
     pcr <- use $ pathCaching . pathCachingRobots
     mapM_ (revalidatePathCache cLoc modType) $ IM.toList pcr
+
+    flagRedraw cLoc
 
 -- * Capabilities
 
@@ -130,12 +133,6 @@ isJustOrFail' c a ts = a `isJustOr` cmdExn c ts
 -- | Create an exception about a command failing.
 cmdExn :: Const -> [Text] -> Exn
 cmdExn c parts = CmdFailed c (T.unwords parts) Nothing
-
--- * Some utility functions
-
--- | Set a flag telling the UI that the world needs to be redrawn.
-flagRedraw :: (Has (State GameState) sig m) => m ()
-flagRedraw = needsRedraw .= True
 
 -- * Randomness
 

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -96,7 +96,7 @@ updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
     pcr <- use $ pathCaching . pathCachingRobots
     mapM_ (revalidatePathCache cLoc modType) $ IM.toList pcr
 
-    flagRedraw cLoc
+    markDirty cLoc
 
 -- * Capabilities
 

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -187,7 +187,8 @@ updateRobotLocation oldLoc newLoc
         removeRobotFromLocationMap oldLoc rid
         addRobotToLocation rid newlocWithPortal
       modify (unsafeSetRobotLocation newlocWithPortal)
-      flagRedraw
+      flagRedraw oldLoc
+      flagRedraw newLoc
  where
   applyPortal loc = do
     lms <- use $ landscape . worldNavigation
@@ -213,10 +214,9 @@ onTarget rid act = do
       mtgt <- use (robotInfo . robotMap . at rid)
       forM_ mtgt $ \tgt -> do
         tgt' <- execState @Robot tgt act
-        zoomRobots $
-          if tgt' ^. selfDestruct
-            then deleteRobot rid
-            else robotMap . ix rid .= tgt'
+        if tgt' ^. selfDestruct
+          then deleteRobotAndFlag rid
+          else zoomRobots $ robotMap . ix rid .= tgt'
 
 -- | Enforces validity of the robot's privileged status to receive
 -- an achievement.
@@ -404,7 +404,6 @@ updateWorldAndRobots ::
 updateWorldAndRobots cmd wf rf = do
   mapM_ (updateWorld cmd) wf
   applyRobotUpdates rf
-  flagRedraw
 
 -- | Format a set of suggested devices for use in an error message,
 --   in the format @device1 or device2 or ... or deviceN@.

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -187,8 +187,8 @@ updateRobotLocation oldLoc newLoc
         removeRobotFromLocationMap oldLoc rid
         addRobotToLocation rid newlocWithPortal
       modify (unsafeSetRobotLocation newlocWithPortal)
-      flagRedraw oldLoc
-      flagRedraw newLoc
+      markDirty oldLoc
+      markDirty newLoc
  where
   applyPortal loc = do
     lms <- use $ landscape . worldNavigation

--- a/src/swarm-scenario/Swarm/Util/Content.hs
+++ b/src/swarm-scenario/Swarm/Util/Content.hs
@@ -29,8 +29,6 @@ getContentAt tm w coords = (underlyingCellTerrain, underlyingCellEntity)
 -- * Rendering
 
 -- | Get a rectangle of cells for rendering.
---
--- Compare to: 'Swarm.TUI.View.worldWidget'
 getMapRectangle ::
   (d -> e) ->
   (Coords -> (TerrainType, Maybe d)) ->

--- a/src/swarm-topography/Swarm/Game/Location.hs
+++ b/src/swarm-topography/Swarm/Game/Location.hs
@@ -69,7 +69,7 @@ import Swarm.Util qualified as Util
 --   conversions between 'Location' and 'Swarm.Game.World.Coords'.
 type Location = Point V2 Int32
 
--- | A convenient way to pattern-match on t'Location' values.
+-- | A convenient way to pattern-match on 'Location' values.
 pattern Location :: Int32 -> Int32 -> Location
 pattern Location x y = P (V2 x y)
 

--- a/src/swarm-topography/Swarm/Game/Universe.hs
+++ b/src/swarm-topography/Swarm/Game/Universe.hs
@@ -24,7 +24,7 @@ import Swarm.Util (quote)
 -- * Referring to subworlds
 
 data SubworldName = DefaultRootSubworld | SubworldName Text
-  deriving (Show, Eq, Ord, Generic, ToJSON, ToJSONKey)
+  deriving (Show, Read, Eq, Ord, Generic, ToJSON, ToJSONKey)
 
 instance FromJSON SubworldName where
   parseJSON = withText "subworld name" $ return . SubworldName
@@ -49,7 +49,7 @@ data Cosmic a = Cosmic
   { _subworld :: SubworldName
   , _planar :: a
   }
-  deriving (Show, Eq, Ord, Functor, Generic, ToJSON, ToJSONKey)
+  deriving (Show, Read, Eq, Ord, Functor, Foldable, Traversable, Generic, ToJSON, ToJSONKey)
 
 makeLenses ''Cosmic
 

--- a/src/swarm-topography/Swarm/Game/World/Coords.hs
+++ b/src/swarm-topography/Swarm/Game/World/Coords.hs
@@ -9,6 +9,7 @@ module Swarm.Game.World.Coords (
   locToCoords,
   coordsToLoc,
   addTuple,
+  diffCoords,
   mapCoords,
   BoundsRectangle,
 )
@@ -47,6 +48,12 @@ coordsToLoc (Coords (r, c)) = Location c (-r)
 
 addTuple :: Coords -> (Int32, Int32) -> Coords
 addTuple (Coords (r, c)) (addR, addC) = Coords (r + addR, c + addC)
+
+-- | Subtract two coordinates, producing the number of rows and
+--   columns needed to add to the first in order to reach the second.
+--   That is, @addTuple a (diffCoords a b) = b@.
+diffCoords :: Coords -> Coords -> (Int32, Int32)
+diffCoords (Coords (r1, c1)) (Coords (r2, c2)) = (r2 - r1, c2 - c1)
 
 mapCoords :: (Int32 -> Int32) -> Coords -> Coords
 mapCoords f (Coords (r,c)) = Coords (f r, f c)

--- a/src/swarm-topography/Swarm/Game/World/Coords.hs
+++ b/src/swarm-topography/Swarm/Game/World/Coords.hs
@@ -9,6 +9,7 @@ module Swarm.Game.World.Coords (
   locToCoords,
   coordsToLoc,
   addTuple,
+  mapCoords,
   BoundsRectangle,
 )
 where
@@ -31,7 +32,7 @@ import Swarm.Game.Location (Location, pattern Location)
 --   and forth between this type and t'Location', which is used when
 --   presenting coordinates externally to the player.
 newtype Coords = Coords {unCoords :: (Int32, Int32)}
-  deriving (Eq, Ord, Show, Ix, Generic)
+  deriving (Eq, Ord, Show, Read, Ix, Generic)
 
 instance Rewrapped Coords t
 instance Wrapped Coords
@@ -46,6 +47,9 @@ coordsToLoc (Coords (r, c)) = Location c (-r)
 
 addTuple :: Coords -> (Int32, Int32) -> Coords
 addTuple (Coords (r, c)) (addR, addC) = Coords (r + addR, c + addC)
+
+mapCoords :: (Int32 -> Int32) -> Coords -> Coords
+mapCoords f (Coords (r,c)) = Coords (f r, f c)
 
 -- | Represents the top-left and bottom-right coordinates
 -- of a bounding rectangle of cells in the world map

--- a/src/swarm-topography/Swarm/Game/World/Coords.hs
+++ b/src/swarm-topography/Swarm/Game/World/Coords.hs
@@ -56,7 +56,7 @@ diffCoords :: Coords -> Coords -> (Int32, Int32)
 diffCoords (Coords (r1, c1)) (Coords (r2, c2)) = (r2 - r1, c2 - c1)
 
 mapCoords :: (Int32 -> Int32) -> Coords -> Coords
-mapCoords f (Coords (r,c)) = Coords (f r, f c)
+mapCoords f (Coords (r, c)) = Coords (f r, f c)
 
 -- | Represents the top-left and bottom-right coordinates
 -- of a bounding rectangle of cells in the world map

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -121,6 +121,7 @@ handleEvent e = do
     AppEvent (UpstreamVersion ev) -> handleUpstreamVersionResponse ev
     AppEvent (Web (RunWebCode {..})) | not playing -> liftIO . webReply $ Rejected NoActiveGame
     AppEvent (PopupEvent event) -> event >> continueWithoutRedraw
+    VtyEvent (V.EvResize _ _) -> invalidateCache
     _ -> do
       -- Handle popup display at the very top level, so it is
       -- unaffected by any other state, e.g. even when starting or
@@ -346,7 +347,6 @@ handleMainEvent forceRedraw ev = do
       UpstreamVersion _ -> pure ()
       -- PopupEvent event should already be handled by top-level handler, so this shouldn't happen.
       PopupEvent _ -> pure ()
-    VtyEvent (V.EvResize _ _) -> invalidateCache
     EscapeKey
       | Just m <- s ^. playState . scenarioState . uiGameplay . uiDialogs . uiModal ->
           Brick.zoom (playState . scenarioState) $

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -541,6 +541,10 @@ handleModalEvent = \case
 -- * returns to the previous menu
 quitGame :: Bool -> EventM Name AppState ()
 quitGame isNoMenu = do
+  -- Invalidate drawing cache so the world preview in the menu will be
+  -- refreshed
+  -- invalidateCache
+
   -- Write out REPL history.
   history <- use $ playState . scenarioState . uiGameplay . uiREPL . replHistory
   let hist = mapMaybe getREPLSubmitted $ getLatestREPLHistoryItems maxBound history

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -396,7 +396,7 @@ handleMainEvent forceRedraw ev = do
         (UIShortcut "hide REPL") -> Brick.zoom (playState . scenarioState) toggleREPLVisibility
         (UIShortcut "show REPL") -> Brick.zoom (playState . scenarioState) toggleREPLVisibility
         (UIShortcut "debug") -> showCESKDebug
-        (UIShortcut "hide robots") -> Brick.zoom (playState . scenarioState . uiGameplay) hideRobots
+        (UIShortcut "hide robots") -> Brick.zoom (playState . scenarioState) hideRobots
         (UIShortcut "goal") -> Brick.zoom (playState . scenarioState) viewGoal
         _ -> continueWithoutRedraw
     MouseUp n _ _mouseLoc ->

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -541,10 +541,6 @@ handleModalEvent = \case
 -- * returns to the previous menu
 quitGame :: Bool -> EventM Name AppState ()
 quitGame isNoMenu = do
-  -- Invalidate drawing cache so the world preview in the menu will be
-  -- refreshed
-  -- invalidateCache
-
   -- Write out REPL history.
   history <- use $ playState . scenarioState . uiGameplay . uiREPL . replHistory
   let hist = mapMaybe getREPLSubmitted $ getLatestREPLHistoryItems maxBound history

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -46,9 +46,8 @@ oneSecond = 1_000_000_000 -- one second = 10^9 nanoseconds
 runFramePlayState :: EventM Name PlayState ()
 runFramePlayState = Brick.zoom scenarioState $ do
   -- Reset the needsRedraw flag and the dirty cells.  While processing
-  -- the frame and stepping the robots, the flag will get set to true
-  -- if anything changes that requires redrawing the world (e.g. a
-  -- robot moving or disappearing). XXX
+  -- the frame and stepping the robots, individual cells that change will
+  -- be marked as dirty, so we can be sure to redraw them next frame.
   gameState . needsRedraw .= False
   gameState . dirtyCells .= mempty
 

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -45,15 +45,6 @@ oneSecond = 1_000_000_000 -- one second = 10^9 nanoseconds
 
 runFramePlayState :: EventM Name PlayState ()
 runFramePlayState = Brick.zoom scenarioState $ do
-  -- Reset the redrawWorld and drawFrame flags and the dirty cells.
-  -- While processing the frame and stepping the robots, individual
-  -- cells that change will be marked as dirty, so we can be sure to
-  -- redraw them next frame, and redrawWorld and drawFrame can be set
-  -- as appropriate.
-  gameState . redrawWorld .= False
-  gameState . drawFrame .= False
-  gameState . dirtyCells .= mempty
-
   -- The logic here is taken from https://gafferongames.com/post/fix_your_timestep/ .
 
   curTime <- liftIO $ getTime Monotonic

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -82,7 +82,7 @@ runFramePlayState = Brick.zoom scenarioState $ do
         uiTPF .= fromIntegral uiTicks / fromIntegral frames
 
       -- ensure this frame gets drawn
-      gameState . drawFrame .= True
+      gameState . redraw . drawFrame .= True
 
     Brick.zoom (uiGameplay . uiTiming) $ do
       -- Reset the counter and wait another seconds for the next update

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -45,10 +45,13 @@ oneSecond = 1_000_000_000 -- one second = 10^9 nanoseconds
 
 runFramePlayState :: EventM Name PlayState ()
 runFramePlayState = Brick.zoom scenarioState $ do
-  -- Reset the needsRedraw flag and the dirty cells.  While processing
-  -- the frame and stepping the robots, individual cells that change will
-  -- be marked as dirty, so we can be sure to redraw them next frame.
-  gameState . needsRedraw .= False
+  -- Reset the redrawWorld and drawFrame flags and the dirty cells.
+  -- While processing the frame and stepping the robots, individual
+  -- cells that change will be marked as dirty, so we can be sure to
+  -- redraw them next frame, and redrawWorld and drawFrame can be set
+  -- as appropriate.
+  gameState . redrawWorld .= False
+  gameState . drawFrame .= False
   gameState . dirtyCells .= mempty
 
   -- The logic here is taken from https://gafferongames.com/post/fix_your_timestep/ .
@@ -88,7 +91,7 @@ runFramePlayState = Brick.zoom scenarioState $ do
         uiTPF .= fromIntegral uiTicks / fromIntegral frames
 
       -- ensure this frame gets drawn
-      gameState . needsRedraw .= True
+      gameState . drawFrame .= True
 
     Brick.zoom (uiGameplay . uiTiming) $ do
       -- Reset the counter and wait another seconds for the next update

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Frame.hs
@@ -45,10 +45,12 @@ oneSecond = 1_000_000_000 -- one second = 10^9 nanoseconds
 
 runFramePlayState :: EventM Name PlayState ()
 runFramePlayState = Brick.zoom scenarioState $ do
-  -- Reset the needsRedraw flag.  While processing the frame and stepping the robots,
-  -- the flag will get set to true if anything changes that requires redrawing the
-  -- world (e.g. a robot moving or disappearing).
+  -- Reset the needsRedraw flag and the dirty cells.  While processing
+  -- the frame and stepping the robots, the flag will get set to true
+  -- if anything changes that requires redrawing the world (e.g. a
+  -- robot moving or disappearing). XXX
   gameState . needsRedraw .= False
+  gameState . dirtyCells .= mempty
 
   -- The logic here is taken from https://gafferongames.com/post/fix_your_timestep/ .
 

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -146,7 +146,7 @@ hideRobots :: EventM Name ScenarioState ()
 hideRobots = do
   t <- liftIO $ getTime Monotonic
   uiGameplay . uiHideRobotsUntil .= Just (t + TimeSpec 2 0)
-  gameState . redrawWorld .= True
+  gameState . redraw . redrawWorld .= True
 
 showCESKDebug :: EventM Name AppState ()
 showCESKDebug = do

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -146,7 +146,7 @@ hideRobots :: EventM Name ScenarioState ()
 hideRobots = do
   t <- liftIO $ getTime Monotonic
   uiGameplay . uiHideRobotsUntil .= Just (t + TimeSpec 2 0)
-  gameState . redraw . redrawWorld .= True
+  gameState . redraw %= redrawWorld
 
 showCESKDebug :: EventM Name AppState ()
 showCESKDebug = do

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -170,7 +170,9 @@ adjustTPS :: (Int -> Int -> Int) -> ScenarioState -> ScenarioState
 adjustTPS (+/-) = uiGameplay . uiTiming . lgTicksPerSecond %~ (+/- 1)
 
 toggleCreativeMode :: EventM Name ScenarioState ()
-toggleCreativeMode = gameState . creativeMode %= not
+toggleCreativeMode = do
+  gameState . creativeMode %= not
+  gameState . redraw %= redrawWorld
 
 toggleWorldEditor :: EventM Name ScenarioState ()
 toggleWorldEditor = do

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -152,7 +152,9 @@ hideRobots = do
     -- hide for two seconds
     False -> do
       uiHideRobotsUntil .= t + TimeSpec 2 0
-      invalidateCacheEntry WorldCache
+      -- XXX need to mark world for complete redraw.  How to do that?
+      -- needsRedraw is in GameState, which we don't have here.
+      -- Actually maybe we can widen its scope a bit...
 
 showCESKDebug :: EventM Name AppState ()
 showCESKDebug = do
@@ -184,14 +186,10 @@ toggleWorldEditor = do
   setFocus WorldEditorPanel
 
 toggleREPLVisibility :: EventM Name ScenarioState ()
-toggleREPLVisibility = do
-  invalidateCacheEntry WorldCache
-  uiGameplay . uiShowREPL %= not
+toggleREPLVisibility = uiGameplay . uiShowREPL %= not
 
 viewBase :: EventM Name ScenarioState ()
-viewBase = do
-  invalidateCacheEntry WorldCache
-  gameState . robotInfo . viewCenterRule .= VCRobot 0
+viewBase = gameState . robotInfo . viewCenterRule .= VCRobot 0
 
 toggleFPS :: EventM Name ScenarioState ()
 toggleFPS = uiGameplay . uiTiming . uiShowFPS %= not

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -152,9 +152,8 @@ hideRobots = do
     -- hide for two seconds
     False -> do
       uiHideRobotsUntil .= t + TimeSpec 2 0
-      -- XXX need to mark world for complete redraw.  How to do that?
-      -- needsRedraw is in GameState, which we don't have here.
-      -- Actually maybe we can widen its scope a bit...
+      invalidateCache
+      -- XXX need to redraw world again after 2 seconds... schedule an event?
 
 showCESKDebug :: EventM Name AppState ()
 showCESKDebug = do

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/World.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/World.hs
@@ -38,10 +38,5 @@ worldScrollDist = 8
 
 -- | Manually scroll the world view.
 scrollView :: (Location -> Location) -> EventM Name AppState ()
-scrollView update = do
-  -- Manually invalidate the 'WorldCache' instead of just setting
-  -- 'needsRedraw'.  I don't quite understand why the latter doesn't
-  -- always work, but there seems to be some sort of race condition
-  -- where 'needsRedraw' gets reset before the UI drawing code runs.
-  invalidateCacheEntry WorldCache
+scrollView update =
   playState . scenarioState . gameState . robotInfo %= modifyViewCenter (fmap update)

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -170,7 +170,7 @@ checkUnhideRobots = do
     Nothing -> pure ()
     Just ht -> when (t >= ht) $ do
       uiGameplay . uiHideRobotsUntil .= Nothing
-      Brick.zoom (gameState . redraw) $ redrawWorld .= True
+      gameState . redraw %= redrawWorld
 
 -- | Update the UI.  This function is used after running the
 --   game for some number of ticks.
@@ -186,7 +186,7 @@ updateUI = do
   -- some cells marked as dirty
   let worldPanelUpdated = needsRedraw (g ^. redraw)
 
-  if g ^. redraw . redrawWorld
+  if g ^. redraw . redrawWorldFlag
     then invalidateCache -- Invalidate entire view chunk cache
     else
       -- Invalidate cache entries for view chunks containing cells that were updated,

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -170,13 +170,10 @@ updateUI = do
   -- Some part of the world needs a redraw if either needsRedraw is
   -- set (meaning the world must be completely redrawn), or there are
   -- some cells marked as dirty
-  let worldNeededRedraw = g ^. needsRedraw || not (S.null $ g ^. dirtyCells)
+  let worldPanelUpdated = g ^. redrawWorld || g ^. drawFrame || not (S.null $ g ^. dirtyCells)
 
-  -- XXX invalidate all view chunk cache entries (for the current subworld)
-  --   if (g ^. needsRedraw) is true
-  -- Need to keep track of which entries are currently in the cache.
-  if (g ^. needsRedraw)
-    then invalidateCache  -- XXX for now, invalidate entire cache
+  if (g ^. redrawWorld)
+    then invalidateCache   -- Invalidate entire view chunk cache
     else
       -- Invalidate cache entries for view chunks containing cells that were updated,
       -- so they will be redrawn.
@@ -213,7 +210,7 @@ updateUI = do
       doRobotListUpdate dOps g
 
   let redraw =
-        worldNeededRedraw
+        worldPanelUpdated
           || inventoryUpdated
           || replUpdated
           || logUpdated

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -168,7 +168,9 @@ updateUI = do
 
   -- If the game state indicates a redraw is needed, invalidate the
   -- world cache so it will be redrawn.
-  when (g ^. needsRedraw) $ invalidateCacheEntry WorldCache
+  --
+  -- XXX update this to redraw individual cells from 'dirtyCells'
+  when (g ^. needsRedraw || not (S.null $ g ^. dirtyCells)) $ invalidateCacheEntry WorldCache
 
   let fr = g ^. to focusedRobot
   inventoryUpdated <- Brick.zoom (playState . scenarioState) $ checkInventoryUpdated fr

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -170,7 +170,8 @@ updateUI = do
   -- world cache so it will be redrawn.
   --
   -- XXX update this to redraw individual cells from 'dirtyCells'
-  when (g ^. needsRedraw || not (S.null $ g ^. dirtyCells)) $ invalidateCacheEntry WorldCache
+  let worldNeedsRedraw = g ^. needsRedraw || not (S.null $ g ^. dirtyCells)
+  when worldNeedsRedraw $ invalidateCacheEntry WorldCache
 
   let fr = g ^. to focusedRobot
   inventoryUpdated <- Brick.zoom (playState . scenarioState) $ checkInventoryUpdated fr
@@ -203,7 +204,7 @@ updateUI = do
       doRobotListUpdate dOps g
 
   let redraw =
-        g ^. needsRedraw
+        worldNeedsRedraw
           || inventoryUpdated
           || replUpdated
           || logUpdated

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -55,7 +55,7 @@ import Swarm.TUI.Model.ViewChunk
 import Swarm.TUI.View.Objective qualified as GR
 import Swarm.TUI.View.Robot
 import Swarm.TUI.View.Robot.Type
-import System.Clock (getTime, Clock (Monotonic))
+import System.Clock (Clock (Monotonic), getTime)
 import Witch (into)
 
 -- | Update the UI and redraw if needed.
@@ -187,7 +187,7 @@ updateUI = do
   let worldPanelUpdated = needsRedraw (g ^. redraw)
 
   if (g ^. redraw . redrawWorld)
-    then invalidateCache   -- Invalidate entire view chunk cache
+    then invalidateCache -- Invalidate entire view chunk cache
     else
       -- Invalidate cache entries for view chunks containing cells that were updated,
       -- so they will be redrawn.

--- a/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/UpdateUI.hs
@@ -186,7 +186,7 @@ updateUI = do
   -- some cells marked as dirty
   let worldPanelUpdated = needsRedraw (g ^. redraw)
 
-  if (g ^. redraw . redrawWorld)
+  if g ^. redraw . redrawWorld
     then invalidateCache -- Invalidate entire view chunk cache
     else
       -- Invalidate cache entries for view chunks containing cells that were updated,

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -177,11 +177,6 @@ toggleEndScenarioModal mt m = do
 setFocus :: FocusablePanel -> EventM Name ScenarioState ()
 setFocus name = uiGameplay . uiFocusRing %= focusSetCurrent (FocusablePanel name)
 
-immediatelyRedrawWorld :: EventM Name GameState ()
-immediatelyRedrawWorld = do
-  invalidateCacheEntry WorldCache
-  loadVisibleRegion
-
 -- | Make sure all tiles covering the visible part of the world are
 --   loaded.
 loadVisibleRegion :: EventM Name GameState ()

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -67,8 +67,7 @@ handleCtrlLeftClick mouseLoc = do
     Brick.zoom (uiGameplay . uiWorldEditor) $ do
       worldOverdraw . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
       lastWorldEditorMessage .= Nothing
-  Brick.zoom gameState $ redrawWorld .= True
-  pure ()
+  Brick.zoom (gameState . redraw) $ redrawWorld .= True
 
 handleRightClick :: B.Location -> EventM Name ScenarioState ()
 handleRightClick mouseLoc = do
@@ -77,8 +76,7 @@ handleRightClick mouseLoc = do
     guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
     uiGameplay . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
-  Brick.zoom gameState $ redrawWorld .= True
-  pure ()
+  Brick.zoom (gameState . redraw) $ redrawWorld .= True
 
 -- | "Eye Dropper" tool:
 handleMiddleClick :: B.Location -> EventM Name ScenarioState ()

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -67,7 +67,7 @@ handleCtrlLeftClick mouseLoc = do
     Brick.zoom (uiGameplay . uiWorldEditor) $ do
       worldOverdraw . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
       lastWorldEditorMessage .= Nothing
-  Brick.zoom (gameState . redraw) $ redrawWorld .= True
+  gameState . redraw %= redrawWorld
 
 handleRightClick :: B.Location -> EventM Name ScenarioState ()
 handleRightClick mouseLoc = do
@@ -76,7 +76,7 @@ handleRightClick mouseLoc = do
     guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
     uiGameplay . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
-  Brick.zoom (gameState . redraw) $ redrawWorld .= True
+  gameState . redraw %= redrawWorld
 
 -- | "Eye Dropper" tool:
 handleMiddleClick :: B.Location -> EventM Name ScenarioState ()

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -67,7 +67,9 @@ handleCtrlLeftClick mouseLoc = do
     Brick.zoom (uiGameplay . uiWorldEditor) $ do
       worldOverdraw . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
       lastWorldEditorMessage .= Nothing
-  Brick.zoom gameState immediatelyRedrawWorld
+  -- XXX mark a view chunk as dirty here?
+  -- Brick.zoom gameState immediatelyRedrawWorld
+  pure ()
 
 handleRightClick :: B.Location -> EventM Name ScenarioState ()
 handleRightClick mouseLoc = do
@@ -76,7 +78,9 @@ handleRightClick mouseLoc = do
     guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
     uiGameplay . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
-  Brick.zoom gameState immediatelyRedrawWorld
+  -- XXX mark view chunk as dirty?
+  -- Brick.zoom gameState immediatelyRedrawWorld
+  pure ()
 
 -- | "Eye Dropper" tool:
 handleMiddleClick :: B.Location -> EventM Name ScenarioState ()

--- a/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Editor/Controller.hs
@@ -67,8 +67,7 @@ handleCtrlLeftClick mouseLoc = do
     Brick.zoom (uiGameplay . uiWorldEditor) $ do
       worldOverdraw . paintedTerrain %= M.insert (mouseCoords ^. planar) (terrain, maybeToErasable maybeEntityPaint)
       lastWorldEditorMessage .= Nothing
-  -- XXX mark a view chunk as dirty here?
-  -- Brick.zoom gameState immediatelyRedrawWorld
+  Brick.zoom gameState $ redrawWorld .= True
   pure ()
 
 handleRightClick :: B.Location -> EventM Name ScenarioState ()
@@ -78,8 +77,7 @@ handleRightClick mouseLoc = do
     guard $ worldEditor ^. worldOverdraw . isWorldEditorEnabled
     mouseCoords <- MaybeT $ Brick.zoom gameState $ mouseLocToWorldCoords mouseLoc
     uiGameplay . uiWorldEditor . worldOverdraw . paintedTerrain %= M.delete (mouseCoords ^. planar)
-  -- XXX mark view chunk as dirty?
-  -- Brick.zoom gameState immediatelyRedrawWorld
+  Brick.zoom gameState $ redrawWorld .= True
   pure ()
 
 -- | "Eye Dropper" tool:

--- a/src/swarm-tui/Swarm/TUI/Model/Name.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Name.hs
@@ -9,6 +9,7 @@
 module Swarm.TUI.Model.Name where
 
 import Data.Text (Text)
+import Swarm.TUI.Model.ViewChunk
 
 data WorldEditorFocusable
   = BrushSelector
@@ -84,8 +85,10 @@ data Name
     REPLInput
   | -- | The REPL history cache.
     REPLHistoryCache
-  | -- | The render cache for the world view.
+  | -- | Cache for the entire world view.  XXX remove me.
     WorldCache
+  | -- | Caches for rendered chunks of the world view.
+    ViewChunkCache ViewChunk
   | -- | The cached extent for the world view.
     WorldExtent
   | -- | The cursor/viewCenter display in the bottom left of the World view

--- a/src/swarm-tui/Swarm/TUI/Model/Name.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Name.hs
@@ -85,8 +85,6 @@ data Name
     REPLInput
   | -- | The REPL history cache.
     REPLHistoryCache
-  | -- | Cache for the entire world view.  XXX remove me.
-    WorldCache
   | -- | Caches for rendered chunks of the world view.
     ViewChunkCache ViewChunk
   | -- | The cached extent for the world view.

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -292,7 +292,7 @@ constructAppState (PersistentState rs ui key progState) opts@(AppOpts {..}) mCha
             }
       , _uiShowREPL = True
       , _uiShowDebug = False
-      , _uiHideRobotsUntil = startTime - 1
+      , _uiHideRobotsUntil = Nothing
       , _scenarioRef = Nothing
       }
 

--- a/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
@@ -207,7 +207,6 @@ data UIGameplay = UIGameplay
   { _uiFocusRing :: FocusRing Name
   , _uiWorldCursor :: Maybe (Cosmic Coords)
   , _uiWorldEditor :: WorldEditor Name
---  , _uiWorldView :: XXX   -- LRU cache of ViewChunk s? see https://hackage.haskell.org/package/lrucaching.
   , _uiREPL :: REPLState
   , _uiREPLReplay :: [REPLHistItem]
   , _uiInventory :: UIInventory

--- a/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
@@ -207,6 +207,7 @@ data UIGameplay = UIGameplay
   { _uiFocusRing :: FocusRing Name
   , _uiWorldCursor :: Maybe (Cosmic Coords)
   , _uiWorldEditor :: WorldEditor Name
+--  , _uiWorldView :: XXX   -- LRU cache of ViewChunk s? see https://hackage.haskell.org/package/lrucaching.
   , _uiREPL :: REPLState
   , _uiREPLReplay :: [REPLHistItem]
   , _uiInventory :: UIInventory

--- a/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/UI/Gameplay.hs
@@ -57,6 +57,7 @@ import Brick.Focus
 import Brick.Widgets.List qualified as BL
 import Control.Lens hiding (from, (<.>))
 import Data.Bits (FiniteBits (finiteBitSize))
+import Data.Maybe (isNothing)
 import Data.Text (Text)
 import Swarm.Game.Cosmetic.Color (AttributeMap)
 import Swarm.Game.Scenario (scenarioCosmetics, scenarioLandscape)
@@ -216,7 +217,7 @@ data UIGameplay = UIGameplay
   , _uiAutoShowObjectives :: Bool
   , _uiShowREPL :: Bool
   , _uiShowDebug :: Bool
-  , _uiHideRobotsUntil :: TimeSpec
+  , _uiHideRobotsUntil :: Maybe TimeSpec
   , _uiTiming :: UITiming
   , _scenarioRef :: Maybe (ScenarioWith ScenarioPath)
   }
@@ -268,12 +269,12 @@ uiShowREPL :: Lens' UIGameplay Bool
 -- the debug option 'Swarm.TUI.Model.DebugOption.DebugCESK'.
 uiShowDebug :: Lens' UIGameplay Bool
 
--- | Hide robots on the world map.
-uiHideRobotsUntil :: Lens' UIGameplay TimeSpec
+-- | Hide robots on the world map until the specified time.
+uiHideRobotsUntil :: Lens' UIGameplay (Maybe TimeSpec)
 
 -- | Whether to show or hide robots on the world map.
 uiShowRobots :: Getter UIGameplay Bool
-uiShowRobots = to (\ui -> ui ^. uiTiming . lastFrameTime > ui ^. uiHideRobotsUntil)
+uiShowRobots = uiHideRobotsUntil . to isNothing
 
 -- | The currently active Scenario description, useful for starting over.
 scenarioRef :: Lens' UIGameplay (Maybe (ScenarioWith ScenarioPath))

--- a/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
@@ -1,0 +1,50 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- A "view chunk" is the smallest rectangular unit by which the game caches XXX world view
+--
+module Swarm.TUI.Model.ViewChunk where
+
+import Control.Lens
+import Data.Bits (shiftL, shiftR)
+import Data.Int (Int32)
+import Data.Ix (range)
+import Data.List.Split (chunksOf)
+import Swarm.Game.Universe
+import Swarm.Game.World.Coords
+
+newtype ViewChunk = ViewChunk { unViewChunk :: Cosmic Coords }
+  deriving (Eq, Ord, Show, Read)
+
+-- | XXX
+viewChunkBits :: Int
+viewChunkBits = 4
+
+viewChunkSize :: Int32
+viewChunkSize = 1 `shiftL` viewChunkBits
+
+viewChunk :: Cosmic Coords -> ViewChunk
+viewChunk c = ViewChunk (over (_Wrapped . both) (`shiftR` viewChunkBits) (c ^. planar) <$ c)
+
+viewChunkBounds :: ViewChunk -> Cosmic BoundsRectangle
+viewChunkBounds (ViewChunk cc) = (,lr) <$> ul
+  where
+    ul = mapCoords (`shiftL` viewChunkBits) <$> cc
+    lr = addTuple (ul ^. planar) (viewChunkSize - 1, viewChunkSize - 1)
+
+-- XXX property-based test that viewChunkBounds always produces rectangle which is viewChunkSize^2
+-- XXX add a property-based test that c is always within viewChunkBounds (viewChunk c)
+
+-- XXX generate smallest possible list of ViewChunks necessary to
+-- entirely cover the given BoundsRectangle.  Returned in row-major
+-- (i.e. top-to-bottom, left-to-right) order.  i.e. a list of rows
+-- XXX change to use NonEmpty
+viewChunkCover :: Cosmic BoundsRectangle -> [[ViewChunk]]
+viewChunkCover c@(Cosmic _ (ul, lr)) = chunksOf (fromIntegral cols) (map ViewChunk vcCoords)
+  where
+    ulvc = viewChunk (ul <$ c)
+    lrvc = viewChunk (lr <$ c)
+    getCol = snd . unCoords . view planar . unViewChunk
+    cols = getCol lrvc - getCol ulvc + 1
+    vcCoords :: [Cosmic Coords]
+    vcCoords = traverse (curry range (unViewChunk ulvc ^. planar)) (unViewChunk lrvc)

--- a/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
@@ -28,9 +28,9 @@ newtype ViewChunk = ViewChunk {unViewChunk :: Cosmic Coords}
   deriving (Eq, Ord, Show, Read)
 
 -- | If viewChunkBits = k then each view chunk will be 2^k x 2^k
---   cells.
+--   cells.  Empirically, k = 2 seems to give the best performance.
 viewChunkBits :: Int
-viewChunkBits = 3
+viewChunkBits = 2
 
 -- | The number of cells on one side of a view chunk.
 viewChunkSize :: Int32

--- a/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
@@ -31,7 +31,7 @@ newtype ViewChunk = ViewChunk { unViewChunk :: Cosmic Coords }
 -- | If viewChunkBits = k then each view chunk will be 2^k x 2^k
 --   cells.
 viewChunkBits :: Int
-viewChunkBits = 4
+viewChunkBits = 3
 
 -- | The number of cells on one side of a view chunk.
 viewChunkSize :: Int32

--- a/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
@@ -1,7 +1,9 @@
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- A "view chunk" is the smallest rectangular unit by which the game caches XXX world view
+-- A "view chunk" is a square 2^k x 2^k section of the world
+-- which is individually cached when drawing the world.  View chunks
+-- which have not changed do not need to be re-rendered.
 --
 module Swarm.TUI.Model.ViewChunk where
 
@@ -14,22 +16,41 @@ import Swarm.Game.Universe
 import Swarm.Game.World.Coords
 import Swarm.Util (chunksOfNE, rangeNE)
 
+-- | A 'ViewChunk' is a square 2^k x 2^k chunk of the world which is
+--   individually cached when rendering.  View chunks are always
+--   aligned with multiples of 2^k, so that the view chunk for given
+--   coordinates can be determined by a simple bit shift.
+--
+--   Note the 'Coords' stored here are in "view chunk space", which is
+--   expressed in units of 2^k.  For example, if @viewChunkBits = 4@
+--   then the view chunk with coordinates @(1,2)@ spans world
+--   coordinates @(16,32) - (31,47)@.
 newtype ViewChunk = ViewChunk { unViewChunk :: Cosmic Coords }
   deriving (Eq, Ord, Show, Read)
 
--- | XXX
+-- | If viewChunkBits = k then each view chunk will be 2^k x 2^k
+--   cells.
 viewChunkBits :: Int
 viewChunkBits = 4
 
+-- | The number of cells on one side of a view chunk.
 viewChunkSize :: Int32
 viewChunkSize = 1 `shiftL` viewChunkBits
 
+-- | Compute the view chunk that contains the given coordinates.
+--   Since view chunks are always aligned to multiples of 2^k, this
+--   can be computed simply by right shifting each coordinate by
+--   'viewChunkBits'.
 viewChunk :: Cosmic Coords -> ViewChunk
 viewChunk c = ViewChunk (over (_Wrapped . both) (`shiftR` viewChunkBits) (c ^. planar) <$ c)
 
+-- | Like 'viewChunk', but for a 'Location' instead of 'Coords'.
 viewChunkFor :: Cosmic Location -> ViewChunk
 viewChunkFor = viewChunk . fmap locToCoords
 
+-- | Compute the bounding rectangle, in world coordinates, for a given
+--   'ViewChunk'.  For example, if @viewChunkBits = 4@ then view chunk
+--   @(1,2)@ will have bounds @(16,32) - (31,47)@.
 viewChunkBounds :: ViewChunk -> Cosmic BoundsRectangle
 viewChunkBounds (ViewChunk cc) = (,lr) <$> ul
   where
@@ -39,16 +60,27 @@ viewChunkBounds (ViewChunk cc) = (,lr) <$> ul
 -- XXX property-based test that viewChunkBounds always produces rectangle which is viewChunkSize^2
 -- XXX add a property-based test that c is always within viewChunkBounds (viewChunk c)
 
--- XXX generate smallest possible list of ViewChunks necessary to
--- entirely cover the given BoundsRectangle.  Returned in row-major
--- (i.e. top-to-bottom, left-to-right) order.  i.e. a list of rows
--- XXX change to use NonEmpty
+-- | @viewChunkCover r@ generates the smallest possible set of
+--   'ViewChunk's necessary to entirely cover the given rectangle @r@.
+--   The resulting 'ViewChunk's are returned in row-major order, that
+--   is, the first list represents the topmost row from left to right,
+--   the second list represents the second row, and so on.
 viewChunkCover :: Cosmic BoundsRectangle -> NonEmpty (NonEmpty ViewChunk)
-viewChunkCover c@(Cosmic _ (tl, br)) = chunksOfNE (fromIntegral cols) (fmap ViewChunk vcCoords)
+viewChunkCover c@(Cosmic _ (tl, br)) = chunksOfNE (fromIntegral cols) vcs
   where
-    tlvc = viewChunk (tl <$ c)
-    brvc = viewChunk (br <$ c)
-    getCol = snd . unCoords . view planar . unViewChunk
+    -- Coordinates of the top-left and bottom-right view chunks, in
+    -- view chunk space
+    tlvc, brvc :: Cosmic Coords
+    tlvc = unViewChunk $ viewChunk (tl <$ c)
+    brvc = unViewChunk $ viewChunk (br <$ c)
+
+    -- Number of view chunks needed to cover the rectangle horizontally
+    cols :: Int32
     cols = getCol brvc - getCol tlvc + 1
-    vcCoords :: NonEmpty (Cosmic Coords)
-    vcCoords = traverse (curry rangeNE (unViewChunk tlvc ^. planar)) (unViewChunk brvc)
+     where
+      getCol = snd . unCoords . view planar
+
+    -- List of all view chunks from top-left to bottom-right,
+    -- generated using 'rangeNE'
+    vcs :: NonEmpty ViewChunk
+    vcs = fmap ViewChunk $ traverse (curry rangeNE (tlvc ^. planar)) brvc

--- a/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
@@ -57,9 +57,6 @@ viewChunkBounds (ViewChunk cc) = (,lr) <$> ul
     ul = mapCoords (`shiftL` viewChunkBits) <$> cc
     lr = addTuple (ul ^. planar) (viewChunkSize - 1, viewChunkSize - 1)
 
--- XXX property-based test that viewChunkBounds always produces rectangle which is viewChunkSize^2
--- XXX add a property-based test that c is always within viewChunkBounds (viewChunk c)
-
 -- | @viewChunkCover r@ generates the smallest possible set of
 --   'ViewChunk's necessary to entirely cover the given rectangle @r@.
 --   The resulting 'ViewChunk's are returned in row-major order, that

--- a/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
@@ -79,4 +79,4 @@ viewChunkCover c@(Cosmic _ (tl, br)) = chunksOfNE (fromIntegral cols) vcs
   -- List of all view chunks from top-left to bottom-right,
   -- generated using 'rangeNE'
   vcs :: NonEmpty ViewChunk
-  vcs = fmap ViewChunk $ traverse (curry rangeNE (tlvc ^. planar)) brvc
+  vcs = ViewChunk <$> traverse (curry rangeNE (tlvc ^. planar)) brvc

--- a/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/ViewChunk.hs
@@ -4,7 +4,6 @@
 -- A "view chunk" is a square 2^k x 2^k section of the world
 -- which is individually cached when drawing the world.  View chunks
 -- which have not changed do not need to be re-rendered.
---
 module Swarm.TUI.Model.ViewChunk where
 
 import Control.Lens
@@ -25,7 +24,7 @@ import Swarm.Util (chunksOfNE, rangeNE)
 --   expressed in units of 2^k.  For example, if @viewChunkBits = 4@
 --   then the view chunk with coordinates @(1,2)@ spans world
 --   coordinates @(16,32) - (31,47)@.
-newtype ViewChunk = ViewChunk { unViewChunk :: Cosmic Coords }
+newtype ViewChunk = ViewChunk {unViewChunk :: Cosmic Coords}
   deriving (Eq, Ord, Show, Read)
 
 -- | If viewChunkBits = k then each view chunk will be 2^k x 2^k
@@ -53,9 +52,9 @@ viewChunkFor = viewChunk . fmap locToCoords
 --   @(1,2)@ will have bounds @(16,32) - (31,47)@.
 viewChunkBounds :: ViewChunk -> Cosmic BoundsRectangle
 viewChunkBounds (ViewChunk cc) = (,lr) <$> ul
-  where
-    ul = mapCoords (`shiftL` viewChunkBits) <$> cc
-    lr = addTuple (ul ^. planar) (viewChunkSize - 1, viewChunkSize - 1)
+ where
+  ul = mapCoords (`shiftL` viewChunkBits) <$> cc
+  lr = addTuple (ul ^. planar) (viewChunkSize - 1, viewChunkSize - 1)
 
 -- | @viewChunkCover r@ generates the smallest possible set of
 --   'ViewChunk's necessary to entirely cover the given rectangle @r@.
@@ -64,20 +63,20 @@ viewChunkBounds (ViewChunk cc) = (,lr) <$> ul
 --   the second list represents the second row, and so on.
 viewChunkCover :: Cosmic BoundsRectangle -> NonEmpty (NonEmpty ViewChunk)
 viewChunkCover c@(Cosmic _ (tl, br)) = chunksOfNE (fromIntegral cols) vcs
-  where
-    -- Coordinates of the top-left and bottom-right view chunks, in
-    -- view chunk space
-    tlvc, brvc :: Cosmic Coords
-    tlvc = unViewChunk $ viewChunk (tl <$ c)
-    brvc = unViewChunk $ viewChunk (br <$ c)
+ where
+  -- Coordinates of the top-left and bottom-right view chunks, in
+  -- view chunk space
+  tlvc, brvc :: Cosmic Coords
+  tlvc = unViewChunk $ viewChunk (tl <$ c)
+  brvc = unViewChunk $ viewChunk (br <$ c)
 
-    -- Number of view chunks needed to cover the rectangle horizontally
-    cols :: Int32
-    cols = getCol brvc - getCol tlvc + 1
-     where
-      getCol = snd . unCoords . view planar
+  -- Number of view chunks needed to cover the rectangle horizontally
+  cols :: Int32
+  cols = getCol brvc - getCol tlvc + 1
+   where
+    getCol = snd . unCoords . view planar
 
-    -- List of all view chunks from top-left to bottom-right,
-    -- generated using 'rangeNE'
-    vcs :: NonEmpty ViewChunk
-    vcs = fmap ViewChunk $ traverse (curry rangeNE (tlvc ^. planar)) brvc
+  -- List of all view chunks from top-left to bottom-right,
+  -- generated using 'rangeNE'
+  vcs :: NonEmpty ViewChunk
+  vcs = fmap ViewChunk $ traverse (curry rangeNE (tlvc ^. planar)) brvc

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -1119,8 +1119,8 @@ worldWidget renderCoord gameViewCenter = Widget Greedy Greedy $ do
   -- It's important that we render all the view chunks in a context
   -- with enough available width + height to accommodate all of
   -- them, and then crop to the desired final size.
-  withReaderT ((availWidthL .~ vcWidth) . (availHeightL .~ vcHeight)) $
-    render
+  withReaderT ((availWidthL .~ vcWidth) . (availHeightL .~ vcHeight))
+    $ render
       . cropTopBy (fromIntegral tlRowOff)
       . cropLeftBy (fromIntegral tlColOff)
       . cropBottomBy (fromIntegral brRowOff)
@@ -1129,7 +1129,7 @@ worldWidget renderCoord gameViewCenter = Widget Greedy Greedy $ do
       . NE.toList
       . fmap (hBox . NE.toList)
       . (fmap . fmap) (viewChunkWidget renderCoord)
-      $ chunks
+    $ chunks
 
 -- | Render a single 2^k x 2^k view chunk, by rendering all the
 --   individual cells into a Vty Image, then turning them into a
@@ -1137,15 +1137,15 @@ worldWidget renderCoord gameViewCenter = Widget Greedy Greedy $ do
 viewChunkWidget :: (Cosmic Coords -> V.Image) -> ViewChunk -> Widget Name
 viewChunkWidget renderCoord vc =
   cached (ViewChunkCache vc)
-  . raw
-  . V.vertCat
-  . map V.horizCat
-  . chunksOf (fromIntegral viewChunkSize)
-  . map (renderCoord . (<$ bounds))
-  $ ixs
-  where
-    bounds = viewChunkBounds vc
-    ixs = range $ bounds ^. planar
+    . raw
+    . V.vertCat
+    . map V.horizCat
+    . chunksOf (fromIntegral viewChunkSize)
+    . map (renderCoord . (<$ bounds))
+    $ ixs
+ where
+  bounds = viewChunkBounds vc
+  ixs = range $ bounds ^. planar
 
 ------------------------------------------------------------
 -- Robot inventory panel

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -1127,8 +1127,7 @@ worldWidget renderCoord gameViewCenter = Widget Greedy Greedy $ do
       . cropRightBy (fromIntegral brColOff)
       . vBox
       . NE.toList
-      . fmap (hBox . NE.toList)
-      . (fmap . fmap) (viewChunkWidget renderCoord)
+      . fmap (hBox . NE.toList . fmap (viewChunkWidget renderCoord))
     $ chunks
 
 -- | Render a single 2^k x 2^k view chunk, by rendering all the

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -1096,7 +1096,7 @@ worldWidget ::
   -- | View center
   Cosmic Location ->
   Widget Name
-worldWidget shouldCache  renderCoord gameViewCenter = Widget Greedy Greedy $ do
+worldWidget shouldCache renderCoord gameViewCenter = Widget Greedy Greedy $ do
   -- Get the width and height available to this widget
   ctx <- getContext
   let w = ctx ^. availWidthL

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -18,6 +18,8 @@ module Swarm.Util (
   enumerateNonEmpty,
   showEnum,
   indexWrapNonEmpty,
+  chunksOfNE,
+  rangeNE,
   uniq,
   binTuples,
   histogram,
@@ -81,6 +83,7 @@ module Swarm.Util (
   smallHittingSet,
 ) where
 
+import Control.Arrow ((***))
 import Control.Carrier.Throw.Either
 import Control.Effect.State (State, modify, state)
 import Control.Lens (ASetter', Lens', LensLike, LensLike', Over, lens, (<&>), (<>~))
@@ -93,6 +96,7 @@ import Data.Foldable (Foldable (..))
 import Data.Foldable qualified as Foldable
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IM
+import Data.Ix (Ix, range)
 import Data.List (maximumBy, partition)
 import Data.List qualified as List
 import Data.List.Extra (enumerate)
@@ -183,6 +187,25 @@ indexWrapNonEmpty list idx =
   NE.toList list !! fromIntegral wrappedIdx
  where
   wrappedIdx = idx `mod` fromIntegral (NE.length list)
+
+-- | Split the given list into chunks of the given size; the last
+--   chunk may be smaller.  If @n <= 0@, chunks of size 1 will be
+--   returned.
+chunksOfNE :: Int -> NonEmpty a -> NonEmpty (NonEmpty a)
+chunksOfNE n xs
+  | n <= 0 = fmap NE.singleton xs
+  | otherwise = NE.unfoldr takeN xs
+  where
+   takeN :: NonEmpty a -> (NonEmpty a, Maybe (NonEmpty a))
+   takeN = (NE.fromList *** NE.nonEmpty) . NE.splitAt n
+     -- Calling NE.fromList is safe here, since we know n > 0, so
+     -- NE.splitAt n will generate a first chunk of length n > 0.
+
+-- | Like 'range', except that at least the first index is always
+--   returned, even if the indices are out of order.  For example,
+--   'range (4,0) = []' but 'rangeNE (4,0) = [4]'.
+rangeNE :: (Ord a, Ix a) => (a, a) -> NonEmpty a
+rangeNE (lo, hi) = NE.fromList $ range (lo, max lo hi)
 
 -- | Drop repeated elements that are adjacent to each other.
 --

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -195,11 +195,12 @@ chunksOfNE :: Int -> NonEmpty a -> NonEmpty (NonEmpty a)
 chunksOfNE n xs
   | n <= 0 = fmap NE.singleton xs
   | otherwise = NE.unfoldr takeN xs
-  where
-   takeN :: NonEmpty a -> (NonEmpty a, Maybe (NonEmpty a))
-   takeN = (NE.fromList *** NE.nonEmpty) . NE.splitAt n
-     -- Calling NE.fromList is safe here, since we know n > 0, so
-     -- NE.splitAt n will generate a first chunk of length n > 0.
+ where
+  takeN :: NonEmpty a -> (NonEmpty a, Maybe (NonEmpty a))
+  takeN = (NE.fromList *** NE.nonEmpty) . NE.splitAt n
+
+-- Calling NE.fromList is safe here, since we know n > 0, so
+-- NE.splitAt n will generate a first chunk of length n > 0.
 
 -- | Like 'range', except that at least the first index is always
 --   returned, even if the indices are out of order.  For example,

--- a/src/swarm-util/Swarm/Util.hs
+++ b/src/swarm-util/Swarm/Util.hs
@@ -96,7 +96,7 @@ import Data.Foldable (Foldable (..))
 import Data.Foldable qualified as Foldable
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IM
-import Data.Ix (Ix, range)
+import Data.Ix (Ix, range, rangeSize)
 import Data.List (maximumBy, partition)
 import Data.List qualified as List
 import Data.List.Extra (enumerate)
@@ -205,8 +205,10 @@ chunksOfNE n xs
 -- | Like 'range', except that at least the first index is always
 --   returned, even if the indices are out of order.  For example,
 --   'range (4,0) = []' but 'rangeNE (4,0) = [4]'.
-rangeNE :: (Ord a, Ix a) => (a, a) -> NonEmpty a
-rangeNE (lo, hi) = NE.fromList $ range (lo, max lo hi)
+rangeNE :: Ix a => (a, a) -> NonEmpty a
+rangeNE rng@(lo, _)
+  | rangeSize rng == 0 = NE.singleton lo
+  | otherwise = NE.fromList $ range rng
 
 -- | Drop repeated elements that are adjacent to each other.
 --

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -1093,6 +1093,7 @@ library swarm-tui
     Swarm.TUI.Model.StateUpdate
     Swarm.TUI.Model.UI
     Swarm.TUI.Model.UI.Gameplay
+    Swarm.TUI.Model.ViewChunk
     Swarm.TUI.Model.WebCommand
     Swarm.TUI.Panel
     Swarm.TUI.View

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -1284,6 +1284,7 @@ test-suite swarm-unit
     TestRequirements
     TestScoring
     TestUtil
+    TestViewChunk
 
   build-depends:
     swarm:swarm-doc,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -743,6 +743,7 @@ library swarm-engine
     Swarm.Game.State
     Swarm.Game.State.GameMetrics
     Swarm.Game.State.Initialize
+    Swarm.Game.State.Redraw
     Swarm.Game.State.Robot
     Swarm.Game.State.Runtime
     Swarm.Game.State.Substate

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -43,6 +43,7 @@ import TestQQ (testQQ)
 import TestRepl (testRepl)
 import TestRequirements (testRequirements)
 import TestScoring (testHighScores)
+import TestViewChunk (testViewChunk)
 import Witch (from)
 
 main :: IO ()
@@ -94,6 +95,7 @@ statelessTests =
     , testMisc
     , testLSP
     , testQQ
+    , testViewChunk
     ]
 
 testMisc :: TestTree

--- a/test/unit/TestViewChunk.hs
+++ b/test/unit/TestViewChunk.hs
@@ -47,8 +47,12 @@ testViewChunk :: TestTree
 testViewChunk =
   testGroup
     "View chunks"
-    [ testProperty "rangeNE is nonempty" $ \rng -> NE.length (rangeNE @(Int, Int) rng) > 0
-    , testProperty "chunksOfNE is nonempty" $ \i (NonEmpty ne) -> NE.length (chunksOfNE @() i (NE.fromList ne)) > 0
+    [ testProperty "rangeNE is nonempty" $ \rng -> not (null (rangeNE @(Int, Int) rng))
+    , testProperty "chunksOfNE is nonempty" $ \i ne ->
+        not (null ne) ==>
+          case ne of
+            [] -> True
+            (x : xs) -> not (null (chunksOfNE @() i (x NE.:| xs)))
     , testProperty "view chunk size" $ \vc ->
         sizeOf (viewChunkBounds vc ^. planar) == (viewChunkSize, viewChunkSize)
     , testProperty "view chunk contains loc" $ \c ->

--- a/test/unit/TestViewChunk.hs
+++ b/test/unit/TestViewChunk.hs
@@ -7,7 +7,7 @@
 -- View chunk unit tests
 module TestViewChunk where
 
-import Control.Lens ((^.), allOf, both, to)
+import Control.Lens (allOf, both, to, (^.))
 import Data.Int (Int32)
 import Swarm.Game.Universe
 import Swarm.Game.World.Coords
@@ -19,9 +19,10 @@ instance Arbitrary Coords where
   arbitrary = curry Coords <$> arbitrary <*> arbitrary
 
 instance Arbitrary a => Arbitrary (Cosmic a) where
-  arbitrary = Cosmic
-     <$> oneof [pure DefaultRootSubworld, pure $ SubworldName "a", pure $ SubworldName "b"]
-     <*> arbitrary
+  arbitrary =
+    Cosmic
+      <$> oneof [pure DefaultRootSubworld, pure $ SubworldName "a", pure $ SubworldName "b"]
+      <*> arbitrary
 
 instance Arbitrary ViewChunk where
   arbitrary = ViewChunk <$> arbitrary
@@ -35,12 +36,12 @@ testViewChunk =
     , testProperty "view chunk contains loc" $ \c ->
         c `isWithin` viewChunkBounds (viewChunk c)
     , testProperty "view chunk is aligned" $ \vc ->
-        allOf (planar . to fst . to unCoords . both) ((==0) . (`mod` viewChunkSize)) (viewChunkBounds vc)
+        allOf (planar . to fst . to unCoords . both) ((== 0) . (`mod` viewChunkSize)) (viewChunkBounds vc)
     ]
 
 sizeOf :: BoundsRectangle -> (Int32, Int32)
-sizeOf (Coords (r1,c1), Coords (r2, c2)) = (r2 - r1 + 1, c2 - c1 + 1)
+sizeOf (Coords (r1, c1), Coords (r2, c2)) = (r2 - r1 + 1, c2 - c1 + 1)
 
 isWithin :: Cosmic Coords -> Cosmic BoundsRectangle -> Bool
-isWithin (Cosmic s (Coords (r,c))) (Cosmic s' (Coords (tlr, tlc), Coords (brr, brc)))
-  = s == s' && tlr <= r && r <= brr && tlc <= c && c <= brc
+isWithin (Cosmic s (Coords (r, c))) (Cosmic s' (Coords (tlr, tlc), Coords (brr, brc))) =
+  s == s' && tlr <= r && r <= brr && tlc <= c && c <= brc

--- a/test/unit/TestViewChunk.hs
+++ b/test/unit/TestViewChunk.hs
@@ -17,7 +17,7 @@ import Data.Set qualified as S
 import Swarm.Game.Universe
 import Swarm.Game.World.Coords
 import Swarm.TUI.Model.ViewChunk
-import Swarm.Util (rangeNE, chunksOfNE)
+import Swarm.Util (chunksOfNE, rangeNE)
 import Test.Tasty
 import Test.Tasty.QuickCheck
 
@@ -33,21 +33,21 @@ instance Arbitrary a => Arbitrary (Cosmic a) where
 instance Arbitrary ViewChunk where
   arbitrary = ViewChunk <$> arbitrary
 
-newtype BR = BR { getBR :: BoundsRectangle }
-  deriving Show
+newtype BR = BR {getBR :: BoundsRectangle}
+  deriving (Show)
 
 instance Arbitrary BR where
   arbitrary = do
     ul <- arbitrary
-    dr <- choose (-5,50)
-    dc <- choose (-5,50)
+    dr <- choose (-5, 50)
+    dc <- choose (-5, 50)
     pure $ BR (ul, ul `addTuple` (dr, dc))
 
 testViewChunk :: TestTree
 testViewChunk =
   testGroup
     "View chunks"
-    [ testProperty "rangeNE is nonempty" $ \rng -> NE.length (rangeNE @(Int,Int) rng) > 0
+    [ testProperty "rangeNE is nonempty" $ \rng -> NE.length (rangeNE @(Int, Int) rng) > 0
     , testProperty "chunksOfNE is nonempty" $ \i (NonEmpty ne) -> NE.length (chunksOfNE @() i (NE.fromList ne)) > 0
     , testProperty "view chunk size" $ \vc ->
         sizeOf (viewChunkBounds vc ^. planar) == (viewChunkSize, viewChunkSize)

--- a/test/unit/TestViewChunk.hs
+++ b/test/unit/TestViewChunk.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- View chunk unit tests
+module TestViewChunk where
+
+import Control.Lens ((^.))
+import Data.Int (Int32)
+import Swarm.Game.Universe
+import Swarm.Game.World.Coords
+import Swarm.TUI.Model.ViewChunk
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+instance Arbitrary Coords where
+  arbitrary = curry Coords <$> arbitrary <*> arbitrary
+
+instance Arbitrary a => Arbitrary (Cosmic a) where
+  arbitrary = Cosmic
+     <$> oneof [pure DefaultRootSubworld, pure $ SubworldName "a", pure $ SubworldName "b"]
+     <*> arbitrary
+
+instance Arbitrary ViewChunk where
+  arbitrary = ViewChunk <$> arbitrary
+
+testViewChunk :: TestTree
+testViewChunk =
+  testGroup
+    "View chunks"
+    [ testProperty "view chunk size" $ \vc -> sizeOf (viewChunkBounds vc ^. planar) == (viewChunkSize, viewChunkSize)
+    , testProperty "view chunk contains loc" $ \c -> c `isWithin` viewChunkBounds (viewChunk c)
+    ]
+
+sizeOf :: BoundsRectangle -> (Int32, Int32)
+sizeOf (Coords (r1,c1), Coords (r2, c2)) = (r2 - r1 + 1, c2 - c1 + 1)
+
+isWithin :: Cosmic Coords -> Cosmic BoundsRectangle -> Bool
+isWithin (Cosmic s (Coords (r,c))) (Cosmic s' (Coords (tlr, tlc), Coords (brr, brc)))
+  = s == s' && tlr <= r && r <= brr && tlc <= c && c <= brc

--- a/test/unit/TestViewChunk.hs
+++ b/test/unit/TestViewChunk.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -9,9 +10,14 @@ module TestViewChunk where
 
 import Control.Lens (allOf, both, to, (^.))
 import Data.Int (Int32)
+import Data.Ix (range)
+import Data.List.NonEmpty qualified as NE
+import Data.Set (Set)
+import Data.Set qualified as S
 import Swarm.Game.Universe
 import Swarm.Game.World.Coords
 import Swarm.TUI.Model.ViewChunk
+import Swarm.Util (rangeNE, chunksOfNE)
 import Test.Tasty
 import Test.Tasty.QuickCheck
 
@@ -27,16 +33,34 @@ instance Arbitrary a => Arbitrary (Cosmic a) where
 instance Arbitrary ViewChunk where
   arbitrary = ViewChunk <$> arbitrary
 
+newtype BR = BR { getBR :: BoundsRectangle }
+  deriving Show
+
+instance Arbitrary BR where
+  arbitrary = do
+    ul <- arbitrary
+    dr <- choose (-5,50)
+    dc <- choose (-5,50)
+    pure $ BR (ul, ul `addTuple` (dr, dc))
+
 testViewChunk :: TestTree
 testViewChunk =
   testGroup
     "View chunks"
-    [ testProperty "view chunk size" $ \vc ->
+    [ testProperty "rangeNE is nonempty" $ \rng -> NE.length (rangeNE @(Int,Int) rng) > 0
+    , testProperty "chunksOfNE is nonempty" $ \i (NonEmpty ne) -> NE.length (chunksOfNE @() i (NE.fromList ne)) > 0
+    , testProperty "view chunk size" $ \vc ->
         sizeOf (viewChunkBounds vc ^. planar) == (viewChunkSize, viewChunkSize)
     , testProperty "view chunk contains loc" $ \c ->
         c `isWithin` viewChunkBounds (viewChunk c)
     , testProperty "view chunk is aligned" $ \vc ->
         allOf (planar . to fst . to unCoords . both) ((== 0) . (`mod` viewChunkSize)) (viewChunkBounds vc)
+    , testProperty "viewChunkCover in same subworld" $ \(fmap getBR -> cbr) ->
+        (all . all) ((== cbr ^. subworld) . (^. subworld) . unViewChunk) (viewChunkCover cbr)
+    , testProperty "viewChunkCover is cover" $ \(fmap getBR -> cbr) ->
+        viewChunkCover cbr `covers` (cbr ^. planar)
+    , testProperty "viewChunkCover is smallest cover" $ \(fmap getBR -> cbr) ->
+        viewChunkCover cbr `isMinimalCover` (cbr ^. planar)
     ]
 
 sizeOf :: BoundsRectangle -> (Int32, Int32)
@@ -45,3 +69,18 @@ sizeOf (Coords (r1, c1), Coords (r2, c2)) = (r2 - r1 + 1, c2 - c1 + 1)
 isWithin :: Cosmic Coords -> Cosmic BoundsRectangle -> Bool
 isWithin (Cosmic s (Coords (r, c))) (Cosmic s' (Coords (tlr, tlc), Coords (brr, brc))) =
   s == s' && tlr <= r && r <= brr && tlc <= c && c <= brc
+
+unnest :: NE.NonEmpty (NE.NonEmpty a) -> [a]
+unnest = concatMap NE.toList . NE.toList
+
+vcCoords :: ViewChunk -> Set Coords
+vcCoords = S.fromList . range . (^. planar) . viewChunkBounds
+
+covers :: NE.NonEmpty (NE.NonEmpty ViewChunk) -> BoundsRectangle -> Bool
+covers vcs br = S.fromList (NE.toList $ rangeNE br) `S.isSubsetOf` (foldMap vcCoords . unnest $ vcs)
+
+isMinimalCover :: NE.NonEmpty (NE.NonEmpty ViewChunk) -> BoundsRectangle -> Bool
+isMinimalCover vcg br = flip all vcs $ \vc ->
+  not $ S.fromList (NE.toList $ rangeNE br) `S.isSubsetOf` foldMap vcCoords (S.delete vc vcs)
+ where
+  vcs = S.fromList $ unnest vcg

--- a/test/unit/TestViewChunk.hs
+++ b/test/unit/TestViewChunk.hs
@@ -7,7 +7,7 @@
 -- View chunk unit tests
 module TestViewChunk where
 
-import Control.Lens ((^.))
+import Control.Lens ((^.), allOf, both, to)
 import Data.Int (Int32)
 import Swarm.Game.Universe
 import Swarm.Game.World.Coords
@@ -30,8 +30,12 @@ testViewChunk :: TestTree
 testViewChunk =
   testGroup
     "View chunks"
-    [ testProperty "view chunk size" $ \vc -> sizeOf (viewChunkBounds vc ^. planar) == (viewChunkSize, viewChunkSize)
-    , testProperty "view chunk contains loc" $ \c -> c `isWithin` viewChunkBounds (viewChunk c)
+    [ testProperty "view chunk size" $ \vc ->
+        sizeOf (viewChunkBounds vc ^. planar) == (viewChunkSize, viewChunkSize)
+    , testProperty "view chunk contains loc" $ \c ->
+        c `isWithin` viewChunkBounds (viewChunk c)
+    , testProperty "view chunk is aligned" $ \vc ->
+        allOf (planar . to fst . to unCoords . both) ((==0) . (`mod` viewChunkSize)) (viewChunkBounds vc)
     ]
 
 sizeOf :: BoundsRectangle -> (Int32, Int32)


### PR DESCRIPTION
Following up on the discussion at https://github.com/jtdaugherty/brick/discussions/531, and building on #2513, this PR splits up the world view into chunks and individually caches each chunk, leading to *much* faster render times.  Closes #2510.

Details
----------

- The chunks are 4 cells x 4 cells (empirically, this seems to give the best performance; see below), and aligned to multiples of 4.  That is, there is always a chunk from (0,0) to (3,3), and a chunk from (0,4) to (3,7), and so on; to calculate which chunk contains a given cell we just need to do some right bit shifts.  This is similar to the way we load world tiles (though world tiles are much larger).  See `Swarm.TUI.Model.ViewChunk`.
- To draw the world view, we generate a grid of chunks which completely cover the desired viewing region, render them all, then crop to the desired region.  See `Swarm.TUI.View.worldWidget`.
- Each view chunk is cached, so it does not need to be re-rendered if nothing in that chunk has changed.
- Note that another nice side benefit of basing the view chunks on world rather than viewing window coordinates is that the game is still very fast when scrolling the world (e.g. when `view`ing a robot which is moving around), because we can still reuse all the rendered view chunks that have not changed; they just end up at a different place on the screen.
- During each tick, we accumulate a set of "dirty" cells which have changed since the last frame.  When rendering a frame, we first invalidate the cache entries for all the view chunks containing dirty cells.
- It is also possible to set a flag to invalidate the entire cache and redraw the world view from scratch, which is necessary in certain situations, e.g. when the currently viewed robot learns about a new entity, so the display of that entity may need to change from a question mark everywhere it occurs.  See #2527.
- Along the way I also fix #2387 by invalidating the cache on terminal resize events at the top level, instead of only when running a scenario.

Performance analysis
--------------------------------

I did some quick & dirty performance analysis by opening a new Creative game in a 61 x 238 terminal, hitting Alt-F to show the FPS meter, and executing
```
def forever = \c. c ; forever c end
build {move; forever (move; turn right)}
```

- Prior to this PR, it maxed out at about 7-8 FPS.
- With this PR, it now runs at 30 FPS - but only because we cap the game at 30 FPS.  When I comment out the line of code that caps the FPS, it runs at up to about 75 FPS.

For a bit more robust (but still pretty quick & dirty) analysis, and to find the best value for `viewChunkBits` (i.e. the value of $k$ such that each view chunk is $2^k \times 2^k$ cells), I opened a Blank game in a 61 x 328 terminal and executed
```
def forever = \c. c ; forever c end
def x = \n. \c. if (n == 0) {} {c ; x (n-1) c} end
x 20 (build {forever (x 20 move; turn left)}; turn left; wait 13)
```
$k = 2$ was the clear winner, with the game running at about 20 FPS when set to 64 ticks per second.  It became slower with both smaller values of $k$ (presumably because of all the extra work brick has to do composing lots of tiny view chunk widgets into a big rectangle) and with larger (presumably because the chunks are too large so we spend too much time unnecessarily re-rendering cells that have not changed).

Admittedly my tests were not very robust, and the optimal value of $k$ might depend a lot on one's hardware and how big you would like your world view to be.  I suppose a nice follow-up could be to make the value of $k$ configurable via a command-line parameter.

Follow-up issues
-------------------------

- #2527
- #2528 
- #2529