### PR TITLE
Add total and active robots metrics

### DIFF
--- a/src/swarm-engine/Swarm/Game/State/GameMetrics.hs
+++ b/src/swarm-engine/Swarm/Game/State/GameMetrics.hs
@@ -15,11 +15,14 @@ module Swarm.Game.State.GameMetrics (
 import System.Metrics
 import System.Metrics.Counter (Counter)
 import System.Metrics.Distribution (Distribution)
+import System.Metrics.Gauge (Gauge)
 
 -- | Metrics tracked in Swarm game engine.
 data GameMetrics = GameMetrics
   { tickCounter :: Counter
   , tickDistribution :: Distribution
+  , robotsGauge :: Gauge
+  , activeRobotsGauge :: Gauge
   }
 
 -- | Create and register the metrics to metric store.
@@ -29,4 +32,6 @@ initGameMetrics :: Store -> IO GameMetrics
 initGameMetrics s = do
   tickCounter <- createCounter "game.tick_count" s
   tickDistribution <- createDistribution "game.tick_time" s
+  robotsGauge <- createGauge "game.robots_total" s
+  activeRobotsGauge <- createGauge "game.robots_active" s
   pure GameMetrics {..}

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -140,7 +140,7 @@ gameTick = measureCpuTimeInSec runTick >>= updateMetrics
       RobotStep ss -> do
         focusedRob <- use $ robotInfo . focusedRobotID
         singleStep ss focusedRob active
-  -- | See if the base is finished with a computation, and if so, record
+  -- See if the base is finished with a computation, and if so, record
   -- the result in the game state so it can be displayed by the REPL;
   -- also save the current store into the robotContext so we can
   -- restore it the next time we start a computation.

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -146,12 +146,11 @@ gameTick = measureCpuTimeInSec runTick >>= updateMetrics
   -- restore it the next time we start a computation.
   updateBaseReplState :: m ()
   updateBaseReplState = do
-    mr <- use (robotInfo . robotMap . at 0)
-    forM_ mr $ \r -> do
+    baseValue <- use . pre $ robotInfo . robotMap . ix 0 . folding getResult
+    forM_ baseValue $ \v -> do
       res <- use $ gameControls . replStatus
       case res of
-        REPLWorking ty Nothing -> forM_ (getResult r) $ \v ->
-          gameControls . replStatus .= REPLWorking ty (Just v)
+        REPLWorking ty Nothing -> gameControls . replStatus .= REPLWorking ty (Just v)
         _otherREPLStatus -> pure ()
   checkWinCondition :: m ()
   checkWinCondition = do


### PR DESCRIPTION
* add `game.robots_active` and `game. robots_total` gauges

You can test it with:
```bash
cabal run swarm -O0 -- +RTS -T -RTS --scenario Creative --run <( echo 'def x=\\i.\\c.if(i<=0){}{_ <-c; x (i-1) c} end; x 100 (build {wait 100; x 20 move})')
```
and then open http://localhost:6543 in browser or with cURL:
```bash
curl -s -H "Accept: application/json" localhost:6543 | jq '.game'
```
```json
{
  "robots_active": {
    "type": "g",
    "val": 16
  },
  "robots_total": {
    "type": "g",
    "val": 46
  },
  ...
}
```