### PR TITLE
Make sure changes to nested imports get picked up

### DIFF
--- a/src/swarm-lang/Swarm/Language/Cache.hs
+++ b/src/swarm-lang/Swarm/Language/Cache.hs
@@ -9,6 +9,7 @@
 module Swarm.Language.Cache (
   moduleCache,
   moduleNeedsLoad,
+  moduleOutdated,
   module GC,
 )
 where
@@ -35,7 +36,7 @@ moduleCache = unsafePerformIO GC.newGlobalCache
 moduleNeedsLoad :: (Has (Lift IO) sig m) => ImportLoc Import.Resolved -> m Bool
 moduleNeedsLoad loc = do
   cached <- sendIO $ GC.lookupCached moduleCache loc
-  maybe (pure True) (isOutdated loc) cached
+  maybe (pure True) (moduleOutdated loc) cached
 
 -- | Check whether a module is outdated and needs to be reloaded +
 --   rechecked.  For local files, this is determined by comparing the
@@ -48,8 +49,8 @@ moduleNeedsLoad loc = do
 --   those loaded from local files.  If you want to pick up a change
 --   to a module imported from a URL, you can restart the entire app
 --   to clear the cache.
-isOutdated :: (Has (Lift IO) sig m) => ImportLoc Import.Resolved -> Module phase -> m Bool
-isOutdated cloc (moduleTimestamp -> mt) = case locToPath cloc of
+moduleOutdated :: (Has (Lift IO) sig m) => ImportLoc Import.Resolved -> Module phase -> m Bool
+moduleOutdated cloc (moduleTimestamp -> mt) = case locToPath cloc of
   -- URLs are never outdated
   URL {} -> pure False
   -- For local files, get the modification time and compare to

--- a/src/swarm-lang/Swarm/Language/Load.hs
+++ b/src/swarm-lang/Swarm/Language/Load.hs
@@ -27,6 +27,7 @@ import Control.Monad (forM_, when)
 import Data.Function ((&))
 import Data.Map.Ordered (OMap)
 import Data.Map.Ordered qualified as OM
+import Data.Maybe (isNothing)
 import Data.Set (Set)
 import Data.Set qualified as S
 import Data.Text (Text)
@@ -129,6 +130,11 @@ resolve ::
   Syntax Raw ->
   m (SourceMap Resolved, (LocalModules, Syntax Resolved))
 resolve prov s = do
+  -- First, remove any scale module cache entries, defined as those
+  -- which have an on-disk modification time more recent than the
+  -- cache timestamp, or which have any stale dependencies.
+  cullModuleCache
+
   cur <- resolveImportDir $
     case prov of
       Nothing -> currentDir
@@ -149,6 +155,51 @@ resolve prov s = do
 resolve' ::
   (Has (Throw SystemFailure) sig m) => Syntax Raw -> m (Syntax Resolved)
 resolve' = traverseSyntax pure (throwError . DisallowedImport)
+
+-- | Do a DFS through the module cache, removing any stale modules.  A
+--   stale module is defined as one which EITHER (a) has a
+--   modification time on disk newer than the cached timestamp, or (b)
+--   has a stale dependency.
+cullModuleCache ::
+  forall sig m.
+  (Has (Lift IO) sig m, Has (Throw SystemFailure) sig m) =>
+  m ()
+cullModuleCache = dfs =<< sendIO (GC.cacheKeys moduleCache)
+ where
+  dfs = evalState emptyImportSet . mapM_ cullRoot
+
+-- | Recursively cull stale modules from the module cache starting
+--   from a particular root, traversing the given root and all its
+--   transitive dependencies (which have not already been visited).
+--   Returns True if the root was culled.
+cullRoot :: (Has (Lift IO) sig m, Has (State VisitedModules) sig m) => ResolvedLoc -> m Bool
+cullRoot loc =
+  S.member loc <$> get @VisitedModules >>= \case
+    -- Root has already been visited: check if it is still in the
+    -- cache to see if it was culled.
+    True -> isNothing <$> sendIO (GC.lookupCached moduleCache loc)
+    -- Root has not been visited before.
+    False -> do
+      -- First, look it up in the module cache.
+      res <- sendIO (GC.lookupCached moduleCache loc)
+      case res of
+        -- (The Nothing case cannot actually happen, since cullRoot
+        -- will only be called on things that started out in the
+        -- module cache in the first place.)
+        Nothing -> pure True
+        Just m -> do
+          -- Recursively cull all its dependencies.
+          depsCulled <- or <$> mapM cullRoot (S.toList $ moduleImports m)
+          -- Check if the root is outdated.
+          outdated <- moduleOutdated loc m
+          -- We should cull the root if it is outdated OR any of its deps were culled.
+          let shouldCull = depsCulled || outdated
+          -- Cull the root if needed.
+          when shouldCull $ sendIO (GC.deleteCached moduleCache loc)
+          -- In any case, add the root to the visited set.
+          modify @VisitedModules $ S.insert loc
+          -- Report whether the root was culled.
+          pure shouldCull
 
 -- | Given a 'SourceMap' containing newly loaded + resolved modules,
 --   ensure that the resulting import graph contains no import cycles.

--- a/src/swarm-lang/Swarm/Language/Load.hs
+++ b/src/swarm-lang/Swarm/Language/Load.hs
@@ -159,12 +159,15 @@ resolve' = traverseSyntax pure (throwError . DisallowedImport)
 --   stale module is defined as one which EITHER (a) has a
 --   modification time on disk newer than the cached timestamp, or (b)
 --   has a stale dependency.
+--
+--   Note that we call cullRoot on *every* module, but all within the
+--   context of a global visited set---so cullRoot does nothing when
+--   called on a module that has already been visited.  Hence this is
+--   still O(n) in the size of the module cache.
 cullModuleCache :: (Has (Lift IO) sig m, Has (Throw SystemFailure) sig m) => m ()
-cullModuleCache = dfs =<< sendIO (GC.cacheKeys moduleCache)
- where
-  dfs = evalState emptyImportSet . mapM_ cullRoot
+cullModuleCache = evalState emptyImportSet $ mapM_ cullRoot =<< sendIO (GC.cacheKeys moduleCache)
 
--- | Recursively cull stale modules from the module cache starting
+-- | DFS to recursively cull stale modules from the module cache starting
 --   from a particular root, traversing the given root and all its
 --   transitive dependencies (which have not already been visited).
 --   Returns True if the root was culled.
@@ -176,7 +179,12 @@ cullRoot loc =
     True -> isNothing <$> sendIO (GC.lookupCached moduleCache loc)
     -- Root has not been visited before.
     False -> do
-      -- First, look it up in the module cache.
+      -- Add the root to the visited set.
+      modify @VisitedModules $ S.insert loc
+
+      -- Now look it up in the module cache --- in particular, we need
+      -- to know its immediate imports so we can recursively cull
+      -- them.
       res <- sendIO (GC.lookupCached moduleCache loc)
       case res of
         -- (The Nothing case cannot actually happen, since cullRoot
@@ -192,8 +200,6 @@ cullRoot loc =
           let shouldCull = depsCulled || outdated
           -- Cull the root if needed.
           when shouldCull $ sendIO (GC.deleteCached moduleCache loc)
-          -- In any case, add the root to the visited set.
-          modify @VisitedModules $ S.insert loc
           -- Report whether the root was culled.
           pure shouldCull
 

--- a/src/swarm-lang/Swarm/Language/Load.hs
+++ b/src/swarm-lang/Swarm/Language/Load.hs
@@ -130,9 +130,8 @@ resolve ::
   Syntax Raw ->
   m (SourceMap Resolved, (LocalModules, Syntax Resolved))
 resolve prov s = do
-  -- First, remove any scale module cache entries, defined as those
-  -- which have an on-disk modification time more recent than the
-  -- cache timestamp, or which have any stale dependencies.
+  -- First, remove any stale module cache entries, to make sure we get
+  -- the most up-to-date versions of everything.
   cullModuleCache
 
   cur <- resolveImportDir $
@@ -160,10 +159,7 @@ resolve' = traverseSyntax pure (throwError . DisallowedImport)
 --   stale module is defined as one which EITHER (a) has a
 --   modification time on disk newer than the cached timestamp, or (b)
 --   has a stale dependency.
-cullModuleCache ::
-  forall sig m.
-  (Has (Lift IO) sig m, Has (Throw SystemFailure) sig m) =>
-  m ()
+cullModuleCache :: (Has (Lift IO) sig m, Has (Throw SystemFailure) sig m) => m ()
 cullModuleCache = dfs =<< sendIO (GC.cacheKeys moduleCache)
  where
   dfs = evalState emptyImportSet . mapM_ cullRoot

--- a/src/swarm-util/Swarm/Util/GlobalCache.hs
+++ b/src/swarm-util/Swarm/Util/GlobalCache.hs
@@ -10,6 +10,7 @@ module Swarm.Util.GlobalCache (
   freezeCache,
   insertCached,
   deleteCached,
+  cacheKeys,
   resetCache,
 )
 where
@@ -26,6 +27,7 @@ data GlobalCache k v = GlobalCache
   , freezeCache :: IO (k -> Maybe v)
   , insertCached :: k -> v -> IO ()
   , deleteCached :: k -> IO ()
+  , cacheKeys :: IO [k]
   , resetCache :: IO ()
   }
 
@@ -43,6 +45,7 @@ newGlobalCache = do
       , freezeCache = freezeCacheImpl var
       , insertCached = insertCachedImpl var
       , deleteCached = deleteCachedImpl var
+      , cacheKeys = cacheKeysImpl var
       , resetCache = resetCachedImpl var
       }
  where
@@ -57,6 +60,9 @@ newGlobalCache = do
 
   deleteCachedImpl :: TVar (HashMap k v) -> k -> IO ()
   deleteCachedImpl var k = atomically $ modifyTVar' var (HashMap.delete k)
+
+  cacheKeysImpl :: TVar (HashMap k v) -> IO [k]
+  cacheKeysImpl var = HashMap.keys <$> readTVarIO var
 
   resetCachedImpl :: TVar (HashMap k v) -> IO ()
   resetCachedImpl var = atomically $ modifyTVar' var (const HashMap.empty)


### PR DESCRIPTION
Fixes #2725.  Every time we process some new top-level source code, first do a DFS through the module cache and remove any modules which have been modified on disk more recently than the cached version, OR which depend (transitively) on any such outdated module.  This guarantees that if e.g. `a` imports `b` and then `b` is changed, importing `a` will automatically pick up the new version of `b`.