### PR TITLE
Fix broken Haskell course link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ standard container types like `Data.Set` and `Data.Map`. Being
 familiar with using `lens` will probably also help. If you'd like to
 learn enough Haskell to contribute to Swarm, we recommend starting by
 [working through these introductory Haskell course
-materials](https://www.cis.upenn.edu/~cis194/spring13/).
+materials](https://www.cis.upenn.edu/~cis1940/fall16/).
 
 If you'd like to contribute some code but are unsure where to begin,
 you can start by looking through [issues tagged "Low-Hanging


### PR DESCRIPTION
Replacement of the broken link  https://www.cis.upenn.edu/~cis194/spring13/ with https://www.cis.upenn.edu/~cis1940/fall16/.

The original link was broken because it should have been https://www.cis.upenn.edu/~cis1940/spring13/ instead. I replaced it with the Fall 2016 version of the course, with backlinks to earlier iterations.

There are also newer versions of the course available ([Fall 2018](https://www.cis.upenn.edu/~cis1940/fall18/), [Spring 2023](https://www.cis.upenn.edu/~cis1940/spring23/)), but the materials are incomplete or broken.