### PR TITLE
Move view center state to internal module

### DIFF
--- a/src/swarm-engine/Swarm/Game/State.hs
+++ b/src/swarm-engine/Swarm/Game/State.hs
@@ -23,7 +23,6 @@ module Swarm.Game.State (
 
   -- *** Subrecord accessors
   temporal,
-  robotNaming,
   recipesInfo,
   messageInfo,
   gameControls,
@@ -75,6 +74,7 @@ module Swarm.Game.State (
 
   -- * Re-exports
   module GameMetrics,
+  module Robots,
 ) where
 
 import Control.Carrier.State.Lazy qualified as Fused
@@ -115,7 +115,8 @@ import Swarm.Game.Scenario.Status
 import Swarm.Game.State.Config
 import Swarm.Game.State.GameMetrics as GameMetrics
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
+import Swarm.Game.State.Robot as Robots hiding (focusedRobot, robotNaming)
+import Swarm.Game.State.Robot qualified as RobotsInternal
 import Swarm.Game.State.Substate
 import Swarm.Game.Step.Path.Type
 import Swarm.Game.Terrain
@@ -398,7 +399,7 @@ viewingRegion (Cosmic sw (Location cx cy)) (w, h) =
 -- | Find out which robot has been last specified by the
 --   'viewCenterRule', if any.
 focusedRobot :: GameState -> Maybe Robot
-focusedRobot g = g ^. robotInfo . robotMap . at (g ^. robotInfo . focusedRobotID)
+focusedRobot g = g ^. robotInfo . RobotsInternal.focusedRobot
 
 -- | Type for describing how far away a robot is from the base, which
 --   determines what kind of communication can take place.

--- a/src/swarm-engine/Swarm/Game/State/Initialize.hs
+++ b/src/swarm-engine/Swarm/Game/State/Initialize.hs
@@ -46,7 +46,6 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (emptyFound
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.State
 import Swarm.Game.State.Landscape (mkLandscape)
-import Swarm.Game.State.Robot (setRobotInfo)
 import Swarm.Game.State.Runtime
 import Swarm.Game.State.Substate
 import Swarm.Game.Step.Util (adaptGameState)

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -394,7 +394,7 @@ removeRobotFromLocationMap (Cosmic oldSubworld oldPlanar) rid =
 
 setRobotInfo :: RID -> [Robot] -> Robots -> Robots
 setRobotInfo rid robotList rState =
-  (setRobotList robotList rState)
+  setRobotList robotList rState
     & viewCenterState . VCInternal.viewRobotID .~ rid
     & viewCenterRule .~ VCRobot rid
 

--- a/src/swarm-engine/Swarm/Game/State/Robot.hs
+++ b/src/swarm-engine/Swarm/Game/State/Robot.hs
@@ -29,6 +29,7 @@ module Swarm.Game.State.Robot (
   viewCenterRule,
   viewCenter,
   focusedRobotID,
+  focusedRobot,
 
   -- * Utilities
   wakeWatchingRobots,
@@ -55,39 +56,28 @@ import Control.Effect.State (State)
 import Control.Effect.Throw (Has)
 import Control.Lens hiding (Const, use, uses, view, (%=), (+=), (.=), (<+=), (<<.=))
 import Control.Monad (forM_, void)
-import Data.Aeson (FromJSON, ToJSON)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IM
 import Data.IntSet (IntSet)
 import Data.IntSet qualified as IS
 import Data.IntSet.Lens (setOf)
 import Data.List (partition)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (mapMaybe)
 import Data.MonoidMap (MonoidMap)
 import Data.MonoidMap qualified as MM
 import Data.Set qualified as S
-import GHC.Generics (Generic)
 import Swarm.Game.CESK (CESK (Waiting))
 import Swarm.Game.Location
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.State.Config
+import Swarm.Game.State.ViewCenter.Internal (ViewCenter, ViewCenterRule (..), defaultViewCenter)
+import Swarm.Game.State.ViewCenter.Internal qualified as VCInternal
 import Swarm.Game.Tick
 import Swarm.Game.Universe as U
 import Swarm.ResourceLoading (NameGenerator)
 import Swarm.Util ((<+=), (<<.=))
 import Swarm.Util.Lens (makeLensesExcluding)
-
--- | The 'ViewCenterRule' specifies how to determine the center of the
---   world viewport.
-data ViewCenterRule
-  = -- | The view should be centered on an absolute position.
-    VCLocation (Cosmic Location)
-  | -- | The view should be centered on a certain robot.
-    VCRobot RID
-  deriving (Eq, Ord, Show, Generic, FromJSON, ToJSON)
-
-makePrisms ''ViewCenterRule
 
 data RobotNaming = RobotNaming
   { _nameGenerator :: NameGenerator
@@ -126,9 +116,7 @@ data Robots = Robots
     -- since there may be many.
     _robotsWatching :: MonoidMap (Cosmic Location) IntSet
   , _robotNaming :: RobotNaming
-  , _viewCenterRule :: ViewCenterRule
-  , _viewCenter :: Cosmic Location
-  , _focusedRobotID :: RID
+  , _viewCenterState :: ViewCenter
   }
 
 -- We want to access active and waiting robots via lenses inside
@@ -139,7 +127,7 @@ makeLensesFor
   ]
   ''Robots
 
-makeLensesExcluding ['_viewCenter, '_viewCenterRule, '_focusedRobotID, '_activeRobots, '_waitingRobots] ''Robots
+makeLensesExcluding ['_activeRobots, '_waitingRobots] ''Robots
 
 -- | All the robots that currently exist in the game, indexed by ID.
 robotMap :: Lens' Robots (IntMap Robot)
@@ -174,12 +162,15 @@ robotsWatching :: Lens' Robots (MonoidMap (Cosmic Location) IntSet)
 -- | State and data for assigning identifiers to robots
 robotNaming :: Lens' Robots RobotNaming
 
+-- | The current view center location, focused robot and the rule for which to follow.
+viewCenterState :: Lens' Robots ViewCenter
+
 -- | The current center of the world view. Note that this cannot be
 --   modified directly, since it is calculated automatically from the
 --   'viewCenterRule'.  To modify the view center, either set the
 --   'viewCenterRule', or use 'modifyViewCenter'.
 viewCenter :: Getter Robots (Cosmic Location)
-viewCenter = to _viewCenter
+viewCenter = viewCenterState . VCInternal.viewCenterLocation
 
 -- | The current robot in focus.
 --
@@ -189,7 +180,26 @@ viewCenter = to _viewCenter
 -- Technically it's the last robot ID specified by 'viewCenterRule',
 -- but that robot may not be alive anymore - to be safe use 'focusedRobot'.
 focusedRobotID :: Getter Robots RID
-focusedRobotID = to _focusedRobotID
+focusedRobotID = viewCenterState . VCInternal.viewRobotID
+
+-- | Find out which robot has been last specified by the
+--   'viewCenterRule', if any.
+focusedRobot :: Getter Robots (Maybe Robot)
+focusedRobot = to $ \r -> r ^. robotMap . at (r ^. focusedRobotID)
+
+-- | The current rule for determining the center of the world view.
+--   It also updates 'viewCenter' and 'focusedRobot' to keep
+--   everything synchronized.
+viewCenterRule :: Lens' Robots ViewCenterRule
+viewCenterRule = lens getter setter
+ where
+  getter :: Robots -> ViewCenterRule
+  getter = view $ viewCenterState . VCInternal.viewCenterRule
+  setter :: Robots -> ViewCenterRule -> Robots
+  setter rInfo rule =
+    rInfo
+      & viewCenterState . VCInternal.viewCenterRule .~ rule
+      & viewCenterState %~ VCInternal.syncViewCenter (getLocationFromRID rInfo)
 
 -- * Utilities
 
@@ -207,33 +217,8 @@ initRobots gsc =
           { _nameGenerator = nameParts gsc
           , _gensym = 0
           }
-    , _viewCenterRule = VCRobot 0
-    , _viewCenter = defaultCosmicLocation
-    , _focusedRobotID = 0
+    , _viewCenterState = defaultViewCenter
     }
-
--- | The current rule for determining the center of the world view.
---   It updates also, 'viewCenter' and 'focusedRobot' to keep
---   everything synchronized.
-viewCenterRule :: Lens' Robots ViewCenterRule
-viewCenterRule = lens getter setter
- where
-  getter :: Robots -> ViewCenterRule
-  getter = _viewCenterRule
-
-  -- The setter takes care of updating 'viewCenter' and 'focusedRobot'
-  -- So none of these fields get out of sync.
-  setter :: Robots -> ViewCenterRule -> Robots
-  setter g rule =
-    case rule of
-      VCLocation loc -> g {_viewCenterRule = rule, _viewCenter = loc}
-      VCRobot rid ->
-        let robotcenter = g ^? robotMap . ix rid . robotLocation
-         in -- retrieve the loc of the robot if it exists, Nothing otherwise.
-            -- sometimes, lenses are amazing...
-            case robotcenter of
-              Nothing -> g
-              Just loc -> g {_viewCenterRule = rule, _viewCenter = loc, _focusedRobotID = rid}
 
 -- | Add a concrete instance of a robot template to the game state:
 --   First, generate a unique ID number for it.  Then, add it to the
@@ -408,9 +393,10 @@ removeRobotFromLocationMap (Cosmic oldSubworld oldPlanar) rid =
     %= MM.adjust (MM.adjust (IS.delete rid) oldPlanar) oldSubworld
 
 setRobotInfo :: RID -> [Robot] -> Robots -> Robots
-setRobotInfo baseID robotList rState =
-  (setRobotList robotList rState) {_focusedRobotID = baseID}
-    & viewCenterRule .~ VCRobot baseID
+setRobotInfo rid robotList rState =
+  (setRobotList robotList rState)
+    & viewCenterState . VCInternal.viewRobotID .~ rid
+    & viewCenterRule .~ VCRobot rid
 
 setRobotList :: [Robot] -> Robots -> Robots
 setRobotList robotList rState =
@@ -427,6 +413,10 @@ setRobotList robotList rState =
     f r = MM.adjust (g r) (r ^. (robotLocation . subworld))
     g r = MM.adjust (IS.insert (r ^. robotID)) (r ^. (robotLocation . planar))
 
+-- | Helper function to get location of robot.
+getLocationFromRID :: Robots -> RID -> Maybe (Cosmic Location)
+getLocationFromRID rs rid = rs ^? robotMap . ix rid . robotLocation
+
 -- | Modify the 'viewCenter' by applying an arbitrary function to the
 --   current value.  Note that this also modifies the 'viewCenterRule'
 --   to match.  After calling this function the 'viewCenterRule' will
@@ -434,35 +424,22 @@ setRobotList robotList rState =
 modifyViewCenter :: (Cosmic Location -> Cosmic Location) -> Robots -> Robots
 modifyViewCenter update rInfo =
   rInfo
-    & case rInfo ^. viewCenterRule of
-      VCLocation l -> viewCenterRule .~ VCLocation (update l)
-      VCRobot _ -> viewCenterRule .~ VCLocation (update (rInfo ^. viewCenter))
+    & viewCenterState %~ VCInternal.modifyViewCenter (getLocationFromRID rInfo) update
 
 -- | "Unfocus" by modifying the view center rule to look at the
 --   current location instead of a specific robot, and also set the
 --   focused robot ID to an invalid value.  In classic mode this
 --   causes the map view to become nothing but static.
 unfocus :: Robots -> Robots
-unfocus = (\ri -> ri {_focusedRobotID = -1000}) . modifyViewCenter id
+unfocus rInfo =
+  rInfo
+    & viewCenterState %~ VCInternal.unfocus (getLocationFromRID rInfo)
 
--- | Recalculate the view center (and cache the result in the
---   'viewCenter' field) based on the current 'viewCenterRule'.  If
---   the 'viewCenterRule' specifies a robot which does not exist,
---   simply leave the current 'viewCenter' as it is.
+-- | Recalculate the 'viewCenter'  based on the current 'viewCenterRule'.
+--
+-- If the 'viewCenterRule' specifies a robot which does not exist,
+-- simply leave the current 'viewCenter' as it is.
 recalcViewCenter :: Robots -> Robots
 recalcViewCenter rInfo =
   rInfo
-    { _viewCenter = newViewCenter
-    }
- where
-  newViewCenter =
-    fromMaybe (rInfo ^. viewCenter) $
-      applyViewCenterRule (rInfo ^. viewCenterRule) (rInfo ^. robotMap)
-
--- | Given a current mapping from robot names to robots, apply a
---   'ViewCenterRule' to derive the location it refers to.  The result
---   is 'Maybe' because the rule may refer to a robot which does not
---   exist.
-applyViewCenterRule :: ViewCenterRule -> IntMap Robot -> Maybe (Cosmic Location)
-applyViewCenterRule (VCLocation l) _ = Just l
-applyViewCenterRule (VCRobot name) m = m ^? at name . _Just . robotLocation
+    & viewCenterState %~ VCInternal.syncViewCenter (getLocationFromRID rInfo)

--- a/src/swarm-engine/Swarm/Game/State/ViewCenter/Internal.hs
+++ b/src/swarm-engine/Swarm/Game/State/ViewCenter/Internal.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- The view center state combines the focused robot, viewed location and rule for which to follow.
+module Swarm.Game.State.ViewCenter.Internal (
+  -- * View center rule
+  ViewCenterRule (..),
+  _VCLocation,
+  _VCRobot,
+
+  -- * View center state
+  ViewCenter,
+  defaultViewCenter,
+
+  -- ** Lenses
+  viewCenterRule,
+  viewCenterLocation,
+  viewRobotID,
+
+  -- ** Updates
+  syncViewCenter,
+  modifyViewCenter,
+  unfocus,
+) where
+
+import Control.Lens (Lens', makePrisms, (%~), (&), (.~), (^.))
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generic)
+import Swarm.Game.Location
+import Swarm.Game.Robot
+import Swarm.Game.Universe as U
+import Swarm.Util.Lens (makeLensesNoSigs)
+
+-- | The 'ViewCenterRule' specifies how to determine the center of the
+--   world viewport.
+data ViewCenterRule
+  = -- | The view should be centered on an absolute position.
+    VCLocation (Cosmic Location)
+  | -- | The view should be centered on a certain robot.
+    VCRobot RID
+  deriving (Eq, Ord, Show, Generic, FromJSON, ToJSON)
+
+makePrisms ''ViewCenterRule
+
+-- | The collection of view center state, which should be kept synchronised.
+--
+-- The player is either looking at a location or following a robot.
+-- But the game needs to at all times show some location and information
+-- about a robot.
+data ViewCenter = ViewCenter
+  { _viewCenterRule :: ViewCenterRule
+  , _viewCenterLocation :: Cosmic Location
+  , _viewRobotID :: RID
+  }
+
+-- | The default view center at the initial base robot and default starting location.
+defaultViewCenter :: ViewCenter
+defaultViewCenter =
+  ViewCenter
+    { _viewCenterRule = VCRobot 0
+    , _viewCenterLocation = defaultCosmicLocation
+    , _viewRobotID = 0
+    }
+
+makeLensesNoSigs ''ViewCenter
+
+-- | The current rule for determining the center of the world view.
+viewCenterRule :: Lens' ViewCenter ViewCenterRule
+
+-- | The current center of the world view. Note that this shouldn't be
+--   modified directly, since it is calculated automatically from the
+--   'viewCenterRule'.  To modify the view center, either set the
+--   'viewCenterRule', or use 'modifyViewCenter'.
+viewCenterLocation :: Lens' ViewCenter (Cosmic Location)
+
+-- | The current robot in focus.
+--
+-- This value should be updated only when
+-- the 'viewCenterRule' is specified to be a robot.
+--
+-- Technically it's the last robot ID specified by 'viewCenterRule',
+-- but that robot may not be alive anymore - to be safe use 'focusedRobot'.
+viewRobotID :: Lens' ViewCenter RID
+
+-- | Synchronise the view center state based on current rule.
+--
+-- If the robot does not exist, this does not 'unfocus' as it would
+-- be annoying in Creative mode.
+syncViewCenter ::
+  (RID -> Maybe (Cosmic Location)) ->
+  ViewCenter ->
+  ViewCenter
+syncViewCenter getRobotLoc vc = case vc ^. viewCenterRule of
+  VCLocation loc -> vc {_viewCenterLocation = loc}
+  VCRobot rid -> case getRobotLoc rid of
+    Nothing -> vc
+    Just loc -> vc {_viewCenterLocation = loc, _viewRobotID = rid}
+
+-- | Modify the 'viewCenter' by applying an arbitrary function to the
+--   current value.  Note that this also modifies the 'viewCenterRule'
+--   to match.  After calling this function the 'viewCenterRule' will
+--   specify a particular location, not a robot.
+modifyViewCenter ::
+  (RID -> Maybe (Cosmic Location)) ->
+  (Cosmic Location -> Cosmic Location) ->
+  ViewCenter ->
+  ViewCenter
+modifyViewCenter getRobotLoc update vc =
+  vc
+    & viewCenterRule %~ modifyViewCenterRule
+    & syncViewCenter getRobotLoc
+ where
+  lastCenter = vc ^. viewCenterLocation
+  modifyViewCenterRule = \case
+    VCLocation l -> VCLocation (update l)
+    VCRobot _ -> VCLocation (update lastCenter)
+
+-- | "Unfocus" by modifying the view center rule to look at the
+--   current location instead of a specific robot, and also set the
+--   focused robot ID to an invalid value.  In classic mode this
+--   causes the map view to become nothing but static.
+unfocus :: (RID -> Maybe (Cosmic Location)) -> ViewCenter -> ViewCenter
+unfocus getRobotLoc = (viewRobotID .~ -1000) . syncViewCenter getRobotLoc

--- a/src/swarm-engine/Swarm/Game/State/ViewCenter/Internal.hs
+++ b/src/swarm-engine/Swarm/Game/State/ViewCenter/Internal.hs
@@ -8,8 +8,6 @@
 module Swarm.Game.State.ViewCenter.Internal (
   -- * View center rule
   ViewCenterRule (..),
-  _VCLocation,
-  _VCRobot,
 
   -- * View center state
   ViewCenter,
@@ -26,7 +24,7 @@ module Swarm.Game.State.ViewCenter.Internal (
   unfocus,
 ) where
 
-import Control.Lens (Lens', makePrisms, (%~), (&), (.~), (^.))
+import Control.Lens (Lens', (%~), (&), (.~), (^.))
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
 import Swarm.Game.Location
@@ -42,8 +40,6 @@ data ViewCenterRule
   | -- | The view should be centered on a certain robot.
     VCRobot RID
   deriving (Eq, Ord, Show, Generic, FromJSON, ToJSON)
-
-makePrisms ''ViewCenterRule
 
 -- | The collection of view center state, which should be kept synchronised.
 --

--- a/src/swarm-engine/Swarm/Game/Step.hs
+++ b/src/swarm-engine/Swarm/Game/Step.hs
@@ -71,7 +71,6 @@ import Swarm.Game.Scenario.Objective qualified as OB
 import Swarm.Game.Scenario.Objective.WinCheck qualified as WC
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Step.Const
 import Swarm.Game.Step.RobotStepState

--- a/src/swarm-engine/Swarm/Game/Step/Combustion.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Combustion.hs
@@ -35,7 +35,6 @@ import Swarm.Game.Robot
 import Swarm.Game.Robot.Walk (emptyExceptions)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Step.Util
 import Swarm.Game.Step.Util.Inspect

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -72,7 +72,6 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry (foundByNam
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Step.Arithmetic
 import Swarm.Game.Step.Combustion qualified as Combustion

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -51,7 +51,6 @@ import Swarm.Game.Scenario.Status (getScenarioPath)
 import Swarm.Game.Scenario.Topography.Navigation.Portal (Navigation (..), destination, reorientation)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Step.Util

--- a/src/swarm-engine/Swarm/Game/Step/Util/Inspect.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Inspect.hs
@@ -14,7 +14,6 @@ import Data.Text (Text)
 import Swarm.Game.Location
 import Swarm.Game.Robot
 import Swarm.Game.State
-import Swarm.Game.State.Robot
 import Swarm.Game.Universe
 import Swarm.Language.Syntax.Direction
 

--- a/src/swarm-tui/Swarm/TUI/Controller.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller.hs
@@ -68,7 +68,6 @@ import Swarm.Game.Scenario.Status (ScenarioPath (..), ScenarioWith (..), getScen
 import Swarm.Game.ScenarioInfo
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Runtime
 import Swarm.Game.State.Substate
 import Swarm.Language.Capability (

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/Main.hs
@@ -27,7 +27,6 @@ import Control.Monad.IO.Class (liftIO)
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Type (originalStructureDefinitions)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Step (finishGameTick)
 import Swarm.TUI.Controller.EventHandlers.Frame (runGameTickUI)

--- a/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/World.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/EventHandlers/World.hs
@@ -17,7 +17,6 @@ import Linear
 import Swarm.Game.Location
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Language.Syntax.Direction (Direction (..), directionSyntax)
 import Swarm.TUI.Controller.Util
 import Swarm.TUI.Model

--- a/src/swarm-tui/Swarm/TUI/Controller/Util.hs
+++ b/src/swarm-tui/Swarm/TUI/Controller/Util.hs
@@ -29,7 +29,6 @@ import Swarm.Game.Robot (robotCapabilities)
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Step (finishGameTick)
 import Swarm.Game.Universe

--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -107,7 +107,6 @@ import Swarm.Game.ScenarioInfo (
  )
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Runtime
 import Swarm.Game.State.Substate
 import Swarm.Game.Tick (TickNumber (..), formatTicks)

--- a/src/swarm-tui/Swarm/TUI/View/Robot.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Robot.hs
@@ -45,7 +45,6 @@ import Swarm.Game.Robot
 import Swarm.Game.Robot.Activity
 import Swarm.Game.Robot.Concrete
 import Swarm.Game.State
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Tick (addTicks)
 import Swarm.Game.Universe

--- a/src/swarm-tui/Swarm/TUI/View/Static.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Static.hs
@@ -14,7 +14,6 @@ import Linear.Affine ((.-.))
 import Swarm.Game.Cosmetic.Color (NamedColor (..), TrueColor (..))
 import Swarm.Game.Cosmetic.Texel (Texel, mkTexel)
 import Swarm.Game.State
-import Swarm.Game.State.Robot (viewCenter)
 import Swarm.Game.State.Substate (ticks)
 import Swarm.Game.Tick (TickNumber (..))
 import Swarm.Game.Universe (planar)

--- a/src/swarm-web/Swarm/Web.hs
+++ b/src/swarm-web/Swarm/Web.hs
@@ -81,7 +81,6 @@ import Swarm.Game.Scenario.Topography.Structure.Recognition.Log
 import Swarm.Game.Scenario.Topography.Structure.Recognition.Registry
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Runtime (eventLog)
 import Swarm.Game.State.Substate
 import Swarm.Game.Step.Path.Type

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -765,8 +765,11 @@ library swarm-engine
     Swarm.Game.Value
     Swarm.Log
 
-  other-modules: Paths_swarm
   autogen-modules: Paths_swarm
+  other-modules:
+    Paths_swarm
+    Swarm.Game.State.ViewCenter.Internal
+    
   build-depends:
     swarm:swarm-lang,
     swarm:swarm-scenario,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -746,6 +746,7 @@ library swarm-engine
     Swarm.Game.State.Robot
     Swarm.Game.State.Runtime
     Swarm.Game.State.Substate
+    Swarm.Game.State.ViewCenter.Internal
     Swarm.Game.Step
     Swarm.Game.Step.Arithmetic
     Swarm.Game.Step.Combustion
@@ -769,7 +770,7 @@ library swarm-engine
   other-modules:
     Paths_swarm
     Swarm.Game.State.ViewCenter.Internal
-    
+
   build-depends:
     swarm:swarm-lang,
     swarm:swarm-scenario,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -767,10 +767,7 @@ library swarm-engine
     Swarm.Log
 
   autogen-modules: Paths_swarm
-  other-modules:
-    Paths_swarm
-    Swarm.Game.State.ViewCenter.Internal
-
+  other-modules: Paths_swarm
   build-depends:
     swarm:swarm-lang,
     swarm:swarm-scenario,

--- a/test/unit/TestNotification.hs
+++ b/test/unit/TestNotification.hs
@@ -12,7 +12,6 @@ import Data.Text qualified as T
 import Swarm.Game.Robot
 import Swarm.Game.Robot.Concrete (robotLog)
 import Swarm.Game.State
-import Swarm.Game.State.Robot
 import Swarm.Game.State.Substate
 import Swarm.Game.Tick (TickNumber (..))
 import Swarm.Log

--- a/test/unit/TestUtil.hs
+++ b/test/unit/TestUtil.hs
@@ -21,7 +21,6 @@ import Swarm.Game.Robot
 import Swarm.Game.Robot.Concrete (isActive)
 import Swarm.Game.State
 import Swarm.Game.State.Landscape
-import Swarm.Game.State.Robot
 import Swarm.Game.Step (gameTick, hypotheticalRobot, stepCESK)
 import Swarm.Language.Pipeline (processTerm)
 import Swarm.Language.Syntax.Pattern (TSyntax)


### PR DESCRIPTION
This is a refactor before I add watch for robots (#2518).
If this is approved, I am going to move Robots
and lenses out to an internal module.

Why?

Because there is documentation for some members
and for public lenses, but I want it to be consistent.
The documentation should be on the lenses, but
some of those lenses will be only in the Internal
module and used qualified in `Robot.hs`.

Also I want to re-export modules, so that when given
a choice where to import from it is always from
the shorter module. In the perfect world, I want to
import `Swarm.Game` and get the functions that 
I actually need.