### PR TITLE
Clean up `getDataDirSafe` and normalise result

### DIFF
--- a/src/swarm-util/Swarm/Util/Effect.hs
+++ b/src/swarm-util/Swarm/Util/Effect.hs
@@ -75,6 +75,8 @@ forMW ::
   m (t b)
 forMW = flip traverseW
 
+infixr 1 ???
+
 -- | Handle an action producing a Maybe by specifying an alternative
 --   action in the Nothing case.
 (???) :: Monad m => m (Maybe a) -> m a -> m a


### PR DESCRIPTION
This is a follow-up to #2611.  @xsebek noted that paths being unnormalized could potentially result in other issues later.  The `getDataDirSafe` function was apparently producing unnormalized paths, so I added normalization to its output and also cleaned up the code quite a bit.