### PR TITLE
Track world metrics in all stateful functions

### DIFF
--- a/src/swarm-engine/Swarm/Game/Step/Combustion.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Combustion.hs
@@ -23,7 +23,7 @@ import Control.Monad (forM_, when)
 import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Linear (zero)
-import Swarm.Effect as Effect (Time, getNow)
+import Swarm.Effect as Effect (Metric, Time, getNow)
 import Swarm.Game.CESK (initMachine)
 import Swarm.Game.Cosmetic.Attribute
 import Swarm.Game.Cosmetic.Display
@@ -47,7 +47,7 @@ import Swarm.Util hiding (both)
 import System.Clock (TimeSpec)
 import Prelude hiding (lookup)
 
-igniteCommand :: (HasRobotStepState sig m, Has Effect.Time sig m) => Const -> Direction -> m ()
+igniteCommand :: HasRobotStepState sig m => Const -> Direction -> m ()
 igniteCommand c d = do
   (loc, me) <- lookInDirection d
   -- Ensure there is an entity here.
@@ -170,7 +170,7 @@ combustionProgram combustionDuration (Combustibility _ _ _ maybeCombustionProduc
 --   on that particular neighbor entity's combustion /rate/, but also
 --   on the @sourceDuration@ time that the current entity will burn.
 igniteNeighbor ::
-  Has (State GameState) sig m =>
+  (Has (State GameState) sig m, Has Effect.Metric sig m, Has Effect.Time sig m) =>
   TimeSpec ->
   Integer ->
   Integer ->

--- a/src/swarm-engine/Swarm/Game/Step/Const.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Const.hs
@@ -122,7 +122,7 @@ data GrabRemoval = DeferRemoval | PerformRemoval
 -- | Interpret the execution (or evaluation) of a constant application
 --   to some values.
 execConst ::
-  (HasRobotStepState sig m, Has Effect.Time sig m, Has (Lift IO) sig m) =>
+  (HasRobotStepState sig m, Has (Lift IO) sig m) =>
   -- | Need to pass this function as an argument to avoid module import cycle
   -- The supplied function invokes 'runCESK', which lives in "Swarm.Game.Step".
   (Store -> Robot -> Value -> m Value) ->

--- a/src/swarm-engine/Swarm/Game/Step/Path/Finding.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Finding.hs
@@ -25,7 +25,7 @@
 -- distance to prevent programming errors from irrecoverably freezing the game.
 module Swarm.Game.Step.Path.Finding where
 
-import Control.Effect.Lens
+import Control.Effect.Lens as Fused
 import Control.Lens ((^.))
 import Control.Monad (filterM, guard)
 import Control.Monad.Trans.Class (lift)
@@ -39,6 +39,7 @@ import Swarm.Game.Entity
 import Swarm.Game.Location
 import Swarm.Game.Robot
 import Swarm.Game.State
+import Swarm.Game.State.Landscape (multiWorld)
 import Swarm.Game.Step.Path.Cache
 import Swarm.Game.Step.Path.Cache.DistanceLimit (withinDistance)
 import Swarm.Game.Step.Path.Type
@@ -46,6 +47,7 @@ import Swarm.Game.Step.RobotStepState
 import Swarm.Game.Step.Util
 import Swarm.Game.Step.Util.Inspect
 import Swarm.Game.Universe
+import Swarm.Game.World (locToCoords, lookupCosmicEntity)
 import Swarm.Language.Syntax
 import Swarm.Language.Syntax.Direction
 
@@ -145,7 +147,8 @@ pathCommand parms = do
   goalReachedFunc loc = case target of
     LocationTarget gLoc -> return $ loc == gLoc
     EntityTarget eName -> do
-      me <- entityAt $ Cosmic currentSubworld loc
+      worlds <- Fused.use $ landscape . multiWorld
+      let me = lookupCosmicEntity (Cosmic currentSubworld $ locToCoords loc) worlds
       return $ (view entityName <$> me) == Just eName
 
   -- A failsafe limit is hardcoded to prevent the game from freezing

--- a/src/swarm-engine/Swarm/Game/Step/RobotStepState.hs
+++ b/src/swarm-engine/Swarm/Game/Step/RobotStepState.hs
@@ -13,6 +13,7 @@ module Swarm.Game.Step.RobotStepState where
 
 import Control.Carrier.State.Lazy
 import Control.Effect.Error
+import Swarm.Effect qualified as Effect
 import Swarm.Game.Exception
 import Swarm.Game.Robot
 import Swarm.Game.State
@@ -21,4 +22,10 @@ import Swarm.Game.State
 --
 -- They can also throw exception of our custom type, which is handled elsewhere.
 -- Because of that the constraint is only 'Throw', but not 'Catch'/'Error'.
-type HasRobotStepState sig m = (Has (State GameState) sig m, Has (State Robot) sig m, Has (Throw Exn) sig m)
+type HasRobotStepState sig m =
+  ( Has (State GameState) sig m
+  , Has (State Robot) sig m
+  , Has (Throw Exn) sig m
+  , Has Effect.Metric sig m
+  , Has Effect.Time sig m
+  )

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -15,7 +15,6 @@ import Control.Effect.Lens
 import Control.Monad (forM_, guard, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..), hoistMaybe, runMaybeT)
