### PR TITLE
Include combustion products in recipe graph analysis

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -546,8 +546,12 @@
     attr: entity
     char: 'O'
   description:
-    - A polished, rounded piece of glass, capable of focusing rays of light.
+    - |
+      A polished, rounded piece of glass, capable of focusing rays of light.
+    - |
+      Focusing the sun's rays can set things on fire via `ignite : Dir -> Cmd Unit`.
   properties: [pickable]
+  capabilities: [ignite]
 - name: LaTeX
   display:
     attr: flower

--- a/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
+++ b/src/swarm-scenario/Swarm/Game/Recipe/Graph.hs
@@ -127,11 +127,19 @@ recipeLevels emap recipeList start = levs
   levs = reverse $ go [start] start
    where
     isKnown known (i, _o) = null $ i Set.\\ known
+
     lookupYield e = case view entityYields e of
       Nothing -> e
       Just yn -> fromMaybe e (E.lookupEntityName yn emap)
     yielded = Set.map lookupYield
-    nextLevel known = Set.unions $ yielded known : map snd (filter (isKnown known) m)
+
+    lookupCombust e = case view E.entityCombustion e of
+      Just (E.Combustibility _ _ _ (Just productName)) ->
+        fromMaybe e (E.lookupEntityName productName emap)
+      _ -> e
+    combusted = Set.map lookupCombust
+
+    nextLevel known = Set.unions $ yielded known : combusted known : map snd (filter (isKnown known) m)
     go ls known =
       let n = nextLevel known Set.\\ known
        in if null n

--- a/test/integration/TestRecipeCoverage.hs
+++ b/test/integration/TestRecipeCoverage.hs
@@ -52,8 +52,7 @@ nonCoveredList :: [EntityName]
 nonCoveredList =
   map
     T.toCaseFold
-    [ "ash"
-    , "blueprint"
+    [ "blueprint"
     , "decoder ring"
     , "linotype"
     , "tape drive"


### PR DESCRIPTION
Closes #2525.  Also adds the `ignite` capability to the `lens` entity, to make it possible to combust things in classic mode.