### PR TITLE
Fix ToJSON instance for types

### DIFF
--- a/src/swarm-doc/Swarm/Doc/Command.hs
+++ b/src/swarm-doc/Swarm/Doc/Command.hs
@@ -1,14 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- |
 -- SPDX-License-Identifier: BSD-3-Clause
 --
 -- Auto-generation of command attributes matrix.
 module Swarm.Doc.Command where
 
-import Data.Aeson (ToJSON)
+import Data.Aeson (ToJSON, (.=))
+import Data.Aeson qualified as Ae
 import Data.List.Extra (enumerate)
 import Data.List.NonEmpty qualified as NE
 import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Servant.Docs qualified as SD
 import Swarm.Doc.Util
@@ -16,6 +20,7 @@ import Swarm.Language.Syntax
 import Swarm.Language.Syntax.CommandMetadata
 import Swarm.Language.Typecheck (inferConst)
 import Swarm.Language.Types
+import Swarm.Pretty (prettyTextLine)
 
 data DerivedAttrs = DerivedAttrs
   { hasActorTarget :: Bool
@@ -34,7 +39,16 @@ data CommandEntry = CommandEntry
   , argTypes :: NE.NonEmpty Type
   , derivedAttrs :: DerivedAttrs
   }
-  deriving (Generic, ToJSON)
+  deriving (Generic)
+
+instance ToJSON CommandEntry where
+  toJSON c =
+    Ae.object
+      [ "cmd" .= cmd c
+      , "effects" .= effects c
+      , "argTypes" .= (prettyTextLine <$> argTypes c)
+      , "derivedAttrs" .= derivedAttrs c
+      ]
 
 newtype CommandCatalog = CommandCatalog {entries :: [CommandEntry]}
   deriving newtype (ToJSON)
@@ -54,7 +68,7 @@ mkEntry c =
       , modifiesRobot = not . Set.disjoint cmdEffects . Set.fromList $ map (Mutation . RobotChange) enumerate
       , movesRobot = Mutation (RobotChange PositionChange) `Set.member` cmdEffects
       , returnsValue = theOutputType /= TyCmd TyUnit
-      , outputType = show theOutputType
+      , outputType = T.unpack $ prettyTextLine theOutputType
       }
  where
   cmdInfo = constInfo c

--- a/src/swarm-doc/Swarm/Doc/Wiki/Matrix.hs
+++ b/src/swarm-doc/Swarm/Doc/Wiki/Matrix.hs
@@ -9,7 +9,7 @@ module Swarm.Doc.Wiki.Matrix where
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import Swarm.Doc.Command
-import Swarm.Pretty (prettyTextLine, PrettyPrec)
+import Swarm.Pretty (PrettyPrec, prettyTextLine)
 import Text.Pandoc
 import Text.Pandoc.Builder
 

--- a/src/swarm-doc/Swarm/Doc/Wiki/Matrix.hs
+++ b/src/swarm-doc/Swarm/Doc/Wiki/Matrix.hs
@@ -9,6 +9,7 @@ module Swarm.Doc.Wiki.Matrix where
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import Swarm.Doc.Command
+import Swarm.Pretty (prettyTextLine)
 import Text.Pandoc
 import Text.Pandoc.Builder
 
@@ -37,4 +38,4 @@ genPropsRow e =
  where
   showCode :: Show a => a -> Blocks
   showCode = plain . code . T.pack . show
-  completeTypeMembers = NE.map showCode $ argTypes e
+  completeTypeMembers = NE.map (showCode . prettyTextLine) $ argTypes e

--- a/src/swarm-doc/Swarm/Doc/Wiki/Matrix.hs
+++ b/src/swarm-doc/Swarm/Doc/Wiki/Matrix.hs
@@ -9,7 +9,7 @@ module Swarm.Doc.Wiki.Matrix where
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import Swarm.Doc.Command
-import Swarm.Pretty (prettyTextLine)
+import Swarm.Pretty (prettyTextLine, PrettyPrec)
 import Text.Pandoc
 import Text.Pandoc.Builder
 
@@ -30,7 +30,7 @@ makePropsTable headingsList =
 
 genPropsRow :: CommandEntry -> [Blocks]
 genPropsRow e =
