### PR TITLE
List upcoming goals after active ones

### DIFF
--- a/src/swarm-tui/Swarm/TUI/View/Objective.hs
+++ b/src/swarm-tui/Swarm/TUI/View/Objective.hs
@@ -15,6 +15,7 @@ import Control.Lens hiding (Const, from)
 import Data.List (intercalate)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as M
+import Data.Maybe (mapMaybe)
 import Data.Vector qualified as V
 import Swarm.Game.Scenario.Objective
 import Swarm.Language.Syntax (Anchor, ImportPhaseFor, Phase (..), Syntax, Unresolvable)
@@ -31,8 +32,11 @@ makeListWidget :: GoalTracking -> BL.List Name GoalEntry
 makeListWidget (GoalTracking _announcements categorizedObjs) =
   BL.listMoveTo 1 $ BL.list (GoalWidgets ObjectivesList) (V.fromList objList) 1
  where
-  objList = intercalate [Spacer] $ map f $ M.toList categorizedObjs
-  f (h, xs) = Header h : map (Goal h) (NE.toList xs)
+  categoryDisplayOrder :: [GoalStatus]
+  categoryDisplayOrder = [Active, Upcoming, Completed, Failed]
+  objListList = mapMaybe (\cat -> (cat,) <$> M.lookup cat categorizedObjs) categoryDisplayOrder
+  objList = intercalate [Spacer] $ map itemize objListList
+  itemize (h, xs) = Header h : map (Goal h) (NE.toList xs)
 
 renderGoalsDisplay ::
   (Unresolvable (ImportPhaseFor phase), PrettyPrec (Anchor (ImportPhaseFor phase))) =>


### PR DESCRIPTION
Closes #1169, by implementing the second idea I listed there: fix an order in which to display goal categories and update the display code so it explicitly uses that order, rather than implicitly relying on the order in which the `GoalStatus` constructors were declared.  The downside is that if we were to ever add a new type of `GoalStatus` we would need to manually update that list in order to display those goals.  However, if someone adds a new goal type it should be obvious if those goals are not being displayed.

To see the difference, try first running
```
cabal run -O0 swarm:exe:swarm -- -i Testing/795-prerequisite/795-prerequisite-or
```
and note that the first highlighted goal is "Upcoming":
<img width="956" height="347" alt="before" src="https://github.com/user-attachments/assets/9b76e2e5-b665-4ab6-bdf8-c0d6df9cb180" />

Then, after applying this patch, run the same command; the first highlighted goal is now one of the "Active" ones:
<img width="956" height="347" alt="after" src="https://github.com/user-attachments/assets/43a697a5-4a77-45d8-ae2b-970d4de038d5" />
