### PR TITLE
Remove `cabal.project` and add `lsp-types` constraint to `swarm.cabal`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,0 @@
-packages: .
-
-constraints:
-  # Required for build success with ghc-9.6 and ghc-9.8
-  # See https://github.com/swarm-game/swarm/issues/2713
-  lsp-types >= 2.1.1

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -242,7 +242,9 @@ common linear
 
 common lsp
   -- See https://github.com/swarm-game/swarm/issues/2713
-  build-depends: lsp-types >= 2.1.1, lsp >=2.4 && <2.8
+  build-depends:
+    lsp >=2.4 && <2.8,
+    lsp-types >=2.1.1,
 
 common megaparsec
   build-depends: megaparsec >=9.6.1 && <9.8

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -241,7 +241,8 @@ common linear
   build-depends: linear >=1.21.6 && <1.24
 
 common lsp
-  build-depends: lsp >=2.4 && <2.8
+  -- See https://github.com/swarm-game/swarm/issues/2713
+  build-depends: lsp-types >= 2.1.1, lsp >=2.4 && <2.8
 
 common megaparsec
   build-depends: megaparsec >=9.6.1 && <9.8


### PR DESCRIPTION
In the discussion on #2714 we discovered that `cabal.project` is apparently not being considered by our CI, so this PR removes it, and adds the `lsp-types` lower bound constraint to the common `lsp` section in the `swarm.cabal` file.  Technically we do not directly depend on `lsp-types`, but since we depend on it transitively, explicitly listing it as a dependency seems fine in order to express a lower bound on its version.