### PR TITLE
ci(mergify): replace deprecated `commit_message_template`

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,10 +1,9 @@
 queue_rules:
   - name: default
     merge_method: squash
-    commit_message_template: |
-      {{ title }} (#{{ number }})
-
-      {{ body }}
+    commit_message_format:
+      title: pr-title
+      body: pr-body
     queue_conditions:
       - or:
         - and:


### PR DESCRIPTION
See https://docs.mergify.com/workflow/actions/merge/#migrating-from-commit_message_template.  Closes #2750.  Closes #2749.