### PR TITLE
Fix date of 0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for swarm
 
-## **0.8.0.0** - 2025-11-XX
+## **0.8.0.0** - 2025-11-16
 
 ### Breaking changes
 


### PR DESCRIPTION
I was silly and didn't update the `XX` in the date when tagging the release.