### PR TITLE
Use Vector.Strict in TyConF to avoid space leak

### DIFF
--- a/src/swarm-engine/Swarm/Game/Scenario/Objective/WinCheck.hs
+++ b/src/swarm-engine/Swarm/Game/Scenario/Objective/WinCheck.hs
@@ -9,7 +9,6 @@ module Swarm.Game.Scenario.Objective.WinCheck where
 import Control.Lens (andOf, view, (^.), (^..))
 import Data.Aeson (ToJSON)
 import Data.BoolExpr qualified as BE
-import Data.BoolExpr.Simplify qualified as Simplify
 import Data.List (partition)
 import Data.Map qualified as M
 import Data.Set (Set)
@@ -17,6 +16,7 @@ import Data.Set qualified as Set
 import GHC.Generics (Generic)
 import Servant.Docs (ToSample)
 import Servant.Docs qualified as SD
+import Swarm.Data.BoolExpr.Simplify qualified as Simplify
 import Swarm.Game.Scenario.Objective
 import Swarm.Game.Scenario.Objective.Graph (getDistinctConstants)
 import Swarm.Game.Scenario.Objective.Logic as L

--- a/src/swarm-lang/Swarm/Language/SmallVector.hs
+++ b/src/swarm-lang/Swarm/Language/SmallVector.hs
@@ -1,0 +1,57 @@
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Strict small vector type to save on allocations, specifically for type parameters.
+-- Most swarm functions will not have more than two parameters.
+module Swarm.Language.SmallVector (
+  SmallVector,
+  toList,
+  fromList,
+) where
+
+import Data.Data (Data)
+import Data.Functor.Classes (Eq1 (..), Ord1 (liftCompare), Show1 (..))
+import Data.Hashable (Hashable (..))
+import Data.Hashable.Lifted (Hashable1 (..))
+import Data.Vector.Instances ()
+import Data.Vector.Strict (Vector)
+import Data.Vector.Strict qualified as Vec
+import GHC.Generics (Generic, Generic1)
+
+data SmallVector a = Nil | One a | Two a a | Three a a a | Many (Vector a)
+  deriving (Functor, Foldable, Traversable, Generic, Generic1, Data, Hashable, Hashable1)
+
+toList :: SmallVector a -> [a]
+toList = \case
+  Nil -> []
+  One a -> [a]
+  Two a b -> [a, b]
+  Three a b c -> [a, b, c]
+  Many v -> Vec.toList v
+
+fromList :: [a] -> SmallVector a
+fromList = \case
+  [] -> Nil
+  [a] -> One a
+  [a, b] -> Two a b
+  [a, b, c] -> Three a b c
+  l -> Many $ Vec.fromList l
+
+instance Eq a => Eq (SmallVector a) where
+  v1 == v2 = toList v1 == toList v2
+
+instance Ord a => Ord (SmallVector a) where
+  compare v1 v2 = compare (toList v1) (toList v2)
+
+instance Show a => Show (SmallVector a) where
+  show = show . toList
+
+instance Eq1 SmallVector where
+  liftEq p v1 v2 = liftEq p (toList v1) (toList v2)
+
+instance Ord1 SmallVector where
+  liftCompare p v1 v2 = liftCompare p (toList v1) (toList v2)
+
+instance Show1 SmallVector where
+  liftShowsPrec a b c v = liftShowsPrec a b c (toList v)
+  liftShowList a b vs = liftShowList a b (map toList vs)

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -164,10 +164,10 @@ import Effectful.Error.Static
 import Effectful.Reader.Static
 import GHC.Generics (Generic, Generic1)
 import Prettyprinter (align, braces, brackets, concatWith, flatAlt, hsep, pretty, punctuate, softline, (<+>))
+import Swarm.Data.SmallVector (SmallVector)
+import Swarm.Data.SmallVector qualified as SVec
 import Swarm.Language.Context (Ctx)
 import Swarm.Language.Context qualified as Ctx
