### PR TITLE
mergify: remove deprecated `delete_head_brach` action

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -67,8 +67,3 @@ pull_request_rules:
   - label=merge me
   - ! '#approved-reviews-by>=1'
   - ! '#changes-requested-reviews-by=0'
-- actions:
-    delete_head_branch: {}
-  name: Delete head branch after merge
-  conditions:
-  - merged


### PR DESCRIPTION
See #2706.  The `delete_head_branch` action is deprecated.  As suggested, I have instead configured the repo to automatically delete head branches for closed PRs.

Closes #2706.