### PR TITLE
Update GHC and Cabal in haskell-ci-simple.yml

### DIFF
--- a/.github/workflows/haskell-ci-simple.yml
+++ b/.github/workflows/haskell-ci-simple.yml
@@ -29,8 +29,8 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        cabal: ["3.16.0.0"]
-        ghc: ["9.12.1"]
+        cabal: ["3.16.1.0"]
+        ghc: ["9.12.4"]
     timeout-minutes:
       60
 


### PR DESCRIPTION
GHCup warn about the old releases:
```
  [ Warn  ] !!! This release is considered broken due to a correctness bug affecting sub-word division !!!
  [ ...   ] !!! See https://gitlab.haskell.org/ghc/ghc/-/issues/25653 !!!
  [ ...   ] !!! Please update to 9.12.2 !!!
```
