### PR TITLE
Auto-insert matching close quotes

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Model/Repl.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Repl.hs
@@ -41,6 +41,7 @@ module Swarm.TUI.Model.Repl (
   replPromptEditor,
   replPromptText,
   replPromptZipper,
+  textBeforeCursor,
   replPromptTextBeforeCursor,
   replValid,
   replLast,
@@ -391,7 +392,11 @@ replPromptZipper = replPromptEditor . editContentsL
 -- | Get all the text currently entered at the REPL prior to the cursor.
 replPromptTextBeforeCursor :: REPLState -> Text
 replPromptTextBeforeCursor r =
-  r ^. replPromptEditor . editContentsL . to TZ.killToEOF . to TZ.getText . to T.unlines
+  r ^. replPromptEditor . editContentsL . to textBeforeCursor
+
+-- | Get the text before the cursor in a text zipper.
+textBeforeCursor :: TZ.TextZipper Text -> Text
+textBeforeCursor = T.unlines . TZ.getText . TZ.killToEOF
 
 -- | Whether the prompt text is a valid 'Swarm.Language.Syntax.Term'.
 --   If it is invalid, the location of error. ('NoLoc' means the whole


### PR DESCRIPTION
Closes #2545. Implements the three rules described there, i.e. when a double quote character is typed:

1. If the cursor is positioned just before a double quote, do not insert a new quote character; simply move the cursor to the right one position.
2. If there are currently an odd number of double quote characters before the cursor, then insert only a single double quote character.
3. Otherwise, insert two double quote characters and position the cursor in between them.