### PR TITLE
Have inventory search look at entity description in addition to names

### DIFF
--- a/src/swarm-scenario/Swarm/Game/Entity.hs
+++ b/src/swarm-scenario/Swarm/Game/Entity.hs
@@ -671,8 +671,7 @@ entityNameFor _ = to $ \e ->
     Just pl -> pl
     Nothing -> plural (e ^. entityName)
 
--- | A longer, free-form description of the entity.  Each 'Text' value
---   represents a paragraph.
+-- | A longer, free-form description of the entity.
 entityDescription :: Lens' Entity (Document Syntax)
 entityDescription = hashedLens _entityDescription (\e x -> e {_entityDescription = x})
 

--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -281,14 +281,12 @@ populateInventoryList (Just r) = do
 
       matchesSearch :: (Count, Entity) -> Bool
       matchesSearch (_, e) =
-        or
-          [ -- Fuzzy search within entity names.
-            maybe (const True) Fuzzy.test search (e ^. E.entityName)
-          , -- Also do a literal substring search within entity
-            -- descriptions.  Since descriptions are long, a fuzzy
-            -- search tends to yield too many false positives.
-            maybe (const True) T.isInfixOf search (Markdown.docToText (e ^. E.entityDescription))
-          ]
+        -- Fuzzy search within entity names.
+        maybe (const True) Fuzzy.test search (e ^. E.entityName)
+          -- Also do a literal substring search within entity
+          -- descriptions.  Since descriptions are long, a fuzzy
+          -- search tends to yield too many false positives.
+          || maybe (const True) T.isInfixOf search (Markdown.docToText (e ^. E.entityDescription))
 
       items =
         (r ^. robotInventory . to (itemList True mkInvEntry "Compendium"))


### PR DESCRIPTION
Closes #1879 .

At first I tried doing fuzzy search within entity descriptions, just like we currently do for searching in entity names, but subjectively that yielded way too many false positives.  The letters of any word you might type in could be found somewhere in almost all entity descriptions.  Doing fuzzy search within names but literal substring search within descriptions subjectively seems to yield useful results.