### PR TITLE
Refactor: pull out KeyCmd infrastructure into a separate module

### DIFF
--- a/src/swarm-tui/Swarm/TUI/View.hs
+++ b/src/swarm-tui/Swarm/TUI/View.hs
@@ -16,7 +16,6 @@ module Swarm.TUI.View (
   -- * Key hint menu
   drawKeyMenu,
   drawModalMenu,
-  drawKeyCmd,
 
   -- * Robot panel
   drawRobotPanel,
@@ -139,6 +138,7 @@ import Swarm.TUI.Panel
 import Swarm.TUI.View.Achievement
 import Swarm.TUI.View.Attribute.Attr
 import Swarm.TUI.View.CellDisplay
+import Swarm.TUI.View.KeyCmd
 import Swarm.TUI.View.Logo
 import Swarm.TUI.View.Objective qualified as GR
 import Swarm.TUI.View.Popup
@@ -151,10 +151,6 @@ import Swarm.Util
 import Text.Printf
 import Text.Wrap
 import Witch (into)
-
-data KeyCmd
-  = SingleButton KeyHighlight Text Text
-  | MultiButton KeyHighlight [(Text, Text)] Text
 
 -- | The main entry point for drawing the entire UI.
 drawUI :: AppState -> [Widget Name]
@@ -885,7 +881,7 @@ colorSeverity = \case
 
 -- | Draw the F-key modal menu. This is displayed in the top left world corner.
 drawModalMenu :: GameState -> KeyConfig SE.SwarmEvent -> Widget Name
-drawModalMenu gs keyConf = vLimit 1 . hBox $ map (padLeftRight 1 . drawKeyCmd) globalKeyCmds
+drawModalMenu gs keyConf = vLimit 1 $ drawKeyCmds globalKeyCmds
  where
   notificationKey :: Getter GameState (Notifications a) -> SE.MainEvent -> Text -> Maybe KeyCmd
   notificationKey notifLens key name
@@ -928,17 +924,15 @@ drawKeyMenu ps keyConf debugOpts =
     hBox
       [ padBottom Max $
           vBox
-            [ mkCmdRow globalKeyCmds
+            [ drawKeyCmds globalKeyCmds
             , padLeft (Pad 2) contextCmds
             ]
       , gameModeWidget
       ]
  where
-  mkCmdRow = hBox . map drawPaddedCmd
-  drawPaddedCmd = padLeftRight 1 . drawKeyCmd
   contextCmds
     | ctrlMode == Handling = txt $ fromMaybe "" (gs ^? gameControls . inputHandler . _Just . _1)
-    | otherwise = mkCmdRow focusedPanelCmds
+    | otherwise = drawKeyCmds focusedPanelCmds
   focusedPanelCmds =
     map highlightKeyCmds
       . keyCmdsFor
@@ -1046,27 +1040,6 @@ drawKeyMenu ps keyConf debugOpts =
   keyR = VU.bindingText keyConf . SE.REPL
   keyE = VU.bindingText keyConf . SE.Robot
   keyW = VU.bindingText keyConf . SE.World
-
-data KeyHighlight = NoHighlight | Alert | PanelSpecific
-
--- | Draw a single key command in the menu.
-drawKeyCmd :: KeyCmd -> Widget Name
-drawKeyCmd keycmd =
-  case keycmd of
-    (SingleButton h key cmd) ->
-      clickable (UIShortcut cmd) $
-        hBox
-          [ withAttr (attr h) (txt $ brackets key)
-          , txt cmd
-          ]
-    (MultiButton h keyArr cmd) ->
-      hBox $ intersperse (txt "/") (map (createCmd h) keyArr) ++ [txt cmd]
- where
-  createCmd h (key, cmd) = clickable (UIShortcut cmd) $ withAttr (attr h) (txt $ brackets key)
-  attr h = case h of
-    NoHighlight -> defAttr
-    Alert -> notifAttr
-    PanelSpecific -> highlightAttr
 
 ------------------------------------------------------------
 -- World panel

--- a/src/swarm-tui/Swarm/TUI/View/KeyCmd.hs
+++ b/src/swarm-tui/Swarm/TUI/View/KeyCmd.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Code for describing and displaying clickable keybinding hints.
+module Swarm.TUI.View.KeyCmd (
+  KeyHighlight (..),
+  KeyCmd (..),
+  drawKeyCmd,
+  drawKeyCmds,
+) where
+
+import Brick (Widget, clickable, hBox, padLeftRight, txt, withAttr)
+import Data.List (intersperse)
+import Data.Text (Text)
+import Swarm.TUI.Model (Name (..))
+import Swarm.TUI.View.Attribute.Attr (defAttr, highlightAttr, notifAttr)
+import Swarm.Util (brackets)
+
+-- | How should a keybinding be highlighted?
+data KeyHighlight
+  = -- | No special highlighting
+    NoHighlight
+  | -- | Alert the user that something new/exciting is behind this keybinding
+    Alert
+  | -- | Highlight the fact that this keybinding is specific to a particular panel
+    PanelSpecific
+
+-- | A description of keybinding(s) for a single event.
+data KeyCmd
+  = SingleButton KeyHighlight Text Text
+  | MultiButton KeyHighlight [(Text, Text)] Text
+
+-- | Draw a single clickable keybinding.
+drawKeyCmd :: KeyCmd -> Widget Name
+drawKeyCmd keycmd =
+  case keycmd of
+    SingleButton h key cmd ->
+      clickable (UIShortcut cmd) $
+        hBox
+          [ withAttr (attr h) (txt $ brackets key)
+          , txt cmd
+          ]
+    MultiButton h keyArr cmd ->
+      hBox $ intersperse (txt "/") (map (createCmd h) keyArr) ++ [txt cmd]
+ where
+  createCmd h (key, cmd) = clickable (UIShortcut cmd) $ withAttr (attr h) (txt $ brackets key)
+  attr h = case h of
+    NoHighlight -> defAttr
+    Alert -> notifAttr
+    PanelSpecific -> highlightAttr
+
+-- | Lay out a sequence of keybindings with 1 space of padding on either
+--   end and 2 spaces of padding between each.
+drawKeyCmds :: [KeyCmd] -> Widget Name
+drawKeyCmds = hBox . map (padLeftRight 1 . drawKeyCmd)

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -1176,6 +1176,7 @@ library swarm-tui
     Swarm.TUI.View.Attribute.CustomStyling
     Swarm.TUI.View.Attribute.Util
     Swarm.TUI.View.CellDisplay
+    Swarm.TUI.View.KeyCmd
     Swarm.TUI.View.Logo
     Swarm.TUI.View.Objective
     Swarm.TUI.View.Popup


### PR DESCRIPTION
There are a few data types + functions used to render clickable keybinding hints at the top and bottom of the world panel.  I would like to also use them on the help pages (#2789), so this PR just pulls out some of that code into a separate module.