### PR TITLE
Fix Accum effect stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ package.json
 *.eventlog
 *.eventlog.html
 *.prof
+
+example/long_import/*.sw

--- a/example/long_import/README.md
+++ b/example/long_import/README.md
@@ -1,0 +1,8 @@
+# Benchmark long import chains
+
+This folder is filled with generated chain of imports when running benchmarks.
+The files look like:
+```
+import "a_009"
+def a_010 = 1 + a_009 end
+```

--- a/src/swarm-lang/Swarm/Language/Cache.hs
+++ b/src/swarm-lang/Swarm/Language/Cache.hs
@@ -9,6 +9,7 @@
 module Swarm.Language.Cache (
   moduleCache,
   moduleNeedsLoad,
+  module GC,
 )
 where
 

--- a/src/swarm-lang/Swarm/Language/Load.hs
+++ b/src/swarm-lang/Swarm/Language/Load.hs
@@ -17,9 +17,8 @@ module Swarm.Language.Load (
 where
 
 import Control.Algebra (Has)
-import Control.Carrier.Accum.Strict (runAccum)
+import Control.Carrier.Accum.Strict (AccumC (..), runAccum)
 import Control.Carrier.State.Strict (evalState, runState)
-import Control.Effect.Accum (Accum, add)
 import Control.Effect.Lift (Lift, sendIO)
 import Control.Effect.State (State, get, modify)
 import Control.Effect.Throw (Throw, throwError)
@@ -213,26 +212,31 @@ resolveImports parent = runAccum emptyImportSet . traverseSyntax pure (resolveIm
 --   location, and add it to the ambient @Accum@ effect which is
 --   keeping track of all imports seen in a given module.
 --
---   See Note [Module loading] for an overview.
+-- See Note [Module loading] for an overview.
+--
+-- #### WARNING [#2729](https://github.com/swarm-game/swarm/issues/2729):
+-- Note that 'AccumC' is "popped" here. It only passes information
+-- to 'resolveImport' and it /must not/ be added to the effect stack.
+-- Otherwise the monad transformers keep adding up with each transitive import
+-- and the IO operations at the bottom of the stack slow to a crawl.
 resolveImport ::
   forall sig m.
   ( Has (Throw SystemFailure) sig m
   , Has (State (SourceMap Resolved)) sig m
   , Has (State VisitedModules) sig m
-  , Has (Accum LocalModules) sig m
   , Has (Lift IO) sig m
   ) =>
   ImportDir Import.Resolved ->
   ImportLoc Import.Raw ->
-  m ResolvedLoc
-resolveImport parent loc = do
+  AccumC LocalModules m ResolvedLoc
+resolveImport parent loc = AccumC $ \w -> do
   -- Compute the canonicalized location for the import, and record it
   canonicalLoc <- resolveImportLoc (unresolveImportDir parent <//> loc)
 
   -- Accumulate the resolved import location; this is used in
   -- 'resolveImports' to collect the set of all imports of a given
   -- module.
-  add @LocalModules $ S.singleton canonicalLoc
+  let w' = S.insert canonicalLoc w
 
   -- Check whether the module needs to be loaded (either because it is
   -- not in the cache, or the version on disk is newer than the
@@ -241,7 +245,7 @@ resolveImport parent loc = do
 
   -- If it does, import it and stick it in the ambient SourceMap.
   when needsLoad $ importModule canonicalLoc
-  pure canonicalLoc
+  pure (w', canonicalLoc)
 
 -- | Load a module from a specific import location, i.e. from disk or
 --   over the network, as well as recursively loading any modules it

--- a/src/swarm-util/Swarm/Util/GlobalCache.hs
+++ b/src/swarm-util/Swarm/Util/GlobalCache.hs
@@ -10,6 +10,7 @@ module Swarm.Util.GlobalCache (
   freezeCache,
   insertCached,
   deleteCached,
+  resetCache,
 )
 where
 
@@ -25,6 +26,7 @@ data GlobalCache k v = GlobalCache
   , freezeCache :: IO (k -> Maybe v)
   , insertCached :: k -> v -> IO ()
   , deleteCached :: k -> IO ()
+  , resetCache :: IO ()
   }
 
 -- | Create a new (empty) GlobalCache.
@@ -41,6 +43,7 @@ newGlobalCache = do
       , freezeCache = freezeCacheImpl var
       , insertCached = insertCachedImpl var
       , deleteCached = deleteCachedImpl var
+      , resetCache = resetCachedImpl var
       }
  where
   lookupCachedImpl :: TVar (HashMap k v) -> k -> IO (Maybe v)
@@ -54,3 +57,6 @@ newGlobalCache = do
 
   deleteCachedImpl :: TVar (HashMap k v) -> k -> IO ()
   deleteCachedImpl var k = atomically $ modifyTVar' var (HashMap.delete k)
+
+  resetCachedImpl :: TVar (HashMap k v) -> IO ()
+  resetCachedImpl var = atomically $ modifyTVar' var (const HashMap.empty)

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -1469,6 +1469,7 @@ benchmark benchmark
     text,
 
   main-is: Benchmark.hs
+  other-modules: ImportChain
   hs-source-dirs: test/bench
   ghc-options:
     -hiedir=.hie/test/bench

--- a/test/bench/Benchmark.hs
+++ b/test/bench/Benchmark.hs
@@ -13,6 +13,7 @@ import Data.Map qualified as M
 import Data.Sequence (Seq)
 import Data.Text qualified as T
 import Data.Tuple.Extra (dupe)
+import ImportChain
 import Swarm.Effect (runCacheIO, runMetricIO, runTimeIO)
 import Swarm.Failure (SystemFailure, simpleErrorHandle)
 import Swarm.Game.CESK (initMachine)
@@ -171,6 +172,7 @@ main = do
   movers <- mkGameStates robotNumbers moverProgram
   wavesInlined <- mkGameStates robotNumbers $ waveProgram True
   wavesWithDef <- mkGameStates robotNumbers $ waveProgram False
+  genImportChain
   -- In theory we should force the evaluation of these game states to normal
   -- form before running the benchmarks. In practice, the first of the many
   -- criterion runs for each of these benchmarks doesn't look like an outlier.
@@ -191,6 +193,7 @@ main = do
                 )
             ]
         ]
+    , benchImportChain
     ]
  where
   bgroupTicks label ticks bots =

--- a/test/bench/ImportChain.hs
+++ b/test/bench/ImportChain.hs
@@ -4,7 +4,7 @@ module ImportChain (benchImportChain, genImportChain) where
 import Control.Carrier.Error.Either (runError)
 import Control.Carrier.Lift (runM)
 import Control.Monad (forM_)
-import Data.Text.IO.Utf8 qualified as T8
+import Data.Text.IO qualified as T -- GHC >9.6 use .Utf8
 import Swarm.Failure (SystemFailure)
 import Swarm.Language.Cache
 import Swarm.Language.Module (Module)
@@ -33,7 +33,7 @@ importFile :: Int -> IO (Module Elaborated)
 importFile i = do
   let path = pathA i
   resetCache moduleCache
-  importText <- T8.readFile path
+  importText <- T.readFile path
   res <- runM . runError @SystemFailure $ processSource (Just path) Nothing importText
   case res of
     Left e -> fail $ "Failed to process " <> path <> ": " <> prettyString e

--- a/test/bench/ImportChain.hs
+++ b/test/bench/ImportChain.hs
@@ -10,6 +10,8 @@ import Swarm.Language.Module (Module)
 import Swarm.Language.Pipeline (processSource)
 import Swarm.Language.Syntax (Elaborated)
 import Swarm.Pretty (prettyString)
+import Swarm.Language.Cache
+import Swarm.Util.GlobalCache
 import Test.Tasty.Bench (Benchmark, bench, bgroup, whnfAppIO)
 
 benchImportChain :: Benchmark
@@ -19,6 +21,8 @@ benchImportChain =
     [ bench "import a_000" $ whnfAppIO importFile 0
     , bench "import a_001" $ whnfAppIO importFile 1
     , bench "import a_010" $ whnfAppIO importFile 10
+    , bench "import a_020" $ whnfAppIO importFile 20
+    , bench "import a_050" $ whnfAppIO importFile 50
     , bench "import a_100" $ whnfAppIO importFile 100
     ]
 
@@ -28,6 +32,7 @@ longImports = "example/long_import/"
 importFile :: Int -> IO (Module Elaborated)
 importFile i = do
   let path = pathA i
+  resetCache moduleCache
   importText <- T8.readFile path
   res <- runM . runError @SystemFailure $ processSource (Just path) Nothing importText
   case res of

--- a/test/bench/ImportChain.hs
+++ b/test/bench/ImportChain.hs
@@ -1,0 +1,51 @@
+{- HLINT ignore "Avoid restricted function" -}
+module ImportChain (benchImportChain, genImportChain) where
+
+import Control.Carrier.Error.Either (runError)
+import Control.Carrier.Lift (runM)
+import Control.Monad (forM_)
+import Data.Text.IO.Utf8 qualified as T8
+import Swarm.Failure (SystemFailure)
+import Swarm.Language.Module (Module)
+import Swarm.Language.Pipeline (processSource)
+import Swarm.Language.Syntax (Elaborated)
+import Swarm.Pretty (prettyString)
+import Test.Tasty.Bench (Benchmark, bench, bgroup, whnfAppIO)
+
+benchImportChain :: Benchmark
+benchImportChain =
+  bgroup
+    "Import chain"
+    [ bench "import a_000" $ whnfAppIO importFile 0
+    , bench "import a_001" $ whnfAppIO importFile 1
+    , bench "import a_010" $ whnfAppIO importFile 10
+    , bench "import a_100" $ whnfAppIO importFile 100
+    ]
+
+longImports :: String
+longImports = "example/long_import/"
+
+importFile :: Int -> IO (Module Elaborated)
+importFile i = do
+  let path = pathA i
+  importText <- T8.readFile path
+  res <- runM . runError @SystemFailure $ processSource (Just path) Nothing importText
+  case res of
+    Left e -> fail $ "Failed to process " <> path <> ": " <> prettyString e
+    Right v -> pure v
+
+genImportChain :: IO ()
+genImportChain = do
+  writeFile (pathA 0) "def a_000 = 0 end\n"
+  forM_ [1 .. 100] $ \i ->
+    writeFile (pathA i) $
+      unlines
+        [ "import \"" <> fmtA (i - 1) <> "\""
+        , unwords ["def", fmtA i, "= 1 +", fmtA (i - 1), "end"]
+        ]
+
+fmtA :: Int -> String
+fmtA i = let x = show i in "a_" <> replicate (3 - length x) '0' <> x
+
+pathA :: Int -> String
+pathA i = longImports <> "/" <> fmtA i <> ".sw"

--- a/test/bench/ImportChain.hs
+++ b/test/bench/ImportChain.hs
@@ -6,11 +6,11 @@ import Control.Carrier.Lift (runM)
 import Control.Monad (forM_)
 import Data.Text.IO.Utf8 qualified as T8
 import Swarm.Failure (SystemFailure)
+import Swarm.Language.Cache
 import Swarm.Language.Module (Module)
 import Swarm.Language.Pipeline (processSource)
 import Swarm.Language.Syntax (Elaborated)
 import Swarm.Pretty (prettyString)
-import Swarm.Language.Cache
 import Swarm.Util.GlobalCache
 import Test.Tasty.Bench (Benchmark, bench, bgroup, whnfAppIO)
 


### PR DESCRIPTION
* use `AccumC` constructor directly
* add warning to docs
* add benchmarks

|  | 0 | 1 | 10 | 20 | 50 | 100 |
|:--:|-:|-:|-:|-:|-:|-:|
| before | 0.0004s | 0.001s | 0.033s | 20.722s | ? | ? |
| after | 0.0004s | 0.001s | 0.012s | 0.026s | 0.066s | 0.132s |

It seems the inner operations had to go through a stack of Accum effects that they did not need.
The solution is to use the effect just between parent and child, leaving grand children alone.

Why was this _exponentially_ slower? I am not sure, maybe it is how fused-effects work. I think they are only performant for statically known effect stacks that can be inlined and skipped. What we created was a growing runtime list of effects.

Closes #2729