### PR TITLE
Load world tiles in parallel

### DIFF
--- a/src/swarm-scenario/Swarm/Game/World.hs
+++ b/src/swarm-scenario/Swarm/Game/World.hs
@@ -107,12 +107,11 @@ worldFunFromArray arr = WF $ \(Coords (r, c)) ->
 --   the locations in a tile.  In other words, each tile has a size of
 --   @2^tileBits x 2^tileBits@.
 --
---   Currently, 'tileBits' is set to 6, giving us 64x64 tiles, with
---   4096 cells in each tile. That seems intuitively like a good size,
---   but I don't have a good sense for the tradeoffs here, and I don't
---   know how much the choice of tile size matters.
+--   Currently, 'tileBits' is set to 5, giving us 32x32 tiles, with
+--   1024 cells in each tile. This seems to result in more smooth
+--   scrolling of the world map.
 tileBits :: Int
-tileBits = 6
+tileBits = 5
 
 -- | The number consisting of 'tileBits' many 1 bits.  We can use this
 --   to mask out the tile offset of a coordinate.

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -294,6 +294,9 @@ common pandoc
 common pandoc-types
   build-depends: pandoc-types >=1.23 && <1.24
 
+common parallel
+  build-depends: parallel >=3.2 && <3.3
+
 common parser-combinators
   build-depends: parser-combinators >=1.2 && <1.4
 
@@ -608,6 +611,7 @@ library swarm-scenario
     mtl,
     murmur3,
     palette,
+    parallel,
     parser-combinators,
     prettyprinter,
     random,


### PR DESCRIPTION
* Make tile size 2**5=32
* Load world tiles in parallel using [Control.Parallel.Strategies](https://hackage-content.haskell.org/package/parallel-3.2.2.0/docs/Control-Parallel-Strategies.html#v:parMap)
* [ ] TODO: Add metrics
* [ ] TODO: Add `-N[x]` to cabal file 

Tested with
```sh
cabal run swarm -- --debug=all --scenario Creative +RTS -s -N10  # try setting number of threads
```