-import Control.Monad.Trans.State.Strict qualified as TS
 import Data.Array (bounds, (!))
 import Data.IntMap qualified as IM
 import Data.Set qualified as S

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -62,15 +62,6 @@ lookInDirection d = do
   let nextLoc = loc `offsetBy` newHeading
   (nextLoc,) <$> entityAt nextLoc
 
-adaptGameState ::
-  Has (State GameState) sig m =>
-  TS.State GameState b ->
-  m b
-adaptGameState f = do
-  (newRecognizer, newGS) <- TS.runState f <$> get
-  put newGS
-  return newRecognizer
-
 -- | Modify the entity (if any) at a given location, and mark the cell
 --   dirty (i.e. needing to be redrawn) if anything changes.
 updateEntityAt ::

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -80,8 +80,8 @@ updateEntityAt ::
   m ()
 updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
   someChange <-
-    zoomWorld subworldName $ \_ ->
-      W.updateM @Int (locToCoords loc) upd
+    zoomWorld subworldName $ \wMetric ->
+      W.updateM @Int wMetric (locToCoords loc) upd
 
   forM_ (WM.getModification =<< someChange) $ \modType -> do
     currentTick <- use $ temporal . ticks

--- a/src/swarm-engine/Swarm/Game/Step/Util.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util.hs
@@ -74,13 +74,13 @@ adaptGameState f = do
 -- | Modify the entity (if any) at a given location, and mark the cell
 --   dirty (i.e. needing to be redrawn) if anything changes.
 updateEntityAt ::
-  (Has (State Robot) sig m, Has (State GameState) sig m) =>
+  HasRobotStepState sig m =>
   Cosmic Location ->
   (Maybe Entity -> Maybe Entity) ->
   m ()
 updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
   someChange <-
-    zoomWorld subworldName $
+    zoomWorld subworldName $ \_ ->
       W.updateM @Int (locToCoords loc) upd
 
   forM_ (WM.getModification =<< someChange) $ \modType -> do
@@ -90,7 +90,7 @@ updateEntityAt cLoc@(Cosmic subworldName loc) upd = do
 
     structureRecognizer <- use $ landscape . recognizerAutomatons
     oldRecognition <- use $ discovery . structureRecognition
-    newRecognition <- adaptGameState $ SRT.entityModified mtlEntityAt modType cLoc structureRecognizer oldRecognition
+    newRecognition <- SRT.entityModified entityAt modType cLoc structureRecognizer oldRecognition
     discovery . structureRecognition .= newRecognition
 
     pcr <- use $ pathCaching . pathCachingRobots

--- a/src/swarm-engine/Swarm/Game/Step/Validate.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Validate.hs
@@ -13,7 +13,7 @@ import Control.Lens (use, (^.))
 import Control.Monad.State (StateT, gets)
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
-import Swarm.Effect.Time (runTimeIO)
+import Swarm.Effect (runMetricIO, runTimeIO)
 import Swarm.Game.Robot.Concrete (robotLog)
 import Swarm.Game.State (GameState, messageInfo, robotInfo, winCondition)
 import Swarm.Game.State.Robot (robotMap)
@@ -33,7 +33,7 @@ playUntilWin = do
     Just badErrs -> return $ Left badErrs
     Nothing -> case w of
       WinConditions (Won _ ts) _ -> return $ Right ts
-      _ -> runTimeIO gameTick >> playUntilWin
+      _ -> runMetricIO (runTimeIO gameTick) >> playUntilWin
 
 -- | Extract any bad error messages from robot logs or the global
 --   message queue, where "bad" errors are either fatal errors or

--- a/src/swarm-scenario/Swarm/Game/World/Stateful.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Stateful.hs
@@ -120,11 +120,11 @@ loadRegionM wm = updateMetric . state @(World t e) . loadRegion'
     Nothing -> void m
     Just wMetrics -> do
       (loadTime, loadedTiles) <- Effect.measureCpuTimeInSec m
-      inMemoryTiles <- M.size . (.tileCache) <$> get @(World t e)
-      Effect.gaugeSet wMetrics.inMemoryTiles inMemoryTiles
       unless (null loadedTiles) $ do
+        inMemoryTiles <- M.size . (.tileCache) <$> get @(World t e)
         let loadedCount = length loadedTiles
         let avgTime = loadTime / fromIntegral loadedCount
+        Effect.gaugeSet wMetrics.inMemoryTiles inMemoryTiles
         Effect.gaugeAdd wMetrics.loadedTiles loadedCount
         Effect.distributionAdd wMetrics.tilesBatchLoadTime loadTime
         Effect.distributionAdd wMetrics.tileAverageLoadTime avgTime

