### PR TITLE
Removing `version` command in favour of `--version` flag (#2645)

### DIFF
--- a/src/swarm-tui/Swarm/TUI/Model.hs
+++ b/src/swarm-tui/Swarm/TUI/Model.hs
@@ -319,7 +319,8 @@ populateInventoryList (Just r) = do
 
 -- | Command-line options for configuring the app.
 data AppOpts = AppOpts
-  { userSeed :: Maybe Seed
+  { version :: Bool
+  , userSeed :: Maybe Seed
   -- ^ Explicit seed chosen by the user.
   , userScenario :: Maybe FilePath
   -- ^ Scenario the user wants to play.
@@ -368,6 +369,7 @@ defaultAppOpts =
     , userWebPort = Nothing
     , userMetricsPort = Nothing
     , repoGitInfo = Nothing
+    , version = False
     }
 
 --------------------------------------------------


### PR DESCRIPTION
With this change, I'm removing support for the `version` command, and exposing the `--version` option instead.

Closes #2645.