### PR TITLE
Set max frame rate to 35 FPS

### DIFF
--- a/app/game/Swarm/App.hs
+++ b/app/game/Swarm/App.hs
@@ -152,18 +152,21 @@ startMetricsThread mPort store = do
 createChannel :: IO (BChan AppEvent)
 createChannel = newBChan 5
 
--- | Send Frame events as at a reasonable rate for 30 fps.
+-- | Send Frame events as at a reasonable rate for 35 fps.
 --
 -- The game is responsible for figuring out how many steps to take
 -- each frame to achieve the desired speed, regardless of the
--- frame rate.  Note that if the game cannot keep up with 30
+-- frame rate.  Note that if the game cannot keep up with 35
 -- fps, it's not a problem: the channel will fill up and this
 -- thread will block.  So the force of the threadDelay is just
 -- to set a *maximum* possible frame rate.
+--
+-- We use 35 FPS so that even at double the default ticks/second
+-- (i.e. 32 t/s) we can run at over 1 frame per tick.
 sendFrameEvents :: BChan AppEvent -> IO ()
 sendFrameEvents chan = void . forkIO . forever $ do
   writeBChan chan Frame
-  threadDelay 33_333 -- cap maximum framerate at 30 FPS
+  threadDelay (1_000_000 `div` 35) -- cap maximum framerate at 35 FPS
 
 -- | Get newer upstream version and send event to channel.
 sendUpstreamVersion :: BChan AppEvent -> Maybe GitInfo -> IO ()


### PR DESCRIPTION
For a long time the max frame rate has been arbitrarily set to 30 FPS.  (The reason we have a max frame rate set at all is so that the game doesn't just eat 100% of your CPU.)  However, since the default speed is 16 ticks/s, doubling it results in 32 ticks/s, which at a frame rate of 30 FPS will run just under one frame per tick.  i.e. if you speed up the game just a bit, there will necessarily start being dropped ticks that are not rendered as a frame.  This seems unfortunate, so I propose upping the max frame rate slightly to better correspond to the power-of-two tick rates.  Setting the FPS to 32 exactly will probably still result in occasional dropped ticks (typically the actual frame rate hovers slightly below the maximum), so I propose setting it to 35.