--- a/src/swarm-scenario/Swarm/Game/World/Stateful.hs
+++ b/src/swarm-scenario/Swarm/Game/World/Stateful.hs
@@ -88,12 +88,14 @@ lookupEntityM wm c = snd <$> lookupContentM @t @e wm c
 --   containing the given coordinates is loaded.
 updateM ::
   forall t sig m.
-  (Has (State (World t Entity)) sig m, IArray U.UArray t) =>
+  HasWorldStateEffect t Entity sig m =>
+  Maybe WorldMetrics ->
   Coords ->
   (Maybe Entity -> Maybe Entity) ->
   m (CellUpdate Entity)
-updateM c g = do
-  state @(World t Entity) $ update c g . loadCell c
+updateM wm c g = do
+  loadCellM @t @Entity wm c
+  state @(World t Entity) $ update c g
 
 loadCellM ::
   forall t e sig m.

--- a/test/bench/Benchmark.hs
+++ b/test/bench/Benchmark.hs
@@ -13,7 +13,7 @@ import Data.Map qualified as M
 import Data.Sequence (Seq)
 import Data.Text qualified as T
 import Data.Tuple.Extra (dupe)
-import Swarm.Effect (runTimeIO, runMetricIO)
+import Swarm.Effect (runMetricIO, runTimeIO)
 import Swarm.Failure (SystemFailure, simpleErrorHandle)
 import Swarm.Game.CESK (initMachine)
 import Swarm.Game.Cosmetic.Display (defaultRobotDisplay)

--- a/test/bench/Benchmark.hs
+++ b/test/bench/Benchmark.hs
@@ -13,7 +13,7 @@ import Data.Map qualified as M
 import Data.Sequence (Seq)
 import Data.Text qualified as T
 import Data.Tuple.Extra (dupe)
-import Swarm.Effect (runTimeIO)
+import Swarm.Effect (runTimeIO, runMetricIO)
 import Swarm.Failure (SystemFailure, simpleErrorHandle)
 import Swarm.Game.CESK (initMachine)
 import Swarm.Game.Cosmetic.Display (defaultRobotDisplay)
@@ -23,7 +23,7 @@ import Swarm.Game.Robot.Walk (emptyExceptions)
 import Swarm.Game.Scenario (loadStandaloneScenario)
 import Swarm.Game.Scenario.Status
 import Swarm.Game.State (GameState, creativeMode, landscape, zoomRobots)
-import Swarm.Game.State.Initialize (pureScenarioToGameState)
+import Swarm.Game.State.Initialize (scenarioToGameStateForTests)
 import Swarm.Game.State.Landscape (multiWorld)
 import Swarm.Game.State.Robot (addTRobot)
 import Swarm.Game.State.Runtime (RuntimeOptions (..), initRuntimeState, stdGameConfigInputs)
@@ -148,7 +148,7 @@ mkGameState prog robotMaker numRobots = do
       runAccum mempty . initRuntimeState $
         RuntimeOptions {startPaused = False, pauseOnObjectiveCompletion = False, loadTestScenarios = False}
     (scenario, _gsi) <- loadStandaloneScenario "classic"
-    return $ pureScenarioToGameState (ScenarioWith scenario Nothing) 0 0 Nothing Nothing Nothing $ view stdGameConfigInputs initRS
+    return $ scenarioToGameStateForTests (ScenarioWith scenario Nothing) 0 0 Nothing $ view stdGameConfigInputs initRS
 
   execStateT
     (zoomRobots $ mapM_ (addTRobot $ initMachine prog) robots)
@@ -159,7 +159,7 @@ mkGameState prog robotMaker numRobots = do
 
 -- | Runs numGameTicks ticks of the game.
 runGame :: Int -> GameState -> IO ()
-runGame numGameTicks = evalStateT (replicateM_ numGameTicks $ runTimeIO gameTick)
+runGame numGameTicks = evalStateT (replicateM_ numGameTicks . runMetricIO $ runTimeIO gameTick)
 
 main :: IO ()
 main = do

--- a/weeder.toml
+++ b/weeder.toml
@@ -30,7 +30,7 @@ roots = [
     "^Swarm.Game.Step.traceLogShow$",
     "^Swarm.Game.World.DSL.Compile.compile$",
     "^Swarm.Game.World.DSL.Compile.runCTerm$",
-    "^Swarm.Game.World.Stateful.loadCellM$",
+    "^Swarm.Game.World.Pure.loadCell$",
     "^Swarm.Game.World.Stateful.lookupTerrainM$",
     "^Swarm.Language.Context.withBindings$",
     "^Swarm.Language.Context.singleton$",


### PR DESCRIPTION
* add metric effect to lookup and update functions
* replace MTL style entity lookup with fused-effects version
  * add fake time effect for tests
* refactor the robot metrics to use the new metric fused-effect
* refactor copy-paste zoom* functions to call one function that accepts a lens
* split from #2555

This is the last part that I wanted to split off from #2555. I rewrote most of it and I think I arrived at a cleaner solution for the MTL function and the signatures of Step functions.