### PR TITLE
Recurse through import+export in `pathToPosition`

### DIFF
--- a/src/swarm-lang/Swarm/Language/LSP/Position.hs
+++ b/src/swarm-lang/Swarm/Language/LSP/Position.hs
@@ -131,8 +131,8 @@ pathToPosition s0 pos = s0 :| fromMaybe [] (innerPath s0)
     SRequirements _ s -> d s
     SParens s -> d s
     -- TODO (#2660): what to do with import here?
-    SImportIn {} -> mempty
-    SExportIn {} -> mempty
+    SImportIn _ _ s -> d s
+    SExportIn _ s -> d s
     -- atoms - return their position and end recursion
     TUnit -> mempty
     TConst {} -> mempty

--- a/test/integration/TestScenarioSolutions.hs
+++ b/test/integration/TestScenarioSolutions.hs
@@ -309,7 +309,7 @@ customTimeoutScenarios =
     , "Challenges/Algorithmic/dimsum" ==> 20
     , "Challenges/Algorithmic/gallery" ==> 30
     , "Challenges/Mechanics/telephone" ==> 40
-    , "Challenges/Story/flower-count" ==> 30
+    , "Challenges/Story/flower-count" ==> 40
     , "Challenges/Mechanics/photocopier" ==> 40
     , "Challenges/Mazes/invisible_maze" ==> 2
     , "Challenges/Story/Ranching/beekeeping" ==> 100


### PR DESCRIPTION
When I added import + export, I wasn't sure how to handle things like jump-to-position for imports (I'm still not), so in the `pathToPosition` function I added cases for import/export that just return `mempty`.  However, this was *definitely* not the right thing to do.  It means that for any file that begins with an `import`, things like hover + jump-to-def are completely broken.  Instead, we ought to simply ignore import/export and recurse through into their bodies when searching for a position.

If you want to see the effect of this change in action:
1. Before applying this change, open a `.sw` file beginning with an `import`, and try hovering over an identifier in the file.  Rather than highlighting the identifier and showing its type etc., the entire file will be highlighted.
2. Now apply this change and make sure it is installed in the executable that is used by LSP.
3. Now hovering over things in a file beginning with an import should work better (although many types will still be shown with a `?`, but that is another issue).