### PR TITLE
Add up direction to syntax

### DIFF
--- a/editors/emacs/swarm-mode.el
+++ b/editors/emacs/swarm-mode.el
@@ -132,6 +132,7 @@
       "west"
       "south"
       "down"
+      "up"
       "forward"
       "left"
       "back"

--- a/editors/vim/swarm.vim
+++ b/editors/vim/swarm.vim
@@ -1,7 +1,7 @@
 syn keyword Keyword def tydef rec end let in require stock
 syn keyword Builtins waypoint waypoints hastag tagmembers self parent base if inl inr case match force undefined default fail not format read chars split charat tochar key
 syn keyword Command noop wait selfdestruct move backup volume path push stride turn grab harvest sow ignite place ping give equip unequip make has equipped count drill use build salvage reprogram say listen log view appear create halt time scout whereami locateme structures floorplan detect resonate density sniff chirp watch surveil heading blocked scan upload ishere isempty meet meetall whoami setname random pure try print erase swap atomic instant installkeyhandler teleport warp as robotnamed robotnumbered knows destroy
-syn keyword Direction east north west south down forward left back right
+syn keyword Direction east north west south down up forward left back right
 syn match Type "\<[A-Z][a-zA-Z_]*\>"
 syn match Operators "[-=!<>|&+*/^$:]"
 

--- a/editors/vscode/syntaxes/swarm.tmLanguage.yaml
+++ b/editors/vscode/syntaxes/swarm.tmLanguage.yaml
@@ -86,7 +86,7 @@ repository:
       # cabal run swarm:swarm-docs -- editors --code
       # ---------------------------------------------
       - name: variable.language.dir
-        match: \b(east|north|west|south|down|forward|left|back|right)\b
+        match: \b(east|north|west|south|down|up|forward|left|back|right)\b
       - name: variable.parameter
         match: \b([a-z]\w*)\b
   parens:

--- a/src/swarm-topography/Swarm/Game/Location.hs
+++ b/src/swarm-topography/Swarm/Game/Location.hs
@@ -125,6 +125,9 @@ west = V2 (-1) 0
 down :: Heading
 down = zero
 
+up :: Heading
+up = zero
+
 -- | The 'applyTurn' function gives the meaning of each 'Direction' by
 --   turning relative to the given heading or by turning to an absolute
 --   heading.
@@ -141,6 +144,7 @@ applyTurn d = case d of
     DPlanar DBack -> negated
     DPlanar DForward -> id
     DDown -> const down
+    DUp -> const up
   DAbsolute e -> const $ toHeading e
 
 -- | Mapping from heading to their corresponding cardinal directions.

--- a/src/swarm-util/Swarm/Language/Syntax/Direction.hs
+++ b/src/swarm-util/Swarm/Language/Syntax/Direction.hs
@@ -92,7 +92,7 @@ instance FromJSONKey AbsoluteDir where
 -- | A relative direction is one which is defined with respect to the
 --   robot's frame of reference; no special capability is needed to
 --   use them.
-data RelativeDir = DPlanar PlanarRelativeDir | DDown
+data RelativeDir = DPlanar PlanarRelativeDir | DDown | DUp
   deriving (Eq, Ord, Show, Read, Generic, Data, Hashable)
 
 instance ToJSON RelativeDir where
@@ -142,4 +142,4 @@ isCardinal = \case
   _ -> False
 
 allDirs :: [Direction]
-allDirs = map DAbsolute enumerate <> map DRelative (DDown : map DPlanar enumerate)
+allDirs = map DAbsolute enumerate <> map DRelative (DDown : DUp : map DPlanar enumerate)

--- a/test/unit/TestEval.hs
+++ b/test/unit/TestEval.hs
@@ -315,6 +315,9 @@ testEval g =
             "read down"
             ("read @Dir \"down\"" `evaluatesTo` VDir (DRelative DDown))
         , testCase
+            "read up"
+            ("read @Dir \"up\"" `evaluatesTo` VDir (DRelative DUp))
+        , testCase
             "read text"
             ("read @Text \"\\\"hi\\\"\"" `evaluatesToV` ("hi" :: Text))
         , testCase


### PR DESCRIPTION
Implements #2591

Adds the `up` direction to the syntax as a noop.
Will be useful later for things that can be traversed both up and down.