-import Swarm.Language.SmallVector (SmallVector)
-import Swarm.Language.SmallVector qualified as SVec
 import Swarm.Language.Syntax.Import (ImportLoc, ImportPhase (Resolved))
 import Swarm.Language.TDVar (TDVar (..), mkTDVar, setVersion)
 import Swarm.Language.Var (Var)

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -22,6 +23,7 @@ module Swarm.Language.Types (
 
   -- ** Type structure functor
   TypeF (..),
+  pattern TyConF,
 
   -- ** Recursive types
   Nat (..),
@@ -145,7 +147,7 @@ import Data.Fix
 import Data.Foldable (fold)
 import Data.Functor.Classes (Eq1)
 import Data.Hashable (Hashable (..))
-import Data.Hashable.Lifted (Hashable1)
+import Data.Hashable.Lifted (Hashable1 (..))
 import Data.Kind qualified
 import Data.List.NonEmpty ((<|))
 import Data.List.NonEmpty qualified as NE
@@ -157,6 +159,8 @@ import Data.Set qualified as S
 import Data.String (IsString (..))
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Vector.Strict (Vector)
+import Data.Vector.Strict qualified as Vec
 import Effectful
 import Effectful.Error.Static
 import Effectful.Reader.Static
@@ -286,7 +290,7 @@ data TypeF t
     --   saturated (higher kinds are not supported), so we just
     --   directly store a list of all arguments (as opposed to
     --   iterating binary application).
-    TyConF TyCon [t]
+    TyConVF TyCon (Vector t)
   | -- | A type variable.  The first Var represents the original name,
     --   and should be ignored except for use in e.g. error messages.
     --   The second Var is the real name of the variable; it may be the
@@ -303,6 +307,22 @@ data TypeF t
     --   via de Bruijn indices.
     TyRecF Var t
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic, Generic1, Data, Hashable)
+
+pattern TyConF :: TyCon -> [t] -> TypeF t
+pattern TyConF t ts <- TyConVF t (Vec.toList -> ts)
+  where
+    TyConF t ts = TyConVF t (Vec.fromList ts)
+
+{-# COMPLETE TyConF, TyVarF, TyRcdF, TyRecVarF, TyRecF #-}
+
+-- TODO: replace with import Data.Vector.Instances
+instance (Hashable a) => Hashable (Vector a) where
+  hashWithSalt salt = hashWithSalt salt . Vec.toList
+  {-# INLINE hashWithSalt #-}
+
+instance Hashable1 Vector where
+  liftHashWithSalt itemHashWithSalt salt = liftHashWithSalt itemHashWithSalt salt . Vec.toList
+  {-# INLINE liftHashWithSalt #-}
 
 deriveEq1 ''TypeF
 deriveOrd1 ''TypeF

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -145,7 +145,7 @@ import Data.Data.Lens (uniplate)
 import Data.Eq.Deriving (deriveEq1)
 import Data.Fix
 import Data.Foldable (fold)
-import Data.Functor.Classes (Eq1)
+import Data.Functor.Classes (Eq1 (..))
 import Data.Hashable (Hashable (..))
 import Data.Hashable.Lifted (Hashable1 (..))
 import Data.Kind qualified
@@ -159,8 +159,6 @@ import Data.Set qualified as S
 import Data.String (IsString (..))
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Vector.Strict (Vector)
-import Data.Vector.Strict qualified as Vec
 import Effectful
 import Effectful.Error.Static
 import Effectful.Reader.Static
@@ -168,6 +166,8 @@ import GHC.Generics (Generic, Generic1)
 import Prettyprinter (align, braces, brackets, concatWith, flatAlt, hsep, pretty, punctuate, softline, (<+>))
 import Swarm.Language.Context (Ctx)
 import Swarm.Language.Context qualified as Ctx
+import Swarm.Language.SmallVector (SmallVector)
+import Swarm.Language.SmallVector qualified as SVec
 import Swarm.Language.Syntax.Import (ImportLoc, ImportPhase (Resolved))
 import Swarm.Language.TDVar (TDVar (..), mkTDVar, setVersion)
 import Swarm.Language.Var (Var)
@@ -285,12 +285,9 @@ natToInt (NS n) = 1 + natToInt n
 --   so that we can easily use generic recursion schemes to implement
 --   things like substitution.
 data TypeF t
-  = -- | A type constructor applied to some type arguments. For now,
-    --   all type constructor applications are required to be fully
-    --   saturated (higher kinds are not supported), so we just
-    --   directly store a list of all arguments (as opposed to
-    --   iterating binary application).
-    TyConVF TyCon (Vector t)
+  = -- | A type constructor applied to some type arguments.
+    --   See the pattern synonym 'TyConF'.
+    TyConVF TyCon (SmallVector t)
   | -- | A type variable.  The first Var represents the original name,
     --   and should be ignored except for use in e.g. error messages.
     --   The second Var is the real name of the variable; it may be the
@@ -308,21 +305,20 @@ data TypeF t
     TyRecF Var t
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic, Generic1, Data, Hashable)
 
+-- | A type constructor applied to some type arguments. For now,
+--   all type constructor applications are required to be fully
+--   saturated (higher kinds are not supported), so we just
+--   directly store a list of all arguments (as opposed to
+--   iterating binary application).
+--
+--   Note that this is a pattern for easier matching on lists.
+--   See 'TyConVF' which uses 'SmallVector' for storage.
 pattern TyConF :: TyCon -> [t] -> TypeF t
-pattern TyConF t ts <- TyConVF t (Vec.toList -> ts)
+pattern TyConF t ts <- TyConVF t (SVec.toList -> ts)
   where
-    TyConF t ts = TyConVF t (Vec.fromList ts)
+    TyConF t ts = TyConVF t (SVec.fromList ts)
 
 {-# COMPLETE TyConF, TyVarF, TyRcdF, TyRecVarF, TyRecF #-}
-
--- TODO: replace with import Data.Vector.Instances
-instance (Hashable a) => Hashable (Vector a) where
-  hashWithSalt salt = hashWithSalt salt . Vec.toList
-  {-# INLINE hashWithSalt #-}
-
-instance Hashable1 Vector where
-  liftHashWithSalt itemHashWithSalt salt = liftHashWithSalt itemHashWithSalt salt . Vec.toList
-  {-# INLINE liftHashWithSalt #-}
 
 deriveEq1 ''TypeF
 deriveOrd1 ''TypeF

--- a/src/swarm-util/Swarm/Data/BoolExpr/Simplify.hs
+++ b/src/swarm-util/Swarm/Data/BoolExpr/Simplify.hs
@@ -3,7 +3,7 @@
 --
 -- Simplification logic for boolean expressions that is not
 -- provided in the 'boolexpr' package.
-module Data.BoolExpr.Simplify (
+module Swarm.Data.BoolExpr.Simplify (
   cannotBeTrue,
   replace,
 ) where

--- a/src/swarm-util/Swarm/Data/SmallVector.hs
+++ b/src/swarm-util/Swarm/Data/SmallVector.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE TypeFamilies #-}
+
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Strict small vector type to save on allocations, specifically for type parameters.
+-- Strict small vector type to save on allocations, created for type parameters.
 -- Most swarm functions will not have more than two parameters.
-module Swarm.Language.SmallVector (
+module Swarm.Data.SmallVector (
   SmallVector,
   toList,
   fromList,
@@ -16,9 +18,11 @@ import Data.Hashable.Lifted (Hashable1 (..))
 import Data.Vector.Instances ()
 import Data.Vector.Strict (Vector)
 import Data.Vector.Strict qualified as Vec
+import GHC.Exts qualified as GHC (IsList (..))
 import GHC.Generics (Generic, Generic1)
 
-data SmallVector a = Nil | One a | Two a a | Three a a a | Many (Vector a)
+-- | Strict vector optimized for less than three elements.
+data SmallVector a = Nil | One a | Two a a | Many (Vector a)
   deriving (Functor, Foldable, Traversable, Generic, Generic1, Data, Hashable, Hashable1)
 
 toList :: SmallVector a -> [a]
@@ -26,16 +30,22 @@ toList = \case
   Nil -> []
   One a -> [a]
   Two a b -> [a, b]
-  Three a b c -> [a, b, c]
   Many v -> Vec.toList v
+{-# INLINE toList #-}
 
 fromList :: [a] -> SmallVector a
 fromList = \case
   [] -> Nil
   [a] -> One a
   [a, b] -> Two a b
-  [a, b, c] -> Three a b c
   l -> Many $ Vec.fromList l
+{-# INLINE fromList #-}
+
+-- instance for OverloadedLists
+instance GHC.IsList (SmallVector a) where
+  type Item (SmallVector a) = a
+  fromList = fromList
+  toList = toList
 
 instance Eq a => Eq (SmallVector a) where
   v1 == v2 = toList v1 == toList v2

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -469,7 +469,6 @@ library swarm-lang
     time,
     unicode-show,
     vector,
-    vector-instances,
     vty,
     witch,
     yaml,
@@ -513,7 +512,6 @@ library swarm-lang
     Swarm.Language.Requirements
     Swarm.Language.Requirements.Analysis
     Swarm.Language.Requirements.Type
-    Swarm.Language.SmallVector
     Swarm.Language.Syntax
     Swarm.Language.Syntax.AST
     Swarm.Language.Syntax.CommandMetadata
@@ -976,6 +974,7 @@ library swarm-util
     transformers,
     unordered-containers,
     vector,
+    vector-instances,
     witch,
     witherable,
     yaml,
@@ -983,7 +982,8 @@ library swarm-util
   visibility: public
   -- cabal-gild: discover src/swarm-util
   exposed-modules:
-    Data.BoolExpr.Simplify
+    Swarm.Data.BoolExpr.Simplify
+    Swarm.Data.SmallVector
     Swarm.Effect
     Swarm.Effect.Accum.Local
     Swarm.Effect.Cache

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -402,6 +402,9 @@ common utf8-string
 common vector
   build-depends: vector >=0.12 && <0.14
 
+common vector-instances
+  build-depends: vector-instances >=3.4 && <3.5
+
 common vty
   build-depends: vty >=6.1 && <6.6
 
@@ -466,6 +469,7 @@ library swarm-lang
     time,
     unicode-show,
     vector,
+    vector-instances,
     vty,
     witch,
     yaml,
@@ -509,6 +513,7 @@ library swarm-lang
     Swarm.Language.Requirements
     Swarm.Language.Requirements.Analysis
     Swarm.Language.Requirements.Type
+    Swarm.Language.SmallVector
     Swarm.Language.Syntax
     Swarm.Language.Syntax.AST
     Swarm.Language.Syntax.CommandMetadata

--- a/test/unit/TestBoolExpr.hs
+++ b/test/unit/TestBoolExpr.hs
@@ -7,9 +7,9 @@
 module TestBoolExpr where
 
 import Data.BoolExpr qualified as BE
-import Data.BoolExpr.Simplify qualified as Simplify
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Set qualified as Set
+import Swarm.Data.BoolExpr.Simplify qualified as Simplify
 import Swarm.Game.Scenario.Objective.Logic
 import Swarm.Game.Scenario.Objective.WinCheck qualified as WC
 import Test.Tasty


### PR DESCRIPTION
* requires #2779 to avoid having to write ToJSON(1) instance for vectors

Co-Authored-By @patrickestrada