### PR TITLE
Update few scripts

### DIFF
--- a/scripts/autoplay-tutorials.sh
+++ b/scripts/autoplay-tutorials.sh
@@ -1,18 +1,13 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-cd $(git rev-parse --show-toplevel)
-
-if command -v stack &> /dev/null; then
-    SWARM="stack exec swarm --"
-else
-    SWARM="cabal run -j -O0 swarm --"
-fi
+cd "$(git rev-parse --show-toplevel)"
 
 for tutorial in $(cat scenarios/Tutorials/00-ORDER.txt | xargs); do
     echo -n "$tutorial"
-    $SWARM -i "scenarios/Tutorials/$tutorial" --autoplay --cheat;
+    scripts/play.sh -i "scenarios/Tutorials/$tutorial" --autoplay --cheat;
     echo -en "\tCONTINUE [Y/n]: "
-    read answer;
+    read -r answer;
     case "${answer:0:1}" in
         n|N )
             exit 1

--- a/scripts/build-game.sh
+++ b/scripts/build-game.sh
@@ -1,10 +1,10 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
+set -euo pipefail
 
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 # NOTE: There are several executables within the swarm.cabal project.
 # If you only want to play the swarm game, you should specify an explicit
-# target 'swarm:exe:swarm' to the 'stack' command, to avoid building
+# target 'swarm:exe:swarm' to the 'cabal' command, to avoid building
 # extra dependencies.
-
-cabal build -j -O0 swarm:exe:swarm
+cabal build -j --semaphore swarm:exe:swarm 

--- a/scripts/gen/list-sublibraries.sh
+++ b/scripts/gen/list-sublibraries.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-cd $(git rev-parse --show-toplevel)
-
-grep '^library \w' swarm.cabal | cut -d' ' -f2

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -1,9 +1,9 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
+set -euo pipefail
 
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
-# This compiles without optimizations and then runs the resulting executable.
-# It's been observed in certain versions of GHC that compiling with optimizations
-# results in the swarm UI freezing for a potentially long time upon starting a scenario.
-# See https://github.com/swarm-game/swarm/issues/1000#issuecomment-1378632269
-scripts/build-game.sh && cabal run -j -O0 swarm:exe:swarm -- "$@"
+# This compiles with optimizations and then runs the resulting executable.
+# Building with optimizations takes longer, but is noticeable when running
+# scenarios with swarms of robots.
+cabal run -j --semaphore swarm:exe:swarm -- "$@"

--- a/scripts/playtest.sh
+++ b/scripts/playtest.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# This compiles the dependencies with optimizations (as they are not built frequently)
+# and then builds the swarm executable without optimizations.
+# Expect the game to run slow with many robots, but most scenarios are fine.
+# This is the development workflow when making changes to the game.
+
+cabal build -j --semaphore swarm:exe:swarm --dependencies-only
+cabal run swarm:exe:swarm -O0 -- "$@"
+
+# PS: Don't forget to also run tests and at least build benchmarks or the CI will catch you ;)


### PR DESCRIPTION
* add [`--semaphore`](https://discord.com/channels/1260717118576525372/1260717118576525376/1410352637701914718) to Cabal invocations
* remove Stack option from tutorial autoplay script
* add `playtest.sh` script which builds swarm with `-O0` but dependencies with `-O1`
* remove sub-libraries script as we now have [`cabal target`](https://cabal.readthedocs.io/en/stable/cabal-commands.html#cabal-target)
