### PR TITLE
Close #1149 as wontfix

### DIFF
--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldPalette.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldPalette.hs
@@ -122,8 +122,6 @@ prepForJson (PaletteAndMaskChar (StructurePalette _ _ suggestedPalette) maybeMas
 
   unassignedCharacters :: Set.Set Char
   unassignedCharacters =
-    -- TODO (#1149): How can we efficiently use the Unicode categories (in "Data.Char")
-    -- to generate this pool?
     Set.difference availableCharacterPool usedCharacters
    where
     usedCharacters =


### PR DESCRIPTION
Delete a TODO comment linking to #1149.  The idea was to use some generic Unicode tools to automatically create a pool of viable map palette characters (e.g. ones that do not have a wide display). However, as explained in the comments at #1149, it appears that there is really no way to do that.

After merging this PR, we should close the relevant issue as wontfix.