### PR TITLE
Use `T.intercalate` instead of `T.unlines` so we don't add trailing newline to REPL text

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Model/Repl.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Repl.hs
@@ -381,7 +381,7 @@ replPromptEditor :: Lens' REPLState (Editor Text Name)
 replPromptText :: Lens' REPLState Text
 replPromptText = lens g s
  where
-  g r = r ^. replPromptEditor . to getEditContents . to T.unlines
+  g r = r ^. replPromptEditor . to getEditContents . to (T.intercalate "\n")
   s r t = r & replPromptEditor .~ newREPLEditor t
 
 -- | Lens to get a zipper into the REPL text.


### PR DESCRIPTION
#2543 changed `T.concat` to `T.unlines` in the `replPromptText` function.  It is true that `getEditContents` returns a list of lines, so `unlines` is more appropriate than `concat` in theory (though as @xsebek pointed out at https://github.com/swarm-game/swarm/pull/2543#discussion_r2241548051 , right now it does not make much difference since REPL input is always only one line).  However, `T.unlines` had the side effect of adding a trailing newline character, which confused the pretty-printer for parse errors.

This PR changes it to `T.intercalate "\n"` which correctly puts together lines of text without adding an extra trailing newline. 

Closes #2548.