### PR TITLE
Shorten parse error "expected..."

### DIFF
--- a/src/swarm-lang/Swarm/Language/Parser/Term.hs
+++ b/src/swarm-lang/Swarm/Language/Parser/Term.hs
@@ -65,13 +65,13 @@ parseTermAtom = do
 parseTermAtom2 :: Parser (Syntax Raw)
 parseTermAtom2 =
   parseLoc
-    ( TUnit <$ symbol "()"
+    ( TUnit <$ (symbol "()" <?> "unit literal")
         <|> TConst <$> parseConst
         <|> TVar <$> tmVar
         <|> TDir <$> parseDirection
         <|> TInt <$> integer
         <|> TText <$> textLiteral
-        <|> TBool <$> ((True <$ reserved "true") <|> (False <$ reserved "false"))
+        <|> TBool <$> ((True <$ reserved "true") <|> (False <$ reserved "false") <?> "boolean literal")
         <|> reserved "require" *> parseRequire
         <|> reserved "stock" *> parseStock
         <|> uncurry SRequirements <$> (reserved "requirements" *> match parseTerm)
@@ -80,17 +80,17 @@ parseTermAtom2 =
           <*> optional (symbol ":" *> parseType)
           <*> (symbol "." *> parseTerm)
         <|> sLet LSLet
-          <$> (reserved "let" *> locTmVar)
+          <$> (reserved "let" *> locTmVar <?> "binding")
           <*> optional (symbol ":" *> parsePolytype)
           <*> (symbol "=" *> parseTerm)
           <*> (reserved "in" *> parseTerm)
         <|> do
-          reserved "def"
+          reserved "def" <?> "binding"
           locVar@(Loc _srcLoc nameText) <- locTmVar
           mTy <- optional (symbol ":" *> parsePolytype)
           _ <- symbol "="
           body <- parseTerm
-          reserved "end" <?> ("'end' keyword for definition of '" <> T.unpack nameText <> "'")
+          reserved "end" <?> ("\"end\" keyword for definition of '" <> T.unpack nameText <> "'")
           rest <- optional (symbol ";") *> (parseTerm <|> (eof $> sNoop))
           return $ sLet LSDef locVar mTy body rest
         <|> STydef
@@ -221,7 +221,7 @@ binOps = M.unionsWith (++) $ mapMaybe binOpToTuple allConst
     pure $
       M.singleton
         (fixity ci)
-        [assI (mkOp c <$> parseLocG (operator (syntax ci)))]
+        [assI (mkOp c <$> parseLocG (operator (syntax ci)) <?> "operator")]
 
 -- | Precedences and parsers of unary operators (currently only 'Neg').
 --
@@ -239,7 +239,7 @@ unOps = M.unionsWith (++) $ mapMaybe unOpToTuple allConst
     pure $
       M.singleton
         (fixity ci)
-        [assI (exprLoc1 $ SApp (noLoc $ TConst c) <$ operator (syntax ci))]
+        [assI (exprLoc1 . label "operator" $ SApp (noLoc $ TConst c) <$ operator (syntax ci))]
 
   -- combine location for ExprParser
   exprLoc1 :: Parser (Syntax Raw -> Term Raw) -> Parser (Syntax Raw -> Syntax Raw)

--- a/test/unit/TestLanguagePipeline.hs
+++ b/test/unit/TestLanguagePipeline.hs
@@ -751,7 +751,7 @@ testLanguagePipeline =
             "missing end"
             ( process
                 "def x = 3;\n def y = 3 end;\n def z = 3 end"
-                "3:15:\n  |\n3 |  def z = 3 end\n  |               ^\nunexpected end of input\nexpecting \"!=\", \"&&\", \"()\", \"++\", \"<=\", \"==\", \">=\", \"def\", \"export\", \"false\", \"import\", \"let\", \"require\", \"requirements\", \"stock\", \"true\", \"tydef\", \"||\", '\"', '$', '(', '*', '+', '-', '.', '/', ':', ';', '<', '>', '@', '[', '\\', '^', 'end' keyword for definition of 'x', '{', built-in user function, direction constant, integer literal, or variable name\n"
+                "3:15:\n  |\n3 |  def z = 3 end\n  |               ^\nunexpected end of input\nexpecting \"end\" keyword for definition of 'x', \"export\", \"import\", \"require\", \"requirements\", \"stock\", \"tydef\", '\"', '(', '.', ':', ';', '@', '[', '\\', '{', binding, boolean literal, built-in user function, direction constant, integer literal, operator, unit literal, or variable name\n"
             )
         ]
     , testGroup


### PR DESCRIPTION
* label operators just as "operator"
* use double quotes for `end` so that it gets sorted first
* label unit literal `()` (would have been before `"end"`)
* label `let`/`def` bindings (would have been before `"end"`)
* Closes #2676