### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,7 +252,7 @@ modules.
 #### UI enhancements
 
 * Fix REPL type display ([#1610](https://github.com/swarm-game/swarm/pull/1610))
-* Handle backword kill word event in REPL ([#1861](https://github.com/swarm-game/swarm/pull/1861))
+* Handle backward kill word event in REPL ([#1861](https://github.com/swarm-game/swarm/pull/1861))
 * Make log error messages ephemeral ([#1877](https://github.com/swarm-game/swarm/pull/1877))
 * Pretty print code blocks according to widget size ([#1897](https://github.com/swarm-game/swarm/pull/1897))
 * Automatically insert matching close brackets at REPL ([#1953](https://github.com/swarm-game/swarm/pull/1953))

--- a/app/game/Swarm/App.hs
+++ b/app/game/Swarm/App.hs
@@ -218,7 +218,7 @@ logPort api savePort eport =
   logP p = logEvent SystemLog Info api ("started on :" <> T.pack (show p))
   logE e = logEvent SystemLog Error api (T.pack e)
 
--- | Build VTY with preffered color mode and bracketed paste mode if available.
+-- | Build VTY with preferred color mode and bracketed paste mode if available.
 --
 -- Note that this will also run whenever the event loop needs to reinitialize
 -- the terminal, e.g. on resume after suspension. See 'customMain'.

--- a/docs/blog/2021-10-swarm-progress.md
+++ b/docs/blog/2021-10-swarm-progress.md
@@ -25,7 +25,7 @@ close to the vision for it, but we've made great progress!  Some
 notable new features added since the initial announcement include:
 
 - New `scan`, `upload`, and `install` commands
-- Semicolons are no longer required beetween consecutive `def`s
+- Semicolons are no longer required between consecutive `def`s
 - Basic help panel, and panel shortcut keys
 - Dramatically reduced CPU usage when idle
 - An overhaul of parsing and pretty-printing of constants (makes

--- a/example/list.sw
+++ b/example/list.sw
@@ -42,7 +42,7 @@ tydef ListI = Int end
 // The length of a number is kept in the header and split into 7bit
 // chunks each prefixed by 1bit that marks if the byte is last in
 // the header (0=YES).
-/* EXAMPLE - [short_x,long_y] - concretly e.g. [42, 2^(2^7)]
+/* EXAMPLE - [short_x,long_y] - concretely e.g. [42, 2^(2^7)]
 
 0   < len short_x < 2^7
 2^7 < len long_y  < 2^14

--- a/scripts/normalize/compare-format.sh
+++ b/scripts/normalize/compare-format.sh
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Build first, otherwise the ouput would go to temporary files
+# Build first, otherwise the output would go to temporary files
 cabal build -j -O0
 
 function compare_format() {

--- a/scripts/remote-repl.sh
+++ b/scripts/remote-repl.sh
@@ -6,7 +6,7 @@ HOST="localhost"
 function help {
   echo "Swarm remote REPL"
   echo
-  echo "This is a shortcut for sending to Swarm REPL via cURL and recieving responses:"
+  echo "This is a shortcut for sending to Swarm REPL via cURL and receiving responses:"
   echo "curl -XGET --header \"Content-Type: text/plain;charset=utf-8\" --data \"build {}\" $HOST:$PORT/code/run"
   echo
   echo "Options:"

--- a/src/swarm-engine/Swarm/Game/Step/Path/Cache.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Cache.hs
@@ -21,7 +21,7 @@
 -- location and a destination, including adding or removing
 -- particular entities at certain locations.
 --
--- Certain events allow for partial re-use of the previously
+-- Certain events allow for partial reuse of the previously
 -- computed path.
 module Swarm.Game.Step.Path.Cache (
   retrieveCachedPath,

--- a/src/swarm-engine/Swarm/Game/Step/Path/Finding.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Finding.hs
@@ -16,7 +16,7 @@
 -- Each @path@ invocation returns the direction of the
 -- next "move" along the computed shortest path.
 --
--- This internally stored path is re-used across invocations until some
+-- This internally stored path is reused across invocations until some
 -- event invalidates its cache (see "Swarm.Game.Step.Path.Cache").
 --
 -- == Max distance

--- a/src/swarm-engine/Swarm/Game/Step/Path/Type.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Path/Type.hs
@@ -9,7 +9,7 @@
 -- By convention, a @[Location]@ /does not/ include the
 -- starting location, whereas a @NonEmpty Location@ does.
 --
--- Consequentially, an empty @[Location]@ implies that
+-- Consequently, an empty @[Location]@ implies that
 -- the robot's current location is already at the goal location.
 --
 -- A gratuitous number of sum types are defined here
@@ -99,7 +99,7 @@ data DifferentArgument
   | NewDistanceLimit DistanceLimitChange
   deriving (Show, Eq, Generic, ToJSON)
 
--- | Reasons why we cannot re-use a precomputed path
+-- | Reasons why we cannot reuse a precomputed path
 -- from the cache upon re-invoking the 'Path' command
 data CacheRetreivalInapplicability
   = NotCached

--- a/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
+++ b/src/swarm-engine/Swarm/Game/Step/Util/Command.hs
@@ -505,7 +505,7 @@ addSeedBot e TickRange {tickRangeMin = minT, tickRangeMax = maxT} seedlingCount 
 --   after it is harvested.
 --
 -- NOTE: Seedling propagation delay (spreadable growth)
--- re-uses the growth timing parameters.
+-- reuses the growth timing parameters.
 seedProgram ::
   -- | min time
   Integer ->

--- a/src/swarm-engine/Swarm/Log.hs
+++ b/src/swarm-engine/Swarm/Log.hs
@@ -78,7 +78,7 @@ instance ToJSON LogSource where
   toJSON = genericToJSON optionsUntagged
 
 instance FromJSON LogSource where
-  -- This is not ambiguos for Robot/System constructor, but
+  -- This is not ambiguous for Robot/System constructor, but
   -- read aeson docs before adding new LogSource constructor
   parseJSON = genericParseJSON optionsUntagged
 

--- a/src/swarm-lang/Swarm/Language/Context.hs
+++ b/src/swarm-lang/Swarm/Language/Context.hs
@@ -189,7 +189,7 @@ rollCtx s = Ctx m (CtxTree h (restructureCtx ctxStruct s))
 -- Context instances
 
 -- | Serialize a context simply as its hash; we assume that a
---   top-level CtxMap has been seralized somewhere, from which we can
+--   top-level CtxMap has been serialized somewhere, from which we can
 --   recover this context by looking it up.
 instance ToJSON (Ctx v t) where
   toJSON = toJSON . ctxHash

--- a/src/swarm-lang/Swarm/Language/Kindcheck.hs
+++ b/src/swarm-lang/Swarm/Language/Kindcheck.hs
@@ -212,7 +212,7 @@ nonVacuous i ty@(Fix tyF) = case tyF of
   -- type, rejoice!
   TyConF {} -> pure True
   TyRcdF {} -> pure True
-  -- This last case can't actully happen if we already checked that
+  -- This last case can't actually happen if we already checked that
   -- the recursive type actually contains its bound variable (with
   -- 'containsVar'), since it would correspond to something like @rec
   -- x. y@.  However, it's still correct to return True.

--- a/src/swarm-lang/Swarm/Language/LSP/Position.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/Position.hs
@@ -152,7 +152,7 @@ pathToPosition s0 pos = s0 :| fromMaybe [] (innerPath s0)
     SSuspend {} -> mempty
 
   d = descend pos
-  -- try and decend into the syntax element if it is contained with position
+  -- try and descend into the syntax element if it is contained with position
   descend ::
     ExplainableType (SwarmType phase) =>
     Int ->

--- a/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
+++ b/src/swarm-lang/Swarm/Language/Syntax/Pattern.hs
@@ -56,7 +56,7 @@ pattern RSyntax l t <- Syntax l t _ ()
 
 {-# COMPLETE RSyntax #-}
 
--- | Untyped syntax with assocated comments.
+-- | Untyped syntax with associated comments.
 pattern CSyntax :: (SwarmType phase ~ ()) => SrcLoc -> Term phase -> Comments -> Syntax phase
 pattern CSyntax l t cs = Syntax l t cs ()
 

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/Cell.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/Cell.hs
@@ -58,7 +58,7 @@ type Cell = PCell Entity
 -- | Supplements a cell with waypoint information
 type AugmentedCell e phase = SignpostableCell (PCell e phase)
 
--- | Re-usable serialization for variants of 'PCell'
+-- | Reusable serialization for variants of 'PCell'
 mkPCellJson :: ToJSON b => (Erasable a -> Maybe b) -> PCell a phase -> Value
 mkPCellJson modifier x =
   toJSON $
@@ -93,7 +93,7 @@ instance FromJSONE (TerrainEntityMaps, RobotMap Raw) (Cell Raw) where
       $ T.unwords
         [ "Unrecognized terrain type"
         , quote $ getTerrainWord terr
-        , "Avaliable:"
+        , "Available:"
         , showT $ M.keys $ terrainByName tm
         ]
 

--- a/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldPalette.hs
+++ b/src/swarm-scenario/Swarm/Game/Scenario/Topography/WorldPalette.hs
@@ -82,7 +82,7 @@ constructWorldMap mappedPairs maskChar =
 
 -- | All alphanumeric characters. These are used as supplemental
 -- map placeholders in case a pre-existing display character is
--- not available to re-use.
+-- not available to reuse.
 genericCharacterPool :: Set.Set Char
 genericCharacterPool = Set.fromList $ ['A' .. 'Z'] <> ['a' .. 'z'] <> ['0' .. '9']
 

--- a/src/swarm-tui/Swarm/TUI/Model/Event.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/Event.hs
@@ -106,7 +106,7 @@ mainEvents = allKeyEvents $ \case
   ShowCESKDebugEvent -> "debug CESK"
   PauseEvent -> "pause"
   RunSingleTickEvent -> "run single tick"
-  IncreaseTpsEvent -> "increse TPS"
+  IncreaseTpsEvent -> "increase TPS"
   DecreaseTpsEvent -> "decrease TPS"
   FocusWorldEvent -> "focus World"
   FocusRobotEvent -> "focus Robot"

--- a/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
+++ b/src/swarm-tui/Swarm/TUI/Model/StateUpdate.hs
@@ -111,7 +111,7 @@ import Swarm.Util
 import Swarm.Util.Effect (asExceptT, withError)
 import System.Clock
 
--- | The resolution at which the animation manager checks animations for updates, in miliseconds
+-- | The resolution at which the animation manager checks animations for updates, in milliseconds
 animMgrTickDuration :: Int
 animMgrTickDuration = 33
 

--- a/src/swarm-util/Swarm/Pretty.hs
+++ b/src/swarm-util/Swarm/Pretty.hs
@@ -106,7 +106,7 @@ pparens True = group . encloseWithIndent 2 lparen rparen
 pparens False = id
 
 -- | Same as pparens but does not indent the lines. Only encloses
---   the document with parantheses.
+--   the document with parentheses.
 pparens' :: Bool -> Doc ann -> Doc ann
 pparens' True = group . enclose lparen rparen
 pparens' False = id

--- a/src/swarm-util/Swarm/Util/Effect.hs
+++ b/src/swarm-util/Swarm/Util/Effect.hs
@@ -27,12 +27,12 @@ withThrow f = runThrow >=> either (throwError . f) return
 withError :: (Has (Error e2) sig m) => (e1 -> e2) -> ErrorC e1 m a -> m a
 withError f = runError >=> either (throwError . f) return
 
--- | Transform a @Throw e@ constrint into a concrete @Maybe@,
+-- | Transform a @Throw e@ constraint into a concrete @Maybe@,
 --   discarding the error.
 throwToMaybe :: forall e m a. Functor m => ThrowC e m a -> m (Maybe a)
 throwToMaybe = fmap eitherToMaybe . runThrow
 
--- | Transform a @Throw e@ constrint into a concrete @Maybe@,
+-- | Transform a @Throw e@ constraint into a concrete @Maybe@,
 --   logging any error as a warning.
 throwToWarning :: (Has (Accum (Seq e)) sig m) => ThrowC e m a -> m (Maybe a)
 throwToWarning m = do

--- a/src/swarm-util/Swarm/Util/OccurrenceEncoder.hs
+++ b/src/swarm-util/Swarm/Util/OccurrenceEncoder.hs
@@ -44,7 +44,7 @@ getIndices (Encoder m) = map fst $ sortOn snd $ M.toList m
 
 -- | Translate each the first occurrence in the structure
 -- to a new integer as it is encountered.
--- Subsequent encounters re-use the allocated integer.
+-- Subsequent encounters reuse the allocated integer.
 encodeOccurrence :: Ord a => a -> OccurrenceEncoder a Int
 encodeOccurrence c = do
   Encoder currentMap <- get

--- a/tournament/scripts/docker/build-server-executable.sh
+++ b/tournament/scripts/docker/build-server-executable.sh
@@ -5,7 +5,7 @@
 #
 #    build-server-executable.sh <output binary location>
 #
-# Note that we use 'cabal' instead of 'stack' becuase
+# Note that we use 'cabal' instead of 'stack' because
 # 'stack' fails to compile the 'vty' package within the Amazon Linux docker image.
 
 BUILD_TARGET=swarm:swarm-host-tournament


### PR DESCRIPTION
Found via `codespell -S web,data -L
parms,failt,mapp,te,withe,drawin,shs,ue,expres,thn,countin,struc,wither,abd,schem,splitted`

