### PR TITLE
Get rid of a use of `Map.!` in `Swarm.Language.Typecheck`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -36,7 +36,7 @@
   - {name: fromJust, within: []}
   - {name: Data.Colour.SRGB.sRGB24read, within: []}
   - {name: Data.IntMap.!, within: []}
-  - {name: Data.Map.!, within: [Swarm.Language.Context.rehydrate, Swarm.Language.Typecheck.check]} # TODO: #1494
+  - {name: Data.Map.!, within: [Swarm.Language.Context.rehydrate]} # TODO: #1494
   - {name: error, within:
       [ Swarm.Language.Parser.QQ  # quasiquoters only run at compile time
       , Swarm.Language.Pipeline.QQ

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -1321,7 +1321,6 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
   -- completely into inference mode.  See Note [Checking and inference
   -- for record literals].
   SRcd fields
-    -- fields :: Map Var (Maybe (Syntax' ty))
     | UTyRcd tyMap <- expected -> do
         let expectedFields = M.keysSet tyMap
             actualFields = M.keysSet fields

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -63,7 +63,7 @@ import Data.Data (Data, gmapM)
 import Data.Foldable (fold)
 import Data.Functor.Identity
 import Data.Generics (mkM)
-import Data.Map (Map, (!))
+import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe
 import Data.Set (Set, (\\))
@@ -1321,13 +1321,18 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
   -- completely into inference mode.  See Note [Checking and inference
   -- for record literals].
   SRcd fields
+    -- fields :: Map Var (Maybe (Syntax' ty))
     | UTyRcd tyMap <- expected -> do
         let expectedFields = M.keysSet tyMap
             actualFields = M.keysSet fields
         when (actualFields /= expectedFields) $
           throwTypeErr l $
             FieldsMismatch (joined expectedFields actualFields)
-        m' <- itraverse (\x ms -> check (fromMaybe (STerm (TVar x)) ms) (tyMap ! x)) fields
+        m' <- itraverse
+          (\x (ms, ty) -> check (fromMaybe (STerm (TVar x)) ms) ty)
+          -- Since we checked above that 'fields' and 'tyMap' have the
+          -- same keys, intersectionWith is really just a zip.
+          (M.intersectionWith (,) fields tyMap)
         return $ Syntax' l (SRcd (Just <$> m')) cs expected
 
   -- The type of @suspend t@ is @Cmd T@ if @t : T@.

--- a/src/swarm-lang/Swarm/Language/Typecheck.hs
+++ b/src/swarm-lang/Swarm/Language/Typecheck.hs
@@ -1328,11 +1328,12 @@ check s@(CSyntax l t cs) expected = addLocToTypeErr l $ case t of
         when (actualFields /= expectedFields) $
           throwTypeErr l $
             FieldsMismatch (joined expectedFields actualFields)
-        m' <- itraverse
-          (\x (ms, ty) -> check (fromMaybe (STerm (TVar x)) ms) ty)
-          -- Since we checked above that 'fields' and 'tyMap' have the
-          -- same keys, intersectionWith is really just a zip.
-          (M.intersectionWith (,) fields tyMap)
+        m' <-
+          itraverse
+            (\x (ms, ty) -> check (fromMaybe (STerm (TVar x)) ms) ty)
+            -- Since we checked above that 'fields' and 'tyMap' have the
+            -- same keys, intersectionWith is really just a zip.
+            (M.intersectionWith (,) fields tyMap)
         return $ Syntax' l (SRcd (Just <$> m')) cs expected
 
   -- The type of @suspend t@ is @Cmd T@ if @t : T@.


### PR DESCRIPTION
Towards #1494 .  We checked that the keys of the map representing a record type and the keys of the map representing a record literal were the same, and then traversed over the record literal, doing a lookup into the record type for each.  Since we already checked that the maps have the same keys, these lookups were guaranteed to succeed, but I still didn't like the use of `Map.!`.  This PR first uses `intersectionWith` to combine the two maps into a single map of pairs, and then traverses over the resulting map.  This accomplishes the same thing but without the use of any partial functions.