### PR TITLE
Rename `Win` to `win` in tutorial scenarios

### DIFF
--- a/data/scenarios/Tutorials/debug-hint.sw
+++ b/data/scenarios/Tutorials/debug-hint.sw
@@ -43,7 +43,7 @@ def set_said_loc: (Int * Int) -> RobotState -> RobotState
   [gave_win = s.gave_win, said_loc = v, said_log_missing = s.said_log_missing]
 end
 
-// At the beginning each robot can be given Win.
+// At the beginning each robot can be given win.
 def defaultState: RobotState =
   [gave_win = false, said_loc = (-100, -100), said_log_missing = false]
 end
@@ -82,7 +82,7 @@ end
 // Running state
 myLoc <- whereami;
 
-// Try to give a robot a Win, filtering out those that were already given a Win.
+// Try to give a robot a `win`, filtering out those that were already given a `win`.
 // The robot will also receive instructions, so it **must have a logger!**
 def tryGive: Text -> State -> Cmd State 
   = \msg. \state.
@@ -108,8 +108,8 @@ def tryGive: Text -> State -> Cmd State
         try {
           reprogram rob {log msg};
           log ("successfully reprogrammed robot " ++ format rob);
-          give rob "Win";
-          log ("successfully gave Win to robot " ++ format rob);
+          give rob "win";
+          log ("successfully gave win to robot " ++ format rob);
           pure (updateList rob (set_gave_win true state) stateAcc)
         } {
           log ("the robot " ++ format rob ++ "is probably still active!");
@@ -126,10 +126,10 @@ end
 log "Hi, I am the system hint robot";
 iterate [can_wait=true, list=emptyList] (tryGive
   $ "Send a robot to `salvage` me and come back to"
-  ++ " `give base \"Win\"`.  When the rescue robot stands"
+  ++ " `give base \"win\"`.  When the rescue robot stands"
   ++ " where I am and executes `salvage`, all my inventory"
-  ++ " and logs will go to it, including the \"Win\". Once you"
-  ++ " have brought the \"Win\" to your base, you will win!\n\n"
+  ++ " and logs will go to it, including the \"win\". Once you"
+  ++ " have brought the \"win\" to your base, you will win!\n\n"
   ++ "NOTE: if you are still viewing me when I am salvaged,"
   ++ " you will be in for a surprise!  If this happens just"
   ++ " type `view base` to return to viewing your base."

--- a/data/scenarios/Tutorials/debug.yaml
+++ b/data/scenarios/Tutorials/debug.yaml
@@ -28,10 +28,10 @@ objectives:
         the situation...
     condition: |
       try {
-        as base {has "Win"}
+        as base {has "win"}
       } { pure false }
 entities:
-  - name: Win
+  - name: win
     display:
       attr: device
       char: 'W'
@@ -43,9 +43,9 @@ solution: |
     turn east; move; move; move; log "brace for impact"; move
   };
   salvager <- build {
-    log "I will bring home the Win!"; // This allows log messages to transfer over
+    log "I will bring home the win!"; // This allows log messages to transfer over
     turn right; turn right; turn right; turn right;
-    turn east; move; move; move; salvage; turn back; move; move; give base "Win"
+    turn east; move; move; move; salvage; turn back; move; move; give base "win"
   };
 robots:
   - name: base
@@ -75,7 +75,7 @@ robots:
       - dictionary
       - 3D printer
     inventory:
-      - [100000, Win]
+      - [100000, win]
     display:
       invisible: true
     system: true

--- a/data/scenarios/Tutorials/type-errors.yaml
+++ b/data/scenarios/Tutorials/type-errors.yaml
@@ -17,22 +17,22 @@ objectives:
       - |
         `move move`{=snippet}
       - The last expression might give the most confusing error. Obviously we are just missing a `;`{=snippet} separating the two `move` commands.  However, without the semicolon, it looks like `move` is a function being applied to an argument, but of course `move` is not a function.
-      - Once you are done experimenting, execute `place "Win"` to finish this challenge and move on to the next.
+      - Once you are done experimenting, execute `place "win"` to finish this challenge and move on to the next.
     condition: |
       try {
-        w <- as base {has "Win"};
+        w <- as base {has "win"};
         pure (not w);
       } { pure false }
 entities:
-  - name: Win
+  - name: win
     display:
       attr: device
       char: 'W'
     description:
-      - Do `place "Win"` once you are done with this challenge.
+      - Do `place "win"` once you are done with this challenge.
     properties: [known, pickable]
 solution: |
-  place "Win"
+  place "win"
 robots:
   - name: base
     dir: east
@@ -42,7 +42,7 @@ robots:
       - logger
       - grabber
     inventory:
-      - [1, Win]
+      - [1, win]
 world:
   palette:
     '>': [grass, null, base]

--- a/data/scenarios/Tutorials/types.yaml
+++ b/data/scenarios/Tutorials/types.yaml
@@ -21,22 +21,22 @@ objectives:
         `3`
       - |
         `"tree"`
-      - Once you are done experimenting, execute `place "Win"` to finish this challenge and move on to the next.
+      - Once you are done experimenting, execute `place "win"` to finish this challenge and move on to the next.
     condition: |
       try {
-        w <- as base {has "Win"};
+        w <- as base {has "win"};
         pure (not w);
       } { pure false }
 entities:
-  - name: Win
+  - name: win
     display:
       attr: device
       char: 'W'
     description:
-      - Do `place "Win"` once you are done with this challenge.
+      - Do `place "win"` once you are done with this challenge.
     properties: [known, pickable]
 solution: |
-  place "Win"
+  place "win"
 robots:
   - name: base
     dir: east
@@ -46,7 +46,7 @@ robots:
       - logger
       - grabber
     inventory:
-      - [1, Win]
+      - [1, win]
 world:
   palette:
     '>': [grass, null, base]


### PR DESCRIPTION
Someone at ZuriHac noted that it was inconsistent the way all our entities start with lowercase except the special `Win` entities in a few tutorials, and I think I agree.  This PR renames them all to `win`.  Closes #2475 .