-  [ showCode (cmd e)
+  [ prettyCode (cmd e)
   , showCode (effects e)
   , showCode (hasActorTarget $ derivedAttrs e)
   ]
@@ -38,4 +38,6 @@ genPropsRow e =
  where
   showCode :: Show a => a -> Blocks
   showCode = plain . code . T.pack . show
-  completeTypeMembers = NE.map (showCode . prettyTextLine) $ argTypes e
+  prettyCode :: PrettyPrec a => a -> Blocks
+  prettyCode = plain . code . prettyTextLine
+  completeTypeMembers = NE.map prettyCode $ argTypes e

--- a/src/swarm-lang/Swarm/Language/JSON.hs
+++ b/src/swarm-lang/Swarm/Language/JSON.hs
@@ -18,7 +18,7 @@ import GHC.Generics (Generic)
 import Swarm.Language.Module (Module (..), ModuleCtx, ModuleImports, ModuleProvenance (..))
 import Swarm.Language.Parser (readNonemptyTerm)
 import Swarm.Language.Syntax (Anchor, ImportPhaseFor, Phase (Raw), SwarmType, Syntax, Term, Unresolvable, sTerm)
-import Swarm.Language.Value (Env, Value (..))
+import Swarm.Language.Value (Env, Value (..), valueToTerm)
 import Swarm.Pretty (PrettyPrec, prettyText)
 import Swarm.Util.JSON (optionsMinimize)
 import Swarm.Util.Yaml (FromJSONE (..), ParserE, getE, getProvenance, liftE, localE)
@@ -37,10 +37,10 @@ parseProgram v = do
   prov <- getProvenance
   liftE $ Ae.withText "program" (\txt -> fmap (prov,txt,) (parseJSON v)) v
 
-instance (Generic (Anchor (ImportPhaseFor phase)), ToJSON (Anchor (ImportPhaseFor phase)), ToJSON (SwarmType phase), Unresolvable (ImportPhaseFor phase), PrettyPrec (Anchor (ImportPhaseFor phase))) => ToJSON (Term phase) where
+instance (Unresolvable (ImportPhaseFor phase), PrettyPrec (Anchor (ImportPhaseFor phase))) => ToJSON (Term phase) where
   toJSON = Ae.String . prettyText
 
-instance (Generic (Anchor (ImportPhaseFor phase)), ToJSON (Anchor (ImportPhaseFor phase)), ToJSON (SwarmType phase), Unresolvable (ImportPhaseFor phase), PrettyPrec (Anchor (ImportPhaseFor phase))) => ToJSON (Syntax phase) where
+instance (Unresolvable (ImportPhaseFor phase), PrettyPrec (Anchor (ImportPhaseFor phase))) => ToJSON (Syntax phase) where
   toJSON = Ae.String . prettyText
 
 deriving instance (Generic (Anchor (ImportPhaseFor phase)), ToJSON (Anchor (ImportPhaseFor phase)), ToJSON (SwarmType phase), ToJSON (ModuleCtx phase), ToJSON (ModuleImports phase), Unresolvable (ImportPhaseFor phase), PrettyPrec (Anchor (ImportPhaseFor phase))) => ToJSON (Module phase)
@@ -63,7 +63,7 @@ instance FromJSONE ModuleProvenance (Module Raw) where
       <*> getE
 
 instance ToJSON Value where
-  toJSON = genericToJSON optionsMinimize
+  toJSON = toJSON . valueToTerm
 
 -- TODO (#2213): Craft some appropriate FromJSONE instances for things
 -- like Value and Env.  Below is an early experiment.

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -137,6 +137,7 @@ module Swarm.Language.Types (
 import Control.Lens (Plated (..), makeLenses, rewriteM, view)
 import Control.Monad.Free
 import Data.Aeson (FromJSON (..), FromJSON1 (..), ToJSON (..), ToJSON1 (..), genericLiftParseJSON, genericLiftToJSON, genericParseJSON, genericToJSON)
+import Data.Aeson qualified as Ae
 import Data.Data (Data)
 import Data.Data.Lens (uniplate)
 import Data.Eq.Deriving (deriveEq1)
@@ -166,7 +167,7 @@ import Swarm.Language.Context qualified as Ctx
 import Swarm.Language.Syntax.Import (ImportLoc, ImportPhase (Resolved))
 import Swarm.Language.TDVar (TDVar (..), mkTDVar, setVersion)
 import Swarm.Language.Var (Var)
-import Swarm.Pretty (PrettyPrec (..), pparens, pparens', ppr, prettyBinding)
+import Swarm.Pretty (PrettyPrec (..), pparens, pparens', ppr, prettyBinding, prettyTextLine)
 import Swarm.Util (showT, unsnocNE)
 import Swarm.Util.JSON (optionsMinimize, optionsUnwrapUnary)
 import Text.Show.Deriving (deriveShow1)
@@ -308,12 +309,6 @@ deriveOrd1 ''TypeF
 deriveShow1 ''TypeF
 
 instance Hashable1 TypeF -- needs the Eq1 instance
-
-instance ToJSON1 TypeF where
-  liftToJSON = genericLiftToJSON optionsMinimize
-
-instance FromJSON1 TypeF where
-  liftParseJSON = genericLiftParseJSON optionsMinimize
 
 -- | @Type@ is now defined as the fixed point of 'TypeF'.  It would be
 --   annoying to manually apply and match against 'Fix' constructors
@@ -462,6 +457,9 @@ instance (UnchainableFun t, PrettyPrec t, SubstRec t) => PrettyPrec (TypeF t) wh
     TyConF c [] -> ppr c
     TyConF c tys -> pparens (p > 9) $ ppr c <+> hsep (map (prettyPrec 10) tys)
 
+instance (UnchainableFun t, PrettyPrec t, SubstRec t) => ToJSON (TypeF t) where
+  toJSON = Ae.String . prettyTextLine
+
 ------------------------------------------------------------
 -- Generic folding over type representations
 ------------------------------------------------------------
@@ -539,7 +537,7 @@ data ImplicitQuantification = Unquantified | Quantified
 --   only way to create a @Poly Quantified@ is through the 'quantify'
 --   function.
 data Poly (q :: ImplicitQuantification) t = Forall {_ptVars :: [Var], ptBody :: t}
-  deriving (Show, Eq, Functor, Foldable, Traversable, Data, Generic, FromJSON, ToJSON, Hashable)
+  deriving (Show, Eq, Functor, Foldable, Traversable, Data, Generic, Hashable)
 
 -- | Create a raw, unquantified @Poly@ value.
 mkPoly :: [Var] -> t -> Poly 'Unquantified t
@@ -592,6 +590,9 @@ type UPolytype = Poly 'Quantified UType
 instance PrettyPrec (Poly q UType) where
   prettyPrec _ (Forall [] t) = ppr t
   prettyPrec _ (Forall xs t) = hsep ("∀" : map ppr xs) <> "." <+> ppr t
+
+instance ToJSON Polytype where
+  toJSON = Ae.String . prettyTextLine
 
 ------------------------------------------------------------
 -- WithU
@@ -831,7 +832,7 @@ data TydefInfo = TydefInfo
   { _tydefType :: Polytype
   , _tydefArity :: Arity
   }
-  deriving (Eq, Show, Generic, Data, FromJSON, ToJSON, Hashable)
+  deriving (Eq, Show, Generic, Data, Hashable)
 
 makeLenses ''TydefInfo
 

--- a/src/swarm-lang/Swarm/Language/Types.hs
+++ b/src/swarm-lang/Swarm/Language/Types.hs
@@ -136,7 +136,7 @@ module Swarm.Language.Types (
 
 import Control.Lens (Plated (..), makeLenses, rewriteM, view)
 import Control.Monad.Free
-import Data.Aeson (FromJSON (..), FromJSON1 (..), ToJSON (..), ToJSON1 (..), genericLiftParseJSON, genericLiftToJSON, genericParseJSON, genericToJSON)
+import Data.Aeson (FromJSON (..), ToJSON (..), genericParseJSON, genericToJSON)
 import Data.Aeson qualified as Ae
 import Data.Data (Data)
 import Data.Data.Lens (uniplate)

--- a/src/swarm-lang/Swarm/Language/WithType.hs
+++ b/src/swarm-lang/Swarm/Language/WithType.hs
@@ -5,8 +5,6 @@
 module Swarm.Language.WithType (WithType (..), value, polytype, requires) where
 
 import Control.Lens (makeLenses)
-import Data.Aeson (ToJSON)
-import Data.Aeson.Types (FromJSON)
 import GHC.Generics (Generic)
 import Swarm.Language.Requirements.Type (Requirements)
 import Swarm.Language.Types (Polytype)
@@ -17,6 +15,6 @@ data WithType v = WithType
   , _polytype :: Polytype
   , _requires :: Requirements
   }
-  deriving (Show, Eq, Generic, FromJSON, ToJSON)
+  deriving (Show, Eq, Generic)
 
 makeLenses ''WithType


### PR DESCRIPTION
* remove unused FromJSON(1) instances
* use pretty in ToJSON instance for TypeF
* use pretty in ToJSON instance for PolyType
* remove unused WithType JSON instances
* remove unused WithType JSON instances
* remove unused Generic constraint from Term/Syntax instance
* use pretty in Value ToJSON instance via Term
* fix printing of types in `swarm-docs`
* closes